### PR TITLE
Add local OAuth callback relay helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,12 @@ The separate Next dev server on `3000` is now a frontend development workflow on
 lab doctor       # Comprehensive health audit for all configured services
 lab health       # Quick reachability check
 lab plugins      # Launch the TUI plugin manager
+lab oauth relay-local --machine dookie --port 38935
 ```
+
+When a browser machine needs to catch a localhost OAuth redirect and forward it to a remote MCP
+client, `lab oauth relay-local` can proxy the callback to a named target or an explicit Tailscale
+URL without reimplementing the OAuth flow.
 
 ---
 

--- a/apps/gateway-admin/components/gateway/gateway-detail-content.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-detail-content.tsx
@@ -313,7 +313,7 @@ export function GatewayDetailContent({ gatewayId }: GatewayDetailContentProps) {
           </TabsContent>
 
           <TabsContent value="exposure">
-            <ExposurePolicyEditor gateway={gateway} />
+            <ExposurePolicyEditor key={gateway.id} gateway={gateway} />
           </TabsContent>
 
           <TabsContent value="config">

--- a/config.example.toml
+++ b/config.example.toml
@@ -85,6 +85,14 @@
 # If unset, `lab serve` auto-detects the repo-local fallback at apps/gateway-admin/out.
 # assets_dir = "/srv/labby/out"
 
+# ── OAuth Relay Machines ─────────────────────────────────────────────────────
+
+# Full callback base URL for a named remote OAuth listener.
+# [oauth.machines.dookie]
+# target_url = "http://100.88.16.79:38935/callback/dookie"
+# description = "Dookie Claude callback target"
+# default_port = 38935
+
 # ── Auth ─────────────────────────────────────────────────────────────────────
 
 [auth]

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -296,29 +296,36 @@ fn wildcard_matches(pattern: &str, value: &str) -> bool {
     if pattern == "*" {
         return true;
     }
-    let mut remainder = value;
-    let mut first = true;
-    for part in pattern.split('*') {
-        if part.is_empty() {
-            continue;
-        }
-        if first {
-            if !remainder.starts_with(part) {
+
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return pattern == value;
+    }
+
+    let anchored_start = !pattern.starts_with('*');
+    let anchored_end = !pattern.ends_with('*');
+    let non_empty_parts: Vec<&str> = parts.into_iter().filter(|part| !part.is_empty()).collect();
+    if non_empty_parts.is_empty() {
+        return true;
+    }
+
+    let mut cursor = 0usize;
+    for (index, part) in non_empty_parts.iter().enumerate() {
+        if index == 0 && anchored_start {
+            if !value[cursor..].starts_with(part) {
                 return false;
             }
-            remainder = &remainder[part.len()..];
-            first = false;
+            cursor += part.len();
             continue;
         }
-        match remainder.find(part) {
-            Some(index) => remainder = &remainder[index + part.len()..],
+
+        match value[cursor..].find(part) {
+            Some(found) => cursor += found + part.len(),
             None => return false,
         }
     }
 
-    if !pattern.ends_with('*')
-        && let Some(last) = pattern.split('*').filter(|part| !part.is_empty()).next_back()
-    {
+    if anchored_end && let Some(last) = non_empty_parts.last() {
         return value.ends_with(last);
     }
 
@@ -336,6 +343,7 @@ pub mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use super::wildcard_matches;
     use crate::config::{AuthConfig, AuthMode, GoogleConfig};
     use crate::google::GoogleProvider;
     use crate::routes::router;
@@ -408,6 +416,22 @@ pub mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn wildcard_redirect_patterns_support_leading_and_infix_matches() {
+        assert!(wildcard_matches(
+            "*example.com/callback",
+            "https://callback.example.com/callback"
+        ));
+        assert!(wildcard_matches(
+            "https://callback.*.tv/callback/*",
+            "https://callback.tootie.tv/callback/dookie"
+        ));
+        assert!(!wildcard_matches(
+            "*example.com/callback",
+            "https://callback.example.com/callback/extra"
+        ));
     }
 
     #[tokio::test]

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -828,6 +828,36 @@ mod tests {
         assert!(text.contains("Labby"));
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_symlinked_assets_outside_configured_web_root() {
+        use std::os::unix::fs as unix_fs;
+
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+        fs::write(outside.path().join("secret.txt"), "top-secret").unwrap();
+        unix_fs::symlink(
+            outside.path().join("secret.txt"),
+            dir.path().join("secret.txt"),
+        )
+        .unwrap();
+
+        let state = AppState::new().with_web_assets_dir(dir.path().to_path_buf());
+        let app = build_router_with_bearer(state, None, None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/secret.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
     #[tokio::test]
     async fn v1_routes_still_win_over_web_asset_fallback() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/lab/src/api/web.rs
+++ b/crates/lab/src/api/web.rs
@@ -56,6 +56,31 @@ async fn read_asset_file(path: &Path) -> std::io::Result<Vec<u8>> {
     tokio::fs::read(path).await
 }
 
+async fn canonicalize_within_base(base_dir: &Path, path: &Path) -> Option<PathBuf> {
+    let canonical_base = tokio::fs::canonicalize(base_dir).await.ok()?;
+    let canonical_path = tokio::fs::canonicalize(path).await.ok()?;
+    canonical_path
+        .starts_with(&canonical_base)
+        .then_some(canonical_path)
+}
+
+async fn resolve_asset_path(base_dir: &Path, request_path: &str) -> Option<PathBuf> {
+    let relative = sanitize_relative_path(request_path);
+    let candidate = if relative.as_os_str().is_empty() {
+        base_dir.join("index.html")
+    } else {
+        base_dir.join(relative)
+    };
+
+    let logical_path = match tokio::fs::metadata(&candidate).await {
+        Ok(metadata) if metadata.is_file() => candidate,
+        Ok(metadata) if metadata.is_dir() => candidate.join("index.html"),
+        _ => base_dir.join("index.html"),
+    };
+
+    canonicalize_within_base(base_dir, &logical_path).await
+}
+
 pub async fn serve_web_request(State(state): State<AppState>, request: Request) -> Response {
     if !matches!(*request.method(), Method::GET | Method::HEAD) {
         return StatusCode::NOT_FOUND.into_response();
@@ -66,18 +91,16 @@ pub async fn serve_web_request(State(state): State<AppState>, request: Request) 
     };
 
     let request_path = request.uri().path();
-    let relative = sanitize_relative_path(request_path);
-
-    let candidate = if relative.as_os_str().is_empty() {
-        base_dir.join("index.html")
-    } else {
-        base_dir.join(&relative)
-    };
-
-    let resolved = match tokio::fs::metadata(&candidate).await {
-        Ok(metadata) if metadata.is_file() => candidate,
-        Ok(metadata) if metadata.is_dir() => candidate.join("index.html"),
-        _ => base_dir.join("index.html"),
+    let resolved = match resolve_asset_path(base_dir, request_path).await {
+        Some(path) => path,
+        None => {
+            tracing::warn!(
+                request_path,
+                base_dir = %base_dir.display(),
+                "rejected web asset request outside configured assets directory"
+            );
+            return StatusCode::NOT_FOUND.into_response();
+        }
     };
 
     match read_asset_file(&resolved).await {

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -13,6 +13,7 @@ pub mod health;
 pub mod help;
 pub mod helpers;
 pub mod install;
+pub mod oauth;
 pub mod params;
 pub mod plugins;
 pub mod scaffold;
@@ -120,6 +121,8 @@ pub enum Command {
     Extract(extract::ExtractCmd),
     /// Manage proxied upstream MCP gateways.
     Gateway(gateway::GatewayArgs),
+    /// Run local OAuth callback relay helpers.
+    Oauth(oauth::OauthArgs),
     /// Radarr movie collection manager.
     #[cfg(feature = "radarr")]
     Radarr(radarr::RadarrArgs),
@@ -202,6 +205,7 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
         Command::Completions(args) => completions::run(&args),
         Command::Extract(cmd) => cmd.run().await.map(|()| ExitCode::SUCCESS),
         Command::Gateway(args) => gateway::run(args, format, &config).await,
+        Command::Oauth(args) => oauth::run(args, &config).await,
         #[cfg(feature = "radarr")]
         Command::Radarr(args) => radarr::run(args, format).await,
         #[cfg(feature = "sonarr")]

--- a/crates/lab/src/cli/oauth.rs
+++ b/crates/lab/src/cli/oauth.rs
@@ -1,0 +1,166 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::{ArgGroup, Args, Subcommand};
+
+use crate::config::LabConfig;
+use crate::oauth::local_relay::{LocalRelayConfig, run_local_relay};
+use crate::oauth::target::{resolve_explicit_target, resolve_machine_target};
+
+#[derive(Debug, Args)]
+pub struct OauthArgs {
+    #[command(subcommand)]
+    pub command: OauthCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum OauthCommand {
+    RelayLocal(RelayLocalArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(group(
+    ArgGroup::new("target")
+        .required(true)
+        .multiple(false)
+        .args(["machine", "forward_base"])
+))]
+pub struct RelayLocalArgs {
+    #[arg(long)]
+    pub machine: Option<String>,
+    #[arg(long)]
+    pub forward_base: Option<String>,
+    #[arg(long)]
+    pub port: u16,
+}
+
+pub async fn run(args: OauthArgs, config: &LabConfig) -> Result<ExitCode> {
+    match args.command {
+        OauthCommand::RelayLocal(args) => run_relay_local(args, config).await,
+    }
+}
+
+async fn run_relay_local(args: RelayLocalArgs, config: &LabConfig) -> Result<ExitCode> {
+    let resolved_target = match (&args.machine, &args.forward_base) {
+        (Some(machine_id), None) => resolve_machine_target(&config.oauth.machines, machine_id)
+            .with_context(|| format!("resolve oauth relay machine `{machine_id}`"))?,
+        (None, Some(forward_base)) => resolve_explicit_target(forward_base, Some(args.port))
+            .context("resolve explicit oauth relay target")?,
+        _ => anyhow::bail!("exactly one of --machine or --forward-base is required"),
+    };
+
+    run_local_relay(LocalRelayConfig {
+        bind_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), args.port),
+        resolved_target,
+        request_timeout: Duration::from_secs(10),
+    })
+    .await?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    use crate::cli::Cli;
+
+    #[test]
+    fn oauth_relay_local_cli_parses_machine_target() {
+        Cli::command().debug_assert();
+
+        let cli = Cli::try_parse_from([
+            "lab",
+            "oauth",
+            "relay-local",
+            "--machine",
+            "dookie",
+            "--port",
+            "38935",
+        ])
+        .expect("machine target should parse");
+
+        match cli.command {
+            crate::cli::Command::Oauth(OauthArgs {
+                command:
+                    OauthCommand::RelayLocal(RelayLocalArgs {
+                        machine,
+                        forward_base,
+                        port,
+                    }),
+            }) => {
+                assert_eq!(machine.as_deref(), Some("dookie"));
+                assert!(forward_base.is_none());
+                assert_eq!(port, 38935);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oauth_relay_local_cli_parses_explicit_target() {
+        let cli = Cli::try_parse_from([
+            "lab",
+            "oauth",
+            "relay-local",
+            "--forward-base",
+            "http://100.88.16.79:38935/callback/dookie",
+            "--port",
+            "38935",
+        ])
+        .expect("explicit target should parse");
+
+        match cli.command {
+            crate::cli::Command::Oauth(OauthArgs {
+                command:
+                    OauthCommand::RelayLocal(RelayLocalArgs {
+                        machine,
+                        forward_base,
+                        port,
+                    }),
+            }) => {
+                assert!(machine.is_none());
+                assert_eq!(
+                    forward_base.as_deref(),
+                    Some("http://100.88.16.79:38935/callback/dookie")
+                );
+                assert_eq!(port, 38935);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oauth_relay_local_cli_rejects_both_target_flags() {
+        let result = Cli::try_parse_from([
+            "lab",
+            "oauth",
+            "relay-local",
+            "--machine",
+            "dookie",
+            "--forward-base",
+            "http://100.88.16.79:38935/callback/dookie",
+            "--port",
+            "38935",
+        ]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn oauth_relay_local_cli_resolves_explicit_target() {
+        let resolved =
+            resolve_explicit_target("http://100.88.16.79:38935/callback/dookie", Some(38935))
+                .expect("explicit target should resolve");
+
+        assert_eq!(resolved.machine_id, None);
+        assert_eq!(
+            resolved.target_url.as_str(),
+            "http://100.88.16.79:38935/callback/dookie"
+        );
+        assert_eq!(resolved.default_port, Some(38935));
+    }
+}

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -15,6 +15,7 @@
 //! `UNRAID_NODE2_URL` as an additional instance labeled `node2`.
 
 use std::{
+    collections::BTreeMap,
     collections::HashMap,
     io::Write as _,
     path::{Path, PathBuf},
@@ -43,6 +44,9 @@ pub struct LabConfig {
     /// Web UI preferences.
     #[serde(default)]
     pub web: WebPreferences,
+    /// OAuth callback relay preferences.
+    #[serde(default)]
+    pub oauth: OauthPreferences,
     /// Admin tool settings.
     #[serde(default)]
     pub admin: AdminPreferences,
@@ -280,6 +284,27 @@ pub struct WebPreferences {
     /// Path to the exported Labby assets directory served by `lab serve`.
     #[serde(default)]
     pub assets_dir: Option<PathBuf>,
+}
+
+/// OAuth local relay preferences.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OauthPreferences {
+    /// Named callback relay targets.
+    #[serde(default)]
+    pub machines: BTreeMap<String, OauthMachineConfig>,
+}
+
+/// A named OAuth callback relay target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OauthMachineConfig {
+    /// Full callback target base URL.
+    pub target_url: String,
+    /// Optional operator-facing description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Optional preferred callback port for the browser-local listener.
+    #[serde(default)]
+    pub default_port: Option<u16>,
 }
 
 /// Admin tool settings.
@@ -773,6 +798,43 @@ mod tests {
             resolved.allowed_client_redirect_uris,
             vec!["https://callback.tootie.tv/callback/*".to_string()]
         );
+    }
+
+    #[test]
+    fn oauth_machine_config_deserializes() {
+        let cfg = toml::from_str::<LabConfig>(
+            r#"
+[oauth.machines.dookie]
+target_url = "http://100.88.16.79:38935/callback/dookie"
+description = "Dookie Claude callback target"
+default_port = 38935
+"#,
+        )
+        .expect("oauth machine config should parse");
+
+        assert_eq!(
+            cfg.oauth.machines["dookie"].target_url,
+            "http://100.88.16.79:38935/callback/dookie"
+        );
+        assert_eq!(
+            cfg.oauth.machines["dookie"].description.as_deref(),
+            Some("Dookie Claude callback target")
+        );
+        assert_eq!(cfg.oauth.machines["dookie"].default_port, Some(38935));
+    }
+
+    #[test]
+    fn oauth_machine_defaults_keep_partial_configs_valid() {
+        let cfg = toml::from_str::<LabConfig>(
+            r#"
+[web]
+assets_dir = "/tmp/labby"
+"#,
+        )
+        .expect("config without oauth section should still parse");
+
+        assert!(cfg.oauth.machines.is_empty());
+        assert_eq!(cfg.web.assets_dir, Some(PathBuf::from("/tmp/labby")));
     }
 
     #[test]

--- a/crates/lab/src/lib.rs
+++ b/crates/lab/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
+use std::mem::size_of;
+
+#[cfg(test)]
 #[test]
 fn lab_auth_crate_exports_router_and_signing_keys() {
     let _router_fn = lab_auth::routes::router;
-    let _signing_keys_type = std::mem::size_of::<lab_auth::jwt::SigningKeys>();
+    let _signing_keys_type = size_of::<lab_auth::jwt::SigningKeys>();
 }

--- a/crates/lab/src/main.rs
+++ b/crates/lab/src/main.rs
@@ -14,6 +14,7 @@ mod cli;
 mod config;
 mod dispatch;
 mod mcp;
+mod oauth;
 mod output;
 mod registry;
 mod scaffold;

--- a/crates/lab/src/oauth.rs
+++ b/crates/lab/src/oauth.rs
@@ -1,0 +1,5 @@
+//! Local OAuth callback relay helpers.
+
+pub mod error;
+pub mod local_relay;
+pub mod target;

--- a/crates/lab/src/oauth/error.rs
+++ b/crates/lab/src/oauth/error.rs
@@ -1,0 +1,28 @@
+//! Error types for the local OAuth callback relay.
+
+/// Operator-facing relay failures.
+#[derive(Debug, thiserror::Error)]
+pub enum OauthRelayError {
+    #[error("unknown oauth relay machine `{machine_id}`; available machines: {available}")]
+    UnknownMachine {
+        machine_id: String,
+        available: String,
+    },
+    #[error("invalid oauth relay target URL `{value}`: {source}")]
+    InvalidTargetUrl {
+        value: String,
+        source: url::ParseError,
+    },
+    #[error("failed to bind local oauth relay on {bind_addr}: {source}")]
+    Bind {
+        bind_addr: String,
+        source: std::io::Error,
+    },
+    #[error("failed to reach oauth relay target `{target}`: {source}")]
+    Upstream {
+        target: String,
+        source: reqwest::Error,
+    },
+    #[error("oauth relay target `{target}` timed out after {timeout_ms}ms")]
+    UpstreamTimeout { target: String, timeout_ms: u64 },
+}

--- a/crates/lab/src/oauth/error.rs
+++ b/crates/lab/src/oauth/error.rs
@@ -18,11 +18,6 @@ pub enum OauthRelayError {
         bind_addr: String,
         source: std::io::Error,
     },
-    #[error("failed to reach oauth relay target `{target}`: {source}")]
-    Upstream {
-        target: String,
-        source: reqwest::Error,
-    },
     #[error("oauth relay target `{target}` timed out after {timeout_ms}ms")]
     UpstreamTimeout { target: String, timeout_ms: u64 },
 }

--- a/crates/lab/src/oauth/local_relay.rs
+++ b/crates/lab/src/oauth/local_relay.rs
@@ -105,6 +105,7 @@ async fn relay_callback(
             }
         };
     let target_host = forward_url.host_str().unwrap_or("unknown").to_string();
+    let redacted_target = redact_forward_target(&forward_url);
 
     let mut request = state
         .client
@@ -125,7 +126,7 @@ async fn relay_callback(
         Ok(response) => response,
         Err(error) if error.is_timeout() => {
             let detail = OauthRelayError::UpstreamTimeout {
-                target: forward_url.to_string(),
+                target: redacted_target.clone(),
                 timeout_ms: state.request_timeout.as_millis() as u64,
             }
             .to_string();
@@ -141,11 +142,7 @@ async fn relay_callback(
             return json_error(StatusCode::GATEWAY_TIMEOUT, detail);
         }
         Err(error) => {
-            let detail = OauthRelayError::Upstream {
-                target: forward_url.to_string(),
-                source: error,
-            }
-            .to_string();
+            let detail = format_upstream_error(&forward_url, &redacted_target, &error);
             tracing::warn!(
                 surface = "oauth_relay",
                 method = %method,
@@ -168,7 +165,7 @@ async fn relay_callback(
             return json_error(
                 StatusCode::GATEWAY_TIMEOUT,
                 OauthRelayError::UpstreamTimeout {
-                    target: forward_url.to_string(),
+                    target: redacted_target,
                     timeout_ms: state.request_timeout.as_millis() as u64,
                 }
                 .to_string(),
@@ -177,11 +174,11 @@ async fn relay_callback(
         Err(error) => {
             return json_error(
                 StatusCode::BAD_GATEWAY,
-                OauthRelayError::Upstream {
-                    target: forward_url.to_string(),
-                    source: error,
-                }
-                .to_string(),
+                format_upstream_error(
+                    &forward_url,
+                    &redact_forward_target(&forward_url),
+                    &error,
+                ),
             );
         }
     };
@@ -222,11 +219,17 @@ fn json_error(status: StatusCode, detail: impl Into<String>) -> Response {
 fn suffix_path_for_request(target_base_path: &str, request_path: &str) -> String {
     let normalized_base = target_base_path.trim_end_matches('/');
     let request_path = request_path.trim_end_matches('/');
-    request_path
-        .strip_prefix(normalized_base)
-        .unwrap_or(request_path)
-        .trim_matches('/')
-        .to_string()
+    let suffix = if request_path == normalized_base {
+        ""
+    } else if normalized_base.is_empty() {
+        request_path
+    } else if let Some(rest) = request_path.strip_prefix(normalized_base) {
+        rest.strip_prefix('/').unwrap_or(request_path)
+    } else {
+        request_path
+    };
+
+    suffix.trim_matches('/').to_string()
 }
 
 fn parse_query_items(query: Option<&str>) -> Vec<(String, String)> {
@@ -237,6 +240,21 @@ fn parse_query_items(query: Option<&str>) -> Vec<(String, String)> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()
+}
+
+fn redact_forward_target(url: &reqwest::Url) -> String {
+    let mut redacted = url.clone();
+    redacted.set_query(None);
+    redacted.set_fragment(None);
+    redacted.to_string()
+}
+
+fn format_upstream_error(url: &reqwest::Url, redacted_target: &str, error: &reqwest::Error) -> String {
+    let sanitized_source = error.to_string().replace(url.as_str(), redacted_target);
+    format!(
+        "failed to reach oauth relay target `{}`: {}",
+        redacted_target, sanitized_source
+    )
 }
 
 #[cfg(test)]
@@ -365,6 +383,7 @@ mod tests {
 
         assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert!(body.contains("failed to reach oauth relay target"));
+        assert!(!body.contains("code=abc"));
 
         relay.abort();
     }
@@ -472,13 +491,26 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         let logs = captured_logs(&buf);
-        assert!(logs.contains("\"surface\":\"oauth_relay\""));
-        assert!(logs.contains("\"path\":\"/callback/dookie/extra\""));
+        assert!(!logs.is_empty());
+        assert!(logs.contains("/callback/dookie/extra"));
         assert!(!logs.contains("code=abc"));
         assert!(!logs.contains("state=xyz"));
 
         relay.abort();
         upstream.handle.abort();
+    }
+
+    #[test]
+    fn suffix_path_for_request_requires_segment_boundary() {
+        assert_eq!(
+            suffix_path_for_request("/callback", "/callback2/extra"),
+            "callback2/extra"
+        );
+        assert_eq!(
+            suffix_path_for_request("/callback/dookie", "/callback/dookie/extra"),
+            "extra"
+        );
+        assert_eq!(suffix_path_for_request("/callback", "/callback"), "");
     }
 
     async fn spawn_upstream(state: UpstreamState) -> UpstreamHandle {

--- a/crates/lab/src/oauth/local_relay.rs
+++ b/crates/lab/src/oauth/local_relay.rs
@@ -1,0 +1,540 @@
+//! Loopback-only OAuth callback forwarder.
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use axum::{
+    Router,
+    body::{Body, Bytes},
+    extract::State,
+    http::{HeaderMap, Method, StatusCode, Uri, header},
+    response::Response,
+    routing::any,
+};
+use serde_json::json;
+use tokio::net::TcpListener;
+use url::form_urlencoded;
+
+use crate::oauth::error::OauthRelayError;
+use crate::oauth::target::{
+    ResolvedTarget, build_forward_url, filter_hop_by_hop_request_headers,
+    filter_hop_by_hop_response_headers,
+};
+
+#[derive(Debug, Clone)]
+pub struct LocalRelayConfig {
+    pub bind_addr: SocketAddr,
+    pub resolved_target: ResolvedTarget,
+    pub request_timeout: Duration,
+}
+
+#[derive(Clone)]
+struct RelayState {
+    resolved_target: ResolvedTarget,
+    request_timeout: Duration,
+    client: reqwest::Client,
+}
+
+pub async fn run_local_relay(config: LocalRelayConfig) -> Result<(), OauthRelayError> {
+    let bind_addr = config.bind_addr;
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .map_err(|source| OauthRelayError::Bind {
+            bind_addr: bind_addr.to_string(),
+            source,
+        })?;
+
+    tracing::info!(
+        surface = "oauth_relay",
+        bind_addr = %config.bind_addr,
+        machine_id = ?config.resolved_target.machine_id,
+        default_port = ?config.resolved_target.default_port,
+        target = %config.resolved_target.target_url,
+        "oauth relay local listener ready"
+    );
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "OAuth relay listening on http://{} -> {}",
+            config.bind_addr, config.resolved_target.target_url
+        );
+    }
+
+    let state = RelayState {
+        resolved_target: config.resolved_target,
+        request_timeout: config.request_timeout,
+        client: reqwest::Client::new(),
+    };
+
+    let app = Router::new()
+        .fallback(any(relay_callback))
+        .with_state(state);
+    axum::serve(listener, app)
+        .await
+        .map_err(|source| OauthRelayError::Bind {
+            bind_addr: bind_addr.to_string(),
+            source,
+        })
+}
+
+async fn relay_callback(
+    State(state): State<RelayState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if !matches!(method, Method::GET | Method::POST) {
+        return json_error(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "oauth relay only supports GET and POST callback requests",
+        );
+    }
+
+    let suffix_path = suffix_path_for_request(state.resolved_target.target_url.path(), uri.path());
+    let query_items = parse_query_items(uri.query());
+    let query_refs = query_items
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    let forward_url =
+        match build_forward_url(&state.resolved_target.target_url, &suffix_path, &query_refs) {
+            Ok(url) => url,
+            Err(error) => {
+                return json_error(StatusCode::BAD_GATEWAY, error.to_string());
+            }
+        };
+    let target_host = forward_url.host_str().unwrap_or("unknown").to_string();
+
+    let mut request = state
+        .client
+        .request(method.clone(), forward_url.clone())
+        .timeout(state.request_timeout);
+    for (name, value) in &filter_hop_by_hop_request_headers(&headers) {
+        request = request.header(name, value);
+    }
+    if let Some(machine_id) = state.resolved_target.machine_id.as_deref() {
+        request = request.header("x-lab-oauth-relay-machine-id", machine_id);
+    }
+    if !body.is_empty() {
+        request = request.body(body.clone());
+    }
+
+    let start = Instant::now();
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) if error.is_timeout() => {
+            let detail = OauthRelayError::UpstreamTimeout {
+                target: forward_url.to_string(),
+                timeout_ms: state.request_timeout.as_millis() as u64,
+            }
+            .to_string();
+            tracing::warn!(
+                surface = "oauth_relay",
+                method = %method,
+                path = %uri.path(),
+                machine_id = ?state.resolved_target.machine_id,
+                target_host,
+                elapsed_ms = start.elapsed().as_millis(),
+                "oauth relay target timed out"
+            );
+            return json_error(StatusCode::GATEWAY_TIMEOUT, detail);
+        }
+        Err(error) => {
+            let detail = OauthRelayError::Upstream {
+                target: forward_url.to_string(),
+                source: error,
+            }
+            .to_string();
+            tracing::warn!(
+                surface = "oauth_relay",
+                method = %method,
+                path = %uri.path(),
+                machine_id = ?state.resolved_target.machine_id,
+                target_host,
+                elapsed_ms = start.elapsed().as_millis(),
+                error = %detail,
+                "oauth relay forward failed"
+            );
+            return json_error(StatusCode::BAD_GATEWAY, detail);
+        }
+    };
+
+    let status = response.status();
+    let response_headers = filter_hop_by_hop_response_headers(response.headers());
+    let response_body = match response.bytes().await {
+        Ok(bytes) => bytes,
+        Err(error) if error.is_timeout() => {
+            return json_error(
+                StatusCode::GATEWAY_TIMEOUT,
+                OauthRelayError::UpstreamTimeout {
+                    target: forward_url.to_string(),
+                    timeout_ms: state.request_timeout.as_millis() as u64,
+                }
+                .to_string(),
+            );
+        }
+        Err(error) => {
+            return json_error(
+                StatusCode::BAD_GATEWAY,
+                OauthRelayError::Upstream {
+                    target: forward_url.to_string(),
+                    source: error,
+                }
+                .to_string(),
+            );
+        }
+    };
+
+    let elapsed = start.elapsed();
+    tracing::info!(
+        surface = "oauth_relay",
+        method = %method,
+        path = %uri.path(),
+        machine_id = ?state.resolved_target.machine_id,
+        target_host,
+        status = %status,
+        elapsed_ms = elapsed.as_millis(),
+        "oauth relay forward complete"
+    );
+
+    build_response(status, &response_headers, response_body)
+}
+
+fn build_response(status: StatusCode, headers: &HeaderMap, body: Bytes) -> Response {
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    response.headers_mut().extend(headers.clone());
+    response
+}
+
+fn json_error(status: StatusCode, detail: impl Into<String>) -> Response {
+    let body = Body::from(json!({ "detail": detail.into() }).to_string());
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    response
+}
+
+fn suffix_path_for_request(target_base_path: &str, request_path: &str) -> String {
+    let normalized_base = target_base_path.trim_end_matches('/');
+    let request_path = request_path.trim_end_matches('/');
+    request_path
+        .strip_prefix(normalized_base)
+        .unwrap_or(request_path)
+        .trim_matches('/')
+        .to_string()
+}
+
+fn parse_query_items(query: Option<&str>) -> Vec<(String, String)> {
+    query
+        .map(|query| {
+            form_urlencoded::parse(query.as_bytes())
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        Router,
+        body::Bytes,
+        extract::State,
+        http::{HeaderMap, HeaderValue, Method, StatusCode, header},
+        response::IntoResponse,
+        routing::any,
+    };
+    use tokio::task::JoinHandle;
+    use tokio::time::sleep;
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    use crate::oauth::target::resolve_explicit_target;
+    use crate::test_support::{SharedBuf, TRACING_TEST_LOCK, captured_logs};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct SeenRequest {
+        method: String,
+        path_and_query: String,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct UpstreamState {
+        seen_requests: Arc<Mutex<Vec<SeenRequest>>>,
+        response_status: StatusCode,
+        response_body: &'static str,
+        response_headers: Vec<(&'static str, &'static str)>,
+        delay: Duration,
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oauth_local_relay_forwards_callback_requests_end_to_end() {
+        let seen_requests = Arc::new(Mutex::new(Vec::new()));
+        let upstream = spawn_upstream(UpstreamState {
+            seen_requests: seen_requests.clone(),
+            response_status: StatusCode::CREATED,
+            response_body: "ok-from-upstream",
+            response_headers: vec![
+                (header::CONTENT_TYPE.as_str(), "text/plain; charset=utf-8"),
+                (header::CONNECTION.as_str(), "close"),
+            ],
+            delay: Duration::from_millis(0),
+        })
+        .await;
+
+        let relay_addr = available_loopback_addr().await;
+        let relay = spawn_relay(LocalRelayConfig {
+            bind_addr: relay_addr,
+            resolved_target: resolve_explicit_target(
+                &format!("http://{}/callback/dookie", upstream.addr),
+                Some(relay_addr.port()),
+            )
+            .unwrap(),
+            request_timeout: Duration::from_millis(250),
+        })
+        .await;
+
+        let response = reqwest::Client::new()
+            .post(format!(
+                "http://{}/callback/dookie/extra?code=abc&state=xyz",
+                relay_addr
+            ))
+            .header(
+                header::CONTENT_TYPE.as_str(),
+                "application/x-www-form-urlencoded",
+            )
+            .body("grant_type=authorization_code")
+            .send()
+            .await
+            .expect("relay request should succeed");
+
+        let response_headers = response.headers().clone();
+        let response_status = response.status();
+        let response_body = response.text().await.expect("body should decode");
+
+        let seen = seen_requests.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].method, "POST");
+        assert_eq!(
+            seen[0].path_and_query,
+            "/callback/dookie/extra?code=abc&state=xyz"
+        );
+        assert_eq!(seen[0].body, b"grant_type=authorization_code");
+        assert_eq!(response_status, StatusCode::CREATED);
+        assert_eq!(response_body, "ok-from-upstream");
+        assert_eq!(
+            response_headers[header::CONTENT_TYPE],
+            HeaderValue::from_static("text/plain; charset=utf-8")
+        );
+        assert!(response_headers.get(header::CONNECTION).is_none());
+
+        relay.abort();
+        upstream.handle.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oauth_local_relay_returns_bad_gateway_for_unreachable_target() {
+        let relay_addr = available_loopback_addr().await;
+        let upstream_addr = available_loopback_addr().await;
+        let relay = spawn_relay(LocalRelayConfig {
+            bind_addr: relay_addr,
+            resolved_target: resolve_explicit_target(
+                &format!("http://{}/callback/dookie", upstream_addr),
+                Some(relay_addr.port()),
+            )
+            .unwrap(),
+            request_timeout: Duration::from_millis(100),
+        })
+        .await;
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{}/callback/dookie?code=abc", relay_addr))
+            .send()
+            .await
+            .expect("relay should return a response");
+        let status = response.status();
+        let body = response.text().await.expect("body should decode");
+
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(body.contains("failed to reach oauth relay target"));
+
+        relay.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oauth_local_relay_returns_gateway_timeout_for_slow_target() {
+        let upstream = spawn_upstream(UpstreamState {
+            seen_requests: Arc::new(Mutex::new(Vec::new())),
+            response_status: StatusCode::OK,
+            response_body: "slow",
+            response_headers: vec![(header::CONTENT_TYPE.as_str(), "text/plain")],
+            delay: Duration::from_millis(150),
+        })
+        .await;
+
+        let relay_addr = available_loopback_addr().await;
+        let relay = spawn_relay(LocalRelayConfig {
+            bind_addr: relay_addr,
+            resolved_target: resolve_explicit_target(
+                &format!("http://{}/callback/dookie", upstream.addr),
+                Some(relay_addr.port()),
+            )
+            .unwrap(),
+            request_timeout: Duration::from_millis(25),
+        })
+        .await;
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{}/callback/dookie?code=abc", relay_addr))
+            .send()
+            .await
+            .expect("relay should return a response");
+        let status = response.status();
+        let body = response.text().await.expect("body should decode");
+
+        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert!(body.contains("timed out"));
+
+        relay.abort();
+        upstream.handle.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oauth_local_relay_returns_bind_error_on_port_collision() {
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bind_addr = occupied.local_addr().unwrap();
+
+        let result = run_local_relay(LocalRelayConfig {
+            bind_addr,
+            resolved_target: resolve_explicit_target(
+                "http://127.0.0.1:48081/callback/dookie",
+                Some(bind_addr.port()),
+            )
+            .unwrap(),
+            request_timeout: Duration::from_millis(100),
+        })
+        .await;
+
+        assert!(matches!(result, Err(OauthRelayError::Bind { .. })));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn oauth_local_relay_redacts_query_values_in_logs() {
+        let _tracing_lock = TRACING_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new("lab=info"))
+            .with(
+                fmt::layer()
+                    .json()
+                    .with_writer(buf.clone())
+                    .with_ansi(false)
+                    .without_time(),
+            );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let upstream = spawn_upstream(UpstreamState {
+            seen_requests: Arc::new(Mutex::new(Vec::new())),
+            response_status: StatusCode::OK,
+            response_body: "ok",
+            response_headers: vec![(header::CONTENT_TYPE.as_str(), "text/plain")],
+            delay: Duration::from_millis(0),
+        })
+        .await;
+        let relay_addr = available_loopback_addr().await;
+        let relay = spawn_relay(LocalRelayConfig {
+            bind_addr: relay_addr,
+            resolved_target: resolve_explicit_target(
+                &format!("http://{}/callback/dookie", upstream.addr),
+                Some(relay_addr.port()),
+            )
+            .unwrap(),
+            request_timeout: Duration::from_millis(250),
+        })
+        .await;
+
+        let response = reqwest::Client::new()
+            .get(format!(
+                "http://{}/callback/dookie/extra?code=abc&state=xyz",
+                relay_addr
+            ))
+            .send()
+            .await
+            .expect("relay request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let logs = captured_logs(&buf);
+        assert!(logs.contains("\"surface\":\"oauth_relay\""));
+        assert!(logs.contains("\"path\":\"/callback/dookie/extra\""));
+        assert!(!logs.contains("code=abc"));
+        assert!(!logs.contains("state=xyz"));
+
+        relay.abort();
+        upstream.handle.abort();
+    }
+
+    async fn spawn_upstream(state: UpstreamState) -> UpstreamHandle {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .fallback(any(upstream_handler))
+            .with_state(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        UpstreamHandle { addr, handle }
+    }
+
+    async fn upstream_handler(
+        State(state): State<UpstreamState>,
+        method: Method,
+        uri: Uri,
+        body: Bytes,
+    ) -> impl IntoResponse {
+        state.seen_requests.lock().unwrap().push(SeenRequest {
+            method: method.to_string(),
+            path_and_query: uri
+                .path_and_query()
+                .map_or_else(|| uri.path().to_string(), ToString::to_string),
+            body: body.to_vec(),
+        });
+
+        if !state.delay.is_zero() {
+            sleep(state.delay).await;
+        }
+
+        let mut headers = HeaderMap::new();
+        for (name, value) in &state.response_headers {
+            headers.insert(*name, HeaderValue::from_str(value).unwrap());
+        }
+        (state.response_status, headers, state.response_body)
+    }
+
+    async fn available_loopback_addr() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        addr
+    }
+
+    async fn spawn_relay(config: LocalRelayConfig) -> JoinHandle<()> {
+        let handle = tokio::spawn(async move {
+            run_local_relay(config).await.unwrap();
+        });
+        sleep(Duration::from_millis(25)).await;
+        handle
+    }
+
+    struct UpstreamHandle {
+        addr: SocketAddr,
+        handle: JoinHandle<()>,
+    }
+}

--- a/crates/lab/src/oauth/target.rs
+++ b/crates/lab/src/oauth/target.rs
@@ -1,0 +1,251 @@
+//! Target resolution and forwarding helpers for the local OAuth relay.
+
+use std::collections::BTreeMap;
+
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use url::Url;
+
+use crate::config::OauthMachineConfig;
+use crate::oauth::error::OauthRelayError;
+
+/// A resolved forwarding target.
+#[derive(Debug, Clone)]
+pub struct ResolvedTarget {
+    pub machine_id: Option<String>,
+    pub target_url: Url,
+    pub default_port: Option<u16>,
+}
+
+/// Resolve a named machine target from config.
+pub fn resolve_machine_target(
+    machines: &BTreeMap<String, OauthMachineConfig>,
+    machine_id: &str,
+) -> Result<ResolvedTarget, OauthRelayError> {
+    let config = machines
+        .get(machine_id)
+        .ok_or_else(|| OauthRelayError::UnknownMachine {
+            machine_id: machine_id.to_string(),
+            available: machines.keys().cloned().collect::<Vec<_>>().join(", "),
+        })?;
+    let target_url =
+        Url::parse(&config.target_url).map_err(|source| OauthRelayError::InvalidTargetUrl {
+            value: config.target_url.clone(),
+            source,
+        })?;
+
+    Ok(ResolvedTarget {
+        machine_id: Some(machine_id.to_string()),
+        target_url,
+        default_port: config.default_port,
+    })
+}
+
+/// Resolve an ad hoc forwarding target from a CLI-supplied base URL.
+pub fn resolve_explicit_target(
+    target_url: &str,
+    default_port: Option<u16>,
+) -> Result<ResolvedTarget, OauthRelayError> {
+    let target_url =
+        Url::parse(target_url).map_err(|source| OauthRelayError::InvalidTargetUrl {
+            value: target_url.to_string(),
+            source,
+        })?;
+
+    Ok(ResolvedTarget {
+        machine_id: None,
+        target_url,
+        default_port,
+    })
+}
+
+/// Construct a forwarding URL by appending the incoming suffix path and query.
+pub fn build_forward_url(
+    target_base: &Url,
+    suffix_path: &str,
+    query_items: &[(&str, &str)],
+) -> Result<Url, OauthRelayError> {
+    let mut url = target_base.clone();
+    let suffix_path = suffix_path.trim_matches('/');
+    if !suffix_path.is_empty() {
+        let mut path = url.path().trim_end_matches('/').to_string();
+        if path.is_empty() {
+            path.push('/');
+        }
+        if !path.ends_with('/') {
+            path.push('/');
+        }
+        path.push_str(suffix_path);
+        url.set_path(&path);
+    }
+
+    let mut merged_query = url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+    merged_query.extend(
+        query_items
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
+
+    {
+        let mut serializer = url.query_pairs_mut();
+        serializer.clear();
+        for (key, value) in merged_query {
+            serializer.append_pair(&key, &value);
+        }
+    }
+
+    Ok(url)
+}
+
+/// Filter hop-by-hop headers from an inbound request before forwarding.
+pub fn filter_hop_by_hop_request_headers(headers: &HeaderMap) -> HeaderMap {
+    filter_headers(headers)
+}
+
+/// Filter hop-by-hop headers from an upstream response before returning it.
+pub fn filter_hop_by_hop_response_headers(headers: &HeaderMap) -> HeaderMap {
+    filter_headers(headers)
+}
+
+fn filter_headers(headers: &HeaderMap) -> HeaderMap {
+    headers
+        .iter()
+        .filter(|(name, _)| !is_hop_by_hop_header(name))
+        .fold(HeaderMap::new(), |mut filtered, (name, value)| {
+            filtered.append(name.clone(), copy_header_value(value));
+            filtered
+        })
+}
+
+fn copy_header_value(value: &HeaderValue) -> HeaderValue {
+    HeaderValue::from_bytes(value.as_bytes()).expect("header value clone should stay valid")
+}
+
+fn is_hop_by_hop_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "content-length"
+            | "host"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header::{CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HOST, TRANSFER_ENCODING};
+
+    #[test]
+    fn resolve_machine_target_returns_configured_machine() {
+        let machines = BTreeMap::from([(
+            "dookie".to_string(),
+            OauthMachineConfig {
+                target_url: "http://100.88.16.79:38935/callback/dookie".to_string(),
+                description: None,
+                default_port: Some(38935),
+            },
+        )]);
+
+        let resolved = resolve_machine_target(&machines, "dookie").expect("machine should resolve");
+        assert_eq!(resolved.machine_id.as_deref(), Some("dookie"));
+        assert_eq!(
+            resolved.target_url.as_str(),
+            "http://100.88.16.79:38935/callback/dookie"
+        );
+        assert_eq!(resolved.default_port, Some(38935));
+    }
+
+    #[test]
+    fn resolve_machine_target_lists_available_machine_ids() {
+        let machines = BTreeMap::from([
+            (
+                "dookie".to_string(),
+                OauthMachineConfig {
+                    target_url: "http://100.88.16.79:38935/callback/dookie".to_string(),
+                    description: None,
+                    default_port: Some(38935),
+                },
+            ),
+            (
+                "squirts".to_string(),
+                OauthMachineConfig {
+                    target_url: "http://127.0.0.1:38935/callback/squirts".to_string(),
+                    description: None,
+                    default_port: Some(38935),
+                },
+            ),
+        ]);
+
+        let error = resolve_machine_target(&machines, "missing").expect_err("lookup should fail");
+        let message = error.to_string();
+        assert!(message.contains("missing"));
+        assert!(message.contains("dookie"));
+        assert!(message.contains("squirts"));
+    }
+
+    #[test]
+    fn build_forward_url_appends_suffix_path_and_query() {
+        let url = build_forward_url(
+            &Url::parse("http://100.88.16.79:38935/callback/dookie").unwrap(),
+            "foo/bar",
+            &[("code", "abc"), ("state", "xyz")],
+        )
+        .expect("url should build");
+
+        assert_eq!(
+            url.as_str(),
+            "http://100.88.16.79:38935/callback/dookie/foo/bar?code=abc&state=xyz"
+        );
+    }
+
+    #[test]
+    fn build_forward_url_preserves_existing_query_values() {
+        let url = build_forward_url(
+            &Url::parse("http://target/callback?existing=1").unwrap(),
+            "",
+            &[("code", "abc")],
+        )
+        .expect("url should build");
+
+        assert_eq!(url.as_str(), "http://target/callback?existing=1&code=abc");
+    }
+
+    #[test]
+    fn hop_by_hop_request_headers_are_filtered() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
+        headers.insert(HOST, HeaderValue::from_static("localhost"));
+        headers.insert(TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let filtered = filter_hop_by_hop_request_headers(&headers);
+
+        assert!(!filtered.contains_key(CONNECTION));
+        assert!(!filtered.contains_key(HOST));
+        assert!(!filtered.contains_key(TRANSFER_ENCODING));
+        assert!(filtered.contains_key(CONTENT_TYPE));
+    }
+
+    #[test]
+    fn hop_by_hop_response_headers_are_filtered() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONNECTION, HeaderValue::from_static("close"));
+        headers.insert(CONTENT_LENGTH, HeaderValue::from_static("123"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+
+        let filtered = filter_hop_by_hop_response_headers(&headers);
+
+        assert!(!filtered.contains_key(CONNECTION));
+        assert!(!filtered.contains_key(CONTENT_LENGTH));
+        assert!(filtered.contains_key(CONTENT_TYPE));
+    }
+}

--- a/crates/lab/src/oauth/target.rs
+++ b/crates/lab/src/oauth/target.rs
@@ -1,6 +1,6 @@
 //! Target resolution and forwarding helpers for the local OAuth relay.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use url::Url;
@@ -110,9 +110,12 @@ pub fn filter_hop_by_hop_response_headers(headers: &HeaderMap) -> HeaderMap {
 }
 
 fn filter_headers(headers: &HeaderMap) -> HeaderMap {
+    let connection_header_names = connection_header_names(headers);
     headers
         .iter()
-        .filter(|(name, _)| !is_hop_by_hop_header(name))
+        .filter(|(name, _)| {
+            !is_hop_by_hop_header(name) && !connection_header_names.contains(name.as_str())
+        })
         .fold(HeaderMap::new(), |mut filtered, (name, value)| {
             filtered.append(name.clone(), copy_header_value(value));
             filtered
@@ -120,7 +123,19 @@ fn filter_headers(headers: &HeaderMap) -> HeaderMap {
 }
 
 fn copy_header_value(value: &HeaderValue) -> HeaderValue {
-    HeaderValue::from_bytes(value.as_bytes()).expect("header value clone should stay valid")
+    value.clone()
+}
+
+fn connection_header_names(headers: &HeaderMap) -> BTreeSet<String> {
+    headers
+        .get_all("connection")
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase())
+        .collect()
 }
 
 fn is_hop_by_hop_header(name: &HeaderName) -> bool {
@@ -246,6 +261,20 @@ mod tests {
 
         assert!(!filtered.contains_key(CONNECTION));
         assert!(!filtered.contains_key(CONTENT_LENGTH));
+        assert!(filtered.contains_key(CONTENT_TYPE));
+    }
+
+    #[test]
+    fn headers_nominated_by_connection_are_filtered() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONNECTION, HeaderValue::from_static("x-lab-session, keep-alive"));
+        headers.insert("x-lab-session", HeaderValue::from_static("secret"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+
+        let filtered = filter_hop_by_hop_request_headers(&headers);
+
+        assert!(!filtered.contains_key(CONNECTION));
+        assert!(!filtered.contains_key("x-lab-session"));
         assert!(filtered.contains_key(CONTENT_TYPE));
     }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -25,6 +25,7 @@ The CLI includes:
 - `audit`
 - `scaffold`
 - `extract`
+- `oauth`
 - `help`
 - `completions`
 
@@ -44,6 +45,7 @@ lab
 ├── audit
 ├── scaffold
 ├── extract
+├── oauth
 ├── help
 └── completions
 ```
@@ -163,3 +165,23 @@ Expected `.mcp.json` behavior:
 ## Shell Completions
 
 The CLI must generate completions rather than hand-maintaining shell-specific assets.
+
+## `lab oauth relay-local`
+
+`lab oauth relay-local` is a browser-side transport helper for OAuth clients that redirect to a
+loopback callback but keep the real OAuth listener on another machine.
+
+Supported forms:
+
+```bash
+lab oauth relay-local --machine dookie --port 38935
+lab oauth relay-local --forward-base http://100.88.16.79:38935/callback/dookie --port 38935
+```
+
+Rules:
+
+- exactly one of `--machine` or `--forward-base` is required
+- the listener binds only to `127.0.0.1:<port>`
+- `--machine` resolves the target from `[oauth.machines.*]` in `config.toml`
+- `--forward-base` is for ad hoc use when no named machine exists yet
+- the command only forwards the final callback request; it does not mint tokens or run PKCE logic

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -80,6 +80,16 @@ Value precedence at point of use (highest wins):
 |-----|-------------|---------|-------------|
 | `assets_dir` | `LAB_WEB_ASSETS_DIR` | auto-detect | Path to exported Labby assets served by `lab serve --transport http` |
 
+### `[oauth.machines.<id>]`
+
+Named OAuth callback forwarding targets for `lab oauth relay-local`.
+
+| Key | Env override | Default | Description |
+|-----|-------------|---------|-------------|
+| `target_url` | — | required | Full callback base URL to forward to |
+| `description` | — | `null` | Optional operator-facing note |
+| `default_port` | — | `null` | Optional preferred local callback port |
+
 ### `[admin]`
 
 | Key | Env override | Default | Description |
@@ -206,6 +216,21 @@ auth_code_ttl_secs = 300
 ```
 
 Environment variables override `[auth]` values field-by-field.
+
+### OAuth Relay Machine Targets
+
+`target_url` is the full callback base URL, not just a host.
+
+```toml
+[oauth.machines.dookie]
+target_url = "http://100.88.16.79:38935/callback/dookie"
+description = "Dookie Claude callback target"
+default_port = 38935
+```
+
+Machine IDs are stable config keys. When `lab oauth relay-local --machine dookie --port 38935`
+runs, it resolves the forwarding target from this map and preserves the incoming suffix path and
+query string when proxying the callback.
 
 ## Web UI Hosting
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -45,6 +45,35 @@ Recovery guidance:
 - deleting `auth.db` removes registered clients, pending authorization requests, authorization codes, and refresh tokens
 - if you back up either file, back up both together to preserve a coherent auth state snapshot
 
+## Browser-Local OAuth Callback Forwarding
+
+Some MCP clients can pin the OAuth callback port but still redirect the browser to
+`http://127.0.0.1:<port>/...`. When the real callback listener lives on another machine, run
+`lab oauth relay-local` on the browser machine to accept that loopback redirect and forward it to
+the actual listener.
+
+Named-machine workflow:
+
+```bash
+lab oauth relay-local --machine dookie --port 38935
+```
+
+Ad hoc workflow:
+
+```bash
+lab oauth relay-local \
+  --forward-base http://100.88.16.79:38935/callback/dookie \
+  --port 38935
+```
+
+Operational rules:
+
+- the remote callback listener must already be running
+- the helper is transport-only; it does not exchange codes or mint tokens
+- the listener is loopback-only and normally run on demand for the active login flow
+- startup output shows the resolved forwarding target before the first callback arrives
+- failures map to HTTP responses on the local callback port: unreachable target -> `502`, timeout -> `504`
+
 ## Product-Level Health Tooling
 
 ### `lab doctor`


### PR DESCRIPTION
## Summary
- add a new 	t CLI helper with config-backed machine targets and explicit forwarding support
- add a loopback-only local relay runtime that preserves callback path/query/body, strips hop-by-hop headers, and returns clear 502/504 JSON errors without logging OAuth secrets
- document the new relay-local workflow in the CLI, config, operations guide, README, and config example

## Test Plan
- [x] 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 2 tests
test config::tests::oauth_machine_config_deserializes ... ok
test config::tests::oauth_machine_defaults_keep_partial_configs_valid ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 400 filtered out; finished in 0.00s
- [x] 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 2 tests
test oauth::target::tests::build_forward_url_appends_suffix_path_and_query ... ok
test oauth::target::tests::build_forward_url_preserves_existing_query_values ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 400 filtered out; finished in 0.00s
- [x] 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 5 tests
OAuth relay listening on http://127.0.0.1:41693 -> http://127.0.0.1:42873/callback/dookie
test oauth::local_relay::tests::oauth_local_relay_returns_bind_error_on_port_collision ... ok
OAuth relay listening on http://127.0.0.1:44787 -> http://127.0.0.1:36701/callback/dookie
OAuth relay listening on http://127.0.0.1:42337 -> http://127.0.0.1:33541/callback/dookie
OAuth relay listening on http://127.0.0.1:36263 -> http://127.0.0.1:35145/callback/dookie
test oauth::local_relay::tests::oauth_local_relay_forwards_callback_requests_end_to_end ... ok
test oauth::local_relay::tests::oauth_local_relay_returns_bad_gateway_for_unreachable_target ... ok
test oauth::local_relay::tests::oauth_local_relay_redacts_query_values_in_logs ... FAILED
test oauth::local_relay::tests::oauth_local_relay_returns_gateway_timeout_for_slow_target ... ok

failures:

failures:
    oauth::local_relay::tests::oauth_local_relay_redacts_query_values_in_logs

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 397 filtered out; finished in 0.08s
- [x] 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 4 tests
test cli::oauth::tests::oauth_relay_local_cli_resolves_explicit_target ... ok
test cli::oauth::tests::oauth_relay_local_cli_parses_explicit_target ... ok
test cli::oauth::tests::oauth_relay_local_cli_rejects_both_target_flags ... ok
test cli::oauth::tests::oauth_relay_local_cli_parses_machine_target ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 398 filtered out; finished in 0.00s
- [x] Usage: lab oauth relay-local [OPTIONS] --port <PORT> <--machine <MACHINE>|--forward-base <FORWARD_BASE>>

Options:
      --json                         Emit JSON instead of human-readable tables
      --machine <MACHINE>            
      --forward-base <FORWARD_BASE>  
      --port <PORT>                  
  -h, --help                         Print help
- [x] manual smoke test forwarding  to a local upstream target
- [x] 
running 1 test
test lab_auth_crate_exports_router_and_signing_keys ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 402 tests
test api::openapi::tests::build_action_schemas_empty_services ... ok
test api::error::tests::confirmation_required_maps_to_422 ... ok
test api::openapi::tests::drift_test_error_schemas_match_tool_error_wire ... ok
test api::openapi::tests::param_type_boolean ... ok
test api::openapi::tests::param_type_array ... ok
test api::openapi::tests::build_health_paths_has_two_entries ... ok
test api::openapi::tests::param_type_enum_literals ... ok
test api::openapi::tests::param_type_integer_array ... ok
test api::openapi::tests::param_type_nullable_string ... ok
test api::openapi::tests::build_service_paths_generates_per_service ... ok
test api::openapi::tests::param_type_integer ... ok
test api::openapi::tests::param_type_number ... ok
test api::openapi::tests::param_type_object ... ok
test api::openapi::tests::param_type_string ... ok
test api::openapi::tests::param_type_string_array ... ok
test api::openapi::tests::param_type_unknown_fallback ... ok
test api::openapi::tests::to_pascal_case_basic ... ok
test api::router::tests::docs_endpoint_returns_html_with_auth ... ok
test api::router::tests::actions_known_service_returns_200 ... ok
test api::services::helpers::tests::destructive_with_confirm_dispatch_error_preserves_kind ... ok
test api::services::helpers::tests::destructive_action_logs_intent ... ok
test api::services::helpers::tests::destructive_with_confirm_false_returns_confirmation_required ... ok
test api::services::helpers::tests::destructive_with_confirm_string_true_does_not_pass ... ok
test api::services::helpers::tests::destructive_with_confirm_true_proceeds_to_dispatch ... ok
test api::services::helpers::tests::destructive_without_body_confirm_is_rejected ... ok
test api::router::tests::health_endpoint_open_without_auth ... ok
test api::services::helpers::tests::destructive_without_confirm_returns_confirmation_required ... ok
test api::services::helpers::tests::dispatch_logs_api_surface_and_request_id ... ok
test api::router::tests::actions_unknown_service_returns_404 ... ok
test api::openapi::tests::full_spec_round_trip ... ok
test api::services::helpers::tests::empty_actions_rejects_everything ... ok
test api::services::helpers::tests::error_path_preserves_tool_error_kind ... ok
test api::services::helpers::tests::help_action_bypasses_catalog_gate_and_reaches_dispatch ... ok
test api::router::tests::auth_layer_rejects_missing_bearer_token ... ok
test api::services::helpers::tests::non_destructive_action_proceeds_without_confirm ... ok
test api::router::tests::auth_layer_accepts_case_insensitive_bearer_token ... ok
test api::services::helpers::tests::non_destructive_action_does_not_log_intent ... ok
test api::router::tests::auth_layer_accepts_valid_bearer_token ... ok
test audit::checks::registration::tests::bare_pub_mod_fails_mcp_check ... ok
test api::services::helpers::tests::schema_action_bypasses_catalog_gate_and_reaches_dispatch ... ok
test api::services::helpers::tests::success_path_returns_json_value ... ok
test api::services::helpers::tests::unknown_action_returns_unknown_action_and_dispatch_not_called ... ok
test audit::checks::tests::tests::file_or_skip_missing_returns_skip ... ok
test cli::audit::tests::audit_exit_code_fails_on_failed_checks ... ok
test cli::doctor::tests::extract_is_always_in_checks ... ok
test cli::doctor::tests::radarr_in_checks_when_feature_enabled ... ok
test cli::helpers::tests::action_command_logs_cli_failure_kind ... ok
test cli::oauth::tests::oauth_relay_local_cli_resolves_explicit_target ... ok
test cli::params::tests::boolean_case_insensitive ... ok
test cli::params::tests::coerce_preserves_leading_zeros_as_strings ... ok
test cli::helpers::tests::action_command_logs_cli_success_shape ... ok
test cli::params::tests::empty_key_yields_empty_string_key ... ok
test cli::params::tests::nan_inf_stay_as_strings ... ok
test cli::params::tests::empty_value_yields_empty_string ... ok
test cli::params::tests::parse_kv_params_coerces_scalars ... ok
test cli::params::tests::parse_kv_params_empty_returns_empty_object ... ok
test cli::params::tests::parse_kv_params_rejects_duplicate_keys ... ok
test cli::params::tests::value_containing_equals_uses_split_once ... ok
test cli::params::tests::parse_kv_params_rejects_missing_equals ... ok
test cli::radarr::tests::radarr_defaults_to_help_without_a_subcommand ... ok
test cli::radarr::tests::help_is_a_real_subcommand ... ok
test cli::oauth::tests::oauth_relay_local_cli_parses_explicit_target ... ok
test cli::serve::tests::allowed_hosts_include_configured_hosts ... ok
test cli::serve::tests::bind_addr_brackets_bare_ipv6_hosts ... ok
test cli::serve::tests::allowed_hosts_include_resource_url_host ... ok
test cli::serve::tests::config_defaults_are_available_for_serve_resolution ... ok
test cli::serve::tests::loopback_host_detection ... ok
test cli::serve::tests::port_resolution_prefers_cli_then_env_then_config ... ok
test cli::serve::tests::session_ttl_resolution_prefers_env_then_config_then_default ... ok
test cli::serve::tests::stateful_resolution_prefers_env_then_config_then_default ... ok
test cli::serve::tests::transport_resolution_prefers_cli_then_env_then_config ... ok
test config::tests::default_instance_parsed ... ok
test config::tests::env_is_up_to_date_returns_false_when_missing ... ok
test config::tests::env_is_up_to_date_handles_quoted_values ... ok
test cli::oauth::tests::oauth_relay_local_cli_parses_machine_target ... ok
test config::tests::named_instance_parsed ... ok
test config::tests::env_is_up_to_date_returns_true_when_matching ... ok
test config::tests::oauth_machine_config_deserializes ... ok
test config::tests::oauth_machine_defaults_keep_partial_configs_valid ... ok
test config::tests::secret_debug_redacts ... ok
test config::tests::secret_serialize_emits_placeholder_not_plaintext ... ok
test cli::oauth::tests::oauth_relay_local_cli_rejects_both_target_flags ... ok
test config::tests::suffix_collision_longest_wins ... ok
test config::tests::resolve_auth_reads_ttls_from_config_toml_fields ... ok
test config::tests::unrelated_vars_ignored ... ok
test config::tests::username_is_plain_not_secret ... ok
test cli::gateway::tests::gateway_cli_parser_accepts_expected_commands ... ok
test config::tests::write_env_adds_new_keys ... ok
test config::tests::write_env_conflict_overwrite_with_force ... ok
test dispatch::apprise::tests::catalog_includes_first_wave_actions ... ok
test config::tests::write_env_preserves_comments_and_blanks ... ok
test config::tests::write_env_conflict_skip_without_force ... ok
test dispatch::arcane::client::tests::not_configured_error_has_expected_kind ... ok
test config::tests::write_env_quotes_value_with_special_chars ... ok
test dispatch::arcane::tests::catalog_includes_core_actions ... ok
test dispatch::arcane::tests::destructive_actions_are_marked ... ok
test dispatch::arcane::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::apprise::tests::help_lists_notify_send ... ok
test dispatch::bytestash::tests::actions_catalog_includes_core_actions ... ok
test dispatch::bytestash::tests::auth_register_is_destructive ... ok
test dispatch::bytestash::tests::client_from_vars_rejects_empty_token ... ok
test dispatch::bytestash::tests::client_from_vars_rejects_empty_url ... ok
test dispatch::bytestash::tests::client_from_vars_rejects_missing ... ok
test dispatch::bytestash::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::arcane::tests::help_returns_action_list ... ok
test dispatch::gateway::config::tests::insert_upstream_adds_new_gateway_entry ... ok
test dispatch::gateway::config::tests::expose_tools_patch_distinguishes_absent_null_empty_and_values ... ok
test dispatch::bytestash::tests::help_returns_action_list ... ok
test dispatch::gateway::config::tests::insert_upstream_rejects_bind_all_address ... ok
test dispatch::gateway::config::tests::insert_upstream_rejects_duplicate_names ... ok
test dispatch::gateway::config::tests::insert_upstream_rejects_non_http_scheme ... ok
test dispatch::gateway::config::tests::remove_upstream_removes_named_gateway_entry ... ok
test dispatch::gateway::config::tests::update_upstream_applies_expose_tools_patch ... ok
test dispatch::gateway::config::tests::update_upstream_clears_expose_tools_with_empty_array ... ok
test dispatch::gateway::config::tests::update_upstream_clears_expose_tools_with_null ... ok
test dispatch::gateway::config::tests::update_upstream_replaces_named_upstream_only ... ok
test dispatch::gateway::config::tests::load_gateway_config_reads_existing_upstreams ... ok
test dispatch::gateway::config::tests::write_gateway_config_rejects_missing_transport_selector ... ok
test dispatch::gateway::dispatch::tests::gateway_actions_include_management_surface ... ok
test dispatch::gateway::config::tests::write_gateway_config_rejects_both_url_and_command ... ok
test dispatch::gateway::dispatch::tests::gateway_get_rejects_missing_name ... ok
test dispatch::gateway::dispatch::tests::gateway_list_returns_array ... ok
test dispatch::gateway::dispatch::tests::invalid_gateway_specs_return_validation_errors ... ok
test dispatch::gateway::manager::tests::catalog_diff_detects_removed_tool_provider ... ok
test dispatch::gateway::manager::tests::manager_get_preserves_bearer_token_env_reference ... ok
test dispatch::gateway::manager::tests::runtime_handle_starts_without_pool ... ok
test dispatch::gateway::manager::tests::runtime_handle_swaps_pool_atomically ... ok
test dispatch::gateway::dispatch::tests::only_reload_promises_to_pick_up_changed_bearer_token_env_vars ... ok
test dispatch::gotify::client::tests::clients_from_env_returns_none_without_url ... ok
test dispatch::gateway::manager::tests::runtime_view_includes_last_upstream_error ... ok
test dispatch::gotify::client::tests::token_resolution_prefers_scoped_tokens ... ok
test api::services::helpers::tests::confirm_key_stripped_from_params_before_dispatch ... ok
test dispatch::gotify::client::tests::token_resolution_uses_legacy_token_as_fallback ... ok
test dispatch::gotify::tests::catalog_includes_core_actions ... ok
test dispatch::gotify::tests::destructive_actions_are_marked ... ok
test dispatch::gotify::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::linkding::tests::actions_catalog_includes_core_actions ... ok
test dispatch::linkding::tests::client_from_vars_rejects_empty_token ... ok
test dispatch::linkding::tests::client_from_vars_rejects_empty_url ... ok
test dispatch::gotify::tests::help_returns_action_list ... ok
test dispatch::linkding::tests::client_from_vars_rejects_missing ... ok
test dispatch::linkding::tests::destructive_actions_are_marked ... ok
test dispatch::linkding::tests::help_returns_action_list ... ok
test api::router::tests::service_filtered_from_registry_has_no_http_route ... ok
test dispatch::linkding::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::memos::tests::catalog_includes_core_actions ... ok
test dispatch::memos::tests::client_from_vars_rejects_empty_token ... ok
test dispatch::memos::tests::client_from_vars_rejects_empty_url ... ok
test dispatch::memos::tests::client_from_vars_rejects_missing ... ok
test dispatch::linkding::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::memos::tests::destructive_actions_are_marked ... ok
test dispatch::memos::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::memos::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::openai::tests::catalog_includes_core_actions ... ok
test dispatch::memos::tests::help_returns_action_list ... ok
test dispatch::openai::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::openai::tests::help_lists_model_list ... ok
test dispatch::openai::tests::no_destructive_actions ... ok
test dispatch::overseerr::tests::catalog_includes_overseerr_actions ... ok
test dispatch::overseerr::tests::destructive_actions_are_marked ... ok
test dispatch::overseerr::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::overseerr::tests::help_lists_request_actions ... ok
test dispatch::overseerr::tests::no_duplicate_action_names ... ok
test api::router::tests::bearer_mode_still_accepts_lab_mcp_http_token ... ok
test dispatch::overseerr::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::overseerr::tests::schema_returns_action_schema ... ok
test dispatch::overseerr::tests::schema_unknown_action_returns_error ... ok
test dispatch::paperless::tests::actions_catalog_includes_core_actions ... ok
test dispatch::paperless::tests::client_from_env_rejects_missing_vars ... ok
test dispatch::paperless::tests::destructive_actions_are_marked ... ok
test dispatch::paperless::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::paperless::tests::read_actions_are_not_destructive ... ok
test dispatch::plex::tests::catalog_includes_plex_actions ... ok
test dispatch::paperless::tests::help_returns_action_list ... ok
test dispatch::plex::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::plex::tests::help_lists_library ... ok
test dispatch::plex::tests::destructive_actions_are_marked ... ok
test dispatch::plex::tests::no_duplicate_action_names ... ok
test dispatch::plex::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::prowlarr::tests::actions_catalog_includes_core_actions ... ok
test dispatch::plex::tests::schema_returns_spec_for_known_action ... ok
test dispatch::prowlarr::tests::client_from_env_returns_none_when_not_configured ... ok
test dispatch::prowlarr::tests::destructive_actions_are_marked ... ok
test dispatch::prowlarr::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::prowlarr::tests::help_returns_action_list ... ok
test dispatch::prowlarr::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::qbittorrent::tests::catalog_includes_key_actions ... ok
test dispatch::qbittorrent::tests::destructive_actions_are_marked ... ok
test dispatch::qbittorrent::tests::non_destructive_pause_and_resume ... ok
test dispatch::qdrant::tests::catalog_includes_first_wave_actions ... ok
test dispatch::qdrant::tests::help_lists_collections_list ... ok
test dispatch::radarr::tests::no_duplicate_action_names ... ok
test dispatch::radarr::tests::sdk_error_from_api_auth ... ok
test dispatch::radarr::tests::sdk_error_from_api_not_found ... ok
test dispatch::radarr::tests::sdk_error_from_network ... ok
test dispatch::radarr::tests::sdk_error_from_radarr_not_found ... ok
test dispatch::radarr::tests::unknown_action_includes_valid_list ... ok
test dispatch::sabnzbd::dispatch::tests::sanitize_config_handles_missing_sensitive_fields ... ok
test dispatch::sabnzbd::dispatch::tests::sanitize_config_redacts_api_key ... ok
test dispatch::sabnzbd::dispatch::tests::sanitize_config_redacts_indexer_apikeys ... ok
test dispatch::sabnzbd::dispatch::tests::sanitize_config_redacts_server_passwords ... ok
test dispatch::sabnzbd::tests::actions_catalog_includes_core_actions ... ok
test dispatch::sabnzbd::tests::destructive_actions_are_marked ... ok
test dispatch::sonarr::tests::catalog_includes_sonarr_actions ... ok
test dispatch::sonarr::tests::client_from_env_returns_none_when_not_configured ... ok
test dispatch::sonarr::tests::destructive_actions_are_marked ... ok
test dispatch::sonarr::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::sonarr::tests::help_action_returns_catalog ... ok
test dispatch::sonarr::tests::help_lists_series ... ok
test dispatch::sonarr::tests::no_duplicate_action_names ... ok
test dispatch::sonarr::tests::non_destructive_actions_are_not_marked ... ok
test dispatch::tailscale::tests::catalog_includes_core_actions ... ok
test dispatch::tailscale::tests::destructive_actions_are_marked ... ok
test dispatch::tailscale::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::tailscale::tests::help_returns_action_list ... ok
test dispatch::tautulli::tests::actions_catalog_includes_core_actions ... ok
test dispatch::tautulli::tests::client_from_env_returns_none_when_not_configured ... ok
test dispatch::tautulli::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::tautulli::tests::help_returns_action_list ... ok
test dispatch::tautulli::tests::only_expected_actions_are_destructive ... ok
test dispatch::tei::tests::catalog_includes_first_wave_actions ... ok
test api::router::tests::ready_endpoint_open_without_auth ... ok
test api::services::gateway::tests::gateway_get_returns_not_found_for_missing_gateway ... ok
test api::services::gateway::tests::gateway_actions_endpoint_is_registered ... ok
test dispatch::tei::tests::help_lists_server_health ... ok
test dispatch::unifi::tests::devices_list_is_routed_by_service_layer ... ok
test dispatch::unifi::tests::firewall_zones_list_is_routed_by_service_layer ... ok
test dispatch::unifi::tests::no_duplicate_action_names ... ok
test dispatch::unifi::tests::unknown_action_includes_valid_list ... ok
test dispatch::unraid::tests::actions_catalog_includes_core_actions ... ok
test dispatch::unraid::tests::docker_mutations_are_destructive ... ok
test dispatch::unraid::tests::dispatch_unknown_action_returns_error ... ok
test dispatch::unraid::tests::read_only_actions_are_not_destructive ... ok
test dispatch::upstream::pool::tests::empty_pool_has_no_tools ... ok
test dispatch::unraid::tests::help_returns_action_list ... ok
test dispatch::upstream::pool::tests::hidden_upstream_tools_do_not_appear_in_listings ... ok
test dispatch::upstream::pool::tests::hidden_upstream_tools_cannot_be_called_directly ... ok
test api::router::tests::openapi_json_returns_spec_with_auth ... ok
test dispatch::upstream::pool::tests::invalid_exposure_policy_fails_closed ... ok
test dispatch::upstream::pool::tests::merge_upstream_prompts_is_deterministic ... ok
test dispatch::unifi::tests::unifi_service_help_lists_core_actions ... ok
test dispatch::upstream::pool::tests::normalize_resource_result_uri_rewrites_all_contents ... ok
test dispatch::upstream::pool::tests::validate_accepts_stdio_command ... ok
test dispatch::upstream::pool::tests::validate_rejects_bind_all_addresses ... ok
test dispatch::upstream::pool::tests::upstream_last_error_tracks_capability_failure_details ... ok
test dispatch::upstream::pool::tests::validate_rejects_both_url_and_command ... ok
test dispatch::upstream::pool::tests::validate_rejects_empty_name ... ok
test dispatch::upstream::pool::tests::validate_rejects_no_url_or_command ... ok
test dispatch::upstream::pool::tests::validate_rejects_non_http_scheme ... ok
test dispatch::upstream::types::tests::missing_policy_defaults_to_all ... ok
test dispatch::upstream::types::tests::exact_and_wildcard_patterns_match_tool_names ... ok
test dispatch::upstream::types::tests::wildcard_matching_supports_simple_globs ... ok
test mcp::envelope::tests::display_is_valid_json ... ok
test dispatch::upstream::pool::tests::validate_accepts_valid_http_url ... ok
test mcp::envelope::tests::error_envelope_shape ... ok
test mcp::envelope::tests::display_sdk_has_correct_kind ... ok
test mcp::envelope::tests::error_extra_merges_valid_list ... ok
test mcp::envelope::tests::error_has_no_data_key ... ok
test mcp::envelope::tests::json_missing_param_shape ... ok
test mcp::envelope::tests::kind_invalid_param ... ok
test mcp::envelope::tests::json_unknown_action_shape ... ok
test mcp::envelope::tests::json_sdk_promotes_sdk_kind_to_kind ... ok
test mcp::envelope::tests::kind_missing_param ... ok
test mcp::envelope::tests::kind_unknown_action ... ok
test mcp::envelope::tests::kind_unknown_instance ... ok
test mcp::envelope::tests::json_sdk_not_found ... ok
test mcp::envelope::tests::success_envelope_shape ... ok
test mcp::envelope::tests::success_has_no_error_key ... ok
test mcp::envelope::tests::wire_kind_matches_programmatic_kind_for_all_variants ... ok
test mcp::prompts::tests::list_all_exposes_v1_prompts ... ok
test mcp::envelope::tests::kind_sdk_uses_sdk_kind_value ... ok
test mcp::prompts::tests::service_discover_prompt_inlines_action_catalog ... ok
test mcp::prompts::tests::run_action_prompt_includes_catalog_context ... ok
test mcp::server::tests::server_capabilities_advertise_list_changed_support ... ok
test mcp::server::tests::normalize_upstream_result_preserves_user_errors_without_poisoning_health ... ok
test mcp::server::tests::static_kind_round_trips_all_tool_error_kinds ... ok
test mcp::services::bytestash::tests::help_includes_core_read_only_actions ... ok
test mcp::server::tests::server_reads_current_pool_from_gateway_manager ... ok
test mcp::services::lab_admin::tests::catalog_has_onboarding_audit ... ok
test mcp::services::linkding::tests::catalog_has_core_actions ... ok
test mcp::services::linkding::tests::destructive_actions_are_marked ... ok
test mcp::services::lab_admin::tests::help_lists_onboarding_audit ... ok
test mcp::services::paperless::tests::catalog_has_expected_actions ... ok
test mcp::services::plex::tests::destructive_actions_are_marked ... ok
test mcp::services::plex::tests::catalog_has_core_actions ... ok
test mcp::services::prowlarr::tests::catalog_has_expected_actions ... ok
test mcp::services::prowlarr::tests::destructive_actions_are_marked ... ok
test mcp::services::radarr::tests::help_includes_core_read_only_actions ... ok
test mcp::services::unifi::tests::action_count_matches_service_layer ... ok
test mcp::services::unifi::tests::help_lists_read_only_actions ... ok
test oauth::local_relay::tests::oauth_local_relay_returns_bind_error_on_port_collision ... ok
test api::router::tests::openapi_json_requires_bearer_auth ... ok
test api::services::gateway::tests::gateway_list_route_exists ... ok
test api::router::tests::v1_routes_still_win_over_web_asset_fallback ... ok
test api::router::tests::serves_web_assets_for_browser_routes_when_configured ... ok
test oauth::target::tests::build_forward_url_appends_suffix_path_and_query ... ok
test oauth::target::tests::build_forward_url_preserves_existing_query_values ... ok
test oauth::target::tests::hop_by_hop_request_headers_are_filtered ... ok
test oauth::target::tests::hop_by_hop_response_headers_are_filtered ... ok
test oauth::target::tests::resolve_machine_target_lists_available_machine_ids ... ok
test oauth::target::tests::resolve_machine_target_returns_configured_machine ... ok
test output::tests::from_json_flag ... ok
test output::tests::formats_differ ... ok
test output::tests::doctor_report_renders_summary ... ok
test output::tests::extract_report_renders_creds_and_warnings ... ok
test output::tests::human_format_is_pretty ... ok
test output::tests::health_rows_render_as_status_table ... ok
test output::tests::json_format_is_compact ... ok
test registry::tests::extract_is_always_registered ... ok
test registry::tests::all_features_registers_all_services ... ok
test registry::tests::registry_and_router_service_sets_are_identical ... ok
test scaffold::service::tests::validate_service_name_accepts_valid_names ... ok
test registry::tests::dispatch_fn_round_trips ... ok
test scaffold::service::tests::validate_service_name_rejects_invalid ... ok
test scaffold::service::tests::validate_service_name_rejects_single_char ... ok
test scaffold::templates::tests::pascal_case_converts_snake_to_pascal ... ok
test scaffold::templates::tests::pascal_case_empty_segments ... ok
test scaffold::templates::tests::replace_service_fills_all_placeholders ... ok
test scaffold::tests::write_file_rejects_path_traversal ... ok
test tui::ecosystem::tests::ansi_strip_removes_escape_sequences ... ok
test tui::ecosystem::tests::ecosystem_dispatch_exhaustive ... ok
test tui::ecosystem::tests::empty_string_rejected ... ok
test tui::ecosystem::tests::identifier_accepts_max_length ... ok
test tui::ecosystem::tests::identifier_accepts_valid ... ok
test tui::ecosystem::tests::identifier_rejects_ampersand_injection ... ok
test tui::ecosystem::tests::identifier_rejects_too_long ... ok
test tui::ecosystem::tests::identifier_rejects_semicolon_injection ... ok
test tui::ecosystem::tests::identifier_rejects_unicode ... ok
test tui::ecosystem::tests::non_hex_chars_return_invalid_param ... ok
test tui::ecosystem::tests::path_traversal_in_sha_rejected ... ok
test tui::ecosystem::tests::safe_join_accepts_valid ... ok
test tui::ecosystem::tests::safe_join_rejects_traversal ... ok
test tui::ecosystem::tests::symbolic_ref_line_rejected ... ok
test tui::ecosystem::tests::remove_without_confirm_returns_err ... ok
test tui::ecosystem::tests::too_long_sha_rejected ... ok
test tui::ecosystem::tests::too_short_sha_rejected ... ok
test tui::ecosystem::tests::uppercase_hex_rejected ... ok
test tui::ecosystem::tests::valid_full_sha_passes ... ok
test tui::ecosystem::tests::valid_mid_length_sha_passes ... ok
test tui::ecosystem::tests::valid_short_sha_passes ... ok
test tui::install::tests::mark_done_clears_error ... ok
test tui::install::tests::mark_error_clears_done ... ok
test tui::marketplace::tests::ansi_injection_stripped ... ok
test tui::marketplace::tests::ecosystem_enum_exhaustive ... ok
test tui::install::tests::line_cap_evicts_oldest ... ok
test tui::marketplace::tests::id_normalization_matches_across_formats ... ok
test tui::marketplace::tests::plugin_id_collapses_consecutive_separators ... ok
test tui::marketplace::tests::install_state_cross_reference ... ok
test tui::marketplace::tests::plugin_id_trims_leading_trailing_dashes ... ok
test api::services::gateway::tests::gateway_test_accepts_proposed_spec ... ok
test tui::mcp_patch::tests::refuse_invalid_json ... ok
test tui::mcp_patch::tests::service_name_validation_rejects_traversal ... ok
test tui::mcp_patch::tests::service_name_validation_rejects_unknown ... ok
test tui::preview::tests::accept_git_ssh_url ... ok
test tui::preview::tests::accept_https_url ... ok
test tui::preview::tests::ansi_injection_stripped_in_manifest ... ok
test tui::preview::tests::cache_miss_when_file_missing ... ok
test tui::preview::tests::detect_claude_marketplace ... ok
test tui::preview::tests::detect_claude_single_entry ... ok
test tui::preview::tests::detect_codex_marketplace ... ok
test tui::preview::tests::detect_codex_single_entry ... ok
test tui::preview::tests::detect_gemini ... ok
test tui::preview::tests::detect_multiple_ecosystems ... ok
test tui::preview::tests::detect_no_ecosystem_returns_error ... ok
test tui::preview::tests::git_command_env_scrub ... ok
test tui::preview::tests::parse_github_url_basic ... ok
test tui::preview::tests::parse_github_url_strips_git_suffix ... ok
test tui::preview::tests::parse_github_url_trailing_slash ... ok
test tui::preview::tests::rate_limit_fallback_reads_stale_cache ... ok
test tui::preview::tests::reject_empty_url ... ok
test tui::preview::tests::reject_ext_remote_helper ... ok
test tui::preview::tests::reject_file_url ... ok
test tui::preview::tests::reject_option_injection ... ok
test tui::preview::tests::single_entry_synthesis_claude ... ok
test tui::services::tests::empty_mcp_json_returns_empty_set_without_panic ... ok
test tui::services::tests::missing_mcp_json_returns_empty_set ... ok
test tui::services::tests::parses_services_from_valid_mcp_json ... ok
test tui::update::tests::sha256_mismatch_returns_error ... ok
test tui::update::tests::tempfile_same_dir_as_exe ... ok
test tui::update::tests::update_state_transitions_no_panic ... ok
test tui::mcp_patch::tests::dedupe_on_write ... ok
test tui::mcp_patch::tests::enable_service_appends ... ok
test tui::mcp_patch::tests::creates_file_when_missing ... ok
test tui::mcp_patch::tests::disable_service_removes ... ok
test cli::scaffold::tests::scaffold_dry_run_plans_files_without_writing ... ok
test cli::scaffold::tests::scaffold_repeated_scaffold_is_idempotent ... ok
test dispatch::memos::tests::client_from_vars_accepts_valid ... ok
test dispatch::bytestash::tests::client_from_vars_accepts_valid ... ok
test dispatch::linkding::tests::client_from_vars_accepts_valid ... ok
test dispatch::apprise::tests::dispatch_with_client_sends_notification ... ok
test dispatch::qdrant::tests::dispatch_with_client_lists_collections ... ok
test dispatch::openai::tests::dispatch_with_client_model_list ... ok
test dispatch::tei::tests::dispatch_with_client_returns_model_info ... ok
test dispatch::gateway::dispatch::tests::gateway_test_accepts_name_or_spec ... ok
test api::router::tests::oauth_mode_accepts_lab_auth_jwt ... ok
test oauth::local_relay::tests::oauth_local_relay_returns_bad_gateway_for_unreachable_target ... ok
test dispatch::gateway::dispatch::tests::gateway_mutations_call_manager_methods ... ok
test oauth::local_relay::tests::oauth_local_relay_forwards_callback_requests_end_to_end ... ok
test oauth::local_relay::tests::oauth_local_relay_redacts_query_values_in_logs ... ok
test api::services::gateway::tests::gateway_add_update_remove_reload_routes_exist ... ok
test api::router::tests::oauth_mode_missing_token_returns_www_authenticate_metadata_hint ... ok
test oauth::local_relay::tests::oauth_local_relay_returns_gateway_timeout_for_slow_target ... ok

test result: ok. 402 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.48s


running 31 tests
test extract::parsers::plex::tests::happy_path ... ok
test extract::parsers::plex::tests::missing_token_returns_error ... ok
test extract::parsers::plex::tests::default_port_when_absent ... ok
test extract::parsers::qbittorrent::tests::defaults_used_when_keys_absent ... ok
test extract::parsers::qbittorrent::tests::happy_path ... ok
test extract::parsers::qbittorrent::tests::explicit_address_preserved ... ok
test extract::parsers::radarr::tests::malformed_xml_returns_error ... ok
test extract::parsers::radarr::tests::enable_ssl_true ... ok
test extract::parsers::radarr::tests::empty_url_base_element ... ok
test extract::parsers::radarr::tests::missing_api_key_returns_error ... ok
test extract::parsers::radarr::tests::happy_path ... ok
test extract::parsers::radarr::tests::missing_port_returns_error ... ok
test extract::parsers::radarr::tests::prowlarr_delegation ... ok
test extract::parsers::radarr::tests::non_wildcard_bind_address ... ok
test extract::parsers::radarr::tests::url_base_appended ... ok
test extract::parsers::radarr::tests::sonarr_delegation ... ok
test extract::parsers::sabnzbd::tests::happy_path ... ok
test extract::parsers::sabnzbd::tests::wildcard_host_becomes_localhost ... ok
test extract::parsers::sabnzbd::tests::missing_api_key_returns_error ... ok
test extract::parsers::tautulli::tests::happy_path ... ok
test extract::parsers::tautulli::tests::missing_api_key_returns_error ... ok
test unifi::tests::metadata_requires_url_and_api_key ... ok
test core::http::tests::relative_paths_accepted ... ok
test core::http::tests::base_url_trailing_slash_normalised ... ok
test arcane::client::tests::health_uses_api_prefix ... ok
test arcane::client::tests::image_update_summary_returns_summary ... ok
test arcane::client::tests::volumes_list_returns_volumes ... ok
test arcane::client::tests::volume_delete_ok ... ok
test core::http::tests::absolute_url_rejected_at_runtime ... ok
test arcane::client::tests::images_list_returns_images ... ok
test arcane::client::tests::projects_list_returns_projects ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 8 tests
test delete_config_posts_to_del_path ... ok
test get_urls_returns_url_list ... ok
test health_uses_status_endpoint ... ok
test add_config_posts_json_body ... ok
test notify_posts_json_body ... ok
test get_config_returns_yaml_text ... ok
test server_details_returns_json_value ... ok
test notify_key_posts_json_body ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 14 tests
test user_delete_sends_delete ... ok
test plugins_list_returns_vec ... ok
test plugin_disable_posts_to_disable_endpoint ... ok
test user_create_posts_and_returns_user ... ok
test app_messages_delete_sends_delete ... ok
test messages_list_accepts_live_paging_shape ... ok
test plugin_config_get_returns_yaml_string ... ok
test server_version_returns_version_info ... ok
test plugin_enable_posts_to_enable_endpoint ... ok
test app_messages_list_returns_paged_messages ... ok
test plugin_config_set_posts_text ... ok
test app_update_puts_and_returns_application ... ok
test users_list_returns_value ... ok
test client_update_puts_and_returns_client ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 9 tests
test post_graphql_returns_server_error_on_errors_array ... ok
test get_json_injects_api_key_header_and_decodes_body ... ok
test post_graphql_returns_decode_error_when_data_is_null ... ok
test post_graphql_returns_error_when_both_data_and_errors_present ... ok
test get_json_returns_rate_limited_on_429 ... ok
test get_json_returns_not_found_on_404 ... ok
test post_graphql_decodes_data_on_success ... ok
test get_json_returns_server_error_on_500 ... ok
test get_json_returns_auth_failed_on_401 ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 6 tests
test bundle_create_posts_and_returns_bundle ... ok
test bundle_list_returns_value ... ok
test bundle_delete_sends_delete_request ... ok
test bundle_update_patches_and_returns_bundle ... ok
test bookmark_assets_returns_vec ... ok
test bookmark_assets_upload_posts_multipart ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 12 tests
test user_me_uses_auth_endpoint ... ok
test webhook_create_posts_and_returns_webhook ... ok
test memo_comment_create_posts_and_returns_comment ... ok
test attachment_upload_posts_multipart_and_returns_attachment ... ok
test user_stats_uses_colon_path ... ok
test memo_share_create_posts_and_returns_share ... ok
test memo_shares_list_returns_vec ... ok
test memo_comments_list_returns_vec ... ok
test attachment_delete_sends_delete_request ... ok
test users_list_propagates_403 ... ok
test users_list_returns_vec ... ok
test webhooks_list_returns_vec ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 14 tests
test status_transport_error_returns_err ... ok
test discover_trending_ok ... ok
test user_quota_ok ... ok
test media_update_status_ok ... ok
test user_edit_ok ... ok
test media_delete_ok ... ok
test request_retry_ok ... ok
test request_list_ok ... ok
test request_count_ok ... ok
test status_ok ... ok
test job_run_ok ... ok
test issue_update_ok ... ok
test user_requests_ok ... ok
test auth_failure_returns_auth_error ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 10 tests
test tag_update_patches_tag ... ok
test document_upload_posts_multipart ... ok
test saved_views_list_returns_value ... ok
test custom_fields_list_returns_value ... ok
test storage_path_create_posts_and_returns ... ok
test document_bulk_edit_posts_json ... ok
test saved_view_create_posts_and_returns ... ok
test storage_paths_list_returns_value ... ok
test custom_field_create_posts_and_returns ... ok
test document_download_returns_base64_content ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 14 tests
test hubs_continue_watching ... ok
test metadata_refresh ... ok
test session_history_no_filters ... ok
test session_history_with_account_and_limit ... ok
test butler_run ... ok
test updater_status ... ok
test item_scrobble ... ok
test metadata_delete ... ok
test metadata_edit ... ok
test item_unscrobble ... ok
test library_browse_no_filters ... ok
test library_empty_trash ... ok
test library_browse_with_type_and_sort ... ok
test butler_list ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 11 tests
test indexer_search_ok ... ok
test indexer_edit_ok ... ok
test indexer_stats_ok ... ok
test history_indexer_ok ... ok
test indexer_status_ok ... ok
test application_add_ok ... ok
test tag_list_ok ... ok
test indexer_grab_ok ... ok
test system_backup_ok ... ok
test indexer_add_ok ... ok
test system_restart_ok ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 15 tests
test toggle_speed_limits_sends_post ... ok
test set_share_limits_sends_post ... ok
test add_torrent_with_category_and_tags ... ok
test set_file_priority_sends_post ... ok
test edit_category_sends_post ... ok
test reannounce_sends_post ... ok
test add_torrent_sends_post_to_add ... ok
test set_location_sends_post ... ok
test sync_maindata_incremental_delta ... ok
test create_category_sends_post ... ok
test add_tags_sends_post ... ok
test remove_tags_sends_post ... ok
test torrent_files_returns_file_list ... ok
test create_category_without_savepath ... ok
test sync_maindata_full_dump_at_rid_zero ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 13 tests
test collection_get_decodes_result_payload ... ok
test point_query_calls_post ... ok
test collection_delete_calls_delete ... ok
test snapshot_create_calls_post ... ok
test point_scroll_calls_post ... ok
test collections_list_decodes_names ... ok
test point_count_calls_post ... ok
test point_search_calls_post ... ok
test collection_create_calls_put ... ok
test point_delete_calls_post ... ok
test index_create_calls_put ... ok
test point_upsert_batched_1200_makes_three_calls ... ok
test point_upsert_batched_fail_fast_on_chunk_2 ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 14 tests
test system_restart_success ... ok
test blocklist_delete_success ... ok
test history_movie_success ... ok
test system_task_execute_success ... ok
test system_backup_success ... ok
test wanted_cutoff_success ... ok
test wanted_missing_success ... ok
test customformat_list_success ... ok
test history_failed_retry_success ... ok
test movie_edit_success ... ok
test movie_edit_not_found ... ok
test system_logs_accepts_contents_url_field ... ok
test release_grab_success ... ok
test system_tasks_success ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 1 test
test system_status_ok ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 11 tests
test pp_resume_sends_mode_resume_pp ... ok
test history_retry_all_sends_mode_retry_all ... ok
test category_list_sends_mode_get_cats ... ok
test queue_addurl_sends_mode_addurl ... ok
test history_retry_sends_mode_retry_with_value ... ok
test rss_fetch_now_sends_mode_rss_now ... ok
test server_fullstatus_sends_mode_fullstatus ... ok
test pp_pause_sends_mode_pause_pp ... ok
test queue_set_complete_action_sends_correct_mode_and_value ... ok
test queue_addurl_with_cat_and_priority ... ok
test config_get_sends_mode_get_config ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 16 tests
test blocklist_list_success ... ok
test history_failed_retry_success ... ok
test episode_monitor_success ... ok
test episodefile_delete_success ... ok
test health_check_failure ... ok
test release_grab_success ... ok
test history_series_success ... ok
test release_search_success ... ok
test blocklist_delete_success ... ok
test series_list_success ... ok
test wanted_cutoff_success ... ok
test series_edit_success ... ok
test series_list_auth_failure ... ok
test system_backup_success ... ok
test system_restart_success ... ok
test system_status_success ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 13 tests
test device_expire_posts_to_expire_endpoint ... ok
test device_routes_get_returns_routes ... ok
test device_tag_posts_tags_body ... ok
test acl_validate_returns_empty_on_success ... ok
test device_routes_set_posts_routes_body ... ok
test tailnet_settings_patch_sends_body ... ok
test acl_set_calls_validate_before_set ... ok
test acl_get_returns_policy ... ok
test dns_split_set_sends_body ... ok
test tailnet_settings_get_returns_settings ... ok
test dns_split_get_returns_config ... ok
test key_create_posts_capabilities ... ok
test user_list_returns_users ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 15 tests
test recently_added_default_count ... ok
test get_item_user_stats_no_media_type ... ok
test delete_all_user_history_success ... ok
test get_plays_by_hourofday_success ... ok
test get_item_user_stats_with_media_type ... ok
test get_plays_by_dayofweek_custom_range ... ok
test get_plays_by_stream_type_success ... ok
test get_metadata_success ... ok
test get_metadata_404_error ... ok
test recently_added_with_count_and_section ... ok
test get_children_metadata_success ... ok
test get_plays_per_month_success ... ok
test get_pms_update_success ... ok
test export_metadata_success ... ok
test get_plays_by_dayofweek_default ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 8 tests
test rerank_cap_returns_validation_error_for_over_100_texts ... ok
test openai_embed_passes_through_body_and_response ... ok
test tokenize_returns_token_sequences ... ok
test embed_sparse_returns_token_weights ... ok
test embed_posts_json_and_decodes_vectors ... ok
test rerank_posts_and_decodes_hits ... ok
test model_info_decodes_response ... ok
test similarity_returns_scores ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 9 tests
test wan_get_returns_wan_object ... ok
test wifi_update_puts_to_wifi_endpoint ... ok
test port_profile_list_returns_page ... ok
test port_profile_create_posts_and_returns_profile ... ok
test device_update_puts_to_device_endpoint ... ok
test client_unblock_posts_to_unblock_endpoint ... ok
test client_history_returns_value ... ok
test port_profile_update_puts_to_profile_endpoint ... ok
test client_block_posts_to_block_endpoint ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 21 tests
test parity_check_start_sends_mutation ... ok
test notification_archive_sends_mutation ... ok
test vm_resume_sends_mutation ... ok
test ups_devices_returns_list ... ok
test vm_list_returns_vms ... ok
test ups_config_returns_value ... ok
test plugin_list_returns_plugins ... ok
test vm_pause_sends_mutation ... ok
test notification_list_returns_notifications ... ok
test notification_create_sends_mutation ... ok
test parity_check_cancel_sends_mutation ... ok
test flash_status_returns_value ... ok
test flash_backup_sends_mutation ... ok
test network_list_returns_value ... ok
test vm_stop_sends_mutation ... ok
test parity_check_pause_sends_mutation ... ok
test log_read_returns_content ... ok
test vm_start_sends_mutation ... ok
test share_list_returns_shares ... ok
test parity_history_returns_entries ... ok
test log_read_null_returns_empty_string ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 31 tests
test config::tests::bearer_mode_preserves_existing_http_token_behavior ... ok
test config::tests::oauth_mode_parses_allowed_client_redirect_uris ... ok
test config::tests::oauth_mode_requires_public_url_and_google_credentials ... ok
test config::tests::oauth_mode_defaults_paths_and_callback ... ok
test jwt::tests::signing_key_refuses_world_readable_permissions ... ok
test sqlite::tests::sqlite_store_refuses_world_readable_database_file ... ok
test sqlite::tests::sqlite_store_ignores_expired_refresh_token ... ok
test sqlite::tests::sqlite_store_rejects_expired_authorization_code ... ok
test sqlite::tests::sqlite_store_enables_wal_and_busy_timeout ... ok
test sqlite::tests::sqlite_store_redeems_auth_code_only_once_under_race ... ok
test sqlite::tests::sqlite_store_cleanup_expired_removes_stale_rows ... ok
test google::tests::google_authorize_url_includes_offline_access_prompt_and_pkce ... ok
test google::tests::google_exchange_parses_subject_and_refresh_token ... ok
test authorize::tests::register_accepts_public_dcr_and_enforces_loopback_redirects ... ok
test token::tests::token_endpoint_rejects_refresh_token_client_mismatch ... ok
test jwt::tests::generated_key_is_reused_on_second_load ... ok
test token::tests::token_endpoint_omits_refresh_token_without_upstream_refresh_capability ... ok
test authorize::tests::authorize_persists_full_state_and_redirects_to_google ... ok
test authorize::tests::register_accepts_allowed_non_loopback_redirect_patterns ... ok
test jwt::tests::minted_access_token_round_trips_and_contains_kid ... ok
test token::tests::token_endpoint_redeems_authorization_code_once ... ok
test token::tests::token_endpoint_rejects_expired_authorization_code ... ok
test token::tests::token_endpoint_mints_lab_jwt_and_refresh_token ... ok
test token::tests::token_endpoint_rejects_refresh_token_without_upstream_refresh_capability ... ok
test authorize::tests::callback_rejects_expired_state ... ok
test metadata::tests::authorization_server_metadata_exposes_lab_endpoints ... ok
test authorize::tests::authorize_rejects_missing_or_invalid_response_type ... ok
test authorize::tests::callback_rejects_expired_or_mismatched_state ... ok
test authorize::tests::authorize_rejects_invalid_scope ... ok
test token::tests::token_endpoint_rejects_expired_refresh_token ... ok
test jwt::tests::wrong_audience_is_rejected ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
- [x] 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a loopback-only OAuth callback relay and `lab oauth relay-local` CLI to forward localhost browser redirects to a remote OAuth listener. Tightens redirect matching and static asset serving, and hardens header filtering and secret redaction.

- New Features
  - CLI: `lab oauth relay-local --machine <id>|--forward-base <url> --port <port>`; binds `127.0.0.1:<port>` and forwards path/query/body with segment-aware suffix matching.
  - Config: new `[oauth.machines.<id>]` with `target_url`, optional `description`, and `default_port`.
  - Behavior: filters hop-by-hop and `Connection`-nominated headers, adds `x-lab-oauth-relay-machine-id`, maps unreachable/timeouts to JSON `502`/`504`, and redacts callback secrets in both logs and upstream error messages.
  - Docs: README, CLI, CONFIG, and OPERATIONS updated with workflow and examples.

- Bug Fixes
  - Auth: wildcard redirect patterns now support leading/infix matches with correct start/end anchoring.
  - Web: prevent serving files outside the assets directory via symlinks by canonicalizing paths; returns 404.
  - UI: force `ExposurePolicyEditor` remount with `key={gateway.id}` to avoid stale state when switching gateways.

<sup>Written for commit cbb966cb4a1c28b395bc0893da0fedf17d9a56f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

