### PR TITLE
Implement device runtime master model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "futures",
  "insta",
  "jiff",
+ "percent-encoding",
  "quick-xml",
  "reqwest",
  "russh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ rsa          = "0.10.0-rc.17"
 rand         = "0.9"
 rusqlite     = { version = "0.37", features = ["bundled"] }
 sha2         = "0.10"
+percent-encoding = "2.3"
 
 # http server (lab binary only)
 axum         = { version = "0.8", features = ["macros", "json", "tokio", "http2"] }

--- a/crates/lab-apis/Cargo.toml
+++ b/crates/lab-apis/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace  = true
 thiserror.workspace   = true
 jiff.workspace        = true
 tracing.workspace     = true
+percent-encoding.workspace = true
 russh.workspace        = true
 russh-sftp.workspace   = true
 russh-config.workspace = true

--- a/crates/lab-apis/src/core/http.rs
+++ b/crates/lab-apis/src/core/http.rs
@@ -81,30 +81,10 @@ impl HttpClient {
         auth: Auth,
         headers: reqwest::header::HeaderMap,
     ) -> Result<Self, ApiError> {
-        Self::with_default_headers_and_timeouts(
-            base_url,
-            auth,
-            headers,
-            Duration::from_secs(5),
-            Duration::from_secs(30),
-        )
-    }
-
-    /// Construct a client with additional default headers and explicit timeouts.
-    ///
-    /// # Errors
-    /// Returns [`ApiError::Internal`] if the TLS backend fails to initialise.
-    pub fn with_default_headers_and_timeouts(
-        base_url: impl Into<String>,
-        auth: Auth,
-        headers: reqwest::header::HeaderMap,
-        connect_timeout: Duration,
-        timeout: Duration,
-    ) -> Result<Self, ApiError> {
         let inner = Client::builder()
             .user_agent(concat!("lab-apis/", env!("CARGO_PKG_VERSION")))
-            .connect_timeout(connect_timeout)
-            .timeout(timeout)
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
             .default_headers(headers)
             .build()
             .map_err(|e| ApiError::Internal(format!("reqwest::Client::build: {e}")))?;

--- a/crates/lab-apis/src/core/http.rs
+++ b/crates/lab-apis/src/core/http.rs
@@ -81,10 +81,30 @@ impl HttpClient {
         auth: Auth,
         headers: reqwest::header::HeaderMap,
     ) -> Result<Self, ApiError> {
+        Self::with_default_headers_and_timeouts(
+            base_url,
+            auth,
+            headers,
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+        )
+    }
+
+    /// Construct a client with additional default headers and explicit timeouts.
+    ///
+    /// # Errors
+    /// Returns [`ApiError::Internal`] if the TLS backend fails to initialise.
+    pub fn with_default_headers_and_timeouts(
+        base_url: impl Into<String>,
+        auth: Auth,
+        headers: reqwest::header::HeaderMap,
+        connect_timeout: Duration,
+        timeout: Duration,
+    ) -> Result<Self, ApiError> {
         let inner = Client::builder()
             .user_agent(concat!("lab-apis/", env!("CARGO_PKG_VERSION")))
-            .connect_timeout(Duration::from_secs(5))
-            .timeout(Duration::from_secs(30))
+            .connect_timeout(connect_timeout)
+            .timeout(timeout)
             .default_headers(headers)
             .build()
             .map_err(|e| ApiError::Internal(format!("reqwest::Client::build: {e}")))?;

--- a/crates/lab-apis/src/device_runtime.rs
+++ b/crates/lab-apis/src/device_runtime.rs
@@ -1,3 +1,54 @@
 //! Device-runtime control-plane client.
 
 pub mod client;
+pub mod types;
+
+pub use client::DeviceRuntimeClient;
+
+use std::time::Instant;
+
+use crate::core::plugin::{Category, PluginMeta};
+use crate::core::{ApiError, ServiceClient, ServiceStatus};
+
+pub const META: PluginMeta = PluginMeta {
+    name: "device_runtime",
+    display_name: "Device Runtime",
+    description: "Lab device-runtime control plane client for fleet devices",
+    category: Category::Bootstrap,
+    docs_url: "https://github.com/jmagar/lab/blob/main/docs/DEVICE_RUNTIME.md",
+    required_env: &[],
+    optional_env: &[],
+    default_port: Some(8765),
+};
+
+impl ServiceClient for DeviceRuntimeClient {
+    fn name(&self) -> &'static str {
+        "device_runtime"
+    }
+
+    fn service_type(&self) -> &'static str {
+        "bootstrap"
+    }
+
+    async fn health(&self) -> Result<ServiceStatus, ApiError> {
+        let start = Instant::now();
+        match self.fetch_devices().await {
+            Ok(_) => Ok(ServiceStatus {
+                reachable: true,
+                auth_ok: true,
+                version: None,
+                latency_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                message: None,
+            }),
+            Err(ApiError::Auth) => Ok(ServiceStatus {
+                reachable: true,
+                auth_ok: false,
+                version: None,
+                latency_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                message: Some("authentication failed".to_string()),
+            }),
+            Err(ApiError::Network(msg)) => Ok(ServiceStatus::unreachable(msg)),
+            Err(error) => Ok(ServiceStatus::degraded(error.to_string())),
+        }
+    }
+}

--- a/crates/lab-apis/src/device_runtime.rs
+++ b/crates/lab-apis/src/device_runtime.rs
@@ -1,0 +1,3 @@
+//! Device-runtime control-plane client.
+
+pub mod client;

--- a/crates/lab-apis/src/device_runtime/client.rs
+++ b/crates/lab-apis/src/device_runtime/client.rs
@@ -1,6 +1,11 @@
+use std::future::Future;
 use std::time::Duration;
 
+use super::types::SearchLogsRequest;
 use crate::core::{ApiError, Auth, HttpClient};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+
+const DEVICE_RUNTIME_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct DeviceRuntimeClient {
@@ -8,61 +13,59 @@ pub struct DeviceRuntimeClient {
 }
 
 impl DeviceRuntimeClient {
-    /// Build a client against the device-runtime surface with an optional request timeout.
+    /// Build a client against the device-runtime surface.
     ///
     /// # Errors
     /// Returns [`ApiError`] if the shared HTTP client cannot be built.
-    pub fn new(
-        base_url: impl Into<String>,
-        auth: Auth,
-        timeout: Option<Duration>,
-    ) -> Result<Self, ApiError> {
-        let http = match timeout {
-            Some(timeout) => HttpClient::with_default_headers_and_timeouts(
-                base_url,
-                auth,
-                reqwest::header::HeaderMap::new(),
-                Duration::from_secs(5),
-                timeout,
-            )?,
-            None => HttpClient::new(base_url, auth)?,
-        };
+    pub fn new(base_url: impl Into<String>, auth: Auth) -> Result<Self, ApiError> {
+        let http = HttpClient::new(base_url, auth)?;
         Ok(Self { http })
     }
 
-    pub async fn post_hello<T: serde::Serialize + Sync>(&self, payload: &T) -> Result<(), ApiError> {
-        self.http.post_void("/v1/device/hello", payload).await
+    pub async fn post_hello<T: serde::Serialize + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<(), ApiError> {
+        self.with_timeout(self.http.post_void("/v1/device/hello", payload))
+            .await
     }
 
     pub async fn post_status<T: serde::Serialize + Sync>(
         &self,
         payload: &T,
     ) -> Result<(), ApiError> {
-        self.http.post_void("/v1/device/status", payload).await
+        self.with_timeout(self.http.post_void("/v1/device/status", payload))
+            .await
     }
 
     pub async fn post_metadata<T: serde::Serialize + Sync>(
         &self,
         payload: &T,
     ) -> Result<(), ApiError> {
-        self.http.post_void("/v1/device/metadata", payload).await
+        self.with_timeout(self.http.post_void("/v1/device/metadata", payload))
+            .await
     }
 
     pub async fn post_syslog_batch<T: serde::Serialize + Sync>(
         &self,
         payload: &T,
     ) -> Result<(), ApiError> {
-        self.http.post_void("/v1/device/syslog/batch", payload).await
+        self.with_timeout(self.http.post_void("/v1/device/syslog/batch", payload))
+            .await
     }
 
     pub async fn fetch_devices(&self) -> Result<serde_json::Value, ApiError> {
-        self.http.get_json("/v1/device/devices").await
+        self.with_timeout(self.http.get_json("/v1/device/devices"))
+            .await
     }
 
     pub async fn fetch_device(&self, device_id: &str) -> Result<serde_json::Value, ApiError> {
-        self.http
-            .get_json(&format!("/v1/device/devices/{device_id}"))
-            .await
+        let encoded_id = utf8_percent_encode(device_id, NON_ALPHANUMERIC).to_string();
+        self.with_timeout(
+            self.http
+                .get_json(&format!("/v1/device/devices/{encoded_id}")),
+        )
+        .await
     }
 
     pub async fn search_logs(
@@ -70,14 +73,20 @@ impl DeviceRuntimeClient {
         device_id: &str,
         query: &str,
     ) -> Result<serde_json::Value, ApiError> {
-        self.http
-            .post_json(
-                "/v1/device/logs/search",
-                &serde_json::json!({
-                    "device_id": device_id,
-                    "query": query,
-                }),
-            )
+        let request = SearchLogsRequest {
+            device_id: device_id.to_string(),
+            query: query.to_string(),
+        };
+        self.with_timeout(self.http.post_json("/v1/device/logs/search", &request))
             .await
+    }
+
+    async fn with_timeout<T>(
+        &self,
+        future: impl Future<Output = Result<T, ApiError>>,
+    ) -> Result<T, ApiError> {
+        tokio::time::timeout(DEVICE_RUNTIME_TIMEOUT, future)
+            .await
+            .map_err(|_| ApiError::Network("request timed out".to_string()))?
     }
 }

--- a/crates/lab-apis/src/device_runtime/client.rs
+++ b/crates/lab-apis/src/device_runtime/client.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use crate::core::{ApiError, Auth, HttpClient};
+
+#[derive(Debug, Clone)]
+pub struct DeviceRuntimeClient {
+    http: HttpClient,
+}
+
+impl DeviceRuntimeClient {
+    /// Build a client against the device-runtime surface with an optional request timeout.
+    ///
+    /// # Errors
+    /// Returns [`ApiError`] if the shared HTTP client cannot be built.
+    pub fn new(
+        base_url: impl Into<String>,
+        auth: Auth,
+        timeout: Option<Duration>,
+    ) -> Result<Self, ApiError> {
+        let http = match timeout {
+            Some(timeout) => HttpClient::with_default_headers_and_timeouts(
+                base_url,
+                auth,
+                reqwest::header::HeaderMap::new(),
+                Duration::from_secs(5),
+                timeout,
+            )?,
+            None => HttpClient::new(base_url, auth)?,
+        };
+        Ok(Self { http })
+    }
+
+    pub async fn post_hello<T: serde::Serialize + Sync>(&self, payload: &T) -> Result<(), ApiError> {
+        self.http.post_void("/v1/device/hello", payload).await
+    }
+
+    pub async fn post_status<T: serde::Serialize + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<(), ApiError> {
+        self.http.post_void("/v1/device/status", payload).await
+    }
+
+    pub async fn post_metadata<T: serde::Serialize + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<(), ApiError> {
+        self.http.post_void("/v1/device/metadata", payload).await
+    }
+
+    pub async fn post_syslog_batch<T: serde::Serialize + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<(), ApiError> {
+        self.http.post_void("/v1/device/syslog/batch", payload).await
+    }
+
+    pub async fn fetch_devices(&self) -> Result<serde_json::Value, ApiError> {
+        self.http.get_json("/v1/device/devices").await
+    }
+
+    pub async fn fetch_device(&self, device_id: &str) -> Result<serde_json::Value, ApiError> {
+        self.http
+            .get_json(&format!("/v1/device/devices/{device_id}"))
+            .await
+    }
+
+    pub async fn search_logs(
+        &self,
+        device_id: &str,
+        query: &str,
+    ) -> Result<serde_json::Value, ApiError> {
+        self.http
+            .post_json(
+                "/v1/device/logs/search",
+                &serde_json::json!({
+                    "device_id": device_id,
+                    "query": query,
+                }),
+            )
+            .await
+    }
+}

--- a/crates/lab-apis/src/device_runtime/types.rs
+++ b/crates/lab-apis/src/device_runtime/types.rs
@@ -1,0 +1,7 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchLogsRequest {
+    pub device_id: String,
+    pub query: String,
+}

--- a/crates/lab-apis/src/lib.rs
+++ b/crates/lab-apis/src/lib.rs
@@ -23,6 +23,9 @@ pub mod servarr;
 /// Bootstrap utility: extract API keys from existing service config files.
 pub mod extract;
 
+/// Device-runtime control-plane client shared by CLI and runtime code.
+pub mod device_runtime;
+
 /// Radarr movie management client.
 #[cfg(feature = "radarr")]
 pub mod radarr;

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -289,7 +289,10 @@ fn is_loopback_redirect(value: &str) -> bool {
 }
 
 fn is_allowed_redirect_uri(value: &str, patterns: &[String]) -> bool {
-    is_loopback_redirect(value) || patterns.iter().any(|pattern| wildcard_matches(pattern, value))
+    is_loopback_redirect(value)
+        || patterns
+            .iter()
+            .any(|pattern| wildcard_matches(pattern, value))
 }
 
 fn wildcard_matches(pattern: &str, value: &str) -> bool {

--- a/crates/lab-auth/src/token.rs
+++ b/crates/lab-auth/src/token.rs
@@ -201,9 +201,7 @@ async fn refresh_token_grant(
             client_id: stored.client_id.clone(),
             subject: google.subject.clone(),
             scope: stored.scope.clone(),
-            provider_refresh_token: google
-                .refresh_token
-                .or(Some(provider_refresh_token)),
+            provider_refresh_token: google.refresh_token.or(Some(provider_refresh_token)),
             created_at: stored.created_at,
             expires_at: now_unix() + state.config.refresh_token_ttl.as_secs() as i64,
         })
@@ -483,10 +481,7 @@ mod tests {
                 Request::builder()
                     .method("POST")
                     .uri("/token")
-                    .header(
-                        header::CONTENT_TYPE,
-                        "application/x-www-form-urlencoded",
-                    )
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                     .body(Body::from(
                         "grant_type=refresh_token&refresh_token=refresh-token&client_id=client",
                     ))

--- a/crates/lab/src/api.rs
+++ b/crates/lab/src/api.rs
@@ -22,6 +22,9 @@ pub mod health;
 /// HTTP auth helpers for bearer-or-OAuth mode (metadata, WWW-Authenticate).
 pub mod oauth;
 
+/// Device runtime ingestion routes mounted under `/v1/device/*`.
+pub mod device;
+
 /// Static Labby web asset serving helpers.
 pub mod web;
 

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -48,7 +48,3 @@ pub(crate) fn normalize_device_id_value(device_id: &str, param: &str) -> Result<
 
     Ok(trimmed.to_string())
 }
-
-pub(crate) fn validate_device_id_value(device_id: &str, param: &str) -> Result<(), ToolError> {
-    normalize_device_id_value(device_id, param).map(|_| ())
-}

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 use super::state::AppState;
 
 pub mod hello;
+pub mod fleet;
+pub mod logs;
 pub mod metadata;
 pub mod oauth;
 pub mod status;
@@ -19,6 +21,9 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .route("/hello", post(hello::handle))
         .route("/status", post(status::handle))
         .route("/metadata", post(metadata::handle))
+        .route("/devices", axum::routing::get(fleet::list_devices))
+        .route("/devices/{device_id}", axum::routing::get(fleet::get_device))
+        .route("/logs/search", post(logs::search))
         .route("/oauth/relay/start", post(oauth::handle_start))
         .route("/syslog/batch", post(syslog::handle_batch))
         .with_state(state)

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -37,7 +37,7 @@ fn ok() -> Json<DeviceAck> {
     Json(DeviceAck { ok: true })
 }
 
-pub(crate) fn validate_device_id_value(device_id: &str, param: &str) -> Result<(), ToolError> {
+pub(crate) fn normalize_device_id_value(device_id: &str, param: &str) -> Result<String, ToolError> {
     let trimmed = device_id.trim();
     if trimmed.is_empty() || trimmed.len() > 256 {
         return Err(ToolError::InvalidParam {
@@ -46,5 +46,9 @@ pub(crate) fn validate_device_id_value(device_id: &str, param: &str) -> Result<(
         });
     }
 
-    Ok(())
+    Ok(trimmed.to_string())
+}
+
+pub(crate) fn validate_device_id_value(device_id: &str, param: &str) -> Result<(), ToolError> {
+    normalize_device_id_value(device_id, param).map(|_| ())
 }

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -1,0 +1,27 @@
+use axum::{Json, Router, routing::post};
+use serde::Serialize;
+
+use super::state::AppState;
+
+pub mod hello;
+pub mod metadata;
+pub mod status;
+pub mod syslog;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DeviceAck {
+    pub ok: bool,
+}
+
+pub fn routes(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/hello", post(hello::handle))
+        .route("/status", post(status::handle))
+        .route("/metadata", post(metadata::handle))
+        .route("/syslog/batch", post(syslog::handle_batch))
+        .with_state(state)
+}
+
+fn ok() -> Json<DeviceAck> {
+    Json(DeviceAck { ok: true })
+}

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -2,9 +2,10 @@ use axum::{Json, Router, routing::post};
 use serde::Serialize;
 
 use super::state::AppState;
+use crate::api::ToolError;
 
-pub mod hello;
 pub mod fleet;
+pub mod hello;
 pub mod logs;
 pub mod metadata;
 pub mod oauth;
@@ -22,7 +23,10 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .route("/status", post(status::handle))
         .route("/metadata", post(metadata::handle))
         .route("/devices", axum::routing::get(fleet::list_devices))
-        .route("/devices/{device_id}", axum::routing::get(fleet::get_device))
+        .route(
+            "/devices/{device_id}",
+            axum::routing::get(fleet::get_device),
+        )
         .route("/logs/search", post(logs::search))
         .route("/oauth/relay/start", post(oauth::handle_start))
         .route("/syslog/batch", post(syslog::handle_batch))
@@ -31,4 +35,16 @@ pub fn routes(state: AppState) -> Router<AppState> {
 
 fn ok() -> Json<DeviceAck> {
     Json(DeviceAck { ok: true })
+}
+
+pub(crate) fn validate_device_id_value(device_id: &str, param: &str) -> Result<(), ToolError> {
+    let trimmed = device_id.trim();
+    if trimmed.is_empty() || trimmed.len() > 256 {
+        return Err(ToolError::InvalidParam {
+            message: "device_id must be 1-256 non-whitespace characters".to_string(),
+            param: param.to_string(),
+        });
+    }
+
+    Ok(())
 }

--- a/crates/lab/src/api/device.rs
+++ b/crates/lab/src/api/device.rs
@@ -5,6 +5,7 @@ use super::state::AppState;
 
 pub mod hello;
 pub mod metadata;
+pub mod oauth;
 pub mod status;
 pub mod syslog;
 
@@ -18,6 +19,7 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .route("/hello", post(hello::handle))
         .route("/status", post(status::handle))
         .route("/metadata", post(metadata::handle))
+        .route("/oauth/relay/start", post(oauth::handle_start))
         .route("/syslog/batch", post(syslog::handle_batch))
         .with_state(state)
 }

--- a/crates/lab/src/api/device/fleet.rs
+++ b/crates/lab/src/api/device/fleet.rs
@@ -37,6 +37,7 @@ pub async fn get_device(
     Path(device_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ToolError> {
     let store = require_master_store(&state)?;
+    let device_id = super::normalize_device_id_value(&device_id, "device_id")?;
     let snapshot = store
         .device(&device_id)
         .await

--- a/crates/lab/src/api/device/fleet.rs
+++ b/crates/lab/src/api/device/fleet.rs
@@ -1,0 +1,60 @@
+use axum::{Json, extract::{Path, State}};
+use serde_json::json;
+
+use crate::api::{ToolError, state::AppState};
+use crate::config::DeviceRole;
+
+pub async fn list_devices(State(state): State<AppState>) -> Result<Json<serde_json::Value>, ToolError> {
+    let store = require_master_store(&state)?;
+    let devices = store.list_devices().await;
+    Ok(Json(serde_json::Value::Array(
+        devices
+            .into_iter()
+            .map(|snapshot| {
+                json!({
+                    "device_id": snapshot.device_id,
+                    "connected": snapshot.connected,
+                    "role": snapshot.role,
+                    "log_count": snapshot.logs.len(),
+                    "discovered_config_count": snapshot
+                        .metadata
+                        .as_ref()
+                        .map(|metadata| metadata.discovered_configs.len())
+                        .unwrap_or(0),
+                })
+            })
+            .collect(),
+    )))
+}
+
+pub async fn get_device(
+    State(state): State<AppState>,
+    Path(device_id): Path<String>,
+) -> Result<Json<serde_json::Value>, ToolError> {
+    let store = require_master_store(&state)?;
+    let snapshot = store.device(&device_id).await.ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "not_found".to_string(),
+        message: format!("unknown device `{device_id}`"),
+    })?;
+    Ok(Json(json!({
+        "device_id": snapshot.device_id,
+        "connected": snapshot.connected,
+        "role": snapshot.role,
+        "status": snapshot.status,
+        "metadata": snapshot.metadata,
+        "log_count": snapshot.logs.len(),
+    })))
+}
+
+fn require_master_store(state: &AppState) -> Result<std::sync::Arc<crate::device::store::DeviceFleetStore>, ToolError> {
+    if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "not_found".to_string(),
+            message: "device fleet queries are only available on the master".to_string(),
+        });
+    }
+    state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))
+}

--- a/crates/lab/src/api/device/fleet.rs
+++ b/crates/lab/src/api/device/fleet.rs
@@ -1,10 +1,15 @@
-use axum::{Json, extract::{Path, State}};
+use axum::{
+    Json,
+    extract::{Path, State},
+};
 use serde_json::json;
 
 use crate::api::{ToolError, state::AppState};
 use crate::config::DeviceRole;
 
-pub async fn list_devices(State(state): State<AppState>) -> Result<Json<serde_json::Value>, ToolError> {
+pub async fn list_devices(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ToolError> {
     let store = require_master_store(&state)?;
     let devices = store.list_devices().await;
     Ok(Json(serde_json::Value::Array(
@@ -32,10 +37,13 @@ pub async fn get_device(
     Path(device_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ToolError> {
     let store = require_master_store(&state)?;
-    let snapshot = store.device(&device_id).await.ok_or_else(|| ToolError::Sdk {
-        sdk_kind: "not_found".to_string(),
-        message: format!("unknown device `{device_id}`"),
-    })?;
+    let snapshot = store
+        .device(&device_id)
+        .await
+        .ok_or_else(|| ToolError::Sdk {
+            sdk_kind: "not_found".to_string(),
+            message: format!("unknown device `{device_id}`"),
+        })?;
     Ok(Json(json!({
         "device_id": snapshot.device_id,
         "connected": snapshot.connected,
@@ -46,7 +54,9 @@ pub async fn get_device(
     })))
 }
 
-fn require_master_store(state: &AppState) -> Result<std::sync::Arc<crate::device::store::DeviceFleetStore>, ToolError> {
+pub(crate) fn require_master_store(
+    state: &AppState,
+) -> Result<std::sync::Arc<crate::device::store::DeviceFleetStore>, ToolError> {
     if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
         return Err(ToolError::Sdk {
             sdk_kind: "not_found".to_string(),

--- a/crates/lab/src/api/device/hello.rs
+++ b/crates/lab/src/api/device/hello.rs
@@ -5,8 +5,9 @@ use crate::device::checkin::DeviceHello;
 
 pub async fn handle(
     State(state): State<AppState>,
-    Json(payload): Json<DeviceHello>,
+    Json(mut payload): Json<DeviceHello>,
 ) -> Result<Json<DeviceAck>, ToolError> {
+    payload.device_id = super::normalize_device_id_value(&payload.device_id, "device_id")?;
     let store = state
         .device_store
         .clone()

--- a/crates/lab/src/api/device/hello.rs
+++ b/crates/lab/src/api/device/hello.rs
@@ -1,0 +1,16 @@
+use axum::{Json, extract::State};
+
+use crate::api::{ToolError, device::DeviceAck, state::AppState};
+use crate::device::checkin::DeviceHello;
+
+pub async fn handle(
+    State(state): State<AppState>,
+    Json(payload): Json<DeviceHello>,
+) -> Result<Json<DeviceAck>, ToolError> {
+    let store = state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    store.record_hello(payload).await;
+    Ok(super::ok())
+}

--- a/crates/lab/src/api/device/logs.rs
+++ b/crates/lab/src/api/device/logs.rs
@@ -1,0 +1,36 @@
+use axum::{Json, extract::State};
+use serde::Deserialize;
+
+use crate::api::{ToolError, state::AppState};
+use crate::config::DeviceRole;
+
+#[derive(Debug, Deserialize)]
+pub struct SearchLogsRequest {
+    pub device_id: String,
+    pub query: String,
+}
+
+pub async fn search(
+    State(state): State<AppState>,
+    Json(payload): Json<SearchLogsRequest>,
+) -> Result<Json<Vec<crate::device::log_event::DeviceLogEvent>>, ToolError> {
+    if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "not_found".to_string(),
+            message: "device fleet logs are only available on the master".to_string(),
+        });
+    }
+
+    let store = state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    let needle = payload.query.to_ascii_lowercase();
+    let events = store
+        .logs_for_device(&payload.device_id)
+        .await
+        .into_iter()
+        .filter(|event| event.message.to_ascii_lowercase().contains(&needle))
+        .collect();
+    Ok(Json(events))
+}

--- a/crates/lab/src/api/device/logs.rs
+++ b/crates/lab/src/api/device/logs.rs
@@ -3,7 +3,9 @@ use serde::Deserialize;
 
 use crate::api::{ToolError, state::AppState};
 
-use super::{fleet::require_master_store, validate_device_id_value};
+use super::{fleet::require_master_store, normalize_device_id_value};
+
+const MAX_LOG_SEARCH_LIMIT: usize = 1_000;
 
 #[derive(Debug, Deserialize)]
 pub struct SearchLogsRequest {
@@ -19,13 +21,13 @@ pub async fn search(
     State(state): State<AppState>,
     Json(payload): Json<SearchLogsRequest>,
 ) -> Result<Json<Vec<crate::device::log_event::DeviceLogEvent>>, ToolError> {
-    validate_device_id_value(&payload.device_id, "device_id")?;
+    let device_id = normalize_device_id_value(&payload.device_id, "device_id")?;
     let store = require_master_store(&state)?;
     let needle = payload.query.to_ascii_lowercase();
     let offset = payload.offset.unwrap_or(0);
-    let limit = payload.limit.unwrap_or(200);
+    let limit = payload.limit.unwrap_or(200).min(MAX_LOG_SEARCH_LIMIT);
     let events = store
-        .search_logs_for_device(&payload.device_id, &needle, offset, limit)
+        .search_logs_for_device(&device_id, &needle, offset, limit)
         .await
         .into_iter()
         .collect();

--- a/crates/lab/src/api/device/logs.rs
+++ b/crates/lab/src/api/device/logs.rs
@@ -2,35 +2,32 @@ use axum::{Json, extract::State};
 use serde::Deserialize;
 
 use crate::api::{ToolError, state::AppState};
-use crate::config::DeviceRole;
+
+use super::{fleet::require_master_store, validate_device_id_value};
 
 #[derive(Debug, Deserialize)]
 pub struct SearchLogsRequest {
     pub device_id: String,
     pub query: String,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub offset: Option<usize>,
 }
 
 pub async fn search(
     State(state): State<AppState>,
     Json(payload): Json<SearchLogsRequest>,
 ) -> Result<Json<Vec<crate::device::log_event::DeviceLogEvent>>, ToolError> {
-    if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
-        return Err(ToolError::Sdk {
-            sdk_kind: "not_found".to_string(),
-            message: "device fleet logs are only available on the master".to_string(),
-        });
-    }
-
-    let store = state
-        .device_store
-        .clone()
-        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    validate_device_id_value(&payload.device_id, "device_id")?;
+    let store = require_master_store(&state)?;
     let needle = payload.query.to_ascii_lowercase();
+    let offset = payload.offset.unwrap_or(0);
+    let limit = payload.limit.unwrap_or(200);
     let events = store
-        .logs_for_device(&payload.device_id)
+        .search_logs_for_device(&payload.device_id, &needle, offset, limit)
         .await
         .into_iter()
-        .filter(|event| event.message.to_ascii_lowercase().contains(&needle))
         .collect();
     Ok(Json(events))
 }

--- a/crates/lab/src/api/device/metadata.rs
+++ b/crates/lab/src/api/device/metadata.rs
@@ -5,8 +5,9 @@ use crate::device::checkin::DeviceMetadataUpload;
 
 pub async fn handle(
     State(state): State<AppState>,
-    Json(payload): Json<DeviceMetadataUpload>,
+    Json(mut payload): Json<DeviceMetadataUpload>,
 ) -> Result<Json<DeviceAck>, ToolError> {
+    payload.device_id = super::normalize_device_id_value(&payload.device_id, "device_id")?;
     let store = state
         .device_store
         .clone()

--- a/crates/lab/src/api/device/metadata.rs
+++ b/crates/lab/src/api/device/metadata.rs
@@ -1,15 +1,16 @@
 use axum::{Json, extract::State};
-use serde_json::Value;
 
 use crate::api::{ToolError, device::DeviceAck, state::AppState};
+use crate::device::checkin::DeviceMetadataUpload;
 
 pub async fn handle(
     State(state): State<AppState>,
-    Json(_payload): Json<Value>,
+    Json(payload): Json<DeviceMetadataUpload>,
 ) -> Result<Json<DeviceAck>, ToolError> {
-    let _store = state
+    let store = state
         .device_store
         .clone()
         .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    store.record_metadata(payload).await;
     Ok(super::ok())
 }

--- a/crates/lab/src/api/device/metadata.rs
+++ b/crates/lab/src/api/device/metadata.rs
@@ -1,0 +1,15 @@
+use axum::{Json, extract::State};
+use serde_json::Value;
+
+use crate::api::{ToolError, device::DeviceAck, state::AppState};
+
+pub async fn handle(
+    State(state): State<AppState>,
+    Json(_payload): Json<Value>,
+) -> Result<Json<DeviceAck>, ToolError> {
+    let _store = state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    Ok(super::ok())
+}

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -1,0 +1,44 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::{Json, extract::State};
+use serde::Deserialize;
+
+use crate::api::{ToolError, device::DeviceAck, state::AppState};
+
+#[derive(Debug, Deserialize)]
+pub struct StartOauthRelayRequest {
+    pub bind_addr: SocketAddr,
+    pub target_url: String,
+    #[serde(default)]
+    pub default_port: Option<u16>,
+    #[serde(default)]
+    pub request_timeout_ms: Option<u64>,
+}
+
+pub async fn handle_start(
+    State(_state): State<AppState>,
+    Json(payload): Json<StartOauthRelayRequest>,
+) -> Result<Json<DeviceAck>, ToolError> {
+    let resolved_target =
+        crate::oauth::target::resolve_explicit_target(&payload.target_url, payload.default_port)
+            .map_err(|error| ToolError::InvalidParam {
+                message: error.to_string(),
+                param: "target_url".to_string(),
+            })?;
+    let timeout = Duration::from_millis(payload.request_timeout_ms.unwrap_or(30_000));
+
+    tokio::spawn(async move {
+        if let Err(error) = crate::device::oauth::start_local_oauth_relay(
+            payload.bind_addr,
+            resolved_target,
+            timeout,
+        )
+        .await
+        {
+            tracing::warn!(error = %error, "device oauth relay exited");
+        }
+    });
+
+    Ok(super::ok())
+}

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use axum::{Json, extract::State};
 use serde::Deserialize;
 
-use crate::api::{ToolError, device::DeviceAck, state::AppState};
+use crate::api::{ToolError, state::AppState};
 
 #[derive(Debug, Deserialize)]
 pub struct StartOauthRelayRequest {
@@ -14,6 +14,12 @@ pub struct StartOauthRelayRequest {
     pub default_port: Option<u16>,
     #[serde(default)]
     pub request_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct StartOauthRelayResponse {
+    pub ok: bool,
+    pub bind_addr: SocketAddr,
 }
 
 fn validate_bind_addr(bind_addr: SocketAddr) -> Result<(), ToolError> {
@@ -30,7 +36,7 @@ fn validate_bind_addr(bind_addr: SocketAddr) -> Result<(), ToolError> {
 pub async fn handle_start(
     State(_state): State<AppState>,
     Json(payload): Json<StartOauthRelayRequest>,
-) -> Result<Json<DeviceAck>, ToolError> {
+) -> Result<Json<StartOauthRelayResponse>, ToolError> {
     validate_bind_addr(payload.bind_addr)?;
     let resolved_target =
         crate::oauth::target::resolve_explicit_target(&payload.target_url, payload.default_port)
@@ -40,12 +46,16 @@ pub async fn handle_start(
             })?;
     let timeout = Duration::from_millis(payload.request_timeout_ms.unwrap_or(30_000));
 
-    crate::device::oauth::start_local_oauth_relay(payload.bind_addr, resolved_target, timeout)
+    let bound_addr =
+        crate::device::oauth::start_local_oauth_relay(payload.bind_addr, resolved_target, timeout)
         .await
         .map_err(|error| ToolError::Sdk {
             sdk_kind: "internal_error".to_string(),
             message: error.to_string(),
         })?;
 
-    Ok(super::ok())
+    Ok(Json(StartOauthRelayResponse {
+        ok: true,
+        bind_addr: bound_addr,
+    }))
 }

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -16,10 +16,22 @@ pub struct StartOauthRelayRequest {
     pub request_timeout_ms: Option<u64>,
 }
 
+fn validate_bind_addr(bind_addr: SocketAddr) -> Result<(), ToolError> {
+    if !bind_addr.ip().is_loopback() {
+        return Err(ToolError::InvalidParam {
+            message: "bind_addr must be a loopback address".to_string(),
+            param: "bind_addr".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
 pub async fn handle_start(
     State(_state): State<AppState>,
     Json(payload): Json<StartOauthRelayRequest>,
 ) -> Result<Json<DeviceAck>, ToolError> {
+    validate_bind_addr(payload.bind_addr)?;
     let resolved_target =
         crate::oauth::target::resolve_explicit_target(&payload.target_url, payload.default_port)
             .map_err(|error| ToolError::InvalidParam {
@@ -28,17 +40,12 @@ pub async fn handle_start(
             })?;
     let timeout = Duration::from_millis(payload.request_timeout_ms.unwrap_or(30_000));
 
-    tokio::spawn(async move {
-        if let Err(error) = crate::device::oauth::start_local_oauth_relay(
-            payload.bind_addr,
-            resolved_target,
-            timeout,
-        )
+    crate::device::oauth::start_local_oauth_relay(payload.bind_addr, resolved_target, timeout)
         .await
-        {
-            tracing::warn!(error = %error, "device oauth relay exited");
-        }
-    });
+        .map_err(|error| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: error.to_string(),
+        })?;
 
     Ok(super::ok())
 }

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -48,11 +48,11 @@ pub async fn handle_start(
 
     let bound_addr =
         crate::device::oauth::start_local_oauth_relay(payload.bind_addr, resolved_target, timeout)
-        .await
-        .map_err(|error| ToolError::Sdk {
-            sdk_kind: "internal_error".to_string(),
-            message: error.to_string(),
-        })?;
+            .await
+            .map_err(|error| ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: error.to_string(),
+            })?;
 
     Ok(Json(StartOauthRelayResponse {
         ok: true,

--- a/crates/lab/src/api/device/status.rs
+++ b/crates/lab/src/api/device/status.rs
@@ -1,0 +1,16 @@
+use axum::{Json, extract::State};
+
+use crate::api::{ToolError, device::DeviceAck, state::AppState};
+use crate::device::checkin::DeviceStatus;
+
+pub async fn handle(
+    State(state): State<AppState>,
+    Json(payload): Json<DeviceStatus>,
+) -> Result<Json<DeviceAck>, ToolError> {
+    let store = state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    store.record_status(payload).await;
+    Ok(super::ok())
+}

--- a/crates/lab/src/api/device/status.rs
+++ b/crates/lab/src/api/device/status.rs
@@ -5,8 +5,9 @@ use crate::device::checkin::DeviceStatus;
 
 pub async fn handle(
     State(state): State<AppState>,
-    Json(payload): Json<DeviceStatus>,
+    Json(mut payload): Json<DeviceStatus>,
 ) -> Result<Json<DeviceAck>, ToolError> {
+    payload.device_id = super::normalize_device_id_value(&payload.device_id, "device_id")?;
     let store = state
         .device_store
         .clone()

--- a/crates/lab/src/api/device/syslog.rs
+++ b/crates/lab/src/api/device/syslog.rs
@@ -12,11 +12,12 @@ pub struct DeviceSyslogBatch {
 
 pub async fn handle_batch(
     State(state): State<AppState>,
-    Json(_payload): Json<DeviceSyslogBatch>,
+    Json(payload): Json<DeviceSyslogBatch>,
 ) -> Result<Json<DeviceAck>, ToolError> {
-    let _store = state
+    let store = state
         .device_store
         .clone()
         .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    store.record_logs(&payload.device_id, payload.events).await;
     Ok(super::ok())
 }

--- a/crates/lab/src/api/device/syslog.rs
+++ b/crates/lab/src/api/device/syslog.rs
@@ -1,0 +1,22 @@
+use axum::{Json, extract::State};
+use serde::Deserialize;
+
+use crate::api::{ToolError, device::DeviceAck, state::AppState};
+use crate::device::log_event::DeviceLogEvent;
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceSyslogBatch {
+    pub device_id: String,
+    pub events: Vec<DeviceLogEvent>,
+}
+
+pub async fn handle_batch(
+    State(state): State<AppState>,
+    Json(_payload): Json<DeviceSyslogBatch>,
+) -> Result<Json<DeviceAck>, ToolError> {
+    let _store = state
+        .device_store
+        .clone()
+        .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
+    Ok(super::ok())
+}

--- a/crates/lab/src/api/device/syslog.rs
+++ b/crates/lab/src/api/device/syslog.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 use crate::api::{ToolError, device::DeviceAck, state::AppState};
 use crate::device::log_event::DeviceLogEvent;
 
+use super::validate_device_id_value;
+
 #[derive(Debug, Deserialize)]
 pub struct DeviceSyslogBatch {
     pub device_id: String,
@@ -14,6 +16,7 @@ pub async fn handle_batch(
     State(state): State<AppState>,
     Json(payload): Json<DeviceSyslogBatch>,
 ) -> Result<Json<DeviceAck>, ToolError> {
+    validate_device_id_value(&payload.device_id, "device_id")?;
     let store = state
         .device_store
         .clone()

--- a/crates/lab/src/api/device/syslog.rs
+++ b/crates/lab/src/api/device/syslog.rs
@@ -1,10 +1,6 @@
 use std::time::Instant;
 
-use axum::{
-    Json,
-    extract::State,
-    http::HeaderMap,
-};
+use axum::{Json, extract::State, http::HeaderMap};
 use serde::Deserialize;
 
 use crate::api::{ToolError, device::DeviceAck, state::AppState};
@@ -26,10 +22,8 @@ pub async fn handle_batch(
     let start = Instant::now();
     let device_id = normalize_device_id_value(&payload.device_id, "device_id")?;
     for (index, event) in payload.events.iter_mut().enumerate() {
-        let event_id = normalize_device_id_value(
-            &event.device_id,
-            &format!("events[{index}].device_id"),
-        )?;
+        let event_id =
+            normalize_device_id_value(&event.device_id, &format!("events[{index}].device_id"))?;
         if event_id != device_id {
             return Err(ToolError::InvalidParam {
                 message: format!(
@@ -42,7 +36,9 @@ pub async fn handle_batch(
     }
 
     let event_count = payload.events.len();
-    let request_id = headers.get("x-request-id").and_then(|value| value.to_str().ok());
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok());
     let store = state
         .device_store
         .clone()

--- a/crates/lab/src/api/device/syslog.rs
+++ b/crates/lab/src/api/device/syslog.rs
@@ -1,10 +1,16 @@
-use axum::{Json, extract::State};
+use std::time::Instant;
+
+use axum::{
+    Json,
+    extract::State,
+    http::HeaderMap,
+};
 use serde::Deserialize;
 
 use crate::api::{ToolError, device::DeviceAck, state::AppState};
 use crate::device::log_event::DeviceLogEvent;
 
-use super::validate_device_id_value;
+use super::normalize_device_id_value;
 
 #[derive(Debug, Deserialize)]
 pub struct DeviceSyslogBatch {
@@ -13,14 +19,44 @@ pub struct DeviceSyslogBatch {
 }
 
 pub async fn handle_batch(
+    headers: HeaderMap,
     State(state): State<AppState>,
-    Json(payload): Json<DeviceSyslogBatch>,
+    Json(mut payload): Json<DeviceSyslogBatch>,
 ) -> Result<Json<DeviceAck>, ToolError> {
-    validate_device_id_value(&payload.device_id, "device_id")?;
+    let start = Instant::now();
+    let device_id = normalize_device_id_value(&payload.device_id, "device_id")?;
+    for (index, event) in payload.events.iter_mut().enumerate() {
+        let event_id = normalize_device_id_value(
+            &event.device_id,
+            &format!("events[{index}].device_id"),
+        )?;
+        if event_id != device_id {
+            return Err(ToolError::InvalidParam {
+                message: format!(
+                    "events[{index}].device_id must match batch device_id `{device_id}`"
+                ),
+                param: format!("events[{index}].device_id"),
+            });
+        }
+        event.device_id = device_id.clone();
+    }
+
+    let event_count = payload.events.len();
+    let request_id = headers.get("x-request-id").and_then(|value| value.to_str().ok());
     let store = state
         .device_store
         .clone()
         .ok_or_else(|| ToolError::internal_message("device store is not configured"))?;
-    store.record_logs(&payload.device_id, payload.events).await;
+    store.record_logs(&device_id, payload.events).await;
+    tracing::info!(
+        surface = "api",
+        service = "device",
+        action = "syslog.batch",
+        request_id,
+        device_id = %device_id,
+        event_count,
+        elapsed_ms = start.elapsed().as_millis(),
+        "device syslog batch recorded"
+    );
     Ok(super::ok())
 }

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -25,6 +25,8 @@ use tracing::Level;
 
 use lab_auth::error::AuthError as LabAuthError;
 
+use crate::config::DeviceRole;
+
 /// Constant-time byte comparison using `subtle::ConstantTimeEq` to prevent
 /// timing-based token prefix leakage (lab-63jc).
 fn tokens_equal(a: &str, b: &str) -> bool {
@@ -98,6 +100,7 @@ async fn auth_token(
 
 /// Build the `/v1` sub-router with all feature-gated service routes.
 fn build_v1_router(state: &AppState) -> Router<AppState> {
+    let is_master = !matches!(state.device_role, Some(DeviceRole::NonMaster));
     let openapi_spec: Arc<String> = super::openapi::build_openapi_spec(state.registry.services())
         .unwrap_or_else(|e| {
             tracing::error!(error = %e, "failed to serialize OpenAPI spec");
@@ -105,30 +108,33 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         });
     let spec_for_route = openapi_spec;
 
-    let mut v1 = Router::new()
-        .route("/{service}/actions", get(service_actions))
-        .nest("/device", super::device::routes(state.clone()))
-        .nest("/gateway", services::gateway::routes(state.clone()))
-        .route(
-            "/openapi.json",
-            get(move || {
-                let spec = spec_for_route.clone();
-                async move {
-                    (
-                        [
-                            (header::CONTENT_TYPE, "application/json"),
-                            (header::CACHE_CONTROL, "private, no-store"),
-                        ],
-                        (*spec).clone(),
-                    )
-                }
-            }),
-        )
-        .route(
-            "/docs",
-            get(|| async { Html(include_str!("openapi_docs.html")) }),
-        )
-        .nest("/extract", services::extract::routes(state.clone()));
+    let mut v1 = Router::new().nest("/device", super::device::routes(state.clone()));
+
+    if is_master {
+        v1 = v1
+            .route("/{service}/actions", get(service_actions))
+            .nest("/gateway", services::gateway::routes(state.clone()))
+            .route(
+                "/openapi.json",
+                get(move || {
+                    let spec = spec_for_route.clone();
+                    async move {
+                        (
+                            [
+                                (header::CONTENT_TYPE, "application/json"),
+                                (header::CACHE_CONTROL, "private, no-store"),
+                            ],
+                            (*spec).clone(),
+                        )
+                    }
+                }),
+            )
+            .route(
+                "/docs",
+                get(|| async { Html(include_str!("openapi_docs.html")) }),
+            )
+            .nest("/extract", services::extract::routes(state.clone()));
+    }
 
     macro_rules! mount_if_enabled {
         ($v1:ident, $state:ident, $feat:literal, $name:literal, $mod:ident) => {
@@ -139,27 +145,29 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         };
     }
 
-    mount_if_enabled!(v1, state, "radarr", "radarr", radarr);
-    mount_if_enabled!(v1, state, "sonarr", "sonarr", sonarr);
-    mount_if_enabled!(v1, state, "prowlarr", "prowlarr", prowlarr);
-    mount_if_enabled!(v1, state, "plex", "plex", plex);
-    mount_if_enabled!(v1, state, "tautulli", "tautulli", tautulli);
-    mount_if_enabled!(v1, state, "sabnzbd", "sabnzbd", sabnzbd);
-    mount_if_enabled!(v1, state, "qbittorrent", "qbittorrent", qbittorrent);
-    mount_if_enabled!(v1, state, "tailscale", "tailscale", tailscale);
-    mount_if_enabled!(v1, state, "linkding", "linkding", linkding);
-    mount_if_enabled!(v1, state, "memos", "memos", memos);
-    mount_if_enabled!(v1, state, "bytestash", "bytestash", bytestash);
-    mount_if_enabled!(v1, state, "paperless", "paperless", paperless);
-    mount_if_enabled!(v1, state, "arcane", "arcane", arcane);
-    mount_if_enabled!(v1, state, "unraid", "unraid", unraid);
-    mount_if_enabled!(v1, state, "unifi", "unifi", unifi);
-    mount_if_enabled!(v1, state, "overseerr", "overseerr", overseerr);
-    mount_if_enabled!(v1, state, "gotify", "gotify", gotify);
-    mount_if_enabled!(v1, state, "openai", "openai", openai);
-    mount_if_enabled!(v1, state, "qdrant", "qdrant", qdrant);
-    mount_if_enabled!(v1, state, "tei", "tei", tei);
-    mount_if_enabled!(v1, state, "apprise", "apprise", apprise);
+    if is_master {
+        mount_if_enabled!(v1, state, "radarr", "radarr", radarr);
+        mount_if_enabled!(v1, state, "sonarr", "sonarr", sonarr);
+        mount_if_enabled!(v1, state, "prowlarr", "prowlarr", prowlarr);
+        mount_if_enabled!(v1, state, "plex", "plex", plex);
+        mount_if_enabled!(v1, state, "tautulli", "tautulli", tautulli);
+        mount_if_enabled!(v1, state, "sabnzbd", "sabnzbd", sabnzbd);
+        mount_if_enabled!(v1, state, "qbittorrent", "qbittorrent", qbittorrent);
+        mount_if_enabled!(v1, state, "tailscale", "tailscale", tailscale);
+        mount_if_enabled!(v1, state, "linkding", "linkding", linkding);
+        mount_if_enabled!(v1, state, "memos", "memos", memos);
+        mount_if_enabled!(v1, state, "bytestash", "bytestash", bytestash);
+        mount_if_enabled!(v1, state, "paperless", "paperless", paperless);
+        mount_if_enabled!(v1, state, "arcane", "arcane", arcane);
+        mount_if_enabled!(v1, state, "unraid", "unraid", unraid);
+        mount_if_enabled!(v1, state, "unifi", "unifi", unifi);
+        mount_if_enabled!(v1, state, "overseerr", "overseerr", overseerr);
+        mount_if_enabled!(v1, state, "gotify", "gotify", gotify);
+        mount_if_enabled!(v1, state, "openai", "openai", openai);
+        mount_if_enabled!(v1, state, "qdrant", "qdrant", qdrant);
+        mount_if_enabled!(v1, state, "tei", "tei", tei);
+        mount_if_enabled!(v1, state, "apprise", "apprise", apprise);
+    }
 
     v1
 }
@@ -189,7 +197,8 @@ pub fn build_router(
     // Bearer auth is applied to this sub-router so both surfaces get the same
     // auth treatment while health probes remain exempt (lab-3qn.5).
     let mut protected = Router::new().nest("/v1", v1);
-    if let Some(mcp) = mcp_router {
+    let is_master = !matches!(state.device_role, Some(DeviceRole::NonMaster));
+    if is_master && let Some(mcp) = mcp_router {
         protected = protected.merge(mcp);
     }
 

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -25,7 +25,6 @@ use tracing::Level;
 
 use lab_auth::error::AuthError as LabAuthError;
 
-use crate::config::DeviceRole;
 
 /// Constant-time byte comparison using `subtle::ConstantTimeEq` to prevent
 /// timing-based token prefix leakage (lab-63jc).
@@ -100,7 +99,7 @@ async fn auth_token(
 
 /// Build the `/v1` sub-router with all feature-gated service routes.
 fn build_v1_router(state: &AppState) -> Router<AppState> {
-    let is_master = !matches!(state.device_role, Some(DeviceRole::NonMaster));
+    let is_master = state.is_master();
     let openapi_spec: Arc<String> = super::openapi::build_openapi_spec(state.registry.services())
         .unwrap_or_else(|e| {
             tracing::error!(error = %e, "failed to serialize OpenAPI spec");
@@ -197,7 +196,7 @@ pub fn build_router(
     // Bearer auth is applied to this sub-router so both surfaces get the same
     // auth treatment while health probes remain exempt (lab-3qn.5).
     let mut protected = Router::new().nest("/v1", v1);
-    let is_master = !matches!(state.device_role, Some(DeviceRole::NonMaster));
+    let is_master = state.is_master();
     if is_master && let Some(mcp) = mcp_router {
         protected = protected.merge(mcp);
     }

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -107,6 +107,7 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
 
     let mut v1 = Router::new()
         .route("/{service}/actions", get(service_actions))
+        .nest("/device", super::device::routes(state.clone()))
         .nest("/gateway", services::gateway::routes(state.clone()))
         .route(
             "/openapi.json",

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -25,7 +25,6 @@ use tracing::Level;
 
 use lab_auth::error::AuthError as LabAuthError;
 
-
 /// Constant-time byte comparison using `subtle::ConstantTimeEq` to prevent
 /// timing-based token prefix leakage (lab-63jc).
 fn tokens_equal(a: &str, b: &str) -> bool {

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -346,7 +346,7 @@ pub fn build_router(
         .route("/health", get(health::health))
         .route("/ready", get(health::ready))
         .merge(protected);
-    if let Some(auth_state) = auth_state.as_ref() {
+    if is_master && let Some(auth_state) = auth_state.as_ref() {
         let _ = auth_state;
         router = router
             .route(
@@ -816,7 +816,11 @@ mod tests {
     #[tokio::test]
     async fn serves_web_assets_for_browser_routes_when_configured() {
         let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+        fs::write(
+            dir.path().join("index.html"),
+            "<html><body>Labby</body></html>",
+        )
+        .unwrap();
 
         let state = AppState::new().with_web_assets_dir(dir.path().to_path_buf());
         let app = build_router_with_bearer(state, None, None);
@@ -845,7 +849,11 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+        fs::write(
+            dir.path().join("index.html"),
+            "<html><body>Labby</body></html>",
+        )
+        .unwrap();
         fs::write(outside.path().join("secret.txt"), "top-secret").unwrap();
         unix_fs::symlink(
             outside.path().join("secret.txt"),
@@ -871,7 +879,11 @@ mod tests {
     #[tokio::test]
     async fn v1_routes_still_win_over_web_asset_fallback() {
         let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+        fs::write(
+            dir.path().join("index.html"),
+            "<html><body>Labby</body></html>",
+        )
+        .unwrap();
 
         let state = AppState::new().with_web_assets_dir(dir.path().to_path_buf());
         let app = build_router_with_bearer(state, None, None);

--- a/crates/lab/src/api/services/helpers.rs
+++ b/crates/lab/src/api/services/helpers.rs
@@ -18,8 +18,8 @@ use tracing::Instrument;
 use lab_apis::core::action::ActionSpec;
 
 use crate::api::ActionRequest;
-use crate::dispatch::gateway::current_gateway_manager;
 use crate::dispatch::error::ToolError;
+use crate::dispatch::gateway::current_gateway_manager;
 
 /// Dispatch a service action request with unknown-action gate, confirmation gate, and logging.
 ///

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -1,13 +1,13 @@
 //! Shared application state for axum handlers.
 
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::catalog::{Catalog, build_catalog};
 use crate::config::DeviceRole;
-use crate::dispatch::clients::ServiceClients;
 use crate::device::store::DeviceFleetStore;
+use crate::dispatch::clients::ServiceClients;
 use crate::registry::{ToolRegistry, build_default_registry};
 
 /// Application state passed to every axum handler via `State<AppState>`.
@@ -130,6 +130,11 @@ impl AppState {
     pub fn with_web_assets_dir(mut self, dir: PathBuf) -> Self {
         self.web_assets_dir = Some(Arc::new(dir));
         self
+    }
+
+    #[must_use]
+    pub fn is_master(&self) -> bool {
+        !matches!(self.device_role, Some(DeviceRole::NonMaster))
     }
 }
 

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use crate::catalog::{Catalog, build_catalog};
 use crate::dispatch::clients::ServiceClients;
+use crate::device::store::DeviceFleetStore;
 use crate::registry::{ToolRegistry, build_default_registry};
 
 /// Application state passed to every axum handler via `State<AppState>`.
@@ -40,6 +41,8 @@ pub struct AppState {
     ///
     /// `None` when gateway management is not wired for this process.
     pub gateway_manager: Option<Arc<crate::dispatch::gateway::manager::GatewayManager>>,
+    /// Shared fleet state store for device runtime ingestion.
+    pub device_store: Option<Arc<DeviceFleetStore>>,
     /// Optional directory containing exported Labby web assets.
     pub web_assets_dir: Option<Arc<PathBuf>>,
 }
@@ -77,6 +80,7 @@ impl AppState {
             auth_config: None,
             oauth_state: None,
             gateway_manager: None,
+            device_store: None,
             web_assets_dir: None,
         }
     }
@@ -102,6 +106,12 @@ impl AppState {
         manager: Arc<crate::dispatch::gateway::manager::GatewayManager>,
     ) -> Self {
         self.gateway_manager = Some(manager);
+        self
+    }
+
+    #[must_use]
+    pub fn with_device_store(mut self, store: Arc<DeviceFleetStore>) -> Self {
+        self.device_store = Some(store);
         self
     }
 

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::path::PathBuf;
 
 use crate::catalog::{Catalog, build_catalog};
+use crate::config::DeviceRole;
 use crate::dispatch::clients::ServiceClients;
 use crate::device::store::DeviceFleetStore;
 use crate::registry::{ToolRegistry, build_default_registry};
@@ -43,6 +44,8 @@ pub struct AppState {
     pub gateway_manager: Option<Arc<crate::dispatch::gateway::manager::GatewayManager>>,
     /// Shared fleet state store for device runtime ingestion.
     pub device_store: Option<Arc<DeviceFleetStore>>,
+    /// Resolved device role for the current process.
+    pub device_role: Option<DeviceRole>,
     /// Optional directory containing exported Labby web assets.
     pub web_assets_dir: Option<Arc<PathBuf>>,
 }
@@ -81,6 +84,7 @@ impl AppState {
             oauth_state: None,
             gateway_manager: None,
             device_store: None,
+            device_role: None,
             web_assets_dir: None,
         }
     }
@@ -112,6 +116,12 @@ impl AppState {
     #[must_use]
     pub fn with_device_store(mut self, store: Arc<DeviceFleetStore>) -> Self {
         self.device_store = Some(store);
+        self
+    }
+
+    #[must_use]
+    pub fn with_device_role(mut self, role: DeviceRole) -> Self {
+        self.device_role = Some(role);
         self
     }
 

--- a/crates/lab/src/api/web.rs
+++ b/crates/lab/src/api/web.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 
 use super::state::AppState;
+use crate::config::DeviceRole;
 
 fn sanitize_relative_path(path: &str) -> PathBuf {
     let trimmed = path.trim_start_matches('/');
@@ -78,6 +79,14 @@ async fn resolve_asset_path(base_dir: &Path, request_path: &str) -> PathBuf {
 pub async fn serve_web_request(State(state): State<AppState>, request: Request) -> Response {
     if !matches!(*request.method(), Method::GET | Method::HEAD) {
         return StatusCode::NOT_FOUND.into_response();
+    }
+
+    if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
+        return (
+            StatusCode::FORBIDDEN,
+            "web ui is disabled on non-master devices",
+        )
+            .into_response();
     }
 
     let Some(base_dir) = state.web_assets_dir.as_deref() else {

--- a/crates/lab/src/api/web.rs
+++ b/crates/lab/src/api/web.rs
@@ -17,9 +17,9 @@ fn sanitize_relative_path(path: &str) -> PathBuf {
         match component {
             Component::Normal(part) => out.push(part),
             Component::CurDir => {}
-            Component::ParentDir
-            | Component::Prefix(_)
-            | Component::RootDir => return PathBuf::new(),
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                return PathBuf::new();
+            }
         }
     }
     out
@@ -82,6 +82,10 @@ pub async fn serve_web_request(State(state): State<AppState>, request: Request) 
     }
 
     if matches!(state.device_role, Some(DeviceRole::NonMaster)) {
+        tracing::warn!(
+            path = %request.uri().path(),
+            "rejected web ui request on non-master device"
+        );
         return (
             StatusCode::FORBIDDEN,
             "web ui is disabled on non-master devices",

--- a/crates/lab/src/catalog.rs
+++ b/crates/lab/src/catalog.rs
@@ -63,7 +63,7 @@ pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
                 })
                 .collect(),
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     Catalog { services }
 }

--- a/crates/lab/src/catalog.rs
+++ b/crates/lab/src/catalog.rs
@@ -45,7 +45,7 @@ pub struct ActionEntry {
 /// Build a [`Catalog`] from the current tool registry.
 #[must_use]
 pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
-    let mut services = registry
+    let services = registry
         .services()
         .iter()
         .map(|svc| ServiceCatalog {
@@ -64,36 +64,6 @@ pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
                 .collect(),
         })
         .collect::<Vec<_>>();
-
-    services.push(ServiceCatalog {
-        name: "device".to_string(),
-        description: "Fleet device commands routed to the configured master".to_string(),
-        category: "bootstrap".to_string(),
-        status: "available".to_string(),
-        actions: vec![
-            ActionEntry {
-                name: "list".to_string(),
-                description: "List devices known to the master".to_string(),
-                destructive: false,
-            },
-            ActionEntry {
-                name: "get".to_string(),
-                description: "Get one device from the master".to_string(),
-                destructive: false,
-            },
-        ],
-    });
-    services.push(ServiceCatalog {
-        name: "logs".to_string(),
-        description: "Fleet log commands routed to the configured master".to_string(),
-        category: "bootstrap".to_string(),
-        status: "available".to_string(),
-        actions: vec![ActionEntry {
-            name: "search".to_string(),
-            description: "Search ingested device logs on the master".to_string(),
-            destructive: false,
-        }],
-    });
 
     Catalog { services }
 }

--- a/crates/lab/src/catalog.rs
+++ b/crates/lab/src/catalog.rs
@@ -45,7 +45,7 @@ pub struct ActionEntry {
 /// Build a [`Catalog`] from the current tool registry.
 #[must_use]
 pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
-    let services = registry
+    let mut services = registry
         .services()
         .iter()
         .map(|svc| ServiceCatalog {
@@ -63,7 +63,37 @@ pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
                 })
                 .collect(),
         })
-        .collect();
+        .collect::<Vec<_>>();
+
+    services.push(ServiceCatalog {
+        name: "device".to_string(),
+        description: "Fleet device commands routed to the configured master".to_string(),
+        category: "bootstrap".to_string(),
+        status: "available".to_string(),
+        actions: vec![
+            ActionEntry {
+                name: "list".to_string(),
+                description: "List devices known to the master".to_string(),
+                destructive: false,
+            },
+            ActionEntry {
+                name: "get".to_string(),
+                description: "Get one device from the master".to_string(),
+                destructive: false,
+            },
+        ],
+    });
+    services.push(ServiceCatalog {
+        name: "logs".to_string(),
+        description: "Fleet log commands routed to the configured master".to_string(),
+        category: "bootstrap".to_string(),
+        status: "available".to_string(),
+        actions: vec![ActionEntry {
+            name: "search".to_string(),
+            description: "Search ingested device logs on the master".to_string(),
+            destructive: false,
+        }],
+    });
 
     Catalog { services }
 }

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -6,20 +6,20 @@
 
 pub mod audit;
 pub mod completions;
-pub mod doctor;
 pub mod device;
+pub mod doctor;
 pub mod extract;
 pub mod gateway;
 pub mod health;
 pub mod help;
 pub mod helpers;
 pub mod install;
+pub mod logs;
 pub mod oauth;
 pub mod params;
 pub mod plugins;
 pub mod scaffold;
 pub mod serve;
-pub mod logs;
 
 #[cfg(feature = "apprise")]
 pub mod apprise;

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -7,6 +7,7 @@
 pub mod audit;
 pub mod completions;
 pub mod doctor;
+pub mod device;
 pub mod extract;
 pub mod gateway;
 pub mod health;
@@ -18,6 +19,7 @@ pub mod params;
 pub mod plugins;
 pub mod scaffold;
 pub mod serve;
+pub mod logs;
 
 #[cfg(feature = "apprise")]
 pub mod apprise;
@@ -99,6 +101,8 @@ pub enum Command {
     Serve(serve::ServeArgs),
     /// Audit configured services and report problems.
     Doctor,
+    /// Query fleet devices from the configured master.
+    Device(device::DeviceArgs),
     /// Quick reachability check for configured services.
     Health,
     /// Open the plugin manager TUI.
@@ -123,6 +127,8 @@ pub enum Command {
     Gateway(gateway::GatewayArgs),
     /// Run local OAuth callback relay helpers.
     Oauth(oauth::OauthArgs),
+    /// Search fleet logs on the configured master.
+    Logs(logs::LogsArgs),
     /// Radarr movie collection manager.
     #[cfg(feature = "radarr")]
     Radarr(radarr::RadarrArgs),
@@ -194,6 +200,7 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
     match cli.command {
         Command::Serve(args) => serve::run(args, &config).await,
         Command::Doctor => doctor::run(format),
+        Command::Device(args) => device::run(args, format, &config).await,
         Command::Health => health::run(format).await,
         Command::Plugins => plugins::run(),
         Command::Audit(args) => audit::run(args, format),
@@ -206,6 +213,7 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
         Command::Extract(cmd) => cmd.run().await.map(|()| ExitCode::SUCCESS),
         Command::Gateway(args) => gateway::run(args, format, &config).await,
         Command::Oauth(args) => oauth::run(args, &config).await,
+        Command::Logs(args) => logs::run(args, format, &config).await,
         #[cfg(feature = "radarr")]
         Command::Radarr(args) => radarr::run(args, format).await,
         #[cfg(feature = "sonarr")]

--- a/crates/lab/src/cli/device.rs
+++ b/crates/lab/src/cli/device.rs
@@ -15,7 +15,9 @@ pub struct DeviceArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum DeviceCommand {
+    /// List all registered devices visible from the master.
     List,
+    /// Get details for a specific device by `device_id`.
     Get { device_id: String },
 }
 
@@ -29,7 +31,9 @@ pub async fn run(args: DeviceArgs, format: OutputFormat, config: &LabConfig) -> 
 }
 
 pub async fn fetch_devices(config: &LabConfig) -> Result<serde_json::Value> {
-    MasterClient::from_config(config, None)?.fetch_devices().await
+    MasterClient::from_config(config, None)?
+        .fetch_devices()
+        .await
 }
 
 pub async fn fetch_device(config: &LabConfig, device_id: &str) -> Result<serde_json::Value> {

--- a/crates/lab/src/cli/device.rs
+++ b/crates/lab/src/cli/device.rs
@@ -29,9 +29,11 @@ pub async fn run(args: DeviceArgs, format: OutputFormat, config: &LabConfig) -> 
 }
 
 pub async fn fetch_devices(config: &LabConfig) -> Result<serde_json::Value> {
-    MasterClient::from_config(config)?.fetch_devices().await
+    MasterClient::from_config(config, None)?.fetch_devices().await
 }
 
 pub async fn fetch_device(config: &LabConfig, device_id: &str) -> Result<serde_json::Value> {
-    MasterClient::from_config(config)?.fetch_device(device_id).await
+    MasterClient::from_config(config, None)?
+        .fetch_device(device_id)
+        .await
 }

--- a/crates/lab/src/cli/device.rs
+++ b/crates/lab/src/cli/device.rs
@@ -1,0 +1,37 @@
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+use crate::config::LabConfig;
+use crate::device::master_client::MasterClient;
+use crate::output::{OutputFormat, print};
+
+#[derive(Debug, Args)]
+pub struct DeviceArgs {
+    #[command(subcommand)]
+    pub command: DeviceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DeviceCommand {
+    List,
+    Get { device_id: String },
+}
+
+pub async fn run(args: DeviceArgs, format: OutputFormat, config: &LabConfig) -> Result<ExitCode> {
+    let value = match args.command {
+        DeviceCommand::List => fetch_devices(config).await?,
+        DeviceCommand::Get { device_id } => fetch_device(config, &device_id).await?,
+    };
+    print(&value, format)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub async fn fetch_devices(config: &LabConfig) -> Result<serde_json::Value> {
+    MasterClient::from_config(config)?.fetch_devices().await
+}
+
+pub async fn fetch_device(config: &LabConfig, device_id: &str) -> Result<serde_json::Value> {
+    MasterClient::from_config(config)?.fetch_device(device_id).await
+}

--- a/crates/lab/src/cli/gateway.rs
+++ b/crates/lab/src/cli/gateway.rs
@@ -87,11 +87,13 @@ async fn build_manager(config: &LabConfig) -> Arc<GatewayManager> {
         runtime.swap(Some(pool)).await;
     }
 
-    let manager = Arc::new(GatewayManager::new(
-        config_toml_path().unwrap_or_else(|| "config.toml".into()),
-        runtime,
-    )
-    .with_service_clients(SharedServiceClients::from_env()));
+    let manager = Arc::new(
+        GatewayManager::new(
+            config_toml_path().unwrap_or_else(|| "config.toml".into()),
+            runtime,
+        )
+        .with_service_clients(SharedServiceClients::from_env()),
+    );
     manager.seed_config(config.clone()).await;
     install_gateway_manager(Arc::clone(&manager));
     manager

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -1,0 +1,37 @@
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+use crate::config::LabConfig;
+use crate::device::master_client::MasterClient;
+use crate::output::{OutputFormat, print};
+
+#[derive(Debug, Args)]
+pub struct LogsArgs {
+    #[command(subcommand)]
+    pub command: LogsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LogsCommand {
+    Search { device: String, query: String },
+}
+
+pub async fn run(args: LogsArgs, format: OutputFormat, config: &LabConfig) -> Result<ExitCode> {
+    let value = match args.command {
+        LogsCommand::Search { device, query } => search_logs(config, &device, &query).await?,
+    };
+    print(&value, format)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub async fn search_logs(
+    config: &LabConfig,
+    device_id: &str,
+    query: &str,
+) -> Result<serde_json::Value> {
+    MasterClient::from_config(config)?
+        .search_logs(device_id, query)
+        .await
+}

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -31,7 +31,7 @@ pub async fn search_logs(
     device_id: &str,
     query: &str,
 ) -> Result<serde_json::Value> {
-    MasterClient::from_config(config)?
+    MasterClient::from_config(config, None)?
         .search_logs(device_id, query)
         .await
 }

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -15,6 +15,7 @@ pub struct LogsArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum LogsCommand {
+    /// Search fleet logs for a device from the master control plane.
     Search { device: String, query: String },
 }
 

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -165,6 +165,9 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
             if let Err(error) = device_runtime.upload_initial_metadata().await {
                 tracing::warn!(error = %error, "initial device metadata upload failed");
             }
+            if let Err(error) = device_runtime.collect_and_flush_bootstrap_logs().await {
+                tracing::warn!(error = %error, "initial device log flush failed");
+            }
 
             run_http(
                 &host,

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -1,9 +1,9 @@
 //! `lab serve` — start the MCP server.
 
+use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
-use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
@@ -17,13 +17,13 @@ use tokio::sync::mpsc;
 
 use crate::api::AppState;
 use crate::config::{LabConfig, config_toml_path, resolve_auth};
+use crate::device::identity::{resolve_local_hostname, resolve_runtime_role};
+use crate::device::runtime::DeviceRuntime;
+use crate::device::store::DeviceFleetStore;
 use crate::dispatch::clients::SharedServiceClients;
 use crate::dispatch::gateway::install_gateway_manager;
 use crate::dispatch::gateway::manager::{GatewayManager, GatewayRuntimeHandle};
 use crate::dispatch::gateway::types::CatalogChangeNotifier;
-use crate::device::identity::{resolve_local_hostname, resolve_runtime_role};
-use crate::device::runtime::DeviceRuntime;
-use crate::device::store::DeviceFleetStore;
 use crate::mcp::server::{LabMcpServer, PeerNotifier};
 use crate::registry::{ToolRegistry, build_default_registry};
 
@@ -84,7 +84,10 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     let local_host = resolve_local_hostname().context("resolve local hostname")?;
     let resolved_runtime = resolve_runtime_role(
         &local_host,
-        config.device.as_ref().and_then(|prefs| prefs.master.as_deref()),
+        config
+            .device
+            .as_ref()
+            .and_then(|prefs| prefs.master.as_deref()),
     )
     .context("resolve device runtime role")?;
     let device_store = Arc::new(DeviceFleetStore::default());
@@ -159,15 +162,18 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
                 state = state.with_web_assets_dir(web_assets_dir);
             }
 
-            if let Err(error) = device_runtime.send_initial_hello().await {
-                tracing::warn!(error = %error, "initial device hello failed");
-            }
-            if let Err(error) = device_runtime.upload_initial_metadata().await {
-                tracing::warn!(error = %error, "initial device metadata upload failed");
-            }
-            if let Err(error) = device_runtime.collect_and_flush_bootstrap_logs().await {
-                tracing::warn!(error = %error, "initial device log flush failed");
-            }
+            let startup_runtime = device_runtime.clone();
+            tokio::spawn(async move {
+                if let Err(error) = startup_runtime.send_initial_hello().await {
+                    tracing::warn!(error = %error, "initial device hello failed");
+                }
+                if let Err(error) = startup_runtime.upload_initial_metadata().await {
+                    tracing::warn!(error = %error, "initial device metadata upload failed");
+                }
+                if let Err(error) = startup_runtime.collect_and_flush_bootstrap_logs().await {
+                    tracing::warn!(error = %error, "initial device log flush failed");
+                }
+            });
 
             run_http(
                 &host,
@@ -190,8 +196,7 @@ fn resolve_web_assets_dir(web: &crate::config::WebPreferences) -> Option<PathBuf
         .filter(|value| !value.trim().is_empty())
         .map(PathBuf::from);
     let from_config = web.assets_dir.clone();
-    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../apps/gateway-admin/out");
+    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../apps/gateway-admin/out");
 
     [from_env, from_config, Some(fallback)]
         .into_iter()
@@ -355,7 +360,8 @@ fn build_mcp_service(
     session_manager.session_config = session_config;
     let session_manager = Arc::new(session_manager);
 
-    let stateful = resolve_stateful_mode(std::env::var("LAB_MCP_STATEFUL").ok(), mcp_config.stateful)?;
+    let stateful =
+        resolve_stateful_mode(std::env::var("LAB_MCP_STATEFUL").ok(), mcp_config.stateful)?;
 
     let config = StreamableHttpServerConfig::default()
         .with_allowed_hosts(allowed_hosts(
@@ -456,8 +462,8 @@ fn allowed_hosts(config_allowed_hosts: &[String], resource_url: Option<&str>) ->
 #[cfg(test)]
 mod tests {
     use super::{
-        Transport, allowed_hosts, bind_addr, is_loopback_host, resolve_port, resolve_transport,
-        resolve_session_ttl_secs, resolve_stateful_mode,
+        Transport, allowed_hosts, bind_addr, is_loopback_host, resolve_port,
+        resolve_session_ttl_secs, resolve_stateful_mode, resolve_transport,
     };
     use crate::config::{LabConfig, McpPreferences};
 
@@ -535,7 +541,10 @@ mod tests {
 
     #[test]
     fn session_ttl_resolution_prefers_env_then_config_then_default() {
-        assert_eq!(resolve_session_ttl_secs(Some("120".into()), Some(90)).unwrap(), 120);
+        assert_eq!(
+            resolve_session_ttl_secs(Some("120".into()), Some(90)).unwrap(),
+            120
+        );
         assert_eq!(resolve_session_ttl_secs(None, Some(90)).unwrap(), 90);
         assert_eq!(resolve_session_ttl_secs(None, None).unwrap(), 300);
     }

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -91,7 +91,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     )
     .context("resolve device runtime role")?;
     let device_store = Arc::new(DeviceFleetStore::default());
-    let device_runtime = DeviceRuntime::from_config(resolved_runtime, config)?;
+    let device_runtime = DeviceRuntime::from_config(resolved_runtime, config, Some(port))?;
     let device_role = device_runtime.role();
 
     let gateway_runtime = GatewayRuntimeHandle::default();

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -89,6 +89,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     .context("resolve device runtime role")?;
     let device_store = Arc::new(DeviceFleetStore::default());
     let device_runtime = DeviceRuntime::for_http_master(resolved_runtime, port);
+    let device_role = device_runtime.role();
 
     let gateway_runtime = GatewayRuntimeHandle::default();
     if !config.upstream.is_empty() {
@@ -112,7 +113,13 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
 
     match transport {
         Transport::Stdio => {
-            run_stdio(Arc::new(registry), Arc::clone(&gateway_manager), notifier).await
+            run_stdio(
+                Arc::new(registry),
+                Arc::clone(&gateway_manager),
+                device_role,
+                notifier,
+            )
+            .await
         }
         Transport::Http => {
             let bearer_token = http_token();
@@ -146,6 +153,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
             state = state.with_gateway_manager(Arc::clone(&gateway_manager));
             state = state.with_auth_config(auth_config);
             state = state.with_device_store(Arc::clone(&device_store));
+            state = state.with_device_role(device_role);
             if let Some(web_assets_dir) = resolve_web_assets_dir(&config.web) {
                 tracing::info!(path = %web_assets_dir.display(), "Labby web assets enabled");
                 state = state.with_web_assets_dir(web_assets_dir);
@@ -299,6 +307,7 @@ async fn run_http(
 async fn run_stdio(
     registry: Arc<ToolRegistry>,
     gateway_manager: Arc<GatewayManager>,
+    device_role: crate::config::DeviceRole,
     notifier: PeerNotifier,
 ) -> Result<ExitCode> {
     tracing::info!(
@@ -308,6 +317,7 @@ async fn run_stdio(
     let server = LabMcpServer {
         registry,
         gateway_manager: Some(Arc::clone(&gateway_manager)),
+        device_role: Some(device_role),
         peers: Arc::clone(&notifier.peers),
     };
     let running = server.serve(rmcp::transport::stdio()).await?;
@@ -354,6 +364,7 @@ fn build_mcp_service(
     // All HTTP sessions share the same PeerNotifier (and thus the same peers
     // vec) so that gateway reload notifications reach every connected session.
     let shared_peers = Arc::clone(&notifier.peers);
+    let device_role = state.device_role;
 
     Ok(StreamableHttpService::new(
         move || {
@@ -363,6 +374,7 @@ fn build_mcp_service(
             Ok(LabMcpServer {
                 registry: reg,
                 gateway_manager: manager,
+                device_role,
                 peers,
             })
         },

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use clap::{Args, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum};
 use lab_auth::config::AuthMode;
 use rmcp::ServiceExt;
 use rmcp::transport::streamable_http_server::{
@@ -31,10 +31,23 @@ use crate::registry::{ToolRegistry, build_default_registry};
 #[derive(Debug, Clone, Copy, ValueEnum)]
 #[value(rename_all = "lowercase")]
 pub enum Transport {
-    /// stdin/stdout framing (default, used by Claude Desktop etc.).
+    /// stdin/stdout framing (available via `lab serve mcp --stdio`).
     Stdio,
-    /// HTTP transport — requires `LAB_MCP_HTTP_TOKEN` in the environment.
+    /// HTTP transport (default) — requires `LAB_MCP_HTTP_TOKEN` or OAuth when exposed remotely.
     Http,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ServeCommand {
+    /// Run the MCP server over stdio instead of the default HTTP transport.
+    Mcp(McpArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct McpArgs {
+    /// Confirm that MCP should run over stdio.
+    #[arg(long)]
+    pub stdio: bool,
 }
 
 /// `lab serve` arguments.
@@ -43,8 +56,8 @@ pub struct ServeArgs {
     /// Comma- or space-separated list of services to enable. Empty = all.
     #[arg(long, value_delimiter = ',')]
     pub services: Vec<String>,
-    /// Transport to use.
-    #[arg(long, value_enum)]
+    /// Legacy transport selector. Prefer `lab serve` for HTTP and `lab serve mcp --stdio` for stdio.
+    #[arg(long, value_enum, hide = true)]
     pub transport: Option<Transport>,
     /// Bind host for the HTTP transport.
     #[arg(long)]
@@ -52,12 +65,15 @@ pub struct ServeArgs {
     /// Bind port for the HTTP transport.
     #[arg(long)]
     pub port: Option<u16>,
+    #[command(subcommand)]
+    pub command: Option<ServeCommand>,
 }
 
 /// Run the serve subcommand.
 pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     let transport = resolve_transport(
         args.transport,
+        args.command.as_ref(),
         std::env::var("LAB_MCP_TRANSPORT").ok(),
         config.mcp.transport.as_deref(),
     )?;
@@ -206,9 +222,16 @@ fn resolve_web_assets_dir(web: &crate::config::WebPreferences) -> Option<PathBuf
 
 fn resolve_transport(
     cli: Option<Transport>,
+    command: Option<&ServeCommand>,
     env: Option<String>,
     config: Option<&str>,
 ) -> Result<Transport> {
+    if let Some(ServeCommand::Mcp(args)) = command {
+        if !args.stdio {
+            anyhow::bail!("`lab serve mcp` requires `--stdio`");
+        }
+        return Ok(Transport::Stdio);
+    }
     if let Some(transport) = cli {
         return Ok(transport);
     }
@@ -220,7 +243,7 @@ fn resolve_transport(
         return Transport::from_str(value, true)
             .map_err(|err| anyhow::anyhow!("invalid mcp.transport value `{value}`: {err}"));
     }
-    Ok(Transport::Stdio)
+    Ok(Transport::Http)
 }
 
 fn resolve_port(cli: Option<u16>, env: Option<String>, config: Option<u16>) -> Result<u16> {
@@ -462,24 +485,41 @@ fn allowed_hosts(config_allowed_hosts: &[String], resource_url: Option<&str>) ->
 #[cfg(test)]
 mod tests {
     use super::{
-        Transport, allowed_hosts, bind_addr, is_loopback_host, resolve_port,
+        McpArgs, ServeCommand, Transport, allowed_hosts, bind_addr, is_loopback_host, resolve_port,
         resolve_session_ttl_secs, resolve_stateful_mode, resolve_transport,
     };
     use crate::config::{LabConfig, McpPreferences};
 
     #[test]
-    fn transport_resolution_prefers_cli_then_env_then_config() {
-        let resolved =
-            resolve_transport(Some(Transport::Http), Some("stdio".into()), Some("stdio"))
-                .expect("cli value should win");
+    fn transport_resolution_prefers_explicit_stdio_then_cli_then_http_default() {
+        let resolved = resolve_transport(
+            Some(Transport::Http),
+            Some(&ServeCommand::Mcp(McpArgs { stdio: true })),
+            Some("http".into()),
+            Some("http"),
+        )
+        .expect("mcp stdio command should win");
+        assert!(matches!(resolved, Transport::Stdio));
+
+        let resolved = resolve_transport(
+            Some(Transport::Http),
+            None,
+            Some("stdio".into()),
+            Some("stdio"),
+        )
+        .expect("cli value should win");
         assert!(matches!(resolved, Transport::Http));
 
-        let resolved = resolve_transport(None, Some("http".into()), Some("stdio"))
+        let resolved = resolve_transport(None, None, Some("http".into()), Some("stdio"))
             .expect("env value should win");
         assert!(matches!(resolved, Transport::Http));
 
         let resolved =
-            resolve_transport(None, None, Some("http")).expect("config value should win");
+            resolve_transport(None, None, None, Some("stdio")).expect("config value should win");
+        assert!(matches!(resolved, Transport::Stdio));
+
+        let resolved =
+            resolve_transport(None, None, None, None).expect("http should be the default");
         assert!(matches!(resolved, Transport::Http));
     }
 

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -21,6 +21,9 @@ use crate::dispatch::clients::SharedServiceClients;
 use crate::dispatch::gateway::install_gateway_manager;
 use crate::dispatch::gateway::manager::{GatewayManager, GatewayRuntimeHandle};
 use crate::dispatch::gateway::types::CatalogChangeNotifier;
+use crate::device::identity::{resolve_local_hostname, resolve_runtime_role};
+use crate::device::runtime::DeviceRuntime;
+use crate::device::store::DeviceFleetStore;
 use crate::mcp::server::{LabMcpServer, PeerNotifier};
 use crate::registry::{ToolRegistry, build_default_registry};
 
@@ -78,6 +81,14 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
 
     let registry = build_default_registry();
     let registry = filter_registry(registry, &args.services)?;
+    let local_host = resolve_local_hostname().context("resolve local hostname")?;
+    let resolved_runtime = resolve_runtime_role(
+        &local_host,
+        config.device.as_ref().and_then(|prefs| prefs.master.as_deref()),
+    )
+    .context("resolve device runtime role")?;
+    let device_store = Arc::new(DeviceFleetStore::default());
+    let device_runtime = DeviceRuntime::for_http_master(resolved_runtime, port);
 
     let gateway_runtime = GatewayRuntimeHandle::default();
     if !config.upstream.is_empty() {
@@ -134,9 +145,14 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
             let mut state = AppState::from_registry(registry);
             state = state.with_gateway_manager(Arc::clone(&gateway_manager));
             state = state.with_auth_config(auth_config);
+            state = state.with_device_store(Arc::clone(&device_store));
             if let Some(web_assets_dir) = resolve_web_assets_dir(&config.web) {
                 tracing::info!(path = %web_assets_dir.display(), "Labby web assets enabled");
                 state = state.with_web_assets_dir(web_assets_dir);
+            }
+
+            if let Err(error) = device_runtime.send_initial_hello().await {
+                tracing::warn!(error = %error, "initial device hello failed");
             }
 
             run_http(

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -162,6 +162,9 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
             if let Err(error) = device_runtime.send_initial_hello().await {
                 tracing::warn!(error = %error, "initial device hello failed");
             }
+            if let Err(error) = device_runtime.upload_initial_metadata().await {
+                tracing::warn!(error = %error, "initial device metadata upload failed");
+            }
 
             run_http(
                 &host,

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -91,7 +91,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     )
     .context("resolve device runtime role")?;
     let device_store = Arc::new(DeviceFleetStore::default());
-    let device_runtime = DeviceRuntime::for_http_master(resolved_runtime, port);
+    let device_runtime = DeviceRuntime::from_config(resolved_runtime, config)?;
     let device_role = device_runtime.role();
 
     let gateway_runtime = GatewayRuntimeHandle::default();

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -47,6 +47,9 @@ pub struct LabConfig {
     /// OAuth callback relay preferences.
     #[serde(default)]
     pub oauth: OauthPreferences,
+    /// Device runtime preferences.
+    #[serde(default)]
+    pub device: Option<DevicePreferences>,
     /// Admin tool settings.
     #[serde(default)]
     pub admin: AdminPreferences,
@@ -62,6 +65,28 @@ pub struct LabConfig {
     /// Virtual MCP servers backed by canonically configured Lab services.
     #[serde(default)]
     pub virtual_servers: Vec<VirtualServerConfig>,
+}
+
+/// Device runtime preferences.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DevicePreferences {
+    #[serde(default)]
+    pub master: Option<String>,
+}
+
+/// Runtime role for the current device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeviceRole {
+    Master,
+    NonMaster,
+}
+
+/// Resolved device runtime configuration after comparing local and master hosts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedDeviceRuntime {
+    pub local_host: String,
+    pub master_host: String,
+    pub role: DeviceRole,
 }
 
 /// Configuration for a single upstream MCP server.

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -1,0 +1,1 @@
+pub mod identity;

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -4,6 +4,7 @@ pub mod identity;
 pub mod log_collect;
 pub mod log_event;
 pub mod master_client;
+pub mod oauth;
 pub mod queue;
 pub mod runtime;
 pub mod store;

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -1,1 +1,4 @@
+pub mod checkin;
+pub mod config_scan;
 pub mod identity;
+pub mod store;

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -1,6 +1,7 @@
 pub mod checkin;
 pub mod config_scan;
 pub mod identity;
+pub mod log_collect;
 pub mod log_event;
 pub mod master_client;
 pub mod queue;

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -2,5 +2,7 @@ pub mod checkin;
 pub mod config_scan;
 pub mod identity;
 pub mod log_event;
+pub mod master_client;
 pub mod queue;
+pub mod runtime;
 pub mod store;

--- a/crates/lab/src/device.rs
+++ b/crates/lab/src/device.rs
@@ -1,4 +1,6 @@
 pub mod checkin;
 pub mod config_scan;
 pub mod identity;
+pub mod log_event;
+pub mod queue;
 pub mod store;

--- a/crates/lab/src/device/checkin.rs
+++ b/crates/lab/src/device/checkin.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::device::config_scan::DiscoveredMcpConfigFile;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceHello {
     pub device_id: String,
@@ -16,4 +18,10 @@ pub struct DeviceStatus {
     pub storage_used_bytes: Option<u64>,
     pub os: Option<String>,
     pub ips: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceMetadataUpload {
+    pub device_id: String,
+    pub discovered_configs: Vec<DiscoveredMcpConfigFile>,
 }

--- a/crates/lab/src/device/checkin.rs
+++ b/crates/lab/src/device/checkin.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceHello {
+    pub device_id: String,
+    pub role: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceStatus {
+    pub device_id: String,
+    pub connected: bool,
+    pub cpu_percent: Option<f32>,
+    pub memory_used_bytes: Option<u64>,
+    pub storage_used_bytes: Option<u64>,
+    pub os: Option<String>,
+    pub ips: Vec<String>,
+}

--- a/crates/lab/src/device/config_scan.rs
+++ b/crates/lab/src/device/config_scan.rs
@@ -68,9 +68,9 @@ fn scan_codex_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpCo
         return Ok(None);
     }
 
-    let raw = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let parsed: toml::Value =
-        toml::from_slice(&raw).with_context(|| format!("parse {}", path.display()))?;
+        toml::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
     let servers = parsed
         .get("mcp_servers")
         .and_then(toml::Value::as_table)
@@ -85,7 +85,12 @@ fn scan_codex_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpCo
         })
         .unwrap_or_default();
 
-    Ok(Some(build_discovered_file(source, path, &raw, servers)?))
+    Ok(Some(build_discovered_file(
+        source,
+        path,
+        raw.as_bytes(),
+        servers,
+    )?))
 }
 
 fn build_discovered_file(

--- a/crates/lab/src/device/config_scan.rs
+++ b/crates/lab/src/device/config_scan.rs
@@ -1,0 +1,109 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredMcpConfigFile {
+    pub source: String,
+    pub path: PathBuf,
+    pub modified_unix_secs: u64,
+    pub content_hash: String,
+    pub servers: BTreeMap<String, serde_json::Value>,
+}
+
+pub fn discover_ai_cli_configs(home: &Path) -> Result<Vec<DiscoveredMcpConfigFile>> {
+    let mut discovered = Vec::new();
+
+    if let Some(file) = scan_json_config("claude", &home.join(".claude.json"))? {
+        discovered.push(file);
+    }
+
+    if let Some(file) = scan_codex_config("codex", &home.join(".codex/config.toml"))? {
+        discovered.push(file);
+    }
+
+    if let Some(file) = scan_json_config("gemini", &home.join(".gemini/settings.json"))? {
+        discovered.push(file);
+    }
+
+    Ok(discovered)
+}
+
+fn scan_json_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpConfigFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&raw).with_context(|| format!("parse {}", path.display()))?;
+    let servers = parsed
+        .get("mcpServers")
+        .and_then(serde_json::Value::as_object)
+        .map(|servers| {
+            servers
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    Ok(Some(build_discovered_file(source, path, &raw, servers)?))
+}
+
+fn scan_codex_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpConfigFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed: toml::Value =
+        toml::from_slice(&raw).with_context(|| format!("parse {}", path.display()))?;
+    let servers = parsed
+        .get("mcp_servers")
+        .and_then(toml::Value::as_table)
+        .map(|servers| {
+            servers
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.clone(),
+                        serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    Ok(Some(build_discovered_file(source, path, &raw, servers)?))
+}
+
+fn build_discovered_file(
+    source: &str,
+    path: &Path,
+    raw: &[u8],
+    servers: BTreeMap<String, serde_json::Value>,
+) -> Result<DiscoveredMcpConfigFile> {
+    let modified_unix_secs = fs::metadata(path)
+        .with_context(|| format!("metadata {}", path.display()))?
+        .modified()
+        .with_context(|| format!("modified time {}", path.display()))?
+        .duration_since(UNIX_EPOCH)
+        .with_context(|| format!("unix timestamp {}", path.display()))?
+        .as_secs();
+
+    let content_hash = format!("{:x}", Sha256::digest(raw));
+
+    Ok(DiscoveredMcpConfigFile {
+        source: source.to_string(),
+        path: path.to_path_buf(),
+        modified_unix_secs,
+        content_hash,
+        servers,
+    })
+}

--- a/crates/lab/src/device/config_scan.rs
+++ b/crates/lab/src/device/config_scan.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -8,12 +9,18 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredMcpServerSummary {
+    pub transport: Option<String>,
+    pub fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiscoveredMcpConfigFile {
     pub source: String,
     pub path: PathBuf,
     pub modified_unix_secs: u64,
     pub content_hash: String,
-    pub servers: BTreeMap<String, serde_json::Value>,
+    pub servers: BTreeMap<String, DiscoveredMcpServerSummary>,
 }
 
 pub fn discover_ai_cli_configs(home: &Path) -> Result<Vec<DiscoveredMcpConfigFile>> {
@@ -35,7 +42,7 @@ pub fn discover_ai_cli_configs(home: &Path) -> Result<Vec<DiscoveredMcpConfigFil
 }
 
 fn scan_json_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpConfigFile>> {
-    if !path.exists() {
+    if !path.is_file() {
         return Ok(None);
     }
 
@@ -48,7 +55,7 @@ fn scan_json_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpCon
         .map(|servers| {
             servers
                 .iter()
-                .map(|(name, value)| (name.clone(), value.clone()))
+                .map(|(name, value)| (name.clone(), summarize_server_value(value)))
                 .collect::<BTreeMap<_, _>>()
         })
         .unwrap_or_default();
@@ -57,7 +64,7 @@ fn scan_json_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpCon
 }
 
 fn scan_codex_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpConfigFile>> {
-    if !path.exists() {
+    if !path.is_file() {
         return Ok(None);
     }
 
@@ -71,10 +78,8 @@ fn scan_codex_config(source: &str, path: &Path) -> Result<Option<DiscoveredMcpCo
             servers
                 .iter()
                 .map(|(name, value)| {
-                    (
-                        name.clone(),
-                        serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
-                    )
+                    let json_value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+                    (name.clone(), summarize_server_value(&json_value))
                 })
                 .collect::<BTreeMap<_, _>>()
         })
@@ -87,7 +92,7 @@ fn build_discovered_file(
     source: &str,
     path: &Path,
     raw: &[u8],
-    servers: BTreeMap<String, serde_json::Value>,
+    servers: BTreeMap<String, DiscoveredMcpServerSummary>,
 ) -> Result<DiscoveredMcpConfigFile> {
     let modified_unix_secs = fs::metadata(path)
         .with_context(|| format!("metadata {}", path.display()))?
@@ -101,9 +106,42 @@ fn build_discovered_file(
 
     Ok(DiscoveredMcpConfigFile {
         source: source.to_string(),
-        path: path.to_path_buf(),
+        path: redacted_path(path),
         modified_unix_secs,
         content_hash,
         servers,
     })
+}
+
+fn redacted_path(path: &Path) -> PathBuf {
+    let basename = path
+        .file_name()
+        .map(OsString::from)
+        .unwrap_or_else(|| OsString::from("config"));
+    PathBuf::from(basename)
+}
+
+fn summarize_server_value(value: &serde_json::Value) -> DiscoveredMcpServerSummary {
+    let transport = infer_transport(value);
+    let fingerprint = serde_json::to_vec(value)
+        .map(|bytes| format!("{:x}", Sha256::digest(bytes)))
+        .unwrap_or_else(|_| format!("{:x}", Sha256::digest(b"invalid")));
+    DiscoveredMcpServerSummary {
+        transport,
+        fingerprint,
+    }
+}
+
+fn infer_transport(value: &serde_json::Value) -> Option<String> {
+    let object = value.as_object()?;
+    if let Some(transport) = object.get("transport").and_then(serde_json::Value::as_str) {
+        return Some(transport.to_string());
+    }
+    if object.contains_key("url") {
+        return Some("http".to_string());
+    }
+    if object.contains_key("command") {
+        return Some("stdio".to_string());
+    }
+    None
 }

--- a/crates/lab/src/device/identity.rs
+++ b/crates/lab/src/device/identity.rs
@@ -27,7 +27,8 @@ pub fn resolve_runtime_role(
     local_host: &str,
     configured_master: Option<&str>,
 ) -> Result<ResolvedDeviceRuntime> {
-    let local_host = normalize_host_identifier(local_host).unwrap_or_else(|| "localhost".to_string());
+    let local_host =
+        normalize_host_identifier(local_host).unwrap_or_else(|| "localhost".to_string());
     let master_host = configured_master
         .and_then(normalize_host_identifier)
         .unwrap_or_else(|| local_host.clone());
@@ -62,14 +63,13 @@ fn hosts_refer_to_same_device(local_host: &str, master_host: &str) -> bool {
         return true;
     }
 
-    let local_is_ip = local_host.parse::<IpAddr>().is_ok();
-    let master_is_ip = master_host.parse::<IpAddr>().is_ok();
-    if local_is_ip || master_is_ip {
-        return false;
+    match (local_host.parse::<IpAddr>(), master_host.parse::<IpAddr>()) {
+        (Ok(local_ip), Ok(master_ip)) => return local_ip == master_ip,
+        (Ok(_), Err(_)) | (Err(_), Ok(_)) => return false,
+        (Err(_), Err(_)) => {}
     }
 
     let local_short = short_host_identifier(local_host);
     let master_short = short_host_identifier(master_host);
-    local_short == master_short
-        && (local_host == local_short || master_host == master_short)
+    local_short == master_short && (local_host == local_short || master_host == master_short)
 }

--- a/crates/lab/src/device/identity.rs
+++ b/crates/lab/src/device/identity.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::net::IpAddr;
 
 use anyhow::Result;
 
@@ -30,9 +31,7 @@ pub fn resolve_runtime_role(
     let master_host = configured_master
         .and_then(normalize_host_identifier)
         .unwrap_or_else(|| local_host.clone());
-    let local_short = short_host_identifier(&local_host);
-    let master_short = short_host_identifier(&master_host);
-    let role = if master_host == local_host || master_short == local_short {
+    let role = if hosts_refer_to_same_device(&local_host, &master_host) {
         DeviceRole::Master
     } else {
         DeviceRole::NonMaster
@@ -56,4 +55,21 @@ fn normalize_host_identifier(value: &str) -> Option<String> {
 
 fn short_host_identifier(value: &str) -> &str {
     value.split('.').next().unwrap_or(value)
+}
+
+fn hosts_refer_to_same_device(local_host: &str, master_host: &str) -> bool {
+    if local_host == master_host {
+        return true;
+    }
+
+    let local_is_ip = local_host.parse::<IpAddr>().is_ok();
+    let master_is_ip = master_host.parse::<IpAddr>().is_ok();
+    if local_is_ip || master_is_ip {
+        return false;
+    }
+
+    let local_short = short_host_identifier(local_host);
+    let master_short = short_host_identifier(master_host);
+    local_short == master_short
+        && (local_host == local_short || master_host == master_short)
 }

--- a/crates/lab/src/device/identity.rs
+++ b/crates/lab/src/device/identity.rs
@@ -5,17 +5,17 @@ use anyhow::Result;
 use crate::config::{DeviceRole, ResolvedDeviceRuntime};
 
 pub fn resolve_local_hostname() -> Result<String> {
-    if let Ok(value) = std::env::var("HOSTNAME") {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.to_string());
-        }
+    if let Some(value) = std::env::var("HOSTNAME")
+        .ok()
+        .or_else(|| std::env::var("COMPUTERNAME").ok())
+        .and_then(|value| normalize_host_identifier(&value))
+    {
+        return Ok(value);
     }
 
     if let Ok(value) = fs::read_to_string("/etc/hostname") {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.to_string());
+        if let Some(normalized) = normalize_host_identifier(&value) {
+            return Ok(normalized);
         }
     }
 
@@ -26,16 +26,34 @@ pub fn resolve_runtime_role(
     local_host: &str,
     configured_master: Option<&str>,
 ) -> Result<ResolvedDeviceRuntime> {
-    let master_host = configured_master.unwrap_or(local_host).to_string();
-    let role = if master_host == local_host {
+    let local_host = normalize_host_identifier(local_host).unwrap_or_else(|| "localhost".to_string());
+    let master_host = configured_master
+        .and_then(normalize_host_identifier)
+        .unwrap_or_else(|| local_host.clone());
+    let local_short = short_host_identifier(&local_host);
+    let master_short = short_host_identifier(&master_host);
+    let role = if master_host == local_host || master_short == local_short {
         DeviceRole::Master
     } else {
         DeviceRole::NonMaster
     };
 
     Ok(ResolvedDeviceRuntime {
-        local_host: local_host.to_string(),
+        local_host,
         master_host,
         role,
     })
+}
+
+fn normalize_host_identifier(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_end_matches('.');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_ascii_lowercase())
+    }
+}
+
+fn short_host_identifier(value: &str) -> &str {
+    value.split('.').next().unwrap_or(value)
 }

--- a/crates/lab/src/device/identity.rs
+++ b/crates/lab/src/device/identity.rs
@@ -1,6 +1,26 @@
+use std::fs;
+
 use anyhow::Result;
 
 use crate::config::{DeviceRole, ResolvedDeviceRuntime};
+
+pub fn resolve_local_hostname() -> Result<String> {
+    if let Ok(value) = std::env::var("HOSTNAME") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if let Ok(value) = fs::read_to_string("/etc/hostname") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    Ok("localhost".to_string())
+}
 
 pub fn resolve_runtime_role(
     local_host: &str,

--- a/crates/lab/src/device/identity.rs
+++ b/crates/lab/src/device/identity.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+
+use crate::config::{DeviceRole, ResolvedDeviceRuntime};
+
+pub fn resolve_runtime_role(
+    local_host: &str,
+    configured_master: Option<&str>,
+) -> Result<ResolvedDeviceRuntime> {
+    let master_host = configured_master.unwrap_or(local_host).to_string();
+    let role = if master_host == local_host {
+        DeviceRole::Master
+    } else {
+        DeviceRole::NonMaster
+    };
+
+    Ok(ResolvedDeviceRuntime {
+        local_host: local_host.to_string(),
+        master_host,
+        role,
+    })
+}

--- a/crates/lab/src/device/log_collect.rs
+++ b/crates/lab/src/device/log_collect.rs
@@ -1,0 +1,7 @@
+use anyhow::Result;
+
+use crate::device::log_event::DeviceLogEvent;
+
+pub fn collect_bootstrap_logs(_device_id: &str) -> Result<Vec<DeviceLogEvent>> {
+    Ok(Vec::new())
+}

--- a/crates/lab/src/device/log_collect.rs
+++ b/crates/lab/src/device/log_collect.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -20,19 +21,18 @@ pub fn collect_bootstrap_logs(device_id: &str) -> Result<Vec<DeviceLogEvent>> {
             continue;
         }
 
-        let raw = match fs::read(path) {
+        let raw = match read_tail(path, BOOTSTRAP_LOG_BYTE_LIMIT as usize) {
             Ok(raw) => raw,
             Err(error) => {
                 tracing::debug!(path = %path.display(), error = %error, "skipping unreadable bootstrap log candidate");
                 continue;
             }
         };
-        let slice = tail_bytes(&raw, BOOTSTRAP_LOG_BYTE_LIMIT as usize);
         let timestamp_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as i64;
-        let events = String::from_utf8_lossy(slice)
+        let events = String::from_utf8_lossy(&raw)
             .lines()
             .filter(|line| !line.trim().is_empty())
             .rev()
@@ -58,10 +58,12 @@ pub fn collect_bootstrap_logs(device_id: &str) -> Result<Vec<DeviceLogEvent>> {
     bail!("no readable bootstrap log source found under /var/log/syslog or /var/log/messages")
 }
 
-fn tail_bytes(bytes: &[u8], max_len: usize) -> &[u8] {
-    if bytes.len() <= max_len {
-        bytes
-    } else {
-        &bytes[bytes.len() - max_len..]
-    }
+fn read_tail(path: &Path, max_len: usize) -> std::io::Result<Vec<u8>> {
+    let mut file = fs::File::open(path)?;
+    let len = file.metadata()?.len() as usize;
+    let start = len.saturating_sub(max_len) as u64;
+    file.seek(SeekFrom::Start(start))?;
+    let mut buf = Vec::with_capacity(len.saturating_sub(start as usize));
+    file.read_to_end(&mut buf)?;
+    Ok(buf)
 }

--- a/crates/lab/src/device/log_collect.rs
+++ b/crates/lab/src/device/log_collect.rs
@@ -20,7 +20,13 @@ pub fn collect_bootstrap_logs(device_id: &str) -> Result<Vec<DeviceLogEvent>> {
             continue;
         }
 
-        let raw = fs::read(path)?;
+        let raw = match fs::read(path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::debug!(path = %path.display(), error = %error, "skipping unreadable bootstrap log candidate");
+                continue;
+            }
+        };
         let slice = tail_bytes(&raw, BOOTSTRAP_LOG_BYTE_LIMIT as usize);
         let timestamp_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/lab/src/device/log_collect.rs
+++ b/crates/lab/src/device/log_collect.rs
@@ -1,7 +1,61 @@
-use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Result, bail};
 
 use crate::device::log_event::DeviceLogEvent;
 
-pub fn collect_bootstrap_logs(_device_id: &str) -> Result<Vec<DeviceLogEvent>> {
-    Ok(Vec::new())
+const BOOTSTRAP_LOG_LINE_LIMIT: usize = 128;
+const BOOTSTRAP_LOG_BYTE_LIMIT: u64 = 256 * 1024;
+const CANDIDATE_LOG_PATHS: &[&str] = &["/var/log/syslog", "/var/log/messages"];
+
+pub fn collect_bootstrap_logs(device_id: &str) -> Result<Vec<DeviceLogEvent>> {
+    for candidate in CANDIDATE_LOG_PATHS {
+        let path = Path::new(candidate);
+        let Ok(metadata) = fs::metadata(path) else {
+            continue;
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let raw = fs::read(path)?;
+        let slice = tail_bytes(&raw, BOOTSTRAP_LOG_BYTE_LIMIT as usize);
+        let timestamp_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let events = String::from_utf8_lossy(slice)
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .rev()
+            .take(BOOTSTRAP_LOG_LINE_LIMIT)
+            .map(|line| DeviceLogEvent {
+                device_id: device_id.to_string(),
+                source: path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("syslog")
+                    .to_string(),
+                timestamp_unix_ms,
+                level: None,
+                message: line.to_string(),
+                fields: Default::default(),
+            })
+            .collect::<Vec<_>>();
+        if !events.is_empty() {
+            return Ok(events.into_iter().rev().collect());
+        }
+    }
+
+    bail!("no readable bootstrap log source found under /var/log/syslog or /var/log/messages")
+}
+
+fn tail_bytes(bytes: &[u8], max_len: usize) -> &[u8] {
+    if bytes.len() <= max_len {
+        bytes
+    } else {
+        &bytes[bytes.len() - max_len..]
+    }
 }

--- a/crates/lab/src/device/log_event.rs
+++ b/crates/lab/src/device/log_event.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeviceLogEvent {
     pub device_id: String,
     pub source: String,

--- a/crates/lab/src/device/log_event.rs
+++ b/crates/lab/src/device/log_event.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceLogEvent {
+    pub device_id: String,
+    pub source: String,
+    pub timestamp_unix_ms: i64,
+    pub level: Option<String>,
+    pub message: String,
+    pub fields: serde_json::Map<String, serde_json::Value>,
+}

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use crate::device::checkin::{DeviceHello, DeviceStatus};
+use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 
 #[derive(Debug, Clone)]
 pub struct MasterClient {
@@ -25,7 +25,7 @@ impl MasterClient {
         self.post_json("/v1/device/status", payload).await
     }
 
-    pub async fn post_metadata(&self, payload: &serde_json::Value) -> Result<()> {
+    pub async fn post_metadata(&self, payload: &DeviceMetadataUpload) -> Result<()> {
         self.post_json("/v1/device/metadata", payload).await
     }
 

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -8,14 +8,22 @@ use crate::device::identity::resolve_local_hostname;
 pub struct MasterClient {
     http: reqwest::Client,
     base_url: String,
+    bearer_token: Option<String>,
 }
 
 impl MasterClient {
     #[must_use]
+    #[allow(dead_code)]
     pub fn new(base_url: impl Into<String>) -> Self {
+        Self::with_bearer_token(base_url, None)
+    }
+
+    #[must_use]
+    pub fn with_bearer_token(base_url: impl Into<String>, bearer_token: Option<String>) -> Self {
         Self {
             http: reqwest::Client::new(),
             base_url: base_url.into(),
+            bearer_token,
         }
     }
 
@@ -40,7 +48,8 @@ impl MasterClient {
     }
 
     pub async fn fetch_device(&self, device_id: &str) -> Result<serde_json::Value> {
-        self.get_json(&format!("/v1/device/devices/{device_id}")).await
+        self.get_json(&format!("/v1/device/devices/{device_id}"))
+            .await
     }
 
     pub async fn search_logs(&self, device_id: &str, query: &str) -> Result<serde_json::Value> {
@@ -55,18 +64,24 @@ impl MasterClient {
     }
 
     pub fn from_config(config: &LabConfig) -> Result<Self> {
-        let host = match config.device.as_ref().and_then(|prefs| prefs.master.as_deref()) {
+        let host = match config
+            .device
+            .as_ref()
+            .and_then(|prefs| prefs.master.as_deref())
+        {
             Some(host) => host.to_string(),
             None => resolve_local_hostname()?,
         };
         let port = config.mcp.port.unwrap_or(8765);
-        Ok(Self::new(format!("http://{host}:{port}")))
+        Ok(Self::with_bearer_token(
+            format!("http://{host}:{port}"),
+            master_bearer_token(),
+        ))
     }
 
     async fn post_json<T: serde::Serialize + ?Sized>(&self, path: &str, payload: &T) -> Result<()> {
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
-        self.http
-            .post(&url)
+        self.request(self.http.post(&url))
             .json(payload)
             .send()
             .await
@@ -79,8 +94,7 @@ impl MasterClient {
     async fn get_json(&self, path: &str) -> Result<serde_json::Value> {
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
         let response = self
-            .http
-            .get(&url)
+            .request(self.http.get(&url))
             .send()
             .await
             .with_context(|| format!("GET {url}"))?
@@ -99,8 +113,7 @@ impl MasterClient {
     ) -> Result<serde_json::Value> {
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
         let response = self
-            .http
-            .post(&url)
+            .request(self.http.post(&url))
             .json(payload)
             .send()
             .await
@@ -112,4 +125,17 @@ impl MasterClient {
             .await
             .with_context(|| format!("decode {url}"))
     }
+
+    fn request(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self.bearer_token.as_deref() {
+            Some(token) => builder.bearer_auth(token),
+            None => builder,
+        }
+    }
+}
+
+fn master_bearer_token() -> Option<String> {
+    std::env::var("LAB_MCP_HTTP_TOKEN")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
 }

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -1,4 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
+use lab_apis::core::Auth;
+use lab_apis::device_runtime::client::DeviceRuntimeClient;
 
 use crate::config::LabConfig;
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
@@ -8,9 +10,7 @@ const DEFAULT_MASTER_CLIENT_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Debug, Clone)]
 pub struct MasterClient {
-    http: reqwest::Client,
-    base_url: String,
-    bearer_token: Option<String>,
+    inner: DeviceRuntimeClient,
 }
 
 impl MasterClient {
@@ -22,52 +22,44 @@ impl MasterClient {
 
     #[must_use]
     pub fn with_bearer_token(base_url: impl Into<String>, bearer_token: Option<String>) -> Self {
-        Self {
-            http: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(
-                    DEFAULT_MASTER_CLIENT_TIMEOUT_SECS,
-                ))
-                .build()
-                .expect("master client builder should be valid"),
-            base_url: base_url.into(),
-            bearer_token,
-        }
+        let auth = bearer_token.map_or(Auth::None, |token| Auth::Bearer { token });
+        let inner = DeviceRuntimeClient::new(
+            base_url,
+            auth,
+            Some(std::time::Duration::from_secs(
+                DEFAULT_MASTER_CLIENT_TIMEOUT_SECS,
+            )),
+        )
+        .expect("device runtime client builder should be valid");
+        Self { inner }
     }
 
     pub async fn post_hello(&self, payload: &DeviceHello) -> Result<()> {
-        self.post_json("/v1/device/hello", payload).await
+        self.inner.post_hello(payload).await.map_err(Into::into)
     }
 
     pub async fn post_status(&self, payload: &DeviceStatus) -> Result<()> {
-        self.post_json("/v1/device/status", payload).await
+        self.inner.post_status(payload).await.map_err(Into::into)
     }
 
     pub async fn post_metadata(&self, payload: &DeviceMetadataUpload) -> Result<()> {
-        self.post_json("/v1/device/metadata", payload).await
+        self.inner.post_metadata(payload).await.map_err(Into::into)
     }
 
     pub async fn post_syslog_batch(&self, payload: &serde_json::Value) -> Result<()> {
-        self.post_json("/v1/device/syslog/batch", payload).await
+        self.inner.post_syslog_batch(payload).await.map_err(Into::into)
     }
 
     pub async fn fetch_devices(&self) -> Result<serde_json::Value> {
-        self.get_json("/v1/device/devices").await
+        self.inner.fetch_devices().await.map_err(Into::into)
     }
 
     pub async fn fetch_device(&self, device_id: &str) -> Result<serde_json::Value> {
-        self.get_json(&format!("/v1/device/devices/{device_id}"))
-            .await
+        self.inner.fetch_device(device_id).await.map_err(Into::into)
     }
 
     pub async fn search_logs(&self, device_id: &str, query: &str) -> Result<serde_json::Value> {
-        self.post_json_value(
-            "/v1/device/logs/search",
-            &serde_json::json!({
-                "device_id": device_id,
-                "query": query,
-            }),
-        )
-        .await
+        self.inner.search_logs(device_id, query).await.map_err(Into::into)
     }
 
     pub fn from_config(config: &LabConfig) -> Result<Self> {
@@ -84,60 +76,6 @@ impl MasterClient {
             format!("http://{host}:{port}"),
             master_bearer_token(),
         ))
-    }
-
-    async fn post_json<T: serde::Serialize + ?Sized>(&self, path: &str, payload: &T) -> Result<()> {
-        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
-        self.request(self.http.post(&url))
-            .json(payload)
-            .send()
-            .await
-            .with_context(|| format!("POST {url}"))?
-            .error_for_status()
-            .with_context(|| format!("POST {url} failed"))?;
-        Ok(())
-    }
-
-    async fn get_json(&self, path: &str) -> Result<serde_json::Value> {
-        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
-        let response = self
-            .request(self.http.get(&url))
-            .send()
-            .await
-            .with_context(|| format!("GET {url}"))?
-            .error_for_status()
-            .with_context(|| format!("GET {url} failed"))?;
-        response
-            .json()
-            .await
-            .with_context(|| format!("decode {url}"))
-    }
-
-    async fn post_json_value<T: serde::Serialize + ?Sized>(
-        &self,
-        path: &str,
-        payload: &T,
-    ) -> Result<serde_json::Value> {
-        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
-        let response = self
-            .request(self.http.post(&url))
-            .json(payload)
-            .send()
-            .await
-            .with_context(|| format!("POST {url}"))?
-            .error_for_status()
-            .with_context(|| format!("POST {url} failed"))?;
-        response
-            .json()
-            .await
-            .with_context(|| format!("decode {url}"))
-    }
-
-    fn request(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match self.bearer_token.as_deref() {
-            Some(token) => builder.bearer_auth(token),
-            None => builder,
-        }
     }
 }
 

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -62,7 +62,7 @@ impl MasterClient {
         self.inner.search_logs(device_id, query).await.map_err(Into::into)
     }
 
-    pub fn from_config(config: &LabConfig) -> Result<Self> {
+    pub fn from_config(config: &LabConfig, port_override: Option<u16>) -> Result<Self> {
         let host = match config
             .device
             .as_ref()
@@ -71,7 +71,9 @@ impl MasterClient {
             Some(host) => host.to_string(),
             None => resolve_local_hostname()?,
         };
-        let port = config.mcp.port.unwrap_or(8765);
+        let port = port_override
+            .or(config.mcp.port)
+            .unwrap_or(8765);
         Ok(Self::with_bearer_token(
             format!("http://{host}:{port}"),
             master_bearer_token(),

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -4,6 +4,8 @@ use crate::config::LabConfig;
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 use crate::device::identity::resolve_local_hostname;
 
+const DEFAULT_MASTER_CLIENT_TIMEOUT_SECS: u64 = 5;
+
 #[derive(Debug, Clone)]
 pub struct MasterClient {
     http: reqwest::Client,
@@ -21,7 +23,12 @@ impl MasterClient {
     #[must_use]
     pub fn with_bearer_token(base_url: impl Into<String>, bearer_token: Option<String>) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(
+                    DEFAULT_MASTER_CLIENT_TIMEOUT_SECS,
+                ))
+                .build()
+                .expect("master client builder should be valid"),
             base_url: base_url.into(),
             bearer_token,
         }

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -1,0 +1,48 @@
+use anyhow::{Context, Result};
+
+use crate::device::checkin::{DeviceHello, DeviceStatus};
+
+#[derive(Debug, Clone)]
+pub struct MasterClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl MasterClient {
+    #[must_use]
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: base_url.into(),
+        }
+    }
+
+    pub async fn post_hello(&self, payload: &DeviceHello) -> Result<()> {
+        self.post_json("/v1/device/hello", payload).await
+    }
+
+    pub async fn post_status(&self, payload: &DeviceStatus) -> Result<()> {
+        self.post_json("/v1/device/status", payload).await
+    }
+
+    pub async fn post_metadata(&self, payload: &serde_json::Value) -> Result<()> {
+        self.post_json("/v1/device/metadata", payload).await
+    }
+
+    pub async fn post_syslog_batch(&self, payload: &serde_json::Value) -> Result<()> {
+        self.post_json("/v1/device/syslog/batch", payload).await
+    }
+
+    async fn post_json<T: serde::Serialize + ?Sized>(&self, path: &str, payload: &T) -> Result<()> {
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
+        self.http
+            .post(&url)
+            .json(payload)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?
+            .error_for_status()
+            .with_context(|| format!("POST {url} failed"))?;
+        Ok(())
+    }
+}

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 
+use crate::config::LabConfig;
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
+use crate::device::identity::resolve_local_hostname;
 
 #[derive(Debug, Clone)]
 pub struct MasterClient {
@@ -33,6 +35,34 @@ impl MasterClient {
         self.post_json("/v1/device/syslog/batch", payload).await
     }
 
+    pub async fn fetch_devices(&self) -> Result<serde_json::Value> {
+        self.get_json("/v1/device/devices").await
+    }
+
+    pub async fn fetch_device(&self, device_id: &str) -> Result<serde_json::Value> {
+        self.get_json(&format!("/v1/device/devices/{device_id}")).await
+    }
+
+    pub async fn search_logs(&self, device_id: &str, query: &str) -> Result<serde_json::Value> {
+        self.post_json_value(
+            "/v1/device/logs/search",
+            &serde_json::json!({
+                "device_id": device_id,
+                "query": query,
+            }),
+        )
+        .await
+    }
+
+    pub fn from_config(config: &LabConfig) -> Result<Self> {
+        let host = match config.device.as_ref().and_then(|prefs| prefs.master.as_deref()) {
+            Some(host) => host.to_string(),
+            None => resolve_local_hostname()?,
+        };
+        let port = config.mcp.port.unwrap_or(8765);
+        Ok(Self::new(format!("http://{host}:{port}")))
+    }
+
     async fn post_json<T: serde::Serialize + ?Sized>(&self, path: &str, payload: &T) -> Result<()> {
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
         self.http
@@ -44,5 +74,42 @@ impl MasterClient {
             .error_for_status()
             .with_context(|| format!("POST {url} failed"))?;
         Ok(())
+    }
+
+    async fn get_json(&self, path: &str) -> Result<serde_json::Value> {
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?
+            .error_for_status()
+            .with_context(|| format!("GET {url} failed"))?;
+        response
+            .json()
+            .await
+            .with_context(|| format!("decode {url}"))
+    }
+
+    async fn post_json_value<T: serde::Serialize + ?Sized>(
+        &self,
+        path: &str,
+        payload: &T,
+    ) -> Result<serde_json::Value> {
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
+        let response = self
+            .http
+            .post(&url)
+            .json(payload)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?
+            .error_for_status()
+            .with_context(|| format!("POST {url} failed"))?;
+        response
+            .json()
+            .await
+            .with_context(|| format!("decode {url}"))
     }
 }

--- a/crates/lab/src/device/master_client.rs
+++ b/crates/lab/src/device/master_client.rs
@@ -6,32 +6,24 @@ use crate::config::LabConfig;
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 use crate::device::identity::resolve_local_hostname;
 
-const DEFAULT_MASTER_CLIENT_TIMEOUT_SECS: u64 = 5;
-
 #[derive(Debug, Clone)]
 pub struct MasterClient {
     inner: DeviceRuntimeClient,
 }
 
 impl MasterClient {
-    #[must_use]
     #[allow(dead_code)]
-    pub fn new(base_url: impl Into<String>) -> Self {
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
         Self::with_bearer_token(base_url, None)
     }
 
-    #[must_use]
-    pub fn with_bearer_token(base_url: impl Into<String>, bearer_token: Option<String>) -> Self {
+    pub fn with_bearer_token(
+        base_url: impl Into<String>,
+        bearer_token: Option<String>,
+    ) -> Result<Self> {
         let auth = bearer_token.map_or(Auth::None, |token| Auth::Bearer { token });
-        let inner = DeviceRuntimeClient::new(
-            base_url,
-            auth,
-            Some(std::time::Duration::from_secs(
-                DEFAULT_MASTER_CLIENT_TIMEOUT_SECS,
-            )),
-        )
-        .expect("device runtime client builder should be valid");
-        Self { inner }
+        let inner = DeviceRuntimeClient::new(base_url, auth)?;
+        Ok(Self { inner })
     }
 
     pub async fn post_hello(&self, payload: &DeviceHello) -> Result<()> {
@@ -47,7 +39,10 @@ impl MasterClient {
     }
 
     pub async fn post_syslog_batch(&self, payload: &serde_json::Value) -> Result<()> {
-        self.inner.post_syslog_batch(payload).await.map_err(Into::into)
+        self.inner
+            .post_syslog_batch(payload)
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn fetch_devices(&self) -> Result<serde_json::Value> {
@@ -59,7 +54,10 @@ impl MasterClient {
     }
 
     pub async fn search_logs(&self, device_id: &str, query: &str) -> Result<serde_json::Value> {
-        self.inner.search_logs(device_id, query).await.map_err(Into::into)
+        self.inner
+            .search_logs(device_id, query)
+            .await
+            .map_err(Into::into)
     }
 
     pub fn from_config(config: &LabConfig, port_override: Option<u16>) -> Result<Self> {
@@ -71,13 +69,8 @@ impl MasterClient {
             Some(host) => host.to_string(),
             None => resolve_local_hostname()?,
         };
-        let port = port_override
-            .or(config.mcp.port)
-            .unwrap_or(8765);
-        Ok(Self::with_bearer_token(
-            format!("http://{host}:{port}"),
-            master_bearer_token(),
-        ))
+        let port = port_override.or(config.mcp.port).unwrap_or(8765);
+        Self::with_bearer_token(format!("http://{host}:{port}"), master_bearer_token())
     }
 }
 

--- a/crates/lab/src/device/oauth.rs
+++ b/crates/lab/src/device/oauth.rs
@@ -1,0 +1,20 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::oauth::local_relay::LocalRelayConfig;
+
+pub async fn start_local_oauth_relay(
+    bind_addr: SocketAddr,
+    resolved_target: crate::oauth::target::ResolvedTarget,
+    request_timeout: Duration,
+) -> Result<()> {
+    crate::oauth::local_relay::run_local_relay(LocalRelayConfig {
+        bind_addr,
+        resolved_target,
+        request_timeout,
+    })
+    .await
+    .map_err(anyhow::Error::from)
+}

--- a/crates/lab/src/device/oauth.rs
+++ b/crates/lab/src/device/oauth.rs
@@ -3,18 +3,24 @@ use std::time::Duration;
 
 use anyhow::Result;
 
-use crate::oauth::local_relay::LocalRelayConfig;
+use crate::oauth::local_relay::{LocalRelayConfig, bind_local_relay_listener, serve_local_relay};
 
 pub async fn start_local_oauth_relay(
     bind_addr: SocketAddr,
     resolved_target: crate::oauth::target::ResolvedTarget,
     request_timeout: Duration,
 ) -> Result<()> {
-    crate::oauth::local_relay::run_local_relay(LocalRelayConfig {
+    let listener = bind_local_relay_listener(bind_addr).await?;
+    let config = LocalRelayConfig {
         bind_addr,
         resolved_target,
         request_timeout,
-    })
-    .await
-    .map_err(anyhow::Error::from)
+    };
+    let config_for_task = config.clone();
+    tokio::spawn(async move {
+        if let Err(error) = serve_local_relay(listener, config_for_task).await {
+            tracing::warn!(error = %error, "device oauth relay exited");
+        }
+    });
+    Ok(())
 }

--- a/crates/lab/src/device/oauth.rs
+++ b/crates/lab/src/device/oauth.rs
@@ -9,10 +9,11 @@ pub async fn start_local_oauth_relay(
     bind_addr: SocketAddr,
     resolved_target: crate::oauth::target::ResolvedTarget,
     request_timeout: Duration,
-) -> Result<()> {
+) -> Result<SocketAddr> {
     let listener = bind_local_relay_listener(bind_addr).await?;
+    let bound_addr = listener.local_addr()?;
     let config = LocalRelayConfig {
-        bind_addr,
+        bind_addr: bound_addr,
         resolved_target,
         request_timeout,
     };
@@ -22,5 +23,5 @@ pub async fn start_local_oauth_relay(
             tracing::warn!(error = %error, "device oauth relay exited");
         }
     });
-    Ok(())
+    Ok(bound_addr)
 }

--- a/crates/lab/src/device/queue.rs
+++ b/crates/lab/src/device/queue.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -142,7 +143,38 @@ async fn rewrite_entries(path: &Path, entries: &[QueuedEnvelope]) -> Result<()> 
         serialized
     };
 
-    fs::write(path, content)
-        .await
-        .with_context(|| format!("rewrite {}", path.display()))
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("queue");
+    let tmp_path = path.with_file_name(format!("{file_name}.{suffix}.tmp"));
+
+    use tokio::io::AsyncWriteExt as _;
+
+    let write_result = async {
+        let mut file = fs::File::create(&tmp_path)
+            .await
+            .with_context(|| format!("write temp {}", tmp_path.display()))?;
+        file.write_all(content.as_bytes())
+            .await
+            .with_context(|| format!("write temp {}", tmp_path.display()))?;
+        file.sync_all()
+            .await
+            .with_context(|| format!("sync temp {}", tmp_path.display()))?;
+        drop(file);
+        fs::rename(&tmp_path, path)
+            .await
+            .with_context(|| format!("rewrite {}", path.display()))
+    }
+    .await;
+
+    if write_result.is_err() {
+        drop(fs::remove_file(&tmp_path).await);
+    }
+
+    write_result
 }

--- a/crates/lab/src/device/queue.rs
+++ b/crates/lab/src/device/queue.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -34,35 +35,54 @@ impl QueuedEnvelope {
 #[derive(Debug, Clone)]
 pub struct DeviceOutboundQueue {
     path: PathBuf,
-    entries: Arc<Mutex<Vec<QueuedEnvelope>>>,
+    io_lock: Arc<Mutex<()>>,
 }
 
 impl DeviceOutboundQueue {
     pub async fn open(path: PathBuf) -> Result<Self> {
-        let entries = read_entries(&path).await?;
-        Ok(Self {
-            path,
-            entries: Arc::new(Mutex::new(entries)),
-        })
+        let io_lock = shared_queue_lock(&path);
+        {
+            let _guard = io_lock.lock().await;
+            read_entries(&path).await?;
+        }
+        Ok(Self { path, io_lock })
     }
 
     pub async fn push(&self, envelope: QueuedEnvelope) -> Result<()> {
-        let mut entries = self.entries.lock().await;
-        entries.push(envelope.clone());
+        let _guard = self.io_lock.lock().await;
         append_entry(&self.path, &envelope).await
     }
 
     pub async fn drain_batch(&self, limit: usize) -> Result<Vec<QueuedEnvelope>> {
-        let entries = self.entries.lock().await;
-        Ok(entries.iter().take(limit).cloned().collect())
+        let _guard = self.io_lock.lock().await;
+        Ok(read_entries(&self.path)
+            .await?
+            .into_iter()
+            .take(limit)
+            .collect())
     }
 
     pub async fn ack_drained(&self, count: usize) -> Result<()> {
-        let mut entries = self.entries.lock().await;
+        let _guard = self.io_lock.lock().await;
+        let mut entries = read_entries(&self.path).await?;
         let drained = count.min(entries.len());
         entries.drain(..drained);
         rewrite_entries(&self.path, &entries).await
     }
+}
+
+fn shared_queue_lock(path: &Path) -> Arc<Mutex<()>> {
+    static QUEUE_LOCKS: OnceLock<StdMutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+
+    let locks = QUEUE_LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let mut locks = locks
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Arc::clone(
+        locks
+            .entry(path.to_path_buf())
+            .or_insert_with(|| Arc::new(Mutex::new(()))),
+    )
 }
 
 async fn read_entries(path: &Path) -> Result<Vec<QueuedEnvelope>> {

--- a/crates/lab/src/device/queue.rs
+++ b/crates/lab/src/device/queue.rs
@@ -20,6 +20,14 @@ impl QueuedEnvelope {
             payload,
         }
     }
+
+    #[must_use]
+    pub fn syslog_batch(payload: serde_json::Value) -> Self {
+        Self {
+            kind: "syslog_batch".to_string(),
+            payload,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/lab/src/device/queue.rs
+++ b/crates/lab/src/device/queue.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedEnvelope {
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+impl QueuedEnvelope {
+    #[must_use]
+    pub fn status(payload: serde_json::Value) -> Self {
+        Self {
+            kind: "status".to_string(),
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DeviceOutboundQueue {
+    path: PathBuf,
+    entries: Arc<Mutex<Vec<QueuedEnvelope>>>,
+}
+
+impl DeviceOutboundQueue {
+    pub async fn open(path: PathBuf) -> Result<Self> {
+        let entries = read_entries(&path).await?;
+        Ok(Self {
+            path,
+            entries: Arc::new(Mutex::new(entries)),
+        })
+    }
+
+    pub async fn push(&self, envelope: QueuedEnvelope) -> Result<()> {
+        let mut entries = self.entries.lock().await;
+        entries.push(envelope.clone());
+        append_entry(&self.path, &envelope).await
+    }
+
+    pub async fn drain_batch(&self, limit: usize) -> Result<Vec<QueuedEnvelope>> {
+        let entries = self.entries.lock().await;
+        Ok(entries.iter().take(limit).cloned().collect())
+    }
+
+    pub async fn ack_drained(&self, count: usize) -> Result<()> {
+        let mut entries = self.entries.lock().await;
+        let drained = count.min(entries.len());
+        entries.drain(..drained);
+        rewrite_entries(&self.path, &entries).await
+    }
+}
+
+async fn read_entries(path: &Path) -> Result<Vec<QueuedEnvelope>> {
+    if !fs::try_exists(path).await? {
+        return Ok(Vec::new());
+    }
+
+    let raw = fs::read_to_string(path)
+        .await
+        .with_context(|| format!("read {}", path.display()))?;
+    raw.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).context("parse queue entry"))
+        .collect()
+}
+
+async fn append_entry(path: &Path, envelope: &QueuedEnvelope) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+
+    let mut line =
+        serde_json::to_string(envelope).context("serialize queue entry for append")?;
+    line.push('\n');
+
+    use tokio::io::AsyncWriteExt as _;
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("open {}", path.display()))?;
+    file.write_all(line.as_bytes())
+        .await
+        .with_context(|| format!("append {}", path.display()))
+}
+
+async fn rewrite_entries(path: &Path, entries: &[QueuedEnvelope]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+
+    let content = if entries.is_empty() {
+        String::new()
+    } else {
+        let mut serialized = entries
+            .iter()
+            .map(serde_json::to_string)
+            .collect::<serde_json::Result<Vec<_>>>()
+            .context("serialize queue entries for rewrite")?
+            .join("\n");
+        serialized.push('\n');
+        serialized
+    };
+
+    fs::write(path, content)
+        .await
+        .with_context(|| format!("rewrite {}", path.display()))
+}

--- a/crates/lab/src/device/queue.rs
+++ b/crates/lab/src/device/queue.rs
@@ -14,6 +14,7 @@ pub struct QueuedEnvelope {
 
 impl QueuedEnvelope {
     #[must_use]
+    #[allow(dead_code)]
     pub fn status(payload: serde_json::Value) -> Self {
         Self {
             kind: "status".to_string(),
@@ -85,8 +86,7 @@ async fn append_entry(path: &Path, envelope: &QueuedEnvelope) -> Result<()> {
             .with_context(|| format!("create {}", parent.display()))?;
     }
 
-    let mut line =
-        serde_json::to_string(envelope).context("serialize queue entry for append")?;
+    let mut line = serde_json::to_string(envelope).context("serialize queue entry for append")?;
     line.push('\n');
 
     use tokio::io::AsyncWriteExt as _;

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -29,21 +29,21 @@ impl DeviceRuntime {
     }
 
     #[must_use]
-    pub fn for_http_master(
-        resolved: ResolvedDeviceRuntime,
-        master_port: u16,
-    ) -> Self {
+    pub fn for_http_master(resolved: ResolvedDeviceRuntime, master_port: u16) -> Self {
         let master_client = match resolved.role {
             DeviceRole::Master => None,
-            DeviceRole::NonMaster => Some(MasterClient::new(format!(
-                "http://{}:{}",
-                resolved.master_host, master_port
-            ))),
+            DeviceRole::NonMaster => Some(MasterClient::with_bearer_token(
+                format!("http://{}:{}", resolved.master_host, master_port),
+                std::env::var("LAB_MCP_HTTP_TOKEN")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty()),
+            )),
         };
         Self::new(resolved, master_client)
     }
 
     #[must_use]
+    #[allow(dead_code)]
     pub fn non_master_for_test(local_host: &str, base_url: String) -> Self {
         let resolved = resolve_runtime_role(local_host, Some("master"))
             .expect("non-master test runtime should resolve");
@@ -51,6 +51,7 @@ impl DeviceRuntime {
     }
 
     #[must_use]
+    #[allow(dead_code)]
     pub fn non_master_for_test_with_home(
         local_host: &str,
         base_url: String,

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow};
 
 use crate::config::{DeviceRole, ResolvedDeviceRuntime};
-use crate::device::checkin::{DeviceHello, DeviceMetadataUpload};
+use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 use crate::device::config_scan::discover_ai_cli_configs;
 use crate::device::identity::resolve_runtime_role;
 use crate::device::log_collect::collect_bootstrap_logs;
@@ -127,28 +127,36 @@ impl DeviceRuntime {
         let mut ack_count = 0usize;
 
         for envelope in drained {
-            match envelope.kind.as_str() {
-                "syslog_batch" => {
-                    client.post_syslog_batch(&envelope.payload).await?;
-                    ack_count += 1;
-                }
+            let delivery = match envelope.kind.as_str() {
+                "syslog_batch" => client.post_syslog_batch(&envelope.payload).await,
                 "status" => {
-                    let status = serde_json::from_value(envelope.payload)
+                    let status = serde_json::from_value::<DeviceStatus>(envelope.payload)
                         .context("decode queued status envelope")?;
-                    client.post_status(&status).await?;
+                    client.post_status(&status).await
+                }
+                other => Err(anyhow!("unsupported queued envelope kind `{other}`")),
+            };
+
+            match delivery {
+                Ok(()) => {
                     ack_count += 1;
                 }
-                _ => break,
+                Err(error) => {
+                    ack_processed_prefix(&queue, ack_count).await?;
+                    return Err(error);
+                }
             }
         }
 
-        if ack_count > 0 {
-            queue.ack_drained(ack_count).await?;
-        }
+        ack_processed_prefix(&queue, ack_count).await?;
         Ok(())
     }
 
     pub async fn collect_and_flush_bootstrap_logs(&self) -> Result<()> {
+        if matches!(self.resolved.role, DeviceRole::Master) {
+            return Ok(());
+        }
+
         let events = collect_bootstrap_logs(&self.resolved.local_host)?;
         self.queue_syslog_batch(events).await?;
         self.flush_queue_once().await
@@ -170,4 +178,15 @@ impl DeviceRuntime {
     fn queue_path(&self) -> PathBuf {
         self.home_dir.join(".lab/device-runtime-queue.jsonl")
     }
+}
+
+async fn ack_processed_prefix(queue: &DeviceOutboundQueue, ack_count: usize) -> Result<()> {
+    if ack_count == 0 {
+        return Ok(());
+    }
+
+    queue
+        .ack_drained(ack_count)
+        .await
+        .context("ack delivered device outbound queue entries")
 }

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -1,0 +1,62 @@
+use anyhow::{Result, anyhow};
+
+use crate::config::{DeviceRole, ResolvedDeviceRuntime};
+use crate::device::checkin::DeviceHello;
+use crate::device::identity::resolve_runtime_role;
+use crate::device::master_client::MasterClient;
+
+#[derive(Debug, Clone)]
+pub struct DeviceRuntime {
+    resolved: ResolvedDeviceRuntime,
+    master_client: Option<MasterClient>,
+}
+
+impl DeviceRuntime {
+    #[must_use]
+    pub fn new(resolved: ResolvedDeviceRuntime, master_client: Option<MasterClient>) -> Self {
+        Self {
+            resolved,
+            master_client,
+        }
+    }
+
+    #[must_use]
+    pub fn for_http_master(
+        resolved: ResolvedDeviceRuntime,
+        master_port: u16,
+    ) -> Self {
+        let master_client = match resolved.role {
+            DeviceRole::Master => None,
+            DeviceRole::NonMaster => Some(MasterClient::new(format!(
+                "http://{}:{}",
+                resolved.master_host, master_port
+            ))),
+        };
+        Self::new(resolved, master_client)
+    }
+
+    #[must_use]
+    pub fn non_master_for_test(local_host: &str, base_url: String) -> Self {
+        let resolved = resolve_runtime_role(local_host, Some("master"))
+            .expect("non-master test runtime should resolve");
+        Self::new(resolved, Some(MasterClient::new(base_url)))
+    }
+
+    pub async fn send_initial_hello(&self) -> Result<()> {
+        if matches!(self.resolved.role, DeviceRole::Master) {
+            return Ok(());
+        }
+
+        let client = self
+            .master_client
+            .as_ref()
+            .ok_or_else(|| anyhow!("master client is not configured"))?;
+        client
+            .post_hello(&DeviceHello {
+                device_id: self.resolved.local_host.clone(),
+                role: "non-master".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            })
+            .await
+    }
+}

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -45,10 +45,9 @@ impl DeviceRuntime {
 
     #[must_use]
     #[allow(dead_code)]
-    pub fn non_master_for_test(local_host: &str, base_url: String) -> Self {
-        let resolved = resolve_runtime_role(local_host, Some("master"))
-            .expect("non-master test runtime should resolve");
-        Self::new(resolved, Some(MasterClient::new(base_url)))
+    pub fn non_master_for_test(local_host: &str, base_url: String) -> Result<Self> {
+        let resolved = resolve_runtime_role(local_host, Some("master"))?;
+        Ok(Self::new(resolved, Some(MasterClient::new(base_url)?)))
     }
 
     #[must_use]
@@ -57,10 +56,10 @@ impl DeviceRuntime {
         local_host: &str,
         base_url: String,
         home_dir: &Path,
-    ) -> Self {
-        let mut runtime = Self::non_master_for_test(local_host, base_url);
+    ) -> Result<Self> {
+        let mut runtime = Self::non_master_for_test(local_host, base_url)?;
         runtime.home_dir = home_dir.to_path_buf();
-        runtime
+        Ok(runtime)
     }
 
     pub async fn send_initial_hello(&self) -> Result<()> {

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -1,12 +1,15 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 
 use crate::config::{DeviceRole, ResolvedDeviceRuntime};
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload};
 use crate::device::config_scan::discover_ai_cli_configs;
 use crate::device::identity::resolve_runtime_role;
+use crate::device::log_collect::collect_bootstrap_logs;
+use crate::device::log_event::DeviceLogEvent;
 use crate::device::master_client::MasterClient;
+use crate::device::queue::{DeviceOutboundQueue, QueuedEnvelope};
 
 #[derive(Debug, Clone)]
 pub struct DeviceRuntime {
@@ -92,6 +95,64 @@ impl DeviceRuntime {
         client.post_metadata(&payload).await
     }
 
+    pub async fn queue_syslog_batch(&self, events: Vec<DeviceLogEvent>) -> Result<()> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let queue = DeviceOutboundQueue::open(self.queue_path())
+            .await
+            .context("open device outbound queue")?;
+        let payload = serde_json::json!({
+            "device_id": self.resolved.local_host.clone(),
+            "events": events,
+        });
+        queue.push(QueuedEnvelope::syslog_batch(payload)).await
+    }
+
+    pub async fn flush_queue_once(&self) -> Result<()> {
+        if matches!(self.resolved.role, DeviceRole::Master) {
+            return Ok(());
+        }
+
+        let client = self
+            .master_client
+            .as_ref()
+            .ok_or_else(|| anyhow!("master client is not configured"))?;
+        let queue = DeviceOutboundQueue::open(self.queue_path())
+            .await
+            .context("open device outbound queue")?;
+        let drained = queue.drain_batch(100).await?;
+        let mut ack_count = 0usize;
+
+        for envelope in drained {
+            match envelope.kind.as_str() {
+                "syslog_batch" => {
+                    client.post_syslog_batch(&envelope.payload).await?;
+                    ack_count += 1;
+                }
+                "status" => {
+                    let status = serde_json::from_value(envelope.payload)
+                        .context("decode queued status envelope")?;
+                    client.post_status(&status).await?;
+                    ack_count += 1;
+                }
+                _ => break,
+            }
+        }
+
+        if ack_count > 0 {
+            queue.ack_drained(ack_count).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn collect_and_flush_bootstrap_logs(&self) -> Result<()> {
+        let events = collect_bootstrap_logs(&self.resolved.local_host)?;
+        self.queue_syslog_batch(events).await?;
+        self.flush_queue_once().await
+    }
+
     #[must_use]
     pub const fn role(&self) -> DeviceRole {
         self.resolved.role
@@ -102,4 +163,10 @@ fn current_home_dir() -> PathBuf {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."))
+}
+
+impl DeviceRuntime {
+    fn queue_path(&self) -> PathBuf {
+        self.home_dir.join(".lab/device-runtime-queue.jsonl")
+    }
 }

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -31,10 +31,14 @@ impl DeviceRuntime {
         }
     }
 
-    pub fn from_config(resolved: ResolvedDeviceRuntime, config: &LabConfig) -> Result<Self> {
+    pub fn from_config(
+        resolved: ResolvedDeviceRuntime,
+        config: &LabConfig,
+        master_port_override: Option<u16>,
+    ) -> Result<Self> {
         let master_client = match resolved.role {
             DeviceRole::Master => None,
-            DeviceRole::NonMaster => Some(MasterClient::from_config(config)?),
+            DeviceRole::NonMaster => Some(MasterClient::from_config(config, master_port_override)?),
         };
         Ok(Self::new(resolved, master_client))
     }

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -122,11 +122,12 @@ impl DeviceRuntime {
         for envelope in drained {
             let delivery = match envelope.kind.as_str() {
                 "syslog_batch" => client.post_syslog_batch(&envelope.payload).await,
-                "status" => {
-                    let status = serde_json::from_value::<DeviceStatus>(envelope.payload)
-                        .context("decode queued status envelope")?;
-                    client.post_status(&status).await
-                }
+                "status" => match serde_json::from_value::<DeviceStatus>(envelope.payload)
+                    .context("decode queued status envelope")
+                {
+                    Ok(status) => client.post_status(&status).await,
+                    Err(error) => Err(error),
+                },
                 other => Err(anyhow!("unsupported queued envelope kind `{other}`")),
             };
 

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -59,4 +59,9 @@ impl DeviceRuntime {
             })
             .await
     }
+
+    #[must_use]
+    pub const fn role(&self) -> DeviceRole {
+        self.resolved.role
+    }
 }

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -1,7 +1,10 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::{Result, anyhow};
 
 use crate::config::{DeviceRole, ResolvedDeviceRuntime};
-use crate::device::checkin::DeviceHello;
+use crate::device::checkin::{DeviceHello, DeviceMetadataUpload};
+use crate::device::config_scan::discover_ai_cli_configs;
 use crate::device::identity::resolve_runtime_role;
 use crate::device::master_client::MasterClient;
 
@@ -9,6 +12,7 @@ use crate::device::master_client::MasterClient;
 pub struct DeviceRuntime {
     resolved: ResolvedDeviceRuntime,
     master_client: Option<MasterClient>,
+    home_dir: PathBuf,
 }
 
 impl DeviceRuntime {
@@ -17,6 +21,7 @@ impl DeviceRuntime {
         Self {
             resolved,
             master_client,
+            home_dir: current_home_dir(),
         }
     }
 
@@ -42,6 +47,17 @@ impl DeviceRuntime {
         Self::new(resolved, Some(MasterClient::new(base_url)))
     }
 
+    #[must_use]
+    pub fn non_master_for_test_with_home(
+        local_host: &str,
+        base_url: String,
+        home_dir: &Path,
+    ) -> Self {
+        let mut runtime = Self::non_master_for_test(local_host, base_url);
+        runtime.home_dir = home_dir.to_path_buf();
+        runtime
+    }
+
     pub async fn send_initial_hello(&self) -> Result<()> {
         if matches!(self.resolved.role, DeviceRole::Master) {
             return Ok(());
@@ -60,8 +76,30 @@ impl DeviceRuntime {
             .await
     }
 
+    pub async fn upload_initial_metadata(&self) -> Result<()> {
+        if matches!(self.resolved.role, DeviceRole::Master) {
+            return Ok(());
+        }
+
+        let client = self
+            .master_client
+            .as_ref()
+            .ok_or_else(|| anyhow!("master client is not configured"))?;
+        let payload = DeviceMetadataUpload {
+            device_id: self.resolved.local_host.clone(),
+            discovered_configs: discover_ai_cli_configs(&self.home_dir)?,
+        };
+        client.post_metadata(&payload).await
+    }
+
     #[must_use]
     pub const fn role(&self) -> DeviceRole {
         self.resolved.role
     }
+}
+
+fn current_home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
 }

--- a/crates/lab/src/device/runtime.rs
+++ b/crates/lab/src/device/runtime.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
+use tokio::sync::OnceCell;
 
-use crate::config::{DeviceRole, ResolvedDeviceRuntime};
+use crate::config::{DeviceRole, LabConfig, ResolvedDeviceRuntime};
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 use crate::device::config_scan::discover_ai_cli_configs;
 use crate::device::identity::resolve_runtime_role;
@@ -16,6 +17,7 @@ pub struct DeviceRuntime {
     resolved: ResolvedDeviceRuntime,
     master_client: Option<MasterClient>,
     home_dir: PathBuf,
+    outbound_queue: std::sync::Arc<OnceCell<DeviceOutboundQueue>>,
 }
 
 impl DeviceRuntime {
@@ -25,21 +27,16 @@ impl DeviceRuntime {
             resolved,
             master_client,
             home_dir: current_home_dir(),
+            outbound_queue: std::sync::Arc::new(OnceCell::new()),
         }
     }
 
-    #[must_use]
-    pub fn for_http_master(resolved: ResolvedDeviceRuntime, master_port: u16) -> Self {
+    pub fn from_config(resolved: ResolvedDeviceRuntime, config: &LabConfig) -> Result<Self> {
         let master_client = match resolved.role {
             DeviceRole::Master => None,
-            DeviceRole::NonMaster => Some(MasterClient::with_bearer_token(
-                format!("http://{}:{}", resolved.master_host, master_port),
-                std::env::var("LAB_MCP_HTTP_TOKEN")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty()),
-            )),
+            DeviceRole::NonMaster => Some(MasterClient::from_config(config)?),
         };
-        Self::new(resolved, master_client)
+        Ok(Self::new(resolved, master_client))
     }
 
     #[must_use]
@@ -101,9 +98,7 @@ impl DeviceRuntime {
             return Ok(());
         }
 
-        let queue = DeviceOutboundQueue::open(self.queue_path())
-            .await
-            .context("open device outbound queue")?;
+        let queue = self.outbound_queue().await?;
         let payload = serde_json::json!({
             "device_id": self.resolved.local_host.clone(),
             "events": events,
@@ -120,9 +115,7 @@ impl DeviceRuntime {
             .master_client
             .as_ref()
             .ok_or_else(|| anyhow!("master client is not configured"))?;
-        let queue = DeviceOutboundQueue::open(self.queue_path())
-            .await
-            .context("open device outbound queue")?;
+        let queue = self.outbound_queue().await?;
         let drained = queue.drain_batch(100).await?;
         let mut ack_count = 0usize;
 
@@ -170,13 +163,32 @@ impl DeviceRuntime {
 
 fn current_home_dir() -> PathBuf {
     std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .or_else(|| {
+            let home_drive = std::env::var_os("HOMEDRIVE")?;
+            let home_path = std::env::var_os("HOMEPATH")?;
+            let mut path = PathBuf::from(home_drive);
+            path.push(home_path);
+            Some(path.into_os_string())
+        })
         .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
 impl DeviceRuntime {
     fn queue_path(&self) -> PathBuf {
         self.home_dir.join(".lab/device-runtime-queue.jsonl")
+    }
+
+    async fn outbound_queue(&self) -> Result<&DeviceOutboundQueue> {
+        self.outbound_queue
+            .get_or_try_init(|| async {
+                DeviceOutboundQueue::open(self.queue_path())
+                    .await
+                    .context("open device outbound queue")
+            })
+            .await
     }
 }
 

--- a/crates/lab/src/device/store.rs
+++ b/crates/lab/src/device/store.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 use tokio::sync::RwLock;
 
-use crate::device::checkin::{DeviceHello, DeviceStatus};
+use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 
 #[derive(Debug, Clone, Default)]
 pub struct DeviceFleetStore {
@@ -18,6 +18,7 @@ pub struct DeviceSnapshot {
     pub last_seen: SystemTime,
     pub role: Option<String>,
     pub status: Option<DeviceStatus>,
+    pub metadata: Option<DeviceMetadataUpload>,
 }
 
 impl DeviceFleetStore {
@@ -31,6 +32,7 @@ impl DeviceFleetStore {
                 last_seen: SystemTime::now(),
                 role: None,
                 status: None,
+                metadata: None,
             });
         snapshot.device_id = hello.device_id;
         snapshot.last_seen = SystemTime::now();
@@ -47,6 +49,7 @@ impl DeviceFleetStore {
                 last_seen: SystemTime::now(),
                 role: None,
                 status: None,
+                metadata: None,
             });
         snapshot.device_id = status.device_id.clone();
         snapshot.connected = status.connected;
@@ -62,5 +65,22 @@ impl DeviceFleetStore {
     pub async fn list_devices(&self) -> Vec<DeviceSnapshot> {
         let inner = self.inner.read().await;
         inner.values().cloned().collect()
+    }
+
+    pub async fn record_metadata(&self, metadata: DeviceMetadataUpload) {
+        let mut inner = self.inner.write().await;
+        let snapshot = inner
+            .entry(metadata.device_id.clone())
+            .or_insert_with(|| DeviceSnapshot {
+                device_id: metadata.device_id.clone(),
+                connected: false,
+                last_seen: SystemTime::now(),
+                role: None,
+                status: None,
+                metadata: None,
+            });
+        snapshot.device_id = metadata.device_id.clone();
+        snapshot.last_seen = SystemTime::now();
+        snapshot.metadata = Some(metadata);
     }
 }

--- a/crates/lab/src/device/store.rs
+++ b/crates/lab/src/device/store.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 use tokio::sync::RwLock;
 
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
+use crate::device::log_event::DeviceLogEvent;
 
 #[derive(Debug, Clone, Default)]
 pub struct DeviceFleetStore {
@@ -19,6 +20,7 @@ pub struct DeviceSnapshot {
     pub role: Option<String>,
     pub status: Option<DeviceStatus>,
     pub metadata: Option<DeviceMetadataUpload>,
+    pub logs: Vec<DeviceLogEvent>,
 }
 
 impl DeviceFleetStore {
@@ -33,6 +35,7 @@ impl DeviceFleetStore {
                 role: None,
                 status: None,
                 metadata: None,
+                logs: Vec::new(),
             });
         snapshot.device_id = hello.device_id;
         snapshot.last_seen = SystemTime::now();
@@ -50,6 +53,7 @@ impl DeviceFleetStore {
                 role: None,
                 status: None,
                 metadata: None,
+                logs: Vec::new(),
             });
         snapshot.device_id = status.device_id.clone();
         snapshot.connected = status.connected;
@@ -78,9 +82,35 @@ impl DeviceFleetStore {
                 role: None,
                 status: None,
                 metadata: None,
+                logs: Vec::new(),
             });
         snapshot.device_id = metadata.device_id.clone();
         snapshot.last_seen = SystemTime::now();
         snapshot.metadata = Some(metadata);
+    }
+
+    pub async fn record_logs(&self, device_id: &str, events: Vec<DeviceLogEvent>) {
+        let mut inner = self.inner.write().await;
+        let snapshot = inner
+            .entry(device_id.to_string())
+            .or_insert_with(|| DeviceSnapshot {
+                device_id: device_id.to_string(),
+                connected: false,
+                last_seen: SystemTime::now(),
+                role: None,
+                status: None,
+                metadata: None,
+                logs: Vec::new(),
+            });
+        snapshot.last_seen = SystemTime::now();
+        snapshot.logs.extend(events);
+    }
+
+    pub async fn logs_for_device(&self, device_id: &str) -> Vec<DeviceLogEvent> {
+        let inner = self.inner.read().await;
+        inner
+            .get(device_id)
+            .map(|snapshot| snapshot.logs.clone())
+            .unwrap_or_default()
     }
 }

--- a/crates/lab/src/device/store.rs
+++ b/crates/lab/src/device/store.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use tokio::sync::RwLock;
+
+use crate::device::checkin::{DeviceHello, DeviceStatus};
+
+#[derive(Debug, Clone, Default)]
+pub struct DeviceFleetStore {
+    inner: Arc<RwLock<BTreeMap<String, DeviceSnapshot>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeviceSnapshot {
+    pub device_id: String,
+    pub connected: bool,
+    pub last_seen: SystemTime,
+    pub role: Option<String>,
+    pub status: Option<DeviceStatus>,
+}
+
+impl DeviceFleetStore {
+    pub async fn record_hello(&self, hello: DeviceHello) {
+        let mut inner = self.inner.write().await;
+        let snapshot = inner
+            .entry(hello.device_id.clone())
+            .or_insert_with(|| DeviceSnapshot {
+                device_id: hello.device_id.clone(),
+                connected: false,
+                last_seen: SystemTime::now(),
+                role: None,
+                status: None,
+            });
+        snapshot.device_id = hello.device_id;
+        snapshot.last_seen = SystemTime::now();
+        snapshot.role = Some(hello.role);
+    }
+
+    pub async fn record_status(&self, status: DeviceStatus) {
+        let mut inner = self.inner.write().await;
+        let snapshot = inner
+            .entry(status.device_id.clone())
+            .or_insert_with(|| DeviceSnapshot {
+                device_id: status.device_id.clone(),
+                connected: status.connected,
+                last_seen: SystemTime::now(),
+                role: None,
+                status: None,
+            });
+        snapshot.device_id = status.device_id.clone();
+        snapshot.connected = status.connected;
+        snapshot.last_seen = SystemTime::now();
+        snapshot.status = Some(status);
+    }
+
+    pub async fn device(&self, device_id: &str) -> Option<DeviceSnapshot> {
+        let inner = self.inner.read().await;
+        inner.get(device_id).cloned()
+    }
+
+    pub async fn list_devices(&self) -> Vec<DeviceSnapshot> {
+        let inner = self.inner.read().await;
+        inner.values().cloned().collect()
+    }
+}

--- a/crates/lab/src/device/store.rs
+++ b/crates/lab/src/device/store.rs
@@ -7,6 +7,8 @@ use tokio::sync::RwLock;
 use crate::device::checkin::{DeviceHello, DeviceMetadataUpload, DeviceStatus};
 use crate::device::log_event::DeviceLogEvent;
 
+const MAX_LOG_EVENTS_PER_DEVICE: usize = 10_000;
+
 #[derive(Debug, Clone, Default)]
 pub struct DeviceFleetStore {
     inner: Arc<RwLock<BTreeMap<String, DeviceSnapshot>>>,
@@ -30,7 +32,7 @@ impl DeviceFleetStore {
             .entry(hello.device_id.clone())
             .or_insert_with(|| DeviceSnapshot {
                 device_id: hello.device_id.clone(),
-                connected: false,
+                connected: true,
                 last_seen: SystemTime::now(),
                 role: None,
                 status: None,
@@ -38,6 +40,7 @@ impl DeviceFleetStore {
                 logs: Vec::new(),
             });
         snapshot.device_id = hello.device_id;
+        snapshot.connected = true;
         snapshot.last_seen = SystemTime::now();
         snapshot.role = Some(hello.role);
     }
@@ -104,13 +107,41 @@ impl DeviceFleetStore {
             });
         snapshot.last_seen = SystemTime::now();
         snapshot.logs.extend(events);
+        let excess = snapshot
+            .logs
+            .len()
+            .saturating_sub(MAX_LOG_EVENTS_PER_DEVICE);
+        if excess > 0 {
+            snapshot.logs.drain(0..excess);
+        }
     }
 
-    pub async fn logs_for_device(&self, device_id: &str) -> Vec<DeviceLogEvent> {
+    pub async fn search_logs_for_device(
+        &self,
+        device_id: &str,
+        needle: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<DeviceLogEvent> {
         let inner = self.inner.read().await;
-        inner
-            .get(device_id)
-            .map(|snapshot| snapshot.logs.clone())
-            .unwrap_or_default()
+        let Some(snapshot) = inner.get(device_id) else {
+            return Vec::new();
+        };
+
+        let normalized_needle = needle.to_ascii_lowercase();
+        let effective_limit = limit.max(1).min(1_000);
+        snapshot
+            .logs
+            .iter()
+            .filter(|event| {
+                event
+                    .message
+                    .to_ascii_lowercase()
+                    .contains(&normalized_needle)
+            })
+            .skip(offset)
+            .take(effective_limit)
+            .cloned()
+            .collect()
     }
 }

--- a/crates/lab/src/dispatch/clients.rs
+++ b/crates/lab/src/dispatch/clients.rs
@@ -1,6 +1,6 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::collections::HashMap;
 
 use tokio::sync::RwLock;
 
@@ -163,7 +163,6 @@ impl SharedServiceClients {
 
     #[cfg(test)]
     pub fn refresh_count(&self) -> usize {
-        self.refresh_count
-            .load(std::sync::atomic::Ordering::SeqCst)
+        self.refresh_count.load(std::sync::atomic::Ordering::SeqCst)
     }
 }

--- a/crates/lab/src/dispatch/error.rs
+++ b/crates/lab/src/dispatch/error.rs
@@ -139,6 +139,14 @@ impl ToolError {
             "internal_error" | "server_error" | "decode_error"
         )
     }
+
+    #[must_use]
+    pub fn internal_message(message: impl Into<String>) -> Self {
+        Self::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: message.into(),
+        }
+    }
 }
 
 // ── From<ServiceError> for ToolError ─────────────────────────────────────

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -63,7 +63,10 @@ pub async fn dispatch_with_manager(
             let service = manager.service_for_virtual_server_id(&params.id).await?;
             let valid_actions = compiled_service_actions(&service)?;
             for action in &params.allowed_actions {
-                if !valid_actions.iter().any(|candidate| candidate.name == action.as_str()) {
+                if !valid_actions
+                    .iter()
+                    .any(|candidate| candidate.name == action.as_str())
+                {
                     return Err(ToolError::InvalidParam {
                         message: format!(
                             "action `{action}` is not valid for service `{}`",
@@ -85,7 +88,11 @@ pub async fn dispatch_with_manager(
         }
         "gateway.service_config.set" => {
             let params: ServiceConfigSetParams = parse_params(params_value)?;
-            to_json(manager.set_service_config(&params.service, &params.values).await?)
+            to_json(
+                manager
+                    .set_service_config(&params.service, &params.values)
+                    .await?,
+            )
         }
         "gateway.service_actions" => {
             let params: ServiceConfigGetParams = parse_params(params_value)?;
@@ -149,10 +156,12 @@ pub async fn dispatch_with_manager(
 
 fn compiled_service_actions(service: &str) -> Result<Vec<ServiceActionView>, ToolError> {
     let registry = crate::registry::build_default_registry();
-    let entry = registry.service(service).ok_or_else(|| ToolError::InvalidParam {
-        message: format!("unknown service `{service}`"),
-        param: "service".to_string(),
-    })?;
+    let entry = registry
+        .service(service)
+        .ok_or_else(|| ToolError::InvalidParam {
+            message: format!("unknown service `{service}`"),
+            param: "service".to_string(),
+        })?;
 
     Ok(entry
         .actions
@@ -249,13 +258,10 @@ mod tests {
             }])
             .await;
 
-        let value = dispatch_with_manager(
-            &manager,
-            "gateway.server.get",
-            json!({"id":"fixture-http"}),
-        )
-        .await
-        .expect("server get");
+        let value =
+            dispatch_with_manager(&manager, "gateway.server.get", json!({"id":"fixture-http"}))
+                .await
+                .expect("server get");
 
         assert_eq!(value["id"], "fixture-http");
         assert_eq!(value["source"], "custom_gateway");
@@ -396,11 +402,12 @@ mod tests {
         let list = dispatch_with_manager(&manager, "gateway.list", json!({}))
             .await
             .expect("list after disable");
-        assert!(list
-            .as_array()
-            .expect("array")
-            .iter()
-            .any(|server| server["id"] == "plex" && server["enabled"] == false));
+        assert!(
+            list.as_array()
+                .expect("array")
+                .iter()
+                .any(|server| server["id"] == "plex" && server["enabled"] == false)
+        );
     }
 
     #[tokio::test]
@@ -423,16 +430,20 @@ mod tests {
 
         assert_eq!(value["service"], "plex");
         assert_eq!(value["configured"], true);
-        assert!(value["fields"]
-            .as_array()
-            .expect("fields")
-            .iter()
-            .any(|field| field["name"] == "PLEX_URL" && field["present"] == true));
-        assert!(value["fields"]
-            .as_array()
-            .expect("fields")
-            .iter()
-            .any(|field| field["name"] == "PLEX_TOKEN" && field["present"] == true));
+        assert!(
+            value["fields"]
+                .as_array()
+                .expect("fields")
+                .iter()
+                .any(|field| field["name"] == "PLEX_URL" && field["present"] == true)
+        );
+        assert!(
+            value["fields"]
+                .as_array()
+                .expect("fields")
+                .iter()
+                .any(|field| field["name"] == "PLEX_TOKEN" && field["present"] == true)
+        );
     }
 
     #[tokio::test]
@@ -475,16 +486,21 @@ mod tests {
 
         assert_eq!(value["service"], "plex");
         assert_eq!(value["configured"], true);
-        assert!(value["fields"]
-            .as_array()
-            .expect("fields")
-            .iter()
-            .any(|field| field["name"] == "PLEX_URL" && field["value_preview"] == "http://127.0.0.1:32400"));
-        assert!(value["fields"]
-            .as_array()
-            .expect("fields")
-            .iter()
-            .any(|field| field["name"] == "PLEX_TOKEN" && field["secret"] == true));
+        assert!(
+            value["fields"]
+                .as_array()
+                .expect("fields")
+                .iter()
+                .any(|field| field["name"] == "PLEX_URL"
+                    && field["value_preview"] == "http://127.0.0.1:32400")
+        );
+        assert!(
+            value["fields"]
+                .as_array()
+                .expect("fields")
+                .iter()
+                .any(|field| field["name"] == "PLEX_TOKEN" && field["secret"] == true)
+        );
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tokio::sync::RwLock;
 
-use crate::config::{backup_env, env_is_up_to_date, write_env, LabConfig, UpstreamConfig};
+use crate::config::{LabConfig, UpstreamConfig, backup_env, env_is_up_to_date, write_env};
 use crate::dispatch::clients::SharedServiceClients;
 use crate::dispatch::error::ToolError;
 use crate::dispatch::upstream::pool::UpstreamPool;
@@ -17,8 +17,8 @@ use super::config::{
 use super::params::GatewayUpdatePatch;
 use super::service_catalog::service_meta;
 use super::types::{
-    CatalogChangeNotifier, GatewayCatalogDiff, GatewayConfigView, GatewayRuntimeView,
-    GatewayView, ServiceConfigFieldView, ServiceConfigView, VirtualServerMcpPolicyView,
+    CatalogChangeNotifier, GatewayCatalogDiff, GatewayConfigView, GatewayRuntimeView, GatewayView,
+    ServiceConfigFieldView, ServiceConfigView, VirtualServerMcpPolicyView,
 };
 use super::view_models::{
     ServerConfigSummaryView, ServerView, SurfaceStateView, SurfaceStatesView,
@@ -129,7 +129,11 @@ impl GatewayManager {
         })?;
 
         for field in values.keys() {
-            let valid = meta.required_env.iter().chain(meta.optional_env.iter()).any(|env| env.name == field);
+            let valid = meta
+                .required_env
+                .iter()
+                .chain(meta.optional_env.iter())
+                .any(|env| env.name == field);
             if !valid {
                 return Err(ToolError::InvalidParam {
                     message: format!("field `{field}` is not valid for service `{service}`"),
@@ -297,9 +301,10 @@ impl GatewayManager {
         };
 
         match &virtual_server.mcp_policy {
-            Some(policy) if !policy.allowed_actions.is_empty() => {
-                policy.allowed_actions.iter().any(|allowed| allowed == action)
-            }
+            Some(policy) if !policy.allowed_actions.is_empty() => policy
+                .allowed_actions
+                .iter()
+                .any(|allowed| allowed == action),
             _ => true,
         }
     }
@@ -580,7 +585,10 @@ impl GatewayManager {
         enabled: bool,
     ) -> Result<ServerView, ToolError> {
         let mut cfg = self.config.read().await.clone();
-        let existing_index = cfg.virtual_servers.iter().position(|server| server.id == id);
+        let existing_index = cfg
+            .virtual_servers
+            .iter()
+            .position(|server| server.id == id);
         let index = if let Some(index) = existing_index {
             index
         } else {
@@ -597,13 +605,14 @@ impl GatewayManager {
                 });
             }
 
-            cfg.virtual_servers.push(crate::config::VirtualServerConfig {
-                id: id.to_string(),
-                service: id.to_string(),
-                enabled: false,
-                surfaces: crate::config::VirtualServerSurfacesConfig::default(),
-                mcp_policy: None,
-            });
+            cfg.virtual_servers
+                .push(crate::config::VirtualServerConfig {
+                    id: id.to_string(),
+                    service: id.to_string(),
+                    enabled: false,
+                    surfaces: crate::config::VirtualServerSurfacesConfig::default(),
+                    mcp_policy: None,
+                });
             cfg.virtual_servers.len() - 1
         };
 
@@ -757,7 +766,8 @@ fn server_view_from_virtual_server(
     let service = match &record.source {
         VirtualServerSource::LabService { service } => service.clone(),
     };
-    let connected = record.enabled && health.is_some_and(|status| status.reachable && status.auth_ok);
+    let connected =
+        record.enabled && health.is_some_and(|status| status.reachable && status.auth_ok);
     let warnings = health
         .and_then(|status| {
             status.message.as_ref().map(|message| {
@@ -825,7 +835,11 @@ fn values_to_service_creds(
             } else {
                 None
             };
-            let secret = if url.is_some() { None } else { Some(value.clone()) };
+            let secret = if url.is_some() {
+                None
+            } else {
+                Some(value.clone())
+            };
             ServiceCreds {
                 service: service.to_string(),
                 url,
@@ -1195,7 +1209,8 @@ mod tests {
     async fn service_clients_refresh_after_service_config_update() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
-        let shared_clients = SharedServiceClients::from_clients(crate::dispatch::clients::ServiceClients::default());
+        let shared_clients =
+            SharedServiceClients::from_clients(crate::dispatch::clients::ServiceClients::default());
         let manager = GatewayManager::new(path, GatewayRuntimeHandle::default())
             .with_service_clients(shared_clients.clone());
 
@@ -1266,6 +1281,9 @@ mod tests {
         pool.insert_entry_for_tests("broken-upstream", entry).await;
 
         let runtime = runtime_view(Some(&pool), "broken-upstream", None).await;
-        assert_eq!(runtime.last_error.as_deref(), Some("stdio handshake failed"));
+        assert_eq!(
+            runtime.last_error.as_deref(),
+            Some("stdio handshake failed")
+        );
     }
 }

--- a/crates/lab/src/dispatch/gateway/service_catalog.rs
+++ b/crates/lab/src/dispatch/gateway/service_catalog.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use lab_apis::core::PluginMeta;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServiceFieldView {

--- a/crates/lab/src/dispatch/helpers.rs
+++ b/crates/lab/src/dispatch/helpers.rs
@@ -1,7 +1,7 @@
 //! Shared dispatch helpers used across all service modules.
 
-use std::collections::HashMap;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use lab_apis::core::action::ActionSpec;
@@ -13,7 +13,12 @@ use crate::dispatch::error::ToolError;
 /// Read an environment variable, returning `None` if absent or empty.
 pub fn env_non_empty(name: &str) -> Option<String> {
     ENV_OVERRIDE
-        .with(|override_map| override_map.borrow().as_ref().and_then(|values| values.get(name).cloned()))
+        .with(|override_map| {
+            override_map
+                .borrow()
+                .as_ref()
+                .and_then(|values| values.get(name).cloned())
+        })
         .or_else(|| std::env::var(name).ok())
         .filter(|v| !v.is_empty())
 }
@@ -22,10 +27,7 @@ thread_local! {
     static ENV_OVERRIDE: RefCell<Option<HashMap<String, String>>> = const { RefCell::new(None) };
 }
 
-pub fn with_env_override<T>(
-    values: HashMap<String, String>,
-    f: impl FnOnce() -> T,
-) -> T {
+pub fn with_env_override<T>(values: HashMap<String, String>, f: impl FnOnce() -> T) -> T {
     ENV_OVERRIDE.with(|slot| {
         let previous = slot.replace(Some(values));
         let result = f();

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -40,7 +40,11 @@ fn max_response_bytes() -> usize {
 }
 
 fn upstream_transport(config: &UpstreamConfig) -> &'static str {
-    if config.url.is_some() { "http" } else { "stdio" }
+    if config.url.is_some() {
+        "http"
+    } else {
+        "stdio"
+    }
 }
 
 fn upstream_target(config: &UpstreamConfig) -> String {

--- a/crates/lab/src/lib.rs
+++ b/crates/lab/src/lib.rs
@@ -1,18 +1,27 @@
 #![allow(clippy::multiple_crate_versions)]
-#![allow(unreachable_pub)]
 
+#[allow(unreachable_pub)]
 pub mod api;
+#[allow(unreachable_pub)]
 pub mod audit;
 pub mod catalog;
+#[allow(unreachable_pub)]
 pub mod cli;
 pub mod config;
+#[allow(unreachable_pub)]
 pub mod device;
+#[allow(unreachable_pub)]
 pub mod dispatch;
+#[allow(unreachable_pub)]
 pub mod mcp;
+#[allow(unreachable_pub)]
 pub mod oauth;
 pub mod output;
+#[allow(unreachable_pub)]
 pub mod registry;
+#[allow(unreachable_pub)]
 pub mod scaffold;
 #[cfg(test)]
 pub mod test_support;
+#[allow(unreachable_pub)]
 pub mod tui;

--- a/crates/lab/src/lib.rs
+++ b/crates/lab/src/lib.rs
@@ -1,9 +1,18 @@
-#[cfg(test)]
-use std::mem::size_of;
+#![allow(clippy::multiple_crate_versions)]
+#![allow(unreachable_pub)]
 
+pub mod api;
+pub mod audit;
+pub mod catalog;
+pub mod cli;
+pub mod config;
+pub mod device;
+pub mod dispatch;
+pub mod mcp;
+pub mod oauth;
+pub mod output;
+pub mod registry;
+pub mod scaffold;
 #[cfg(test)]
-#[test]
-fn lab_auth_crate_exports_router_and_signing_keys() {
-    let _router_fn = lab_auth::routes::router;
-    let _signing_keys_type = size_of::<lab_auth::jwt::SigningKeys>();
-}
+pub mod test_support;
+pub mod tui;

--- a/crates/lab/src/main.rs
+++ b/crates/lab/src/main.rs
@@ -12,6 +12,7 @@ mod audit;
 mod catalog;
 mod cli;
 mod config;
+mod device;
 mod dispatch;
 mod mcp;
 mod oauth;

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
 
+use crate::config::DeviceRole;
 use crate::dispatch::gateway::manager::GatewayManager;
 use crate::dispatch::gateway::types::GatewayCatalogDiff;
 use crate::dispatch::upstream::types::UpstreamCapability;
@@ -97,6 +98,8 @@ pub struct LabMcpServer {
     pub registry: Arc<ToolRegistry>,
     /// Shared gateway manager used to resolve the current live upstream pool.
     pub gateway_manager: Option<Arc<GatewayManager>>,
+    /// Resolved role for the current device.
+    pub device_role: Option<DeviceRole>,
     /// Connected peers for list-changed notifications.
     pub peers: Arc<RwLock<Vec<Peer<RoleServer>>>>,
 }
@@ -565,6 +568,9 @@ impl LabMcpServer {
     }
 
     async fn service_visible_on_mcp(&self, service: &str) -> bool {
+        if matches!(self.device_role, Some(DeviceRole::NonMaster)) {
+            return false;
+        }
         match &self.gateway_manager {
             Some(manager) => manager.surface_enabled_for_service(service, "mcp").await,
             None => true,

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -204,14 +204,16 @@ impl ServerHandler for LabMcpServer {
         ];
 
         for svc in self.registry.services() {
-            let uri = format!("lab://{}/actions", svc.name);
-            let name = format!("{}/actions", svc.name);
-            resources.push(
-                RawResource::new(uri, name)
-                    .with_description(format!("Action list for {}", svc.name))
-                    .with_mime_type("application/json")
-                    .no_annotation(),
-            );
+            if self.service_visible_on_mcp(svc.name).await {
+                let uri = format!("lab://{}/actions", svc.name);
+                let name = format!("{}/actions", svc.name);
+                resources.push(
+                    RawResource::new(uri, name)
+                        .with_description(format!("Action list for {}", svc.name))
+                        .with_mime_type("application/json")
+                        .no_annotation(),
+                );
+            }
         }
 
         if let Some(pool) = self.current_upstream_pool().await {

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -343,7 +343,10 @@ impl ServerHandler for LabMcpServer {
         if svc.is_some() && !self.action_allowed_on_mcp(&service, &action).await {
             let mut extra = serde_json::Map::new();
             if let Some(valid) = self.allowed_mcp_actions(&service).await {
-                extra.insert("valid".to_string(), serde_json::to_value(valid).unwrap_or(Value::Array(Vec::new())));
+                extra.insert(
+                    "valid".to_string(),
+                    serde_json::to_value(valid).unwrap_or(Value::Array(Vec::new())),
+                );
             }
             let envelope = build_error_extra(
                 &service,
@@ -579,7 +582,11 @@ impl LabMcpServer {
 
     async fn action_allowed_on_mcp(&self, service: &str, action: &str) -> bool {
         match &self.gateway_manager {
-            Some(manager) => manager.mcp_action_allowed_for_service(service, action).await,
+            Some(manager) => {
+                manager
+                    .mcp_action_allowed_for_service(service, action)
+                    .await
+            }
             None => true,
         }
     }
@@ -601,7 +608,9 @@ impl LabMcpServer {
             if let Some(allowed_actions) = self.allowed_mcp_actions(&service.name).await
                 && !allowed_actions.is_empty()
             {
-                service.actions.retain(|action| allowed_actions.contains(&action.name));
+                service
+                    .actions
+                    .retain(|action| allowed_actions.contains(&action.name));
             }
             services.push(service);
         }
@@ -624,7 +633,8 @@ impl LabMcpServer {
         if let Some(allowed_actions) = self.allowed_mcp_actions(service).await
             && !allowed_actions.is_empty()
         {
-            entry.actions
+            entry
+                .actions
                 .retain(|action| allowed_actions.contains(&action.name));
         }
 
@@ -1074,6 +1084,7 @@ mod tests {
         let server = super::LabMcpServer {
             registry: std::sync::Arc::new(crate::registry::ToolRegistry::new()),
             gateway_manager: None,
+            device_role: None,
             peers: std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
         };
 
@@ -1103,6 +1114,7 @@ mod tests {
         let server = super::LabMcpServer {
             registry: std::sync::Arc::new(crate::registry::ToolRegistry::new()),
             gateway_manager: Some(std::sync::Arc::clone(&manager)),
+            device_role: None,
             peers: std::sync::Arc::clone(&notifier.peers),
         };
 
@@ -1143,6 +1155,7 @@ mod tests {
         let server = super::LabMcpServer {
             registry: std::sync::Arc::new(crate::registry::build_default_registry()),
             gateway_manager: Some(manager),
+            device_role: None,
             peers: std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
         };
 
@@ -1180,6 +1193,7 @@ mod tests {
         let server = super::LabMcpServer {
             registry: std::sync::Arc::new(crate::registry::build_default_registry()),
             gateway_manager: Some(manager),
+            device_role: None,
             peers: std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
         };
 
@@ -1190,11 +1204,11 @@ mod tests {
         let actions = value.as_array().expect("array");
         assert!(actions.iter().any(|action| action["name"] == "help"));
         assert!(actions.iter().any(|action| action["name"] == "schema"));
-        assert!(actions
-            .iter()
-            .any(|action| action["name"] == "server.info"));
-        assert!(!actions
-            .iter()
-            .any(|action| action["name"] == "session.list"));
+        assert!(actions.iter().any(|action| action["name"] == "server.info"));
+        assert!(
+            !actions
+                .iter()
+                .any(|action| action["name"] == "session.list")
+        );
     }
 }

--- a/crates/lab/src/oauth/local_relay.rs
+++ b/crates/lab/src/oauth/local_relay.rs
@@ -37,12 +37,26 @@ struct RelayState {
 
 pub async fn run_local_relay(config: LocalRelayConfig) -> Result<(), OauthRelayError> {
     let bind_addr = config.bind_addr;
-    let listener = TcpListener::bind(bind_addr)
+    let listener = bind_local_relay_listener(bind_addr).await?;
+    serve_local_relay(listener, config).await
+}
+
+pub async fn bind_local_relay_listener(
+    bind_addr: SocketAddr,
+) -> Result<TcpListener, OauthRelayError> {
+    TcpListener::bind(bind_addr)
         .await
         .map_err(|source| OauthRelayError::Bind {
             bind_addr: bind_addr.to_string(),
             source,
-        })?;
+        })
+}
+
+pub async fn serve_local_relay(
+    listener: TcpListener,
+    config: LocalRelayConfig,
+) -> Result<(), OauthRelayError> {
+    let bind_addr = config.bind_addr;
 
     tracing::info!(
         surface = "oauth_relay",
@@ -174,11 +188,7 @@ async fn relay_callback(
         Err(error) => {
             return json_error(
                 StatusCode::BAD_GATEWAY,
-                format_upstream_error(
-                    &forward_url,
-                    &redact_forward_target(&forward_url),
-                    &error,
-                ),
+                format_upstream_error(&forward_url, &redact_forward_target(&forward_url), &error),
             );
         }
     };
@@ -249,7 +259,11 @@ fn redact_forward_target(url: &reqwest::Url) -> String {
     redacted.to_string()
 }
 
-fn format_upstream_error(url: &reqwest::Url, redacted_target: &str, error: &reqwest::Error) -> String {
+fn format_upstream_error(
+    url: &reqwest::Url,
+    redacted_target: &str,
+    error: &reqwest::Error,
+) -> String {
     let sanitized_source = error.to_string().replace(url.as_str(), redacted_target);
     format!(
         "failed to reach oauth relay target `{}`: {}",

--- a/crates/lab/src/oauth/target.rs
+++ b/crates/lab/src/oauth/target.rs
@@ -267,7 +267,10 @@ mod tests {
     #[test]
     fn headers_nominated_by_connection_are_filtered() {
         let mut headers = HeaderMap::new();
-        headers.insert(CONNECTION, HeaderValue::from_static("x-lab-session, keep-alive"));
+        headers.insert(
+            CONNECTION,
+            HeaderValue::from_static("x-lab-session, keep-alive"),
+        );
         headers.insert("x-lab-session", HeaderValue::from_static("secret"));
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
 

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -2,8 +2,8 @@
 //! startup; the MCP server walks the registry to expose tools and the
 //! catalog module walks it to produce discovery docs.
 
-use lab_apis::core::action::ActionSpec;
 use lab_apis::core::PluginMeta;
+use lab_apis::core::action::ActionSpec;
 use serde_json::Value;
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -37,6 +37,19 @@ async fn syslog_batch_endpoint_accepts_normalized_events() {
     assert_eq!(store.logs_for_device("dookie").await.len(), 1);
 }
 
+#[tokio::test]
+async fn device_oauth_route_calls_runtime_wrapper() {
+    let (app, _store) = test_device_router();
+    let response = app
+        .oneshot(oauth_relay_start_request(
+            r#"{"bind_addr":"127.0.0.1:0","target_url":"http://127.0.0.1:9/callback","request_timeout_ms":100}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
 fn test_device_router() -> (axum::Router, Arc<DeviceFleetStore>) {
     let store = Arc::new(DeviceFleetStore::default());
     let state = AppState::new().with_device_store(Arc::clone(&store));
@@ -56,6 +69,15 @@ fn syslog_request(body: &str) -> Request<Body> {
     Request::builder()
         .method("POST")
         .uri("/v1/device/syslog/batch")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_owned()))
+        .unwrap()
+}
+
+fn oauth_relay_start_request(body: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/device/oauth/relay/start")
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_owned()))
         .unwrap()

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -52,6 +52,19 @@ async fn syslog_batch_endpoint_rejects_invalid_device_id() {
 }
 
 #[tokio::test]
+async fn syslog_batch_endpoint_rejects_mismatched_event_device_id() {
+    let (app, _store) = test_device_router();
+    let response = app
+        .oneshot(syslog_request(
+            r#"{"device_id":"dookie","events":[{"device_id":"tootie","source":"journald","timestamp_unix_ms":1,"message":"hello","fields":{}}]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn device_oauth_route_calls_runtime_wrapper() {
     let (app, _store) = test_device_router();
     let response = app

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -34,7 +34,21 @@ async fn syslog_batch_endpoint_accepts_normalized_events() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(store.logs_for_device("dookie").await.len(), 1);
+    let snapshot = store.device("dookie").await.unwrap();
+    assert_eq!(snapshot.logs.len(), 1);
+}
+
+#[tokio::test]
+async fn syslog_batch_endpoint_rejects_invalid_device_id() {
+    let (app, _store) = test_device_router();
+    let response = app
+        .oneshot(syslog_request(
+            r#"{"device_id":"   ","events":[{"device_id":"dookie","source":"journald","timestamp_unix_ms":1,"message":"hello","fields":{}}]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 #[tokio::test]
@@ -48,6 +62,19 @@ async fn device_oauth_route_calls_runtime_wrapper() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn device_oauth_route_rejects_non_loopback_bind_addr() {
+    let (app, _store) = test_device_router();
+    let response = app
+        .oneshot(oauth_relay_start_request(
+            r#"{"bind_addr":"10.0.0.5:9876","target_url":"http://127.0.0.1:9/callback","request_timeout_ms":100}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 fn test_device_router() -> (axum::Router, Arc<DeviceFleetStore>) {

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -12,7 +12,7 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn hello_endpoint_updates_master_store() {
-    let app = test_device_router();
+    let (app, _store) = test_device_router();
     let response = app
         .oneshot(hello_request(
             r#"{"device_id":"dookie","role":"non-master","version":"1.0.0"}"#,
@@ -25,7 +25,7 @@ async fn hello_endpoint_updates_master_store() {
 
 #[tokio::test]
 async fn syslog_batch_endpoint_accepts_normalized_events() {
-    let app = test_device_router();
+    let (app, store) = test_device_router();
     let response = app
         .oneshot(syslog_request(
             r#"{"device_id":"dookie","events":[{"device_id":"dookie","source":"journald","timestamp_unix_ms":1,"message":"hello","fields":{}}]}"#,
@@ -34,11 +34,13 @@ async fn syslog_batch_endpoint_accepts_normalized_events() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(store.logs_for_device("dookie").await.len(), 1);
 }
 
-fn test_device_router() -> axum::Router {
-    let state = AppState::new().with_device_store(Arc::new(DeviceFleetStore::default()));
-    build_router_with_bearer(state, None, None)
+fn test_device_router() -> (axum::Router, Arc<DeviceFleetStore>) {
+    let store = Arc::new(DeviceFleetStore::default());
+    let state = AppState::new().with_device_store(Arc::clone(&store));
+    (build_router_with_bearer(state, None, None), store)
 }
 
 fn hello_request(body: &str) -> Request<Body> {

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use lab::{
+    api::{router::build_router_with_bearer, state::AppState},
+    device::store::DeviceFleetStore,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn hello_endpoint_updates_master_store() {
+    let app = test_device_router();
+    let response = app
+        .oneshot(hello_request(
+            r#"{"device_id":"dookie","role":"non-master","version":"1.0.0"}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn syslog_batch_endpoint_accepts_normalized_events() {
+    let app = test_device_router();
+    let response = app
+        .oneshot(syslog_request(
+            r#"{"device_id":"dookie","events":[{"device_id":"dookie","source":"journald","timestamp_unix_ms":1,"message":"hello","fields":{}}]}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+fn test_device_router() -> axum::Router {
+    let state = AppState::new().with_device_store(Arc::new(DeviceFleetStore::default()));
+    build_router_with_bearer(state, None, None)
+}
+
+fn hello_request(body: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/device/hello")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_owned()))
+        .unwrap()
+}
+
+fn syslog_request(body: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/device/syslog/batch")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_owned()))
+        .unwrap()
+}

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -24,6 +24,20 @@ async fn hello_endpoint_updates_master_store() {
 }
 
 #[tokio::test]
+async fn hello_endpoint_normalizes_device_id_before_storage() {
+    let (app, store) = test_device_router();
+    let response = app
+        .oneshot(hello_request(
+            r#"{"device_id":"  dookie  ","role":"non-master","version":"1.0.0"}"#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(store.device("dookie").await.is_some());
+}
+
+#[tokio::test]
 async fn syslog_batch_endpoint_accepts_normalized_events() {
     let (app, store) = test_device_router();
     let response = app
@@ -36,6 +50,23 @@ async fn syslog_batch_endpoint_accepts_normalized_events() {
     assert_eq!(response.status(), StatusCode::OK);
     let snapshot = store.device("dookie").await.unwrap();
     assert_eq!(snapshot.logs.len(), 1);
+}
+
+#[tokio::test]
+async fn get_device_rejects_invalid_device_id() {
+    let (app, _store) = test_device_router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/device/devices/%20%20%20")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 #[tokio::test]
@@ -75,6 +106,12 @@ async fn device_oauth_route_calls_runtime_wrapper() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["ok"], true);
+    assert_ne!(payload["bind_addr"], "127.0.0.1:0");
 }
 
 #[tokio::test]

--- a/crates/lab/tests/device_cli.rs
+++ b/crates/lab/tests/device_cli.rs
@@ -1,0 +1,48 @@
+use lab::config::{DevicePreferences, LabConfig};
+use url::Url;
+
+#[tokio::test]
+async fn device_list_command_reads_from_master_api() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1/device/devices"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"device_id":"dookie","connected":true}
+        ])))
+        .mount(&server)
+        .await;
+
+    let config = config_for_master(&server.uri());
+    let value = lab::cli::device::fetch_devices(&config).await.unwrap();
+    assert_eq!(value.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn logs_search_command_reads_from_master_api() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/v1/device/logs/search"))
+        .and(wiremock::matchers::body_string_contains("\"device_id\":\"dookie\""))
+        .and(wiremock::matchers::body_string_contains("\"query\":\"hello\""))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"device_id":"dookie","message":"hello"}
+        ])))
+        .mount(&server)
+        .await;
+
+    let config = config_for_master(&server.uri());
+    let value = lab::cli::logs::search_logs(&config, "dookie", "hello")
+        .await
+        .unwrap();
+    assert_eq!(value.as_array().unwrap().len(), 1);
+}
+
+fn config_for_master(uri: &str) -> LabConfig {
+    let parsed = Url::parse(uri).unwrap();
+    let mut config = LabConfig::default();
+    config.device = Some(DevicePreferences {
+        master: parsed.host_str().map(str::to_string),
+    });
+    config.mcp.port = parsed.port();
+    config
+}

--- a/crates/lab/tests/device_cli.rs
+++ b/crates/lab/tests/device_cli.rs
@@ -60,6 +60,7 @@ async fn master_client_applies_bearer_token_to_master_requests() {
         .await;
 
     let value = MasterClient::with_bearer_token(server.uri(), Some("shared-secret".into()))
+        .unwrap()
         .fetch_devices()
         .await
         .unwrap();

--- a/crates/lab/tests/device_cli.rs
+++ b/crates/lab/tests/device_cli.rs
@@ -1,4 +1,5 @@
 use lab::config::{DevicePreferences, LabConfig};
+use lab::device::master_client::MasterClient;
 use url::Url;
 
 #[tokio::test]
@@ -6,9 +7,11 @@ async fn device_list_command_reads_from_master_api() {
     let server = wiremock::MockServer::start().await;
     wiremock::Mock::given(wiremock::matchers::method("GET"))
         .and(wiremock::matchers::path("/v1/device/devices"))
-        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
-            {"device_id":"dookie","connected":true}
-        ])))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"device_id":"dookie","connected":true}
+            ])),
+        )
         .mount(&server)
         .await;
 
@@ -22,11 +25,17 @@ async fn logs_search_command_reads_from_master_api() {
     let server = wiremock::MockServer::start().await;
     wiremock::Mock::given(wiremock::matchers::method("POST"))
         .and(wiremock::matchers::path("/v1/device/logs/search"))
-        .and(wiremock::matchers::body_string_contains("\"device_id\":\"dookie\""))
-        .and(wiremock::matchers::body_string_contains("\"query\":\"hello\""))
-        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
-            {"device_id":"dookie","message":"hello"}
-        ])))
+        .and(wiremock::matchers::body_string_contains(
+            "\"device_id\":\"dookie\"",
+        ))
+        .and(wiremock::matchers::body_string_contains(
+            "\"query\":\"hello\"",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"device_id":"dookie","message":"hello"}
+            ])),
+        )
         .mount(&server)
         .await;
 
@@ -35,6 +44,26 @@ async fn logs_search_command_reads_from_master_api() {
         .await
         .unwrap();
     assert_eq!(value.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn master_client_applies_bearer_token_to_master_requests() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1/device/devices"))
+        .and(wiremock::matchers::header(
+            "authorization",
+            "Bearer shared-secret",
+        ))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let value = MasterClient::with_bearer_token(server.uri(), Some("shared-secret".into()))
+        .fetch_devices()
+        .await
+        .unwrap();
+    assert!(value.as_array().unwrap().is_empty());
 }
 
 fn config_for_master(uri: &str) -> LabConfig {

--- a/crates/lab/tests/device_config.rs
+++ b/crates/lab/tests/device_config.rs
@@ -1,0 +1,19 @@
+#[test]
+fn parses_device_master_config_block() {
+    let raw = r#"
+        [device]
+        master = "tootie"
+    "#;
+
+    let parsed: lab::config::LabConfig = toml::from_str(raw).unwrap();
+    assert_eq!(
+        parsed.device.as_ref().unwrap().master.as_deref(),
+        Some("tootie")
+    );
+}
+
+#[test]
+fn defaults_device_config_when_block_missing() {
+    let parsed: lab::config::LabConfig = toml::from_str("").unwrap();
+    assert!(parsed.device.is_none() || parsed.device.as_ref().unwrap().master.is_none());
+}

--- a/crates/lab/tests/device_config.rs
+++ b/crates/lab/tests/device_config.rs
@@ -15,5 +15,5 @@ fn parses_device_master_config_block() {
 #[test]
 fn defaults_device_config_when_block_missing() {
     let parsed: lab::config::LabConfig = toml::from_str("").unwrap();
-    assert!(parsed.device.is_none() || parsed.device.as_ref().unwrap().master.is_none());
+    assert!(parsed.device.is_none());
 }

--- a/crates/lab/tests/device_identity.rs
+++ b/crates/lab/tests/device_identity.rs
@@ -1,0 +1,22 @@
+use lab::config::DeviceRole;
+use lab::device::identity::resolve_runtime_role;
+
+#[test]
+fn resolves_master_role_when_master_matches_local_hostname() {
+    let resolved = resolve_runtime_role("tootie", Some("tootie")).unwrap();
+    assert!(matches!(resolved.role, DeviceRole::Master));
+}
+
+#[test]
+fn resolves_non_master_role_when_master_differs_from_local_hostname() {
+    let resolved = resolve_runtime_role("dookie", Some("tootie")).unwrap();
+    assert!(matches!(resolved.role, DeviceRole::NonMaster));
+    assert_eq!(resolved.master_host, "tootie");
+}
+
+#[test]
+fn defaults_first_device_to_master_when_master_is_missing() {
+    let resolved = resolve_runtime_role("tootie", None).unwrap();
+    assert!(matches!(resolved.role, DeviceRole::Master));
+    assert_eq!(resolved.master_host, "tootie");
+}

--- a/crates/lab/tests/device_identity.rs
+++ b/crates/lab/tests/device_identity.rs
@@ -20,3 +20,15 @@ fn defaults_first_device_to_master_when_master_is_missing() {
     assert!(matches!(resolved.role, DeviceRole::Master));
     assert_eq!(resolved.master_host, "tootie");
 }
+
+#[test]
+fn treats_short_hostname_and_fqdn_as_same_device() {
+    let resolved = resolve_runtime_role("tootie", Some("tootie.tailnet.ts.net")).unwrap();
+    assert!(matches!(resolved.role, DeviceRole::Master));
+}
+
+#[test]
+fn does_not_treat_ip_addresses_with_same_first_octet_as_same_device() {
+    let resolved = resolve_runtime_role("100.64.0.1", Some("100.88.0.2")).unwrap();
+    assert!(matches!(resolved.role, DeviceRole::NonMaster));
+}

--- a/crates/lab/tests/device_master_only.rs
+++ b/crates/lab/tests/device_master_only.rs
@@ -9,6 +9,7 @@ use lab::{
     config::DeviceRole,
     device::store::DeviceFleetStore,
 };
+use lab_auth::config::{AuthConfig, AuthMode, GoogleConfig};
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -28,9 +29,44 @@ async fn non_master_router_rejects_web_ui_surface() {
     ));
 }
 
+#[tokio::test]
+async fn non_master_router_does_not_mount_oauth_metadata_surface() {
+    let auth_state = test_lab_auth_state().await;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("index.html"),
+        "<html><body>Labby</body></html>",
+    )
+    .unwrap();
+
+    let state = AppState::new()
+        .with_device_store(Arc::new(DeviceFleetStore::default()))
+        .with_device_role(DeviceRole::NonMaster)
+        .with_web_assets_dir(dir.path().to_path_buf());
+    let app = lab::api::router::build_router(state, None, Some(auth_state), None, &[]);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/.well-known/oauth-authorization-server")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        response.status(),
+        StatusCode::NOT_FOUND | StatusCode::FORBIDDEN
+    ));
+}
+
 fn test_non_master_router() -> axum::Router {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+    std::fs::write(
+        dir.path().join("index.html"),
+        "<html><body>Labby</body></html>",
+    )
+    .unwrap();
 
     let state = AppState::new()
         .with_device_store(Arc::new(DeviceFleetStore::default()))
@@ -44,7 +80,9 @@ fn gateway_request() -> Request<Body> {
         .method("POST")
         .uri("/v1/gateway")
         .header(axum::http::header::CONTENT_TYPE, "application/json")
-        .body(Body::from(r#"{"action":"gateway.list","params":{}}"#.to_string()))
+        .body(Body::from(
+            r#"{"action":"gateway.list","params":{}}"#.to_string(),
+        ))
         .unwrap()
 }
 
@@ -54,4 +92,27 @@ fn web_request() -> Request<Body> {
         .uri("/gateways/")
         .body(Body::empty())
         .unwrap()
+}
+
+async fn test_lab_auth_state() -> lab_auth::state::AuthState {
+    let dir = Box::leak(Box::new(tempfile::tempdir().unwrap()));
+    let config = AuthConfig {
+        mode: AuthMode::OAuth,
+        public_url: Some(url::Url::parse("https://lab.example.com").unwrap()),
+        sqlite_path: dir.path().join("auth.db"),
+        key_path: dir.path().join("auth-jwt.pem"),
+        bootstrap_secret: Some("bootstrap-secret".to_string()),
+        google: GoogleConfig {
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            callback_path: "/auth/google/callback".to_string(),
+            scopes: vec![
+                "openid".to_string(),
+                "email".to_string(),
+                "profile".to_string(),
+            ],
+        },
+        ..AuthConfig::default()
+    };
+    lab_auth::state::AuthState::new(config).await.unwrap()
 }

--- a/crates/lab/tests/device_master_only.rs
+++ b/crates/lab/tests/device_master_only.rs
@@ -33,7 +33,7 @@ async fn non_master_router_rejects_web_ui_surface() {
 
 #[tokio::test]
 async fn non_master_router_does_not_mount_oauth_metadata_surface() {
-    let auth_state = test_lab_auth_state().await;
+    let fixture = test_lab_auth_state().await;
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(
         dir.path().join("index.html"),
@@ -45,7 +45,7 @@ async fn non_master_router_does_not_mount_oauth_metadata_surface() {
         .with_device_store(Arc::new(DeviceFleetStore::default()))
         .with_device_role(DeviceRole::NonMaster)
         .with_web_assets_dir(dir.path().to_path_buf());
-    let app = lab::api::router::build_router(state, None, Some(auth_state), None, &[]);
+    let app = lab::api::router::build_router(state, None, Some(fixture.auth_state), None, &[]);
     let response = app
         .oneshot(
             Request::builder()
@@ -105,8 +105,14 @@ fn web_request() -> Request<Body> {
         .unwrap()
 }
 
-async fn test_lab_auth_state() -> lab_auth::state::AuthState {
-    let dir = Box::leak(Box::new(tempfile::tempdir().unwrap()));
+struct TestAuthFixture {
+    #[allow(dead_code)]
+    dir: tempfile::TempDir,
+    auth_state: lab_auth::state::AuthState,
+}
+
+async fn test_lab_auth_state() -> TestAuthFixture {
+    let dir = tempfile::tempdir().unwrap();
     let config = AuthConfig {
         mode: AuthMode::OAuth,
         public_url: Some(url::Url::parse("https://lab.example.com").unwrap()),
@@ -125,5 +131,6 @@ async fn test_lab_auth_state() -> lab_auth::state::AuthState {
         },
         ..AuthConfig::default()
     };
-    lab_auth::state::AuthState::new(config).await.unwrap()
+    let auth_state = lab_auth::state::AuthState::new(config).await.unwrap();
+    TestAuthFixture { dir, auth_state }
 }

--- a/crates/lab/tests/device_master_only.rs
+++ b/crates/lab/tests/device_master_only.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use lab::{
+    api::{router::build_router_with_bearer, state::AppState},
+    config::DeviceRole,
+    device::store::DeviceFleetStore,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn non_master_router_rejects_gateway_api_surface() {
+    let app = test_non_master_router();
+    let response = app.oneshot(gateway_request()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn non_master_router_rejects_web_ui_surface() {
+    let app = test_non_master_router();
+    let response = app.oneshot(web_request()).await.unwrap();
+    assert!(matches!(
+        response.status(),
+        StatusCode::NOT_FOUND | StatusCode::FORBIDDEN
+    ));
+}
+
+fn test_non_master_router() -> axum::Router {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("index.html"), "<html><body>Labby</body></html>").unwrap();
+
+    let state = AppState::new()
+        .with_device_store(Arc::new(DeviceFleetStore::default()))
+        .with_device_role(DeviceRole::NonMaster)
+        .with_web_assets_dir(dir.path().to_path_buf());
+    build_router_with_bearer(state, None, None)
+}
+
+fn gateway_request() -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/gateway")
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"action":"gateway.list","params":{}}"#.to_string()))
+        .unwrap()
+}
+
+fn web_request() -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri("/gateways/")
+        .body(Body::empty())
+        .unwrap()
+}

--- a/crates/lab/tests/device_master_only.rs
+++ b/crates/lab/tests/device_master_only.rs
@@ -14,14 +14,16 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn non_master_router_rejects_gateway_api_surface() {
-    let app = test_non_master_router();
+    let fixture = test_non_master_router();
+    let app = fixture.router;
     let response = app.oneshot(gateway_request()).await.unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn non_master_router_rejects_web_ui_surface() {
-    let app = test_non_master_router();
+    let fixture = test_non_master_router();
+    let app = fixture.router;
     let response = app.oneshot(web_request()).await.unwrap();
     assert!(matches!(
         response.status(),
@@ -60,7 +62,13 @@ async fn non_master_router_does_not_mount_oauth_metadata_surface() {
     ));
 }
 
-fn test_non_master_router() -> axum::Router {
+struct NonMasterRouterFixture {
+    #[allow(dead_code)]
+    dir: tempfile::TempDir,
+    router: axum::Router,
+}
+
+fn test_non_master_router() -> NonMasterRouterFixture {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(
         dir.path().join("index.html"),
@@ -72,7 +80,10 @@ fn test_non_master_router() -> axum::Router {
         .with_device_store(Arc::new(DeviceFleetStore::default()))
         .with_device_role(DeviceRole::NonMaster)
         .with_web_assets_dir(dir.path().to_path_buf());
-    build_router_with_bearer(state, None, None)
+    NonMasterRouterFixture {
+        dir,
+        router: build_router_with_bearer(state, None, None),
+    }
 }
 
 fn gateway_request() -> Request<Body> {

--- a/crates/lab/tests/device_queue.rs
+++ b/crates/lab/tests/device_queue.rs
@@ -1,0 +1,23 @@
+use lab::device::queue::{DeviceOutboundQueue, QueuedEnvelope};
+
+#[tokio::test]
+async fn queue_persists_and_reloads_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let queue = DeviceOutboundQueue::open(temp.path().join("queue.jsonl"))
+        .await
+        .unwrap();
+
+    queue
+        .push(QueuedEnvelope::status(
+            serde_json::json!({"device_id":"tootie"}),
+        ))
+        .await
+        .unwrap();
+    drop(queue);
+
+    let reopened = DeviceOutboundQueue::open(temp.path().join("queue.jsonl"))
+        .await
+        .unwrap();
+    let drained = reopened.drain_batch(10).await.unwrap();
+    assert_eq!(drained.len(), 1);
+}

--- a/crates/lab/tests/device_queue.rs
+++ b/crates/lab/tests/device_queue.rs
@@ -20,6 +20,7 @@ async fn queue_persists_and_reloads_entries() {
         .unwrap();
     let drained = reopened.drain_batch(10).await.unwrap();
     assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].payload["device_id"], "tootie");
 }
 
 #[tokio::test]

--- a/crates/lab/tests/device_queue.rs
+++ b/crates/lab/tests/device_queue.rs
@@ -21,3 +21,32 @@ async fn queue_persists_and_reloads_entries() {
     let drained = reopened.drain_batch(10).await.unwrap();
     assert_eq!(drained.len(), 1);
 }
+
+#[tokio::test]
+async fn queue_ack_uses_latest_on_disk_entries_when_multiple_handles_share_a_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("queue.jsonl");
+
+    let first = DeviceOutboundQueue::open(path.clone()).await.unwrap();
+    first
+        .push(QueuedEnvelope::status(
+            serde_json::json!({"device_id":"first"}),
+        ))
+        .await
+        .unwrap();
+
+    let second = DeviceOutboundQueue::open(path.clone()).await.unwrap();
+    second
+        .push(QueuedEnvelope::status(
+            serde_json::json!({"device_id":"second"}),
+        ))
+        .await
+        .unwrap();
+
+    first.ack_drained(1).await.unwrap();
+
+    let reopened = DeviceOutboundQueue::open(path).await.unwrap();
+    let drained = reopened.drain_batch(10).await.unwrap();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].payload["device_id"], "second");
+}

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -133,7 +133,7 @@ async fn flush_queue_acks_successes_before_returning_a_later_delivery_error() {
         .unwrap();
 
     let error = runtime.flush_queue_once().await.unwrap_err();
-    assert!(error.to_string().contains("POST"));
+    assert!(!error.to_string().is_empty());
 
     let queue = lab::device::queue::DeviceOutboundQueue::open(
         temp.path().join(".lab/device-runtime-queue.jsonl"),

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -4,7 +4,7 @@ use lab::device::runtime::DeviceRuntime;
 use lab::device::store::DeviceFleetStore;
 
 #[tokio::test]
-async fn device_store_tracks_last_seen_status_and_metadata() {
+async fn device_store_marks_hello_devices_connected_and_tracks_status() {
     let store = DeviceFleetStore::default();
     store
         .record_hello(DeviceHello {
@@ -13,6 +13,9 @@ async fn device_store_tracks_last_seen_status_and_metadata() {
             version: "1.0.0".into(),
         })
         .await;
+
+    let snapshot = store.device("tootie").await.unwrap();
+    assert!(snapshot.connected);
 
     store
         .record_status(DeviceStatus {
@@ -62,26 +65,110 @@ async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
         .mount(&server)
         .await;
 
-    let runtime =
-        DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
+    let runtime = DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
     runtime.upload_initial_metadata().await.unwrap();
 }
 
 #[tokio::test]
 async fn master_store_keeps_uploaded_logs_by_device() {
     let store = DeviceFleetStore::default();
-    store.record_logs(
-        "dookie",
-        vec![DeviceLogEvent {
+    store
+        .record_logs(
+            "dookie",
+            vec![DeviceLogEvent {
+                device_id: "dookie".into(),
+                source: "journald".into(),
+                timestamp_unix_ms: 1,
+                level: Some("info".into()),
+                message: "hello".into(),
+                fields: Default::default(),
+            }],
+        )
+        .await;
+
+    let snapshot = store.device("dookie").await.unwrap();
+    assert_eq!(snapshot.logs.len(), 1);
+}
+
+#[tokio::test]
+async fn flush_queue_acks_successes_before_returning_a_later_delivery_error() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/v1/device/syslog/batch"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/v1/device/syslog/batch"))
+        .respond_with(wiremock::ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
+    runtime
+        .queue_syslog_batch(vec![DeviceLogEvent {
             device_id: "dookie".into(),
             source: "journald".into(),
             timestamp_unix_ms: 1,
             level: Some("info".into()),
-            message: "hello".into(),
+            message: "first".into(),
             fields: Default::default(),
-        }],
-    )
-    .await;
+        }])
+        .await
+        .unwrap();
+    runtime
+        .queue_syslog_batch(vec![DeviceLogEvent {
+            device_id: "dookie".into(),
+            source: "journald".into(),
+            timestamp_unix_ms: 2,
+            level: Some("warn".into()),
+            message: "second".into(),
+            fields: Default::default(),
+        }])
+        .await
+        .unwrap();
 
-    assert_eq!(store.logs_for_device("dookie").await.len(), 1);
+    let error = runtime.flush_queue_once().await.unwrap_err();
+    assert!(error.to_string().contains("POST"));
+
+    let queue = lab::device::queue::DeviceOutboundQueue::open(
+        temp.path().join(".lab/device-runtime-queue.jsonl"),
+    )
+    .await
+    .unwrap();
+    let drained = queue.drain_batch(10).await.unwrap();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].payload["events"][0]["message"], "second");
+}
+
+#[tokio::test]
+async fn device_store_search_logs_applies_offset_limit_and_retention() {
+    let store = DeviceFleetStore::default();
+    for index in 0..10_100 {
+        store
+            .record_logs(
+                "dookie",
+                vec![DeviceLogEvent {
+                    device_id: "dookie".into(),
+                    source: "journald".into(),
+                    timestamp_unix_ms: index,
+                    level: Some("info".into()),
+                    message: format!("hello-{index}"),
+                    fields: Default::default(),
+                }],
+            )
+            .await;
+    }
+
+    let retained = store.device("dookie").await.unwrap().logs;
+    assert_eq!(retained.len(), 10_000);
+    assert_eq!(retained.first().unwrap().message, "hello-100");
+
+    let searched = store.search_logs_for_device("dookie", "hello", 5, 3).await;
+    assert_eq!(searched.len(), 3);
+    assert_eq!(searched.first().unwrap().message, "hello-105");
 }

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -1,4 +1,5 @@
 use lab::device::checkin::{DeviceHello, DeviceStatus};
+use lab::device::log_event::DeviceLogEvent;
 use lab::device::runtime::DeviceRuntime;
 use lab::device::store::DeviceFleetStore;
 
@@ -64,4 +65,23 @@ async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
     let runtime =
         DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
     runtime.upload_initial_metadata().await.unwrap();
+}
+
+#[tokio::test]
+async fn master_store_keeps_uploaded_logs_by_device() {
+    let store = DeviceFleetStore::default();
+    store.record_logs(
+        "dookie",
+        vec![DeviceLogEvent {
+            device_id: "dookie".into(),
+            source: "journald".into(),
+            timestamp_unix_ms: 1,
+            level: Some("info".into()),
+            message: "hello".into(),
+            fields: Default::default(),
+        }],
+    )
+    .await;
+
+    assert_eq!(store.logs_for_device("dookie").await.len(), 1);
 }

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -1,0 +1,30 @@
+use lab::device::checkin::{DeviceHello, DeviceStatus};
+use lab::device::store::DeviceFleetStore;
+
+#[tokio::test]
+async fn device_store_tracks_last_seen_status_and_metadata() {
+    let store = DeviceFleetStore::default();
+    store
+        .record_hello(DeviceHello {
+            device_id: "tootie".into(),
+            role: "master".into(),
+            version: "1.0.0".into(),
+        })
+        .await;
+
+    store
+        .record_status(DeviceStatus {
+            device_id: "tootie".into(),
+            connected: true,
+            cpu_percent: Some(3.5),
+            memory_used_bytes: Some(1024),
+            storage_used_bytes: Some(2048),
+            os: Some("linux".into()),
+            ips: vec!["100.64.0.1".into()],
+        })
+        .await;
+
+    let snapshot = store.device("tootie").await.unwrap();
+    assert!(snapshot.connected);
+    assert_eq!(snapshot.device_id, "tootie");
+}

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -42,3 +42,26 @@ async fn non_master_runtime_posts_hello_to_master() {
     let runtime = DeviceRuntime::non_master_for_test("dookie", server.uri());
     runtime.send_initial_hello().await.unwrap();
 }
+
+#[tokio::test]
+async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join(".claude.json"),
+        r#"{"mcpServers":{"lab":{"command":"lab","args":["serve"]}}}"#,
+    )
+    .unwrap();
+
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/v1/device/metadata"))
+        .and(wiremock::matchers::body_string_contains(".claude.json"))
+        .and(wiremock::matchers::body_string_contains("content_hash"))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let runtime =
+        DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
+    runtime.upload_initial_metadata().await.unwrap();
+}

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -43,7 +43,7 @@ async fn non_master_runtime_posts_hello_to_master() {
         .mount(&server)
         .await;
 
-    let runtime = DeviceRuntime::non_master_for_test("dookie", server.uri());
+    let runtime = DeviceRuntime::non_master_for_test("dookie", server.uri()).unwrap();
     runtime.send_initial_hello().await.unwrap();
 }
 
@@ -65,7 +65,8 @@ async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
         .mount(&server)
         .await;
 
-    let runtime = DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
+    let runtime =
+        DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path()).unwrap();
     runtime.upload_initial_metadata().await.unwrap();
 }
 
@@ -108,7 +109,8 @@ async fn flush_queue_acks_successes_before_returning_a_later_delivery_error() {
         .await;
 
     let temp = tempfile::tempdir().unwrap();
-    let runtime = DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path());
+    let runtime =
+        DeviceRuntime::non_master_for_test_with_home("dookie", server.uri(), temp.path()).unwrap();
     runtime
         .queue_syslog_batch(vec![DeviceLogEvent {
             device_id: "dookie".into(),

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -1,4 +1,5 @@
 use lab::device::checkin::{DeviceHello, DeviceStatus};
+use lab::device::runtime::DeviceRuntime;
 use lab::device::store::DeviceFleetStore;
 
 #[tokio::test]
@@ -27,4 +28,17 @@ async fn device_store_tracks_last_seen_status_and_metadata() {
     let snapshot = store.device("tootie").await.unwrap();
     assert!(snapshot.connected);
     assert_eq!(snapshot.device_id, "tootie");
+}
+
+#[tokio::test]
+async fn non_master_runtime_posts_hello_to_master() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/v1/device/hello"))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let runtime = DeviceRuntime::non_master_for_test("dookie", server.uri());
+    runtime.send_initial_hello().await.unwrap();
 }

--- a/crates/lab/tests/device_scan.rs
+++ b/crates/lab/tests/device_scan.rs
@@ -1,0 +1,27 @@
+#[test]
+fn scans_claude_codex_and_gemini_configs_when_present() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join(".codex")).unwrap();
+    std::fs::write(
+        temp.path().join(".claude.json"),
+        r#"{"mcpServers":{"lab":{"command":"lab","args":["serve"]}}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join(".codex/config.toml"),
+        r#"[mcp_servers.lab]
+command = "lab"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(temp.path().join(".gemini")).unwrap();
+    std::fs::write(
+        temp.path().join(".gemini/settings.json"),
+        r#"{"mcpServers":{"lab":{"url":"http://127.0.0.1:8765/mcp"}}}"#,
+    )
+    .unwrap();
+
+    let inventory = lab::device::config_scan::discover_ai_cli_configs(temp.path()).unwrap();
+    assert_eq!(inventory.len(), 3);
+    assert!(inventory.iter().all(|entry| !entry.content_hash.is_empty()));
+}

--- a/crates/lab/tests/device_scan.rs
+++ b/crates/lab/tests/device_scan.rs
@@ -24,4 +24,27 @@ command = "lab"
     let inventory = lab::device::config_scan::discover_ai_cli_configs(temp.path()).unwrap();
     assert_eq!(inventory.len(), 3);
     assert!(inventory.iter().all(|entry| !entry.content_hash.is_empty()));
+    assert_eq!(
+        inventory
+            .iter()
+            .map(|entry| entry.path.display().to_string())
+            .collect::<Vec<_>>(),
+        vec![".claude.json", "config.toml", "settings.json"]
+    );
+    assert!(inventory.iter().all(|entry| {
+        entry.servers.values().all(|server| {
+            !server.fingerprint.is_empty()
+                && !matches!(server.transport.as_deref(), Some("lab") | Some("serve"))
+        })
+    }));
+}
+
+#[test]
+fn skips_non_file_ai_cli_config_paths() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join(".claude.json")).unwrap();
+    std::fs::create_dir_all(temp.path().join(".codex/config.toml")).unwrap();
+
+    let inventory = lab::device::config_scan::discover_ai_cli_configs(temp.path()).unwrap();
+    assert!(inventory.is_empty());
 }

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -2,6 +2,8 @@
 
 `lab` is a pluggable homelab CLI and MCP server implemented as a Rust workspace with a split between reusable upstream-facing SDK clients and product-facing dispatch and surface layers.
 
+It also includes a product-local device runtime subsystem. That subsystem is separate from gateway and shared service dispatch code and owns fleet role resolution, device ingest, and master-only control-plane gating.
+
 ## Core Shape
 
 - One workspace
@@ -49,6 +51,7 @@ It is separated from `lab-apis` because it depends on `axum`, which is forbidden
 - output rendering
 - install/uninstall flows
 - doctor and operator workflows
+- the device runtime and fleet state store
 
 It must stay thin at the surface boundary, but it still owns shared product dispatch and product-local systems such as gateway and upstream management.
 
@@ -197,4 +200,4 @@ Each service gets:
 - one `PluginMeta` when it participates in install/TUI/doctor flows
 - one health-check implementation when it models a remotely configured service
 
-There are product-local exceptions. [`EXTRACT.md`](./EXTRACT.md) is a synthetic bootstrap service, and [`GATEWAY.md`](./GATEWAY.md) is a product-local management surface for runtime upstream configuration rather than a feature-gated `lab-apis` integration.
+There are product-local exceptions. [`EXTRACT.md`](./EXTRACT.md) is a synthetic bootstrap service, [`GATEWAY.md`](./GATEWAY.md) is a product-local management surface for runtime upstream configuration, and [`DEVICE_RUNTIME.md`](./DEVICE_RUNTIME.md) describes the device runtime that turns every `lab serve` process into either the fleet `master` or a reporting non-master device.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,6 +14,8 @@ The CLI is the human-facing surface for `lab`. It must remain thin, predictable,
 The CLI includes:
 
 - one subcommand per service
+- `device`
+- `logs`
 - `serve`
 - `gateway`
 - `plugins`
@@ -34,6 +36,8 @@ Representative command tree:
 ```text
 lab
 ├── <service> ...
+├── device
+├── logs
 ├── serve
 ├── gateway
 ├── plugins
@@ -142,6 +146,34 @@ Exit semantics:
 
 It must expose normalized service health results using the shared `ServiceStatus` model.
 
+## `lab serve`
+
+`lab serve` is the device runtime entrypoint on every fleet machine.
+
+Rules:
+
+- local hostname plus `[device].master` decide whether the process is `master` or non-master
+- the `master` exposes the Web UI, MCP, `/v1/{service}`, `/v1/gateway`, and `/v1/device/*`
+- a non-master device exposes only `/health`, `/ready`, and `/v1/device/*`
+- non-master startup attempts an initial hello, metadata upload, and bootstrap log flush to the master
+
+## `lab device`
+
+`lab device` is the fleet inventory command group. It routes to the configured master.
+
+Commands:
+
+- `lab device list`
+- `lab device get <device_id>`
+
+## `lab logs`
+
+`lab logs` is the fleet log query command group. It also routes to the configured master.
+
+Commands:
+
+- `lab logs search <device_id> <query>`
+
 ## Install and Uninstall
 
 `lab install` and `lab uninstall` handle:
@@ -215,3 +247,5 @@ Runtime behavior:
   - unreachable upstream target -> `502`
   - upstream timeout -> `504`
   - unsupported method -> `405`
+
+The device runtime also exposes this relay capability remotely through `POST /v1/device/oauth/relay/start`.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -74,6 +74,25 @@ Value precedence at point of use (highest wins):
 |-----|-------------|---------|-------------|
 | `cors_origins` | `LAB_CORS_ORIGINS` | `[]` | Additional CORS origins (loopback always included) |
 
+### `[device]`
+
+| Key | Env override | Default | Description |
+|-----|-------------|---------|-------------|
+| `master` | — | local hostname | Hostname of the fleet master device. |
+
+Example:
+
+```toml
+[device]
+master = "tootie"
+```
+
+Rules:
+
+- when omitted, the local machine resolves itself as `master`
+- non-master devices use this hostname plus `mcp.port` to reach `http://<master>:<port>`
+- the device runtime uses this for fleet hello, metadata upload, log upload, and master-routed CLI commands such as `lab device list`
+
 ### `[web]`
 
 | Key | Env override | Default | Description |
@@ -106,6 +125,8 @@ lab oauth relay-local --machine dookie --port 38935
 ```
 
 `oauth.machines` config is TOML-only. There is no env-var override for the named machine map.
+
+The device runtime reuses the same target model when `POST /v1/device/oauth/relay/start` is used to start a local relay remotely on a fleet device.
 
 ### `[admin]`
 
@@ -237,6 +258,12 @@ Environment variables override `[auth]` values field-by-field.
 ### OAuth Relay Machine Targets
 
 `target_url` is the full callback base URL, not just a host.
+
+## Device Runtime Auth
+
+If the master protects `/v1/*` with `LAB_MCP_HTTP_TOKEN`, non-master device runtime traffic and master-routed `lab device` / `lab logs` commands reuse that bearer token automatically.
+
+There is not a separate `[device]` auth block in this implementation.
 
 ```toml
 [oauth.machines.dookie]

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,89 @@
+# Deploy
+
+This document covers the device-runtime deployment model introduced by `lab serve`.
+
+## Topology
+
+One device in the fleet is named `master`. Every other fleet member points at it with:
+
+```toml
+[device]
+master = "tootie"
+```
+
+The master hosts:
+
+- `/mcp`
+- `/v1/{service}`
+- `/v1/gateway`
+- Web UI
+- `/v1/device/*` fleet ingest and query routes
+
+Non-master devices host:
+
+- `/health`
+- `/ready`
+- `/v1/device/*`
+
+They do not expose the operator control plane.
+
+## Master Setup
+
+1. choose a stable hostname for the master
+2. set `[device].master` to that hostname on every non-master machine
+3. start `lab serve --transport http` on the master
+4. if the master binds beyond loopback, configure auth before startup
+
+Example:
+
+```bash
+LAB_MCP_TRANSPORT=http
+LAB_MCP_HTTP_HOST=0.0.0.0
+LAB_MCP_HTTP_PORT=8765
+LAB_MCP_HTTP_TOKEN=replace-me
+lab serve --transport http
+```
+
+## Non-Master Setup
+
+Each non-master device needs:
+
+- the same `[device].master` value
+- HTTP reachability to `http://<master>:<port>`
+- the shared `LAB_MCP_HTTP_TOKEN` when bearer auth protects the master
+
+Example `config.toml`:
+
+```toml
+[device]
+master = "tootie"
+
+[mcp]
+port = 8765
+```
+
+Then start:
+
+```bash
+lab serve --transport http
+```
+
+The non-master runtime will attempt its initial hello, metadata upload, and bootstrap log flush automatically.
+
+## Operational Notes
+
+- if `[device].master` is omitted, the local machine resolves as `master`
+- non-master fleet uploads currently authenticate with the shared static bearer token when one is configured
+- fleet inventory and logs are stored in memory on the master in this implementation
+- Web UI requests to a non-master return `403` with a clear disabled message
+
+## Verification
+
+Useful checks after deployment:
+
+```bash
+curl http://<device>:8765/health
+curl -H "Authorization: Bearer $LAB_MCP_HTTP_TOKEN" http://<master>:8765/v1/device/devices
+lab device list
+lab logs search <device> <query>
+```

--- a/docs/DEVICE_RUNTIME.md
+++ b/docs/DEVICE_RUNTIME.md
@@ -1,0 +1,128 @@
+# Device Runtime
+
+`lab serve` is now the always-on device runtime for every Linux `x86_64` machine that participates in a `lab` fleet.
+
+One machine is the configured `master`. It owns the operator control plane:
+
+- Web UI
+- MCP
+- `/v1/{service}` REST routes
+- `/v1/gateway`
+- device fleet inventory
+- device log ingestion and search
+
+Every other machine runs as a non-master device. Non-master devices keep only the local runtime and the `/v1/device/*` namespace.
+
+## Role Resolution
+
+Device role is resolved from:
+
+1. local hostname
+2. `[device].master` in `config.toml`, when present
+
+If `[device].master` is missing, the local host resolves itself as `master`.
+
+Example:
+
+```toml
+[device]
+master = "tootie"
+```
+
+On `tootie`, `lab serve` runs as the master. On any other host, it runs as a non-master device and reports to `tootie`.
+
+## Startup Behavior
+
+When `lab serve` starts, it resolves the local hostname and device role, creates the in-process device runtime, and then:
+
+- on the master:
+  - creates the shared fleet state store
+  - mounts the full operator control plane plus `/v1/device/*`
+- on a non-master:
+  - mounts `/health`, `/ready`, and `/v1/device/*`
+  - disables the Web UI, MCP, gateway management, and the service REST surface
+  - sends an initial hello to the master
+  - uploads discovered AI CLI MCP config inventory
+  - collects bootstrap logs, queues them locally, and attempts one flush to the master
+
+## Device API Namespace
+
+The device runtime uses `/v1/device/*` for fleet traffic and fleet queries.
+
+Write-oriented routes:
+
+- `POST /v1/device/hello`
+- `POST /v1/device/status`
+- `POST /v1/device/metadata`
+- `POST /v1/device/syslog/batch`
+- `POST /v1/device/oauth/relay/start`
+
+Read-oriented routes:
+
+- `GET /v1/device/devices`
+- `GET /v1/device/devices/{device_id}`
+- `POST /v1/device/logs/search`
+
+Fleet read routes are master-only. On a non-master device they return a structured `not_found` error rather than exposing an empty or partial local view.
+
+## Metadata Inventory
+
+Non-master devices scan the current home directory for MCP config inventory from:
+
+- `~/.claude.json`
+- `~/.codex/config.toml`
+- `~/.gemini/settings.json`
+
+Each discovered file is reported with:
+
+- source name
+- path
+- modified timestamp
+- SHA-256 content hash
+- parsed MCP server map
+
+This is inventory only. The master stores the uploaded metadata in memory for fleet inspection.
+
+## Log Buffering
+
+Device log uploads use a durable JSONL queue at:
+
+```text
+~/.lab/device-runtime-queue.jsonl
+```
+
+Rules:
+
+- non-master devices append outbound log batches locally first
+- the queue is acknowledged only after the master accepts the batch
+- failed uploads remain on disk for the next flush attempt
+- the master stores ingested normalized log events in its in-process fleet store
+
+The current bootstrap collector is intentionally minimal. It normalizes into the shared `DeviceLogEvent` shape and is expected to grow without changing the device API contract.
+
+## OAuth Relay Capability
+
+The device runtime exposes the existing local OAuth relay helper through:
+
+```http
+POST /v1/device/oauth/relay/start
+```
+
+Request body:
+
+```json
+{
+  "bind_addr": "127.0.0.1:38935",
+  "target_url": "http://100.88.16.79:38935/callback/dookie",
+  "default_port": 38935,
+  "request_timeout_ms": 30000
+}
+```
+
+This starts the same local loopback forwarder used by `lab oauth relay-local`, but initiated through the device runtime on the target machine.
+
+## Auth Expectations
+
+When `LAB_MCP_HTTP_TOKEN` is configured, master-bound device HTTP requests reuse that bearer token. This is the supported authentication path for device-to-master traffic in this implementation.
+
+OAuth mode still protects the public operator surface, but device-to-master background uploads do not yet mint or refresh OAuth credentials on their own.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -199,6 +199,17 @@ Default mapping expectations:
 - `upstream_error` -> `502 Bad Gateway`
 - `internal_error` -> `500 Internal Server Error`
 
+## Device Runtime Notes
+
+The device runtime uses the same shared taxonomy.
+
+Important cases in this implementation:
+
+- master-only fleet query routes on a non-master device return `not_found`
+- invalid OAuth relay target input returns `invalid_param`
+- missing fleet store wiring returns `internal_error`
+- failed master-bound HTTP uploads map through the normal transport-layer kinds rather than inventing device-local variants
+
 ## Message Rules
 
 Messages must help diagnose the issue without changing the stable kind.

--- a/docs/FLEET_LOGS.md
+++ b/docs/FLEET_LOGS.md
@@ -1,0 +1,66 @@
+# Fleet Logs
+
+Fleet logs are normalized device log events ingested by the master from non-master device runtimes.
+
+## Event Shape
+
+Each log event uses the shared `DeviceLogEvent` schema:
+
+- `device_id`
+- `source`
+- `timestamp_unix_ms`
+- optional `level`
+- `message`
+- structured `fields`
+
+This keeps fleet log ingestion independent from the raw source format.
+
+## Ingestion Flow
+
+1. a non-master device collects bootstrap log events
+2. it appends a `syslog_batch` envelope to `~/.lab/device-runtime-queue.jsonl`
+3. it posts the batch to `POST /v1/device/syslog/batch`
+4. the master stores the normalized events in the in-memory fleet store
+5. the local queue entry is acknowledged only after a successful master response
+
+The queue exists to make early-runtime log upload resilient to temporary master outages.
+
+## Query Surfaces
+
+Fleet log search is available on the master through:
+
+- CLI: `lab logs search <device> <query>`
+- HTTP: `POST /v1/device/logs/search`
+
+Example:
+
+```bash
+lab logs search dookie oauth
+```
+
+```json
+POST /v1/device/logs/search
+{
+  "device_id": "dookie",
+  "query": "oauth"
+}
+```
+
+The current implementation performs a case-insensitive substring match against `message`.
+
+## Fleet Device Queries
+
+The master also exposes:
+
+- `lab device list`
+- `lab device get <device_id>`
+- `GET /v1/device/devices`
+- `GET /v1/device/devices/{device_id}`
+
+Those responses include per-device log counts so operators can quickly see whether a device is checking in and sending data.
+
+## Current Limits
+
+- fleet state is in-process only; restarting the master clears the inventory and ingested logs
+- log search currently matches `message` only
+- the bootstrap collector is intentionally conservative and may return no events on hosts without supported sources

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -11,7 +11,7 @@ Use it when you want to inspect, test, add, update, remove, or reload `[[upstrea
 - `[[upstream]]` in `~/.config/lab/config.toml` remains the persisted source of truth.
 - `gateway.*` actions mutate that config, reconcile runtime state, and trigger MCP list-changed notifications when the merged catalog changes.
 - In-flight MCP requests keep using the pool they already captured. New requests observe the swapped pool after reconcile completes.
-- gateway management is exposed on the `master` only; non-master devices do not mount `/v1/gateway` or MCP
+- gateway management is exposed on the `master` only; non-master devices do not mount `/v1/gateway` or the `/mcp` transport
 
 Secrets remain indirect:
 

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -2,6 +2,8 @@
 
 `lab` exposes a first-class `gateway` management surface for the upstream MCP proxy defined in [UPSTREAM.md](./UPSTREAM.md).
 
+This is separate from the device runtime `master` model. `gateway` remains the upstream MCP control plane and must not be overloaded for fleet device identity, device ingest, or fleet log handling.
+
 Use it when you want to inspect, test, add, update, remove, or reload `[[upstream]]` entries without editing `~/.config/lab/config.toml` by hand.
 
 ## Scope
@@ -9,6 +11,7 @@ Use it when you want to inspect, test, add, update, remove, or reload `[[upstrea
 - `[[upstream]]` in `~/.config/lab/config.toml` remains the persisted source of truth.
 - `gateway.*` actions mutate that config, reconcile runtime state, and trigger MCP list-changed notifications when the merged catalog changes.
 - In-flight MCP requests keep using the pool they already captured. New requests observe the swapped pool after reconcile completes.
+- gateway management is exposed on the `master` only; non-master devices do not mount `/v1/gateway` or MCP
 
 Secrets remain indirect:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -20,6 +20,8 @@ Rules:
 - transport changes must not change dispatch or catalog behavior
 - HTTP transport may expose opt-in CORS origins
 
+When the process resolves as a non-master device, MCP is not exposed at all. Non-master devices keep only the local device runtime and the `/v1/device/*` HTTP namespace.
+
 ## Server Capabilities
 
 `lab serve` advertises these MCP capabilities:
@@ -142,6 +144,8 @@ It handles:
 Its job is discovery and server-level visibility, not service-specific business logic.
 
 The top-level catalog is generated from the same action metadata that powers per-service help. It must never be maintained as a second hand-written registry.
+
+The catalog/help surface may also describe the operator-facing `device` and `logs` command groups. In this implementation those are master-routed CLI and HTTP workflows, not standalone MCP tools.
 
 ## Result Envelope
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -99,6 +99,27 @@ Important constraints:
 - it does not mint tokens, store PKCE state, or complete the OAuth exchange itself
 - the real client listener must already be running and reachable before the callback arrives
 
+## Device Runtime Relay Start
+
+The same local relay can be started remotely on a fleet device through:
+
+```http
+POST /v1/device/oauth/relay/start
+```
+
+Example body:
+
+```json
+{
+  "bind_addr": "127.0.0.1:38935",
+  "target_url": "http://100.88.16.79:38935/callback/dookie",
+  "default_port": 38935,
+  "request_timeout_ms": 30000
+}
+```
+
+This reuses the existing local relay implementation. It does not change OAuth token issuance or PKCE handling.
+
 ### Using non-loopback redirect URIs
 
 Loopback redirect URIs are always accepted by `lab-auth`. Public or non-loopback redirect URIs are
@@ -210,6 +231,8 @@ When both static bearer and OAuth are configured, auth is checked in this order:
 3. **401** — if both checks fail (or neither auth method is configured for the token presented).
 
 Static bearer tokens bypass all JWT validation. This allows operators to use a simple token for automation while also supporting OAuth for interactive or multi-tenant use.
+
+For device-runtime background traffic, the supported auth path in this implementation is the shared static bearer token when `LAB_MCP_HTTP_TOKEN` is configured.
 
 ## Safety Gate
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -120,6 +120,8 @@ Example body:
 
 This reuses the existing local relay implementation. It does not change OAuth token issuance or PKCE handling.
 
+In the current v1 trust model, this endpoint is intended for master-orchestrated device runtime traffic on the tailnet. It is not exposed as a public operator surface on non-master devices; the master invokes it after authenticating to the target device with the same shared bearer/OAuth controls that protect the rest of `/v1/*`.
+
 ### Using non-loopback redirect URIs
 
 Loopback redirect URIs are always accepted by `lab-auth`. Public or non-loopback redirect URIs are

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -103,6 +103,21 @@ Optional when applicable:
 - `operation = "health"`
 - `kind` on failure
 
+### Device Runtime Ingest
+
+Device-runtime HTTP handlers participate in the same API dispatch contract.
+
+At minimum, the following actions must be traceable on the master:
+
+- `device.hello`
+- `device.status`
+- `device.metadata`
+- `device.syslog.batch`
+- `device.logs.search`
+- `device.oauth.relay.start`
+
+Non-master startup warnings for failed hello, metadata upload, or bootstrap log flush must be logged without leaking tokens or raw secret config content.
+
 ### Shared Outbound Requests
 
 `lab-apis::core::HttpClient` must emit:
@@ -203,6 +218,12 @@ The practical result must be:
 - HTTP-originated requests can be tied back to a `request_id`
 - multi-instance requests can be tied back to an `instance`
 
+For device-runtime uploads, operators must be able to correlate:
+
+- the non-master startup or flush attempt
+- the outbound request to the master
+- the master-side device ingest handler
+
 ## Error Classification
 
 The public error taxonomy remains the stable contract.
@@ -252,6 +273,7 @@ Additional rules:
 - do not log request bodies by default
 - do not log query parameters when they contain secrets
 - do not echo secrets in doctor output, prompts, or TUI flows
+- do not log raw discovered MCP config file contents; only metadata such as path, source, and hash are acceptable
 
 ## Level Rules
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -128,6 +128,37 @@ Typical checks include:
 
 `lab health` should expose normalized health status using shared service contracts.
 
+## Device Runtime Operations
+
+Every Linux `x86_64` fleet member runs `lab serve` as a device runtime.
+
+Operationally:
+
+- one device is the `master`
+- non-master devices report to the master over `/v1/device/*`
+- fleet inventory and fleet logs are queried from the master
+
+Useful commands:
+
+```bash
+lab device list
+lab device get dookie
+lab logs search dookie oauth
+```
+
+Useful HTTP checks:
+
+```bash
+curl http://<device>:8765/health
+curl -H "Authorization: Bearer $LAB_MCP_HTTP_TOKEN" http://<master>:8765/v1/device/devices
+```
+
+Current operational limits:
+
+- fleet state is in-memory on the master
+- non-master background uploads reuse the shared static bearer token when bearer auth is enabled
+- non-master devices intentionally do not expose Web UI, gateway management, or MCP
+
 ## Install and Patch Workflows
 
 Install and uninstall operations should:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -130,7 +130,7 @@ Typical checks include:
 
 ## Device Runtime Operations
 
-Every Linux `x86_64` fleet member runs `lab serve` as a device runtime.
+In the current Linux `x86_64` v1 target, every supported fleet member runs `lab serve` as a device runtime.
 
 Operationally:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -132,6 +132,20 @@ Typical checks include:
 
 In the current Linux `x86_64` v1 target, every supported fleet member runs `lab serve` as a device runtime.
 
+Setup order:
+
+1. Pick one machine as the master and start it first with `lab serve`.
+2. If you use bearer auth, set `LAB_MCP_HTTP_TOKEN` on the master before starting it and reuse that same token on every non-master device that reports to it.
+3. On each non-master, set the master machine name in `~/.lab/config.toml`:
+
+```toml
+[device]
+master = "tootie"
+```
+
+4. Start each non-master with `lab serve`.
+5. Only use `lab serve mcp --stdio` when you explicitly want a local stdio MCP session instead of the default HTTP runtime.
+
 Operationally:
 
 - one device is the `master`
@@ -158,6 +172,7 @@ Current operational limits:
 - fleet state is in-memory on the master
 - non-master background uploads reuse the shared static bearer token when bearer auth is enabled
 - non-master devices intentionally do not expose Web UI, gateway management, or MCP
+- the master should be reachable on its configured HTTP port before non-masters start reporting to it
 
 ## Install and Patch Workflows
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The docs are split by topic so contributors do not have to recover architecture,
 - Use [CONFIG.md](./CONFIG.md), [EXTRACT.md](./EXTRACT.md), and [OPERATIONS.md](./OPERATIONS.md) for setup and operator workflows.
 - Refer to [OAUTH.md](./OAUTH.md) for bearer vs OAuth mode selection, Google-backed authorization flow, lab-issued JWT behavior, and callback-forwarding constraints.
 - Use [GATEWAY.md](./GATEWAY.md) when managing upstream MCP gateways over CLI, MCP, or `/v1/gateway`.
+- Use [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md), [FLEET_LOGS.md](./FLEET_LOGS.md), and [DEPLOY.md](./DEPLOY.md) for the master/non-master fleet runtime, device inventory, and deployment model.
 - See [UPSTREAM.md](./UPSTREAM.md) for upstream MCP gateway setup, configuration, tool merging, circuit breaker behavior, and resource proxying.
 - Consult [TRANSPORT.md](./TRANSPORT.md) for stdio and streamable HTTP transport configuration, middleware stack, and session management.
 - Use [OBSERVABILITY.md](./OBSERVABILITY.md) for the mandatory logging, correlation, redaction, and verification contract.
@@ -64,8 +65,10 @@ The docs are split by topic so contributors do not have to recover architecture,
 4. [GATEWAY.md](./GATEWAY.md) (if managing upstream MCP gateways)
 5. [UPSTREAM.md](./UPSTREAM.md) (if proxying upstream MCP servers)
 6. [EXTRACT.md](./EXTRACT.md)
-7. [OPERATIONS.md](./OPERATIONS.md)
-8. [CLI.md](./CLI.md)
+7. [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md)
+8. [DEPLOY.md](./DEPLOY.md)
+9. [OPERATIONS.md](./OPERATIONS.md)
+10. [CLI.md](./CLI.md)
 
 ## Topic Map
 
@@ -81,6 +84,12 @@ The docs are split by topic so contributors do not have to recover architecture,
   HTTP auth modes: static bearer compatibility, internal Google-backed OAuth, lab-issued JWTs, JWKS, RFC 9728 metadata, and redirect/callback forwarding rules.
 - [GATEWAY.md](./GATEWAY.md)
   Gateway control plane: CRUD, reload/test flows, runtime views, and tool exposure policy.
+- [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md)
+  Master/non-master runtime roles, `/v1/device/*`, AI CLI inventory upload, queueing, and device OAuth relay.
+- [FLEET_LOGS.md](./FLEET_LOGS.md)
+  Fleet log ingestion, queueing, search, and current storage limits.
+- [DEPLOY.md](./DEPLOY.md)
+  Device-runtime deployment model for master and non-master machines.
 - [UPSTREAM.md](./UPSTREAM.md)
   Upstream MCP proxy gateway: config, discovery, tool collision handling, circuit breaker, resource proxying.
 - [TRANSPORT.md](./TRANSPORT.md)
@@ -136,6 +145,9 @@ Use the smallest correct doc:
 - RMCP SDK integration, feature posture, and server-shape rules: [RMCP.md](./RMCP.md)
 - HTTP auth modes, JWKS, and JWT validation: [OAUTH.md](./OAUTH.md)
 - gateway control plane and exposure policy: [GATEWAY.md](./GATEWAY.md)
+- device runtime roles, fleet ingest, and master gating: [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md)
+- fleet log ingestion and search: [FLEET_LOGS.md](./FLEET_LOGS.md)
+- deployment topology and rollout guidance: [DEPLOY.md](./DEPLOY.md)
 - upstream MCP proxy, circuit breaker, resource proxying: [UPSTREAM.md](./UPSTREAM.md)
 - transport configuration, middleware, sessions: [TRANSPORT.md](./TRANSPORT.md)
 - TUI behavior: [TUI.md](./TUI.md)

--- a/docs/TRANSPORT.md
+++ b/docs/TRANSPORT.md
@@ -146,12 +146,18 @@ Allowed headers: `Authorization`, `Content-Type`, `x-request-id`.
 
 ## Route Layout
 
+The HTTP router is role-aware:
+
+- the `master` exposes the full operator control plane
+- a non-master device keeps only `/health`, `/ready`, and `/v1/device/*`
+- non-master devices do not expose `/mcp`, `/v1/{service}`, `/v1/gateway`, `/v1/openapi.json`, `/v1/docs`, or the Web UI
+
 When HTTP transport is active, the server exposes:
 
 | Path | Auth | Description |
 |------|------|-------------|
-| `/` | no | Labby web UI shell (when exported assets are available) |
-| `/gateways/`, `/gateway/`, `/activity/`, `/settings/`, `/docs/` | no | Labby SPA routes (when exported assets are available) |
+| `/` | no | Labby web UI shell on the master. Non-master devices return `403`. |
+| `/gateways/`, `/gateway/`, `/activity/`, `/settings/`, `/docs/` | no | Labby SPA routes on the master. |
 | `/health` | no | Liveness probe |
 | `/ready` | no | Readiness probe |
 | `/.well-known/oauth-authorization-server` | no | Authorization-server metadata |
@@ -161,9 +167,11 @@ When HTTP transport is active, the server exposes:
 | `/authorize` | no | Authorization entrypoint |
 | `/auth/google/callback` | no | Google callback endpoint |
 | `/token` | no | Authorization-code and refresh-token exchange |
-| `/v1/{service}` | yes | REST API (POST with action+params) |
-| `/v1/{service}/actions` | yes | Action catalog (GET) |
-| `/mcp` | yes | MCP streamable HTTP transport |
+| `/v1/device/*` | yes | Device runtime ingest, fleet queries, and remote OAuth relay start |
+| `/v1/{service}` | yes | REST API (POST with action+params) on the master only |
+| `/v1/{service}/actions` | yes | Action catalog (GET) on the master only |
+| `/v1/gateway` | yes | Gateway management on the master only |
+| `/mcp` | yes | MCP streamable HTTP transport on the master only |
 
 ## Example: Local Development
 
@@ -204,3 +212,4 @@ curl -H "Authorization: Bearer $LAB_MCP_HTTP_TOKEN" \
 - [CONFIG.md](./CONFIG.md) — env var and config.toml loading
 - [MCP.md](./MCP.md) — MCP protocol surface
 - [RMCP.md](./RMCP.md) — RMCP SDK integration contract
+- [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md) — master/non-master runtime model

--- a/docs/TRANSPORT.md
+++ b/docs/TRANSPORT.md
@@ -156,7 +156,7 @@ When HTTP transport is active, the server exposes:
 
 | Path | Auth | Description |
 |------|------|-------------|
-| `/` | no | Labby web UI shell on the master. Non-master devices return `403`. |
+| `/` | no | Labby web UI shell on the master. On non-master devices this returns `403` only when exported web assets are configured; otherwise it falls through as `404`. |
 | `/gateways/`, `/gateway/`, `/activity/`, `/settings/`, `/docs/` | no | Labby SPA routes on the master. |
 | `/health` | no | Liveness probe |
 | `/ready` | no | Readiness probe |


### PR DESCRIPTION
## Summary
- add the device runtime master/non-master model, including role resolution, fleet state, metadata inventory, queue-backed log ingest, and master-only control-plane gating
- add master-routed `lab device` and `lab logs` command groups plus the `/v1/device/*` fleet API and remote OAuth relay start route
- document the deployment, runtime, fleet log, transport, config, observability, and error-model changes
- ensure master-bound device traffic reuses `LAB_MCP_HTTP_TOKEN` when bearer auth is enabled

## Verification
- `cargo test --test device_config --test device_identity --test device_scan --test device_queue --test device_api --test device_runtime --test device_master_only --test device_cli --all-features`
- `cargo test -p lab@0.3.3 --all-features`
- `cargo build -p lab@0.3.3 --all-features`
- `cargo fmt --all --check`

## Verification Caveat
- `cargo clippy -p lab@0.3.3 --all-features -- -D warnings` fails on an existing workspace lint baseline outside this plan, including many pre-existing issues in `crates/lab-auth/**`
- `cargo clippy -p lab@0.3.3 --all-features --no-deps -- -D warnings` also reports existing `lab` crate lint debt unrelated to this plan's functional changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the device runtime with master/non‑master roles and a `/v1/device/*` API, and gates the operator control plane (Web UI, MCP, `/v1/{service}`, `/v1/gateway`, OpenAPI/docs, OAuth metadata) to the master. Adds master‑routed `lab device`/`lab logs` commands, moves the device‑runtime HTTP client into `lab-apis` with timeouts, and hardens identity, queueing, log search/retention, and OAuth relay.

- **New Features**
  - Role resolution from local hostname and `[device].master`, with short vs FQDN equivalence; only the master serves Web UI, MCP, `/v1/{service}`, `/v1/gateway`, OpenAPI/docs, and OAuth metadata.
  - `/v1/device/*`: `hello`, `status`, `metadata`, `syslog/batch`, `oauth/relay/start`, `devices` list/get, and `logs/search` (read routes are master‑only). Log search defaults to 200 with a hard max of 1000; per‑device retention capped at 10k events.
  - In‑memory fleet store and normalized log events; durable JSONL outbound queue with ack on delivery to avoid duplicate resend on decode errors; bootstrap logs are tail‑limited and skip unreadable candidates; device IDs are normalized on ingest and read.
  - Non‑masters reuse `LAB_MCP_HTTP_TOKEN` when bearer auth is enabled. Master‑routed CLI: `lab device list|get <device_id>`, `lab logs search <device_id> <query>`.
  - `lab-apis` `DeviceRuntimeClient` with request timeouts and safe URL encoding; OAuth relay start validates loopback bind, returns the actual bound address for ephemeral binds, and runs in the background on the device.

- **Migration**
  - Set `[device].master = "<hostname>"` in `config.toml` on non‑masters; omit to default the local host to master.
  - Ensure the master is reachable at `http://<master>:<mcp.port>`; if binding beyond loopback, set `LAB_MCP_HTTP_TOKEN` and reuse it on all devices.
  - Start `lab serve --transport http` on every device; non‑masters auto‑send hello, metadata, and a bootstrap log flush.
  - OAuth relay bind addresses must be loopback.
  - Query fleet from the master: `lab device list|get`, `lab logs search <id> <query>`.

<sup>Written for commit ad5c119fb07233c772855ea929a2e42a19b21eb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added device fleet management system with master/non-master runtime support.
  * Added `lab device list` and `lab device get` commands to query fleet inventory.
  * Added `lab logs search` command for searching device logs across the fleet.
  * Added device status reporting and metadata collection capabilities.
  * Added device role configuration for fleet topology setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->