### PR TITLE
fix: unify logging and auth observability across gateway and mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,6 +2525,7 @@ dependencies = [
  "axum",
  "base64",
  "getrandom 0.3.4",
+ "httpdate",
  "jsonwebtoken",
  "rand 0.9.2",
  "reqwest",

--- a/apps/gateway-admin/components/auth/auth-bootstrap.tsx
+++ b/apps/gateway-admin/components/auth/auth-bootstrap.tsx
@@ -32,12 +32,24 @@ export function AuthBootstrap({ children }: AuthBootstrapProps) {
     )
   }
 
+  const returnTo =
+    typeof window === 'undefined'
+      ? '/'
+      : `${window.location.pathname}${window.location.search}${window.location.hash}`
+
   if (session.status === 'unauthenticated') {
-    const returnTo =
-      typeof window === 'undefined'
-        ? '/'
-        : `${window.location.pathname}${window.location.search}${window.location.hash}`
-    return <LoginScreen returnTo={returnTo || '/'} />
+    return <LoginScreen loginAvailable={session.loginAvailable} returnTo={returnTo || '/'} />
+  }
+
+  if (session.status === 'auth_error') {
+    return (
+      <LoginScreen
+        errorMessage={session.message}
+        loginAvailable={session.loginAvailable}
+        requestId={session.requestId}
+        returnTo={returnTo || '/'}
+      />
+    )
   }
 
   if (session.status === 'auth_error') {

--- a/apps/gateway-admin/components/auth/auth-bootstrap.tsx
+++ b/apps/gateway-admin/components/auth/auth-bootstrap.tsx
@@ -38,7 +38,7 @@ export function AuthBootstrap({ children }: AuthBootstrapProps) {
       : `${window.location.pathname}${window.location.search}${window.location.hash}`
 
   if (session.status === 'unauthenticated') {
-    return <LoginScreen loginAvailable={session.loginAvailable} returnTo={returnTo || '/'} />
+    return <LoginScreen loginAvailable={session.loginAvailable} returnTo={returnTo} />
   }
 
   if (session.status === 'auth_error') {
@@ -47,7 +47,7 @@ export function AuthBootstrap({ children }: AuthBootstrapProps) {
         errorMessage={session.message}
         loginAvailable={session.loginAvailable}
         requestId={session.requestId}
-        returnTo={returnTo || '/'}
+        returnTo={returnTo}
       />
     )
   }

--- a/apps/gateway-admin/lib/api/gateway-client-auth.ts
+++ b/apps/gateway-admin/lib/api/gateway-client-auth.ts
@@ -1,0 +1,51 @@
+import { hasApiTokenAuth } from '../auth/auth-mode.ts'
+import { getSessionCsrfToken, loadBrowserSession } from '../auth/session-store.ts'
+import { GatewayApiError, gatewayActionCore } from './gateway-client-core.ts'
+
+// Trigger a silent browser-session refresh only when the backend signals an
+// authentication/CSRF problem. `validation_failed` is reused on the backend
+// for CSRF rejection (see `crates/lab/src/api/router.rs::csrf_error_response`)
+// so we narrow with: auth-status code AND the literal word "csrf" in the
+// message AND the client had actually attempted session auth. Without all
+// three, a plain 422 from a mistyped param would trigger a session reload.
+function shouldRefreshBrowserSession(
+  error: GatewayApiError,
+  attemptedSessionAuth: boolean,
+) {
+  if (hasApiTokenAuth()) {
+    return false
+  }
+
+  if (error.code === 'auth_failed') {
+    return true
+  }
+
+  if (!attemptedSessionAuth || error.code !== 'validation_failed') {
+    return false
+  }
+
+  const isAuthStatus =
+    error.status === 401 || error.status === 403 || error.status === 422
+  const isCsrfMessage = error.message.toLowerCase().includes('csrf')
+  return isAuthStatus && isCsrfMessage
+}
+
+export async function gatewayAction<T>(
+  action: string,
+  params: object,
+  signal?: AbortSignal,
+): Promise<T> {
+  const attemptedSessionAuth = Boolean(getSessionCsrfToken())
+
+  try {
+    return await gatewayActionCore<T>(action, params, signal)
+  } catch (error) {
+    if (
+      error instanceof GatewayApiError &&
+      shouldRefreshBrowserSession(error, attemptedSessionAuth)
+    ) {
+      await loadBrowserSession().catch(() => undefined)
+    }
+    throw error
+  }
+}

--- a/apps/gateway-admin/lib/api/gateway-client-core.ts
+++ b/apps/gateway-admin/lib/api/gateway-client-core.ts
@@ -1,0 +1,64 @@
+import { withRequestId } from '../http/request-id.ts'
+import { gatewayActionUrl } from './gateway-config.ts'
+import { gatewayRequestInit } from './gateway-request.ts'
+
+export class GatewayApiError extends Error {
+  status: number
+  code?: string
+  requestId?: string
+  constructor(
+    message: string,
+    status: number,
+    code?: string,
+    requestId?: string,
+  ) {
+    super(message)
+    this.name = 'GatewayApiError'
+    this.status = status
+    this.code = code
+    this.requestId = requestId
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'AbortError'
+    : error instanceof Error && error.name === 'AbortError'
+}
+
+async function parseActionResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const requestId = response.headers.get('x-request-id') ?? undefined
+    const error = await response.json().catch(() => ({ message: 'An error occurred' }))
+    throw new GatewayApiError(
+      withRequestId(error.message || 'An error occurred', requestId),
+      response.status,
+      error.kind || error.code,
+      requestId,
+    )
+  }
+  return response.json()
+}
+
+export async function gatewayActionCore<T>(
+  action: string,
+  params: object,
+  signal?: AbortSignal,
+): Promise<T> {
+  let response: Response
+  try {
+    response = await fetch(gatewayActionUrl(), gatewayRequestInit(action, params, undefined, signal))
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+    const message = error instanceof Error ? error.message : 'unknown network error'
+    throw new GatewayApiError(
+      `Gateway backend action \`${action}\` failed before a response was received: ${message}`,
+      502,
+      'backend_unreachable',
+    )
+  }
+
+  return parseActionResponse<T>(response)
+}

--- a/apps/gateway-admin/lib/api/gateway-client.test.ts
+++ b/apps/gateway-admin/lib/api/gateway-client.test.ts
@@ -248,3 +248,89 @@ test('gatewayApi.setExposurePolicy sends confirm=true when updating a gateway co
     },
   )
 })
+
+test('gatewayApi destructive mutations send confirm=true', async () => {
+  const actions: Array<{ action: string; params: Record<string, unknown> }> = []
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input)
+    if (url !== '/v1/gateway') {
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const payload = JSON.parse(String(init?.body ?? '{}')) as {
+      action: string
+      params: Record<string, unknown>
+    }
+    actions.push(payload)
+
+    if (payload.action === 'gateway.get') {
+      return new Response(
+        JSON.stringify({
+          config: { name: 'plex', proxy_resources: false },
+          runtime: { tool_count: 1 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }
+
+    if (payload.action === 'gateway.add' || payload.action === 'gateway.update') {
+      return new Response(
+        JSON.stringify({
+          config: {
+            name: 'plex',
+            url: 'https://lab.example.com/mcp',
+            proxy_resources: false,
+          },
+          runtime: {
+            tool_count: 1,
+            resource_count: 0,
+            prompt_count: 0,
+            exposed_tool_count: 1,
+            exposed_resource_count: 0,
+            exposed_prompt_count: 0,
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }
+
+    if (payload.action === 'gateway.remove' || payload.action === 'gateway.reload') {
+      return new Response('null', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    if (
+      payload.action === 'gateway.discovered_tools' ||
+      payload.action === 'gateway.discovered_resources' ||
+      payload.action === 'gateway.discovered_prompts'
+    ) {
+      return new Response('[]', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    throw new Error(`unexpected action: ${payload.action}`)
+  }) as typeof fetch
+
+  await gatewayApi.create({
+    name: 'plex',
+    transport: 'http',
+    config: { url: 'https://lab.example.com/mcp' },
+  })
+  await gatewayApi.update('plex', { name: 'plex-updated' })
+  await gatewayApi.remove('plex')
+  await gatewayApi.reload('plex')
+
+  const destructiveActions = actions.filter(({ action }) =>
+    ['gateway.add', 'gateway.update', 'gateway.remove', 'gateway.reload'].includes(action),
+  )
+
+  assert.equal(destructiveActions.length, 4)
+  for (const action of destructiveActions) {
+    assert.equal(action.params.confirm, true)
+  }
+})

--- a/apps/gateway-admin/lib/api/gateway-client.test.ts
+++ b/apps/gateway-admin/lib/api/gateway-client.test.ts
@@ -249,6 +249,58 @@ test('gatewayApi.setExposurePolicy sends confirm=true when updating a gateway co
   )
 })
 
+test('gatewayApi.list does not refresh browser session for non-csrf validation errors', async () => {
+  __setBrowserSessionStateForTests({
+    status: 'authenticated',
+    user: { sub: 'browser-user', email: 'browser@example.com' },
+    expiresAt: 123,
+    csrfToken: 'csrf-old',
+    loginAvailable: true,
+  })
+
+  const urls: string[] = []
+  globalThis.fetch = (async (input) => {
+    const url = String(input)
+    urls.push(url)
+
+    if (url === '/v1/gateway') {
+      return new Response(
+        JSON.stringify({
+          kind: 'validation_failed',
+          message: 'missing required parameter `name`',
+        }),
+        {
+          status: 422,
+          headers: {
+            'content-type': 'application/json',
+            'x-request-id': 'req-gateway-validation-1',
+          },
+        },
+      )
+    }
+
+    throw new Error(`unexpected fetch: ${url}`)
+  }) as typeof fetch
+
+  await assert.rejects(
+    gatewayApi.list(),
+    (error: unknown) => {
+      assert.ok(error instanceof GatewayApiError)
+      assert.equal(error.code, 'validation_failed')
+      return true
+    },
+  )
+
+  assert.deepEqual(getBrowserSessionState(), {
+    status: 'authenticated',
+    user: { sub: 'browser-user', email: 'browser@example.com' },
+    expiresAt: 123,
+    csrfToken: 'csrf-old',
+    loginAvailable: true,
+  })
+  assert.deepEqual(urls, ['/v1/gateway'])
+})
+
 test('gatewayApi destructive mutations send confirm=true', async () => {
   const actions: Array<{ action: string; params: Record<string, unknown> }> = []
 

--- a/apps/gateway-admin/lib/api/gateway-request.test.ts
+++ b/apps/gateway-admin/lib/api/gateway-request.test.ts
@@ -27,7 +27,7 @@ test('gatewayRequestInit keeps credentialed requests when a token is present wit
 })
 
 test('gatewayHeaders omits authorization when no token is provided', () => {
-  __setBrowserSessionStateForTests({ status: 'unauthenticated' })
+  __setBrowserSessionStateForTests({ status: 'unauthenticated', loginAvailable: false })
   const headers = gatewayHeaders(undefined) as Record<string, string>
 
   assert.equal(headers['Content-Type'], 'application/json')
@@ -40,6 +40,7 @@ test('gatewayRequestInit keeps credentialed requests for session-auth setups', (
     user: { sub: 'browser-user', email: 'browser@example.com' },
     expiresAt: 42,
     csrfToken: 'csrf-123',
+    loginAvailable: true,
   })
   const init = gatewayRequestInit('gateway.list', {}, undefined)
 

--- a/apps/gateway-admin/lib/api/session.test.ts
+++ b/apps/gateway-admin/lib/api/session.test.ts
@@ -117,7 +117,7 @@ test('logoutBrowserSession resets local state after POST', async () => {
   assert.deepEqual(getBrowserSessionState(), { status: 'unauthenticated' })
 })
 
-test('logoutBrowserSession preserves local state when /auth/logout fails', async () => {
+test('logoutBrowserSession clears local state even when /auth/logout fails', async () => {
   __setBrowserSessionStateForTests({
     status: 'authenticated',
     user: { sub: 'browser-user', email: 'browser@example.com' },
@@ -131,7 +131,7 @@ test('logoutBrowserSession preserves local state when /auth/logout fails', async
     logoutBrowserSession(),
     /Failed to logout browser session/,
   )
-  assert.equal(getBrowserSessionState().status, 'authenticated')
+  assert.deepEqual(getBrowserSessionState(), { status: 'unauthenticated', loginAvailable: true })
 })
 
 test('hasApiTokenAuth only enables bearer mode for non-empty tokens', () => {

--- a/apps/gateway-admin/lib/http/request-id.ts
+++ b/apps/gateway-admin/lib/http/request-id.ts
@@ -1,0 +1,3 @@
+export function withRequestId(message: string, requestId?: string) {
+  return requestId ? `${message} (request id: ${requestId})` : message
+}

--- a/apps/gateway-admin/pnpm-lock.yaml
+++ b/apps/gateway-admin/pnpm-lock.yaml
@@ -4108,6 +4108,8 @@ snapshots:
 
   server-only@0.0.1: {}
 
+  server-only@0.0.1: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0

--- a/crates/lab-auth/Cargo.toml
+++ b/crates/lab-auth/Cargo.toml
@@ -15,6 +15,7 @@ categories             = ["authentication", "web-programming::http-server"]
 axum.workspace         = true
 base64.workspace       = true
 getrandom             = "0.3"
+httpdate              = "1"
 jsonwebtoken.workspace = true
 reqwest.workspace      = true
 rsa.workspace          = true

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -25,6 +25,8 @@ pub async fn browser_login(
     State(state): State<AuthState>,
     Query(query): Query<BrowserLoginQuery>,
 ) -> Result<Response, AuthError> {
+    state.check_authorize_rate_limit()?;
+    state.ensure_pending_oauth_state_capacity().await?;
     let return_to = sanitize_return_to(&state, query.return_to.as_deref());
     let provider_code_verifier = random_token(32)?;
     let provider_code_challenge =
@@ -66,6 +68,7 @@ pub async fn register_client(
     State(state): State<AuthState>,
     Json(request): Json<ClientRegistrationRequest>,
 ) -> Result<Json<ClientRegistrationResponse>, AuthError> {
+    state.check_register_rate_limit()?;
     if request.redirect_uris.is_empty() {
         warn!("oauth register rejected: no redirect URIs provided");
         return Err(AuthError::Validation(
@@ -108,6 +111,8 @@ pub async fn authorize(
     State(state): State<AuthState>,
     Query(query): Query<AuthorizeQuery>,
 ) -> Result<Response, AuthError> {
+    state.check_authorize_rate_limit()?;
+    state.ensure_pending_oauth_state_capacity().await?;
     validate_response_type(&query.response_type)?;
     validate_resource(&state, query.resource.as_deref())?;
     let scope = validate_scope(&query.scope)?;
@@ -595,6 +600,50 @@ pub mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    #[tokio::test]
+    async fn register_is_rate_limited_after_configured_burst() {
+        let mut config = test_auth_config();
+        config.register_requests_per_minute = 1;
+        let app = router(test_auth_state_with_config(config).await);
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "redirect_uris": ["http://127.0.0.1:7777/callback"]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "redirect_uris": ["http://127.0.0.1:8888/callback"]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
     #[test]
     fn wildcard_redirect_patterns_support_leading_and_infix_matches() {
         assert!(wildcard_matches(
@@ -660,6 +709,46 @@ pub mod tests {
     }
 
     #[tokio::test]
+    async fn authorize_is_rate_limited_after_configured_burst() {
+        let mut config = test_auth_config();
+        config.authorize_requests_per_minute = 1;
+        let state = test_auth_state_with_config(config).await;
+        state
+            .store
+            .register_client(RegisteredClient {
+                client_id: "client".to_string(),
+                redirect_uris: vec!["http://127.0.0.1:7777/callback".to_string()],
+                created_at: now_unix(),
+            })
+            .await
+            .unwrap();
+        let app = router(state);
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/authorize?response_type=code&client_id=client&redirect_uri=http://127.0.0.1:7777/callback&state=abc&scope=lab&code_challenge=pkce&code_challenge_method=S256")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::FOUND);
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .uri("/authorize?response_type=code&client_id=client&redirect_uri=http://127.0.0.1:7777/callback&state=def&scope=lab&code_challenge=pkce&code_challenge_method=S256")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
     async fn browser_login_starts_upstream_flow_and_persists_return_to_state() {
         let state = test_auth_state().await;
         let app = router(state.clone());
@@ -694,6 +783,36 @@ pub mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.return_to, "/gateways/?tab=lab");
+    }
+
+    #[tokio::test]
+    async fn browser_login_rejects_when_pending_oauth_state_cap_is_reached() {
+        let mut config = test_auth_config();
+        config.max_pending_oauth_states = 1;
+        let state = test_auth_state_with_config(config).await;
+        state
+            .store
+            .insert_browser_login_state(crate::types::BrowserLoginStateRow {
+                state: "existing-login".to_string(),
+                return_to: "/".to_string(),
+                provider_code_verifier: "provider-verifier".to_string(),
+                created_at: now_unix(),
+                expires_at: now_unix() + 300,
+            })
+            .await
+            .unwrap();
+
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/auth/login?return_to=%2Fgateways%2F")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -13,6 +13,9 @@ const DEFAULT_KEY_NAME: &str = "auth-jwt.pem";
 const DEFAULT_ACCESS_TOKEN_TTL_SECS: u64 = 3600;
 const DEFAULT_REFRESH_TOKEN_TTL_SECS: u64 = 30 * 24 * 3600;
 const DEFAULT_AUTH_CODE_TTL_SECS: u64 = 300;
+const DEFAULT_REGISTER_REQUESTS_PER_MINUTE: u32 = 20;
+const DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE: u32 = 60;
+const DEFAULT_MAX_PENDING_OAUTH_STATES: usize = 1024;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -79,6 +82,9 @@ pub struct AuthConfig {
     pub access_token_ttl: Duration,
     pub refresh_token_ttl: Duration,
     pub auth_code_ttl: Duration,
+    pub register_requests_per_minute: u32,
+    pub authorize_requests_per_minute: u32,
+    pub max_pending_oauth_states: usize,
 }
 
 impl Default for AuthConfig {
@@ -95,6 +101,9 @@ impl Default for AuthConfig {
             access_token_ttl: Duration::from_secs(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             refresh_token_ttl: Duration::from_secs(DEFAULT_REFRESH_TOKEN_TTL_SECS),
             auth_code_ttl: Duration::from_secs(DEFAULT_AUTH_CODE_TTL_SECS),
+            register_requests_per_minute: DEFAULT_REGISTER_REQUESTS_PER_MINUTE,
+            authorize_requests_per_minute: DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE,
+            max_pending_oauth_states: DEFAULT_MAX_PENDING_OAUTH_STATES,
         }
     }
 }
@@ -133,6 +142,15 @@ impl AuthConfig {
             auth_code_ttl: Duration::from_secs(
                 read_u64(&vars, "LAB_AUTH_CODE_TTL_SECS")?.unwrap_or(DEFAULT_AUTH_CODE_TTL_SECS),
             ),
+            register_requests_per_minute: read_u32(&vars, "LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE")?
+                .unwrap_or(DEFAULT_REGISTER_REQUESTS_PER_MINUTE),
+            authorize_requests_per_minute: read_u32(
+                &vars,
+                "LAB_AUTH_AUTHORIZE_REQUESTS_PER_MINUTE",
+            )?
+            .unwrap_or(DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE),
+            max_pending_oauth_states: read_usize(&vars, "LAB_AUTH_MAX_PENDING_OAUTH_STATES")?
+                .unwrap_or(DEFAULT_MAX_PENDING_OAUTH_STATES),
         };
 
         config.validate()?;
@@ -243,6 +261,30 @@ fn read_u64(vars: &HashMap<String, String>, key: &str) -> Result<Option<u64>, Au
         })
         .transpose()
         .map(Option::flatten)
+}
+
+fn read_u32(vars: &HashMap<String, String>, key: &str) -> Result<Option<u32>, AuthError> {
+    read_string(vars, key)
+        .map(|value| {
+            value.parse::<u32>().map(Some).map_err(|error| {
+                AuthError::Config(format!(
+                    "{key} must be an integer number of requests per minute: {error}"
+                ))
+            })
+        })
+        .transpose()
+        .map(|value| value.flatten())
+}
+
+fn read_usize(vars: &HashMap<String, String>, key: &str) -> Result<Option<usize>, AuthError> {
+    read_string(vars, key)
+        .map(|value| {
+            value.parse::<usize>().map(Some).map_err(|error| {
+                AuthError::Config(format!("{key} must be a positive integer: {error}"))
+            })
+        })
+        .transpose()
+        .map(|value| value.flatten())
 }
 
 #[cfg(test)]

--- a/crates/lab-auth/src/error.rs
+++ b/crates/lab-auth/src/error.rs
@@ -21,6 +21,15 @@ pub enum AuthError {
     #[error("{0}")]
     Validation(String),
 
+    #[error("{0}")]
+    Network(String),
+
+    #[error("{0}")]
+    Server(String),
+
+    #[error("{0}")]
+    Decode(String),
+
     #[error("{message}")]
     RateLimited {
         message: String,
@@ -43,6 +52,9 @@ impl AuthError {
             Self::InvalidGrant(_) => "invalid_grant",
             Self::AuthFailed(_) | Self::InvalidAccessToken => "auth_failed",
             Self::Validation(_) => "validation_failed",
+            Self::Network(_) => "network_error",
+            Self::Server(_) => "server_error",
+            Self::Decode(_) => "decode_error",
             Self::RateLimited { .. } => "rate_limited",
         }
     }
@@ -52,6 +64,8 @@ impl AuthError {
             Self::InvalidGrant(_) => StatusCode::BAD_REQUEST,
             Self::AuthFailed(_) | Self::InvalidAccessToken => StatusCode::UNAUTHORIZED,
             Self::Validation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::Network(_) | Self::Server(_) => StatusCode::BAD_GATEWAY,
+            Self::Decode(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::RateLimited { .. } => StatusCode::TOO_MANY_REQUESTS,
             Self::Config(_) | Self::Storage(_) | Self::InsecurePermissions { .. } => {
                 StatusCode::INTERNAL_SERVER_ERROR

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -179,20 +179,56 @@ async fn read_json_response<T: DeserializeOwned>(
     errors: GoogleRequestErrors,
 ) -> Result<T, AuthError> {
     let response = request.send().await.map_err(|error| {
+        let auth_error = AuthError::Network(format!("{}: {error}", errors.transport_context));
         trace.error(None, &error);
-        warn!(provider = "google", error = %error, "{}", errors.transport_log);
-        AuthError::Storage(format!("{}: {error}", errors.transport_context))
+        warn!(
+            provider = "google",
+            error = %error,
+            kind = auth_error.kind(),
+            "{}",
+            errors.transport_log
+        );
+        auth_error
     })?;
     let status = response.status();
+    let retry_after_ms = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|seconds| seconds.saturating_mul(1_000));
     let response = response.error_for_status().map_err(|error| {
+        let auth_error = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            AuthError::RateLimited {
+                message: format!("{}: {}", errors.status_context, status),
+                retry_after_ms: retry_after_ms.unwrap_or(1_000),
+            }
+        } else if status.is_server_error() {
+            AuthError::Server(format!("{}: {error}", errors.status_context))
+        } else {
+            AuthError::AuthFailed(format!("{}: {error}", errors.status_context))
+        };
         trace.error(Some(status), &error);
-        warn!(provider = "google", error = %error, "{}", errors.status_log);
-        AuthError::Storage(format!("{}: {error}", errors.status_context))
+        warn!(
+            provider = "google",
+            error = %error,
+            kind = auth_error.kind(),
+            "{}",
+            errors.status_log
+        );
+        auth_error
     })?;
     trace.finish(status);
     response.json::<T>().await.map_err(|error| {
-        warn!(provider = "google", error = %error, "{}", errors.decode_log);
-        AuthError::Storage(format!("{}: {error}", errors.decode_context))
+        let auth_error = AuthError::Decode(format!("{}: {error}", errors.decode_context));
+        warn!(
+            provider = "google",
+            error = %error,
+            kind = auth_error.kind(),
+            "{}",
+            errors.decode_log
+        );
+        auth_error
     })
 }
 

--- a/crates/lab-auth/src/sqlite.rs
+++ b/crates/lab-auth/src/sqlite.rs
@@ -374,6 +374,28 @@ impl SqliteStore {
         .await
     }
 
+    pub async fn count_pending_oauth_states(&self) -> Result<usize, AuthError> {
+        let now = now_unix();
+        self.with_conn(move |conn| {
+            let authorization_requests: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM authorization_requests WHERE expires_at > ?1",
+                    params![now],
+                    |row| row.get(0),
+                )
+                .map_err(sqlite_error)?;
+            let browser_login_states: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM browser_login_states WHERE expires_at > ?1",
+                    params![now],
+                    |row| row.get(0),
+                )
+                .map_err(sqlite_error)?;
+            Ok((authorization_requests + browser_login_states) as usize)
+        })
+        .await
+    }
+
     pub async fn take_browser_login_state(
         &self,
         state: &str,

--- a/crates/lab/src/api.rs
+++ b/crates/lab/src/api.rs
@@ -16,6 +16,9 @@ pub mod error;
 /// Router builder — composes all feature-gated route groups.
 pub mod router;
 
+/// Shared auth-route request-id and dispatch logging helpers.
+pub mod auth_helpers;
+
 /// `GET /health` and `GET /ready` liveness/readiness probes.
 pub mod health;
 

--- a/crates/lab/src/api/auth_helpers.rs
+++ b/crates/lab/src/api/auth_helpers.rs
@@ -1,0 +1,47 @@
+use std::time::Instant;
+
+use axum::http::HeaderMap;
+
+pub(crate) fn request_id(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn log_auth_dispatch(
+    action: &str,
+    request_id: Option<&str>,
+    started: Instant,
+    kind: Option<&str>,
+) {
+    let elapsed_ms = started.elapsed().as_millis();
+    match kind {
+        None => tracing::info!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            "auth oauth dispatch complete"
+        ),
+        Some("internal_error" | "server_error" | "decode_error") => tracing::error!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            kind,
+            "auth oauth dispatch failed"
+        ),
+        Some(kind) => tracing::warn!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            kind,
+            "auth oauth dispatch failed"
+        ),
+    }
+}

--- a/crates/lab/src/api/browser_session.rs
+++ b/crates/lab/src/api/browser_session.rs
@@ -1,7 +1,9 @@
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
+use std::time::Instant;
 
+use crate::api::ToolError;
 use crate::api::state::AppState;
 
 use lab_auth::session::{BROWSER_CSRF_HEADER_NAME, BROWSER_SESSION_COOKIE_NAME};
@@ -19,8 +21,11 @@ fn no_store_json(body: serde_json::Value) -> Response {
         .into_response()
 }
 
-fn unauthenticated_session_response() -> Response {
-    no_store_json(serde_json::json!({ "authenticated": false }))
+fn unauthenticated_session_response(login_available: bool) -> Response {
+    no_store_json(serde_json::json!({
+        "authenticated": false,
+        "login_available": login_available,
+    }))
 }
 
 fn session_cookie(headers: &HeaderMap) -> Option<String> {
@@ -66,25 +71,84 @@ async fn load_browser_session(
     }
 }
 
+fn request_id(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+}
+
+fn log_dispatch(action: &str, request_id: Option<&str>, start: Instant, kind: Option<&str>) {
+    let elapsed_ms = start.elapsed().as_millis();
+    match kind {
+        None => tracing::info!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            "auth browser session dispatch complete"
+        ),
+        Some("internal_error") => tracing::error!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            kind = "internal_error",
+            "auth browser session dispatch failed"
+        ),
+        Some(kind) => tracing::warn!(
+            surface = "api",
+            service = "auth",
+            action,
+            request_id,
+            elapsed_ms,
+            kind,
+            "auth browser session dispatch failed"
+        ),
+    }
+}
+
+fn internal_error_response(message: &'static str) -> Response {
+    let mut response = ToolError::internal_message(message).into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        header::HeaderValue::from_static("private, no-store"),
+    );
+    response
+}
+
 fn invalid_csrf_response() -> Response {
-    (
+    let mut response = (
         StatusCode::UNPROCESSABLE_ENTITY,
         axum::Json(serde_json::json!({
             "kind": "validation_failed",
             "message": "missing or invalid csrf token",
         })),
     )
-        .into_response()
+        .into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        header::HeaderValue::from_static("private, no-store"),
+    );
+    response
 }
 
 pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    let start = Instant::now();
+    let request_id = request_id(&headers).map(ToOwned::to_owned);
+    let login_available = state.oauth_state.is_some();
     let Some(auth_state) = oauth_state(&state) else {
-        return unauthenticated_session_response();
+        let response = unauthenticated_session_response(false);
+        log_dispatch("session.get", request_id.as_deref(), start, None);
+        return response;
     };
 
     let body = match load_browser_session(&auth_state, &headers).await {
         Ok(Some(session)) => serde_json::json!({
             "authenticated": true,
+            "login_available": login_available,
             "user": {
                 "sub": session.subject,
                 "email": session.email,
@@ -92,18 +156,32 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
             "expires_at": session.expires_at,
             "csrf_token": session.csrf_token,
         }),
-        Ok(None) => return unauthenticated_session_response(),
+        Ok(None) => {
+            let response = unauthenticated_session_response(login_available);
+            log_dispatch("session.get", request_id.as_deref(), start, None);
+            return response;
+        }
         Err(error) => {
             tracing::error!(error = %error, "failed to load browser session for auth session");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            log_dispatch(
+                "session.get",
+                request_id.as_deref(),
+                start,
+                Some("internal_error"),
+            );
+            return internal_error_response("failed to load browser session");
         }
     };
 
+    log_dispatch("session.get", request_id.as_deref(), start, None);
     no_store_json(body)
 }
 
 pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    let start = Instant::now();
+    let request_id = request_id(&headers).map(ToOwned::to_owned);
     let Some(auth_state) = oauth_state(&state) else {
+        log_dispatch("session.logout", request_id.as_deref(), start, None);
         return StatusCode::NO_CONTENT.into_response();
     };
 
@@ -119,17 +197,35 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
                         has_csrf_header = csrf.is_some(),
                         "auth logout rejected: missing or invalid csrf token"
                     );
+                    log_dispatch(
+                        "session.logout",
+                        request_id.as_deref(),
+                        start,
+                        Some("validation_failed"),
+                    );
                     return invalid_csrf_response();
                 }
                 if let Err(error) = auth_state.store.revoke_browser_session(&session_id).await {
                     tracing::error!(error = %error, "failed to revoke browser session");
-                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                    log_dispatch(
+                        "session.logout",
+                        request_id.as_deref(),
+                        start,
+                        Some("internal_error"),
+                    );
+                    return internal_error_response("failed to revoke browser session");
                 }
             }
             Ok(None) => {}
             Err(error) => {
                 tracing::error!(error = %error, "failed to load browser session for logout");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                log_dispatch(
+                    "session.logout",
+                    request_id.as_deref(),
+                    start,
+                    Some("internal_error"),
+                );
+                return internal_error_response("failed to load browser session");
             }
         }
     }
@@ -137,5 +233,6 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
         &mut response,
         &lab_auth::session::clear_browser_session_cookie(&auth_state),
     );
+    log_dispatch("session.logout", request_id.as_deref(), start, None);
     response
 }

--- a/crates/lab/src/api/browser_session.rs
+++ b/crates/lab/src/api/browser_session.rs
@@ -4,7 +4,7 @@ use axum::response::{IntoResponse, Response};
 use std::time::Instant;
 
 use crate::api::ToolError;
-use crate::api::router::{log_auth_dispatch, request_id};
+use crate::api::auth_helpers::{log_auth_dispatch, request_id};
 use crate::api::state::AppState;
 
 use lab_auth::session::{BROWSER_CSRF_HEADER_NAME, BROWSER_SESSION_COOKIE_NAME};

--- a/crates/lab/src/api/browser_session.rs
+++ b/crates/lab/src/api/browser_session.rs
@@ -4,6 +4,7 @@ use axum::response::{IntoResponse, Response};
 use std::time::Instant;
 
 use crate::api::ToolError;
+use crate::api::router::{log_auth_dispatch, request_id};
 use crate::api::state::AppState;
 
 use lab_auth::session::{BROWSER_CSRF_HEADER_NAME, BROWSER_SESSION_COOKIE_NAME};
@@ -71,45 +72,6 @@ async fn load_browser_session(
     }
 }
 
-fn request_id(headers: &HeaderMap) -> Option<&str> {
-    headers
-        .get("x-request-id")
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-}
-
-fn log_dispatch(action: &str, request_id: Option<&str>, start: Instant, kind: Option<&str>) {
-    let elapsed_ms = start.elapsed().as_millis();
-    match kind {
-        None => tracing::info!(
-            surface = "api",
-            service = "auth",
-            action,
-            request_id,
-            elapsed_ms,
-            "auth browser session dispatch complete"
-        ),
-        Some("internal_error") => tracing::error!(
-            surface = "api",
-            service = "auth",
-            action,
-            request_id,
-            elapsed_ms,
-            kind = "internal_error",
-            "auth browser session dispatch failed"
-        ),
-        Some(kind) => tracing::warn!(
-            surface = "api",
-            service = "auth",
-            action,
-            request_id,
-            elapsed_ms,
-            kind,
-            "auth browser session dispatch failed"
-        ),
-    }
-}
-
 fn internal_error_response(message: &'static str) -> Response {
     let mut response = ToolError::internal_message(message).into_response();
     response.headers_mut().insert(
@@ -141,7 +103,7 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
     let login_available = state.oauth_state.is_some();
     let Some(auth_state) = oauth_state(&state) else {
         let response = unauthenticated_session_response(false);
-        log_dispatch("session.get", request_id.as_deref(), start, None);
+        log_auth_dispatch("session.get", request_id.as_deref(), start, None);
         return response;
     };
 
@@ -158,12 +120,12 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
         }),
         Ok(None) => {
             let response = unauthenticated_session_response(login_available);
-            log_dispatch("session.get", request_id.as_deref(), start, None);
+            log_auth_dispatch("session.get", request_id.as_deref(), start, None);
             return response;
         }
         Err(error) => {
             tracing::error!(error = %error, "failed to load browser session for auth session");
-            log_dispatch(
+            log_auth_dispatch(
                 "session.get",
                 request_id.as_deref(),
                 start,
@@ -173,7 +135,7 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
         }
     };
 
-    log_dispatch("session.get", request_id.as_deref(), start, None);
+    log_auth_dispatch("session.get", request_id.as_deref(), start, None);
     no_store_json(body)
 }
 
@@ -181,7 +143,7 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
     let start = Instant::now();
     let request_id = request_id(&headers).map(ToOwned::to_owned);
     let Some(auth_state) = oauth_state(&state) else {
-        log_dispatch("session.logout", request_id.as_deref(), start, None);
+        log_auth_dispatch("session.logout", request_id.as_deref(), start, None);
         return StatusCode::NO_CONTENT.into_response();
     };
 
@@ -197,7 +159,7 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
                         has_csrf_header = csrf.is_some(),
                         "auth logout rejected: missing or invalid csrf token"
                     );
-                    log_dispatch(
+                    log_auth_dispatch(
                         "session.logout",
                         request_id.as_deref(),
                         start,
@@ -207,7 +169,7 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
                 }
                 if let Err(error) = auth_state.store.revoke_browser_session(&session_id).await {
                     tracing::error!(error = %error, "failed to revoke browser session");
-                    log_dispatch(
+                    log_auth_dispatch(
                         "session.logout",
                         request_id.as_deref(),
                         start,
@@ -219,7 +181,7 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
             Ok(None) => {}
             Err(error) => {
                 tracing::error!(error = %error, "failed to load browser session for logout");
-                log_dispatch(
+                log_auth_dispatch(
                     "session.logout",
                     request_id.as_deref(),
                     start,
@@ -233,6 +195,6 @@ pub async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> i
         &mut response,
         &lab_auth::session::clear_browser_session_cookie(&auth_state),
     );
-    log_dispatch("session.logout", request_id.as_deref(), start, None);
+    log_auth_dispatch("session.logout", request_id.as_deref(), start, None);
     response
 }

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use axum::{Json, extract::State};
+use axum::{Json, extract::State, http::HeaderMap};
 use serde::Deserialize;
+use std::time::Instant;
 
 use crate::api::{ToolError, state::AppState};
 
@@ -35,8 +36,15 @@ fn validate_bind_addr(bind_addr: SocketAddr) -> Result<(), ToolError> {
 
 pub async fn handle_start(
     State(_state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<StartOauthRelayRequest>,
 ) -> Result<Json<StartOauthRelayResponse>, ToolError> {
+    let start = Instant::now();
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
     validate_bind_addr(payload.bind_addr)?;
     let resolved_target =
         crate::oauth::target::resolve_explicit_target(&payload.target_url, payload.default_port)
@@ -49,10 +57,31 @@ pub async fn handle_start(
     let bound_addr =
         crate::device::oauth::start_local_oauth_relay(payload.bind_addr, resolved_target, timeout)
             .await
-            .map_err(|error| ToolError::Sdk {
-                sdk_kind: "internal_error".to_string(),
-                message: error.to_string(),
+            .map_err(|error| {
+                tracing::error!(
+                    surface = "api",
+                    service = "device",
+                    action = "oauth.relay.start",
+                    request_id = request_id.as_deref(),
+                    elapsed_ms = start.elapsed().as_millis(),
+                    kind = "internal_error",
+                    error = %error,
+                    "device oauth relay start failed"
+                );
+                ToolError::Sdk {
+                    sdk_kind: "internal_error".to_string(),
+                    message: error.to_string(),
+                }
             })?;
+
+    tracing::info!(
+        surface = "api",
+        service = "device",
+        action = "oauth.relay.start",
+        request_id = request_id.as_deref(),
+        elapsed_ms = start.elapsed().as_millis(),
+        "device oauth relay start complete"
+    );
 
     Ok(Json(StartOauthRelayResponse {
         ok: true,

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -5,7 +5,7 @@ use axum::{Json, extract::State, http::HeaderMap};
 use serde::Deserialize;
 use std::time::Instant;
 
-use crate::api::router::request_id;
+use crate::api::auth_helpers::request_id;
 use crate::api::{ToolError, state::AppState};
 
 #[derive(Debug, Deserialize)]
@@ -84,4 +84,52 @@ pub async fn handle_start(
         ok: true,
         bind_addr: bound_addr,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::api::state::AppState;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn handle_start_rejects_non_loopback_bind_addr() {
+        let response = handle_start(
+            State(AppState::new()),
+            HeaderMap::new(),
+            Json(StartOauthRelayRequest {
+                bind_addr: "192.168.1.10:0".parse().unwrap(),
+                target_url: "http://127.0.0.1/callback".to_string(),
+                default_port: None,
+                request_timeout_ms: Some(100),
+            }),
+        )
+        .await
+        .unwrap_err()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn handle_start_returns_bound_loopback_address() {
+        let response = handle_start(
+            State(AppState::new()),
+            HeaderMap::new(),
+            Json(StartOauthRelayRequest {
+                bind_addr: "127.0.0.1:0".parse().unwrap(),
+                target_url: "http://127.0.0.1/callback".to_string(),
+                default_port: None,
+                request_timeout_ms: Some(100),
+            }),
+        )
+        .await
+        .expect("relay start succeeds");
+
+        assert!(response.0.ok);
+        assert!(response.0.bind_addr.ip().is_loopback());
+        assert_ne!(response.0.bind_addr.port(), 0);
+    }
 }

--- a/crates/lab/src/api/device/oauth.rs
+++ b/crates/lab/src/api/device/oauth.rs
@@ -5,6 +5,7 @@ use axum::{Json, extract::State, http::HeaderMap};
 use serde::Deserialize;
 use std::time::Instant;
 
+use crate::api::router::request_id;
 use crate::api::{ToolError, state::AppState};
 
 #[derive(Debug, Deserialize)]
@@ -40,11 +41,7 @@ pub async fn handle_start(
     Json(payload): Json<StartOauthRelayRequest>,
 ) -> Result<Json<StartOauthRelayResponse>, ToolError> {
     let start = Instant::now();
-    let request_id = headers
-        .get("x-request-id")
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+    let request_id = request_id(&headers).map(ToOwned::to_owned);
     validate_bind_addr(payload.bind_addr)?;
     let resolved_target =
         crate::oauth::target::resolve_explicit_target(&payload.target_url, payload.default_port)

--- a/crates/lab/src/api/services/gateway.rs
+++ b/crates/lab/src/api/services/gateway.rs
@@ -161,6 +161,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_destructive_routes_require_confirm() {
+        let response = post_gateway_fresh(json!({
+            "action":"gateway.add",
+            "params":{"spec":{"name":"fixture-http","url":"http://127.0.0.1:9001","bearer_token_env":"FIXTURE_HTTP_TOKEN"}}
+        }))
+        .await;
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
     async fn gateway_actions_endpoint_is_registered() {
         let response = get_gateway_actions(test_app()).await;
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/lab/src/dispatch.rs
+++ b/crates/lab/src/dispatch.rs
@@ -35,6 +35,7 @@ pub mod qbittorrent;
 pub mod qdrant;
 #[cfg(feature = "radarr")]
 pub mod radarr;
+pub mod redact;
 #[cfg(feature = "sabnzbd")]
 pub mod sabnzbd;
 #[cfg(feature = "sonarr")]

--- a/crates/lab/src/dispatch/gateway/catalog.rs
+++ b/crates/lab/src/dispatch/gateway/catalog.rs
@@ -334,4 +334,22 @@ mod tests {
             assert!(!spec.destructive, "{action} should remain non-destructive");
         }
     }
+
+    #[test]
+    fn gateway_read_actions_remain_non_destructive() {
+        for action in [
+            "gateway.list",
+            "gateway.get",
+            "gateway.test",
+            "gateway.discovered_tools",
+            "gateway.discovered_resources",
+            "gateway.discovered_prompts",
+        ] {
+            let spec = ACTIONS
+                .iter()
+                .find(|spec| spec.name == action)
+                .expect("gateway action");
+            assert!(!spec.destructive, "{action} must remain non-destructive");
+        }
+    }
 }

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -216,6 +216,19 @@ mod tests {
         assert!(names.contains(&"gateway.discovered_tools"));
         assert!(names.contains(&"gateway.discovered_resources"));
         assert!(names.contains(&"gateway.discovered_prompts"));
+
+        for name in [
+            "gateway.add",
+            "gateway.update",
+            "gateway.remove",
+            "gateway.reload",
+        ] {
+            let spec = ACTIONS
+                .iter()
+                .find(|spec| spec.name == name)
+                .expect("action");
+            assert!(spec.destructive, "{name} must be destructive");
+        }
     }
 
     fn test_manager() -> GatewayManager {

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -340,6 +340,8 @@ mod tests {
                     .expect("policy"),
                 prompt_count: 3,
                 resource_count: 4,
+                prompt_names: Vec::new(),
+                resource_uris: Vec::new(),
                 tool_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,
                 prompt_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,
                 resource_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -1170,7 +1170,7 @@ fn redacted_gateway_target(upstream: &UpstreamConfig) -> Option<String> {
 
 fn redact_gateway_url(url: &str) -> String {
     let Ok(mut parsed) = Url::parse(url) else {
-        return url.to_string();
+        return "[invalid-url-redacted]".to_string();
     };
 
     let _ = parsed.set_username("");
@@ -1651,6 +1651,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn server_view_redacts_invalid_target_urls() {
+        let upstream = UpstreamConfig {
+            name: "fixture-http".to_string(),
+            url: Some("http://user:pass@[::1".to_string()),
+            bearer_token_env: Some("FIXTURE_HTTP_TOKEN".to_string()),
+            command: None,
+            args: Vec::new(),
+            proxy_resources: false,
+            expose_tools: None,
+        };
+
+        let view = server_view_from_upstream(None, &upstream).await;
+
+        assert_eq!(
+            view.config_summary.target.as_deref(),
+            Some("[invalid-url-redacted]")
+        );
+    }
+
+    #[tokio::test]
     async fn configured_service_appears_in_list_before_virtual_server_enablement() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
@@ -2047,6 +2067,8 @@ mod tests {
             exposure_policy: crate::dispatch::upstream::types::ToolExposurePolicy::All,
             prompt_count: 0,
             resource_count: 0,
+            prompt_names: Vec::new(),
+            resource_uris: Vec::new(),
             tool_health: crate::dispatch::upstream::types::UpstreamHealth::Unhealthy {
                 consecutive_failures: 1,
             },

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -835,16 +835,6 @@ impl GatewayManager {
         self.runtime.swap(fresh_pool).await;
         *self.config.write().await = cfg;
         let diff = diff_catalogs(&before, &after);
-        if self.notifier.is_some() {
-            tracing::info!(
-                action = "gateway.reload",
-                phase = "catalog.notify",
-                tools_changed = diff.tools_changed,
-                resources_changed = diff.resources_changed,
-                prompts_changed = diff.prompts_changed,
-                "gateway reconcile"
-            );
-        }
         self.notify_catalog_changes(&diff);
         tracing::info!(
             action = "gateway.reload",
@@ -1152,20 +1142,29 @@ fn find_virtual_server_for_service<'a>(
 fn config_view(upstream: &UpstreamConfig) -> GatewayConfigView {
     GatewayConfigView {
         name: upstream.name.clone(),
-        url: upstream.url.clone(),
-        command: upstream.command.clone(),
-        args: upstream.args.clone(),
+        url: upstream.url.as_deref().map(redact_gateway_url),
+        command: upstream.command.as_deref().map(redact_gateway_stdio_value),
+        args: upstream
+            .args
+            .iter()
+            .map(|arg| redact_gateway_stdio_value(arg))
+            .collect(),
         bearer_token_env: upstream.bearer_token_env.clone(),
         proxy_resources: upstream.proxy_resources,
     }
 }
 
 fn redacted_gateway_target(upstream: &UpstreamConfig) -> Option<String> {
-    upstream
-        .url
-        .as_deref()
-        .map(redact_gateway_url)
-        .or_else(|| upstream.command.clone())
+    upstream.url.as_deref().map(redact_gateway_url).or_else(|| {
+        upstream.command.as_deref().map(|command| {
+            let args = upstream
+                .args
+                .iter()
+                .map(|arg| redact_gateway_stdio_value(arg))
+                .collect::<Vec<_>>();
+            format_redacted_gateway_command(command, &args)
+        })
+    })
 }
 
 fn redact_gateway_url(url: &str) -> String {
@@ -1199,10 +1198,57 @@ fn redact_gateway_url(url: &str) -> String {
 }
 
 fn is_sensitive_query_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
     matches!(
-        key.to_ascii_lowercase().as_str(),
-        "token" | "access_token" | "apikey" | "api_key" | "password" | "secret" | "bearer"
-    )
+        normalized.as_str(),
+        "token"
+            | "access_token"
+            | "id_token"
+            | "refresh_token"
+            | "apikey"
+            | "api_key"
+            | "password"
+            | "passwd"
+            | "secret"
+            | "client_secret"
+            | "authorization"
+            | "bearer"
+            | "session"
+            | "session_id"
+            | "cookie"
+            | "code"
+    ) || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+        || normalized.ends_with("_password")
+        || normalized.ends_with("_key")
+}
+
+fn redact_gateway_stdio_value(value: &str) -> String {
+    if let Some((key, _)) = value.split_once('=')
+        && is_sensitive_query_key(key)
+    {
+        return format!("{key}=[redacted]");
+    }
+
+    if let Some(flag) = value.strip_prefix("--") {
+        let (key, maybe_value) = flag.split_once('=').map_or((flag, ""), |(k, v)| (k, v));
+        if is_sensitive_query_key(key) {
+            let _ = maybe_value;
+            return format!("--{key}=[redacted]");
+        }
+    }
+
+    value.to_string()
+}
+
+fn format_redacted_gateway_command(command: &str, args: &[String]) -> String {
+    if command == "env"
+        && let Some(actual_command) = args.iter().find(|arg| !arg.contains('='))
+    {
+        return actual_command.clone();
+    }
+
+    redact_gateway_stdio_value(command)
 }
 
 fn empty_upstream_summary() -> UpstreamCachedSummary {
@@ -1631,6 +1677,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manager_get_redacts_sensitive_stdio_arguments() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let manager = GatewayManager::new(path, GatewayRuntimeHandle::default());
+
+        manager
+            .replace_config_for_tests(vec![UpstreamConfig {
+                name: "fixture-stdio".to_string(),
+                url: None,
+                bearer_token_env: Some("FIXTURE_HTTP_TOKEN".to_string()),
+                command: Some("env".to_string()),
+                args: vec![
+                    "OPENAI_API_KEY=super-secret".to_string(),
+                    "npx".to_string(),
+                    "--access_token=abc123".to_string(),
+                ],
+                proxy_resources: false,
+                expose_tools: None,
+            }])
+            .await;
+
+        let gateway = manager.get("fixture-stdio").await.expect("gateway");
+        assert_eq!(gateway.config.command.as_deref(), Some("env"));
+        assert_eq!(
+            gateway.config.args,
+            vec![
+                "OPENAI_API_KEY=[redacted]".to_string(),
+                "npx".to_string(),
+                "--access_token=[redacted]".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn server_view_redacts_sensitive_target_url_components() {
         let upstream = UpstreamConfig {
             name: "fixture-http".to_string(),
@@ -1668,6 +1748,27 @@ mod tests {
             view.config_summary.target.as_deref(),
             Some("[invalid-url-redacted]")
         );
+    }
+
+    #[tokio::test]
+    async fn server_view_redacts_stdio_env_targets() {
+        let upstream = UpstreamConfig {
+            name: "fixture-stdio".to_string(),
+            url: None,
+            bearer_token_env: Some("FIXTURE_HTTP_TOKEN".to_string()),
+            command: Some("env".to_string()),
+            args: vec![
+                "OPENAI_API_KEY=super-secret".to_string(),
+                "npx".to_string(),
+                "--access_token=abc123".to_string(),
+            ],
+            proxy_resources: false,
+            expose_tools: None,
+        };
+
+        let view = server_view_from_upstream(None, &upstream).await;
+
+        assert_eq!(view.config_summary.target.as_deref(), Some("npx"));
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -1198,7 +1198,7 @@ fn redact_gateway_url(url: &str) -> String {
 }
 
 fn is_sensitive_query_key(key: &str) -> bool {
-    let normalized = key.to_ascii_lowercase();
+    let normalized = key.to_ascii_lowercase().replace('-', "_");
     matches!(
         normalized.as_str(),
         "token"
@@ -1242,10 +1242,9 @@ fn redact_gateway_stdio_value(value: &str) -> String {
 }
 
 fn format_redacted_gateway_command(command: &str, args: &[String]) -> String {
-    if command == "env"
-        && let Some(actual_command) = args.iter().find(|arg| !arg.contains('='))
-    {
-        return actual_command.clone();
+    if command == "env" {
+        let _ = args;
+        return "env".to_string();
     }
 
     redact_gateway_stdio_value(command)
@@ -1692,6 +1691,7 @@ mod tests {
                     "OPENAI_API_KEY=super-secret".to_string(),
                     "npx".to_string(),
                     "--access_token=abc123".to_string(),
+                    "--api-key=super-secret".to_string(),
                 ],
                 proxy_resources: false,
                 expose_tools: None,
@@ -1706,6 +1706,7 @@ mod tests {
                 "OPENAI_API_KEY=[redacted]".to_string(),
                 "npx".to_string(),
                 "--access_token=[redacted]".to_string(),
+                "--api-key=[redacted]".to_string(),
             ]
         );
     }
@@ -1768,7 +1769,7 @@ mod tests {
 
         let view = server_view_from_upstream(None, &upstream).await;
 
-        assert_eq!(view.config_summary.target.as_deref(), Some("npx"));
+        assert_eq!(view.config_summary.target.as_deref(), Some("env"));
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use tokio::sync::RwLock;
+use url::Url;
 
 use crate::config::{LabConfig, UpstreamConfig, backup_env, env_is_up_to_date, write_env};
 use crate::dispatch::clients::SharedServiceClients;
@@ -606,6 +607,13 @@ impl GatewayManager {
         mut spec: UpstreamConfig,
         bearer_token_value: Option<String>,
     ) -> Result<GatewayView, ToolError> {
+        tracing::info!(
+            action = "gateway.add",
+            phase = "start",
+            gateway = %spec.name,
+            target = ?redacted_gateway_target(&spec),
+            "gateway reconcile"
+        );
         let mut cfg = self.config.read().await.clone();
 
         // Trim and validate bearer_token_env unconditionally so whitespace typos
@@ -629,7 +637,17 @@ impl GatewayManager {
             insert_upstream(&mut cfg, spec.clone())?;
         }
         self.persist_config(cfg).await?;
-        let _ = self.reload().await?;
+        let diff = self.reload().await?;
+        tracing::info!(
+            action = "gateway.add",
+            phase = "finish",
+            gateway = %spec.name,
+            target = ?redacted_gateway_target(&spec),
+            tools_changed = diff.tools_changed,
+            resources_changed = diff.resources_changed,
+            prompts_changed = diff.prompts_changed,
+            "gateway reconcile"
+        );
         self.get(&spec.name).await
     }
 
@@ -640,8 +658,15 @@ impl GatewayManager {
         bearer_token_value: Option<String>,
     ) -> Result<GatewayView, ToolError> {
         let mut patch = patch;
-        let mut cfg = self.config.read().await.clone();
         let updated_name = patch.name.clone().unwrap_or_else(|| name.to_string());
+        tracing::info!(
+            action = "gateway.update",
+            phase = "start",
+            gateway = %name,
+            new_gateway = %updated_name,
+            "gateway reconcile"
+        );
+        let mut cfg = self.config.read().await.clone();
 
         // Trim and validate bearer_token_env unconditionally so whitespace typos
         // are caught before they silently fail env-var lookup later.
@@ -687,15 +712,41 @@ impl GatewayManager {
             update_upstream(&mut cfg, name, patch)?;
         }
         self.persist_config(cfg).await?;
-        let _ = self.reload().await?;
+        let diff = self.reload().await?;
+        tracing::info!(
+            action = "gateway.update",
+            phase = "finish",
+            gateway = %name,
+            new_gateway = %updated_name,
+            tools_changed = diff.tools_changed,
+            resources_changed = diff.resources_changed,
+            prompts_changed = diff.prompts_changed,
+            "gateway reconcile"
+        );
         self.get(&updated_name).await
     }
 
     pub async fn remove(&self, name: &str) -> Result<GatewayView, ToolError> {
+        tracing::info!(
+            action = "gateway.remove",
+            phase = "start",
+            gateway = %name,
+            "gateway reconcile"
+        );
         let mut cfg = self.config.read().await.clone();
         let removed = remove_upstream(&mut cfg, name)?;
         self.persist_config(cfg).await?;
-        let _ = self.reload().await?;
+        let diff = self.reload().await?;
+        tracing::info!(
+            action = "gateway.remove",
+            phase = "finish",
+            gateway = %name,
+            target = ?redacted_gateway_target(&removed),
+            tools_changed = diff.tools_changed,
+            resources_changed = diff.resources_changed,
+            prompts_changed = diff.prompts_changed,
+            "gateway reconcile"
+        );
         Ok(GatewayView {
             config: config_view(&removed),
             runtime: GatewayRuntimeView {
@@ -706,6 +757,11 @@ impl GatewayManager {
     }
 
     pub async fn reload(&self) -> Result<GatewayCatalogDiff, ToolError> {
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "config.load.start",
+            "gateway reconcile"
+        );
         let path = self.path.clone();
         let cfg = tokio::task::spawn_blocking(move || load_gateway_config(&path))
             .await
@@ -713,6 +769,12 @@ impl GatewayManager {
                 sdk_kind: "internal_error".to_string(),
                 message: format!("config read task failed: {e}"),
             })??;
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "config.load.finish",
+            upstream_count = cfg.upstream.len(),
+            "gateway reconcile"
+        );
         if let Some(cache) = &self.oauth_client_cache {
             let existing = self.config.read().await.clone();
             for upstream in existing
@@ -744,6 +806,11 @@ impl GatewayManager {
             }
         }
         let before = snapshot_from_pool(self.runtime.current_pool().await).await;
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "pool.build.start",
+            "gateway reconcile"
+        );
         let fresh_pool = if cfg.upstream.is_empty() {
             None
         } else {
@@ -754,11 +821,39 @@ impl GatewayManager {
             pool.discover_all(&cfg.upstream).await;
             Some(pool)
         };
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "pool.build.finish",
+            "gateway reconcile"
+        );
         let after = snapshot_from_pool(fresh_pool.clone()).await;
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "pool.swap",
+            "gateway reconcile"
+        );
         self.runtime.swap(fresh_pool).await;
         *self.config.write().await = cfg;
         let diff = diff_catalogs(&before, &after);
+        if self.notifier.is_some() {
+            tracing::info!(
+                action = "gateway.reload",
+                phase = "catalog.notify",
+                tools_changed = diff.tools_changed,
+                resources_changed = diff.resources_changed,
+                prompts_changed = diff.prompts_changed,
+                "gateway reconcile"
+            );
+        }
         self.notify_catalog_changes(&diff);
+        tracing::info!(
+            action = "gateway.reload",
+            phase = "finish",
+            tools_changed = diff.tools_changed,
+            resources_changed = diff.resources_changed,
+            prompts_changed = diff.prompts_changed,
+            "gateway reconcile"
+        );
         Ok(diff)
     }
 
@@ -984,6 +1079,13 @@ impl GatewayManager {
     async fn persist_config(&self, cfg: LabConfig) -> Result<(), ToolError> {
         let path = self.path.clone();
         let cfg_clone = cfg.clone();
+        tracing::info!(
+            action = "gateway.config.write",
+            phase = "start",
+            upstream_count = cfg.upstream.len(),
+            virtual_server_count = cfg.virtual_servers.len(),
+            "gateway reconcile"
+        );
         tokio::task::spawn_blocking(move || write_gateway_config(&path, &cfg_clone))
             .await
             .map_err(|e| ToolError::Sdk {
@@ -991,6 +1093,11 @@ impl GatewayManager {
                 message: format!("config write task failed: {e}"),
             })??;
         *self.config.write().await = cfg;
+        tracing::info!(
+            action = "gateway.config.write",
+            phase = "finish",
+            "gateway reconcile"
+        );
         Ok(())
     }
 }
@@ -1051,6 +1158,51 @@ fn config_view(upstream: &UpstreamConfig) -> GatewayConfigView {
         bearer_token_env: upstream.bearer_token_env.clone(),
         proxy_resources: upstream.proxy_resources,
     }
+}
+
+fn redacted_gateway_target(upstream: &UpstreamConfig) -> Option<String> {
+    upstream
+        .url
+        .as_deref()
+        .map(redact_gateway_url)
+        .or_else(|| upstream.command.clone())
+}
+
+fn redact_gateway_url(url: &str) -> String {
+    let Ok(mut parsed) = Url::parse(url) else {
+        return url.to_string();
+    };
+
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+
+    let query = parsed.query().map(|query| {
+        query
+            .split('&')
+            .filter(|pair| !pair.is_empty())
+            .map(|pair| {
+                let (key, value) = pair.split_once('=').map_or((pair, ""), |(k, v)| (k, v));
+                if is_sensitive_query_key(key) {
+                    format!("{key}=[redacted]")
+                } else if value.is_empty() {
+                    key.to_string()
+                } else {
+                    format!("{key}={value}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("&")
+    });
+    parsed.set_query(query.as_deref());
+
+    parsed.to_string()
+}
+
+fn is_sensitive_query_key(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "token" | "access_token" | "apikey" | "api_key" | "password" | "secret" | "bearer"
+    )
 }
 
 fn empty_upstream_summary() -> UpstreamCachedSummary {
@@ -1132,7 +1284,7 @@ async fn server_view_from_upstream(
             } else {
                 "http".to_string()
             }),
-            target: upstream.url.clone().or_else(|| upstream.command.clone()),
+            target: redacted_gateway_target(upstream),
         },
     }
 }
@@ -1475,6 +1627,26 @@ mod tests {
         assert_eq!(
             gateway.config.bearer_token_env.as_deref(),
             Some("FIXTURE_HTTP_TOKEN")
+        );
+    }
+
+    #[tokio::test]
+    async fn server_view_redacts_sensitive_target_url_components() {
+        let upstream = UpstreamConfig {
+            name: "fixture-http".to_string(),
+            url: Some("http://user:pass@127.0.0.1:9001/callback?token=secret&mode=1".to_string()),
+            bearer_token_env: Some("FIXTURE_HTTP_TOKEN".to_string()),
+            command: None,
+            args: Vec::new(),
+            proxy_resources: false,
+            expose_tools: None,
+        };
+
+        let view = server_view_from_upstream(None, &upstream).await;
+
+        assert_eq!(
+            view.config_summary.target.as_deref(),
+            Some("http://127.0.0.1:9001/callback?token=[redacted]&mode=1")
         );
     }
 

--- a/crates/lab/src/dispatch/redact.rs
+++ b/crates/lab/src/dispatch/redact.rs
@@ -1,0 +1,198 @@
+use reqwest::Url;
+
+pub fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase().replace('-', "_");
+    matches!(
+        normalized.as_str(),
+        "token"
+            | "access_token"
+            | "id_token"
+            | "refresh_token"
+            | "apikey"
+            | "api_key"
+            | "password"
+            | "passwd"
+            | "secret"
+            | "client_secret"
+            | "authorization"
+            | "bearer"
+            | "session"
+            | "session_id"
+            | "cookie"
+            | "code"
+    ) || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+        || normalized.ends_with("_password")
+        || normalized.ends_with("_key")
+}
+
+pub fn redact_url(url: &str) -> String {
+    match Url::parse(url) {
+        Ok(parsed) => redact_parsed_url(parsed),
+        Err(_) => "[invalid-url-redacted]".to_string(),
+    }
+}
+
+pub fn redact_stdio_value(value: &str) -> String {
+    if let Some((key, _)) = value.split_once('=')
+        && is_sensitive_key(key)
+    {
+        return format!("{key}=[redacted]");
+    }
+
+    if let Some(flag) = value.strip_prefix("--") {
+        let (key, _) = flag.split_once('=').map_or((flag, ""), |(k, v)| (k, v));
+        if is_sensitive_key(key) {
+            return format!("--{key}=[redacted]");
+        }
+    }
+
+    value.to_string()
+}
+
+pub fn redact_stdio_args(args: &[String]) -> Vec<String> {
+    let mut redacted = Vec::with_capacity(args.len());
+    let mut redact_next = false;
+
+    for arg in args {
+        if redact_next {
+            redacted.push("[redacted]".to_string());
+            redact_next = false;
+            continue;
+        }
+
+        let is_sensitive_flag = arg
+            .strip_prefix("--")
+            .map(|value| value.split_once('=').map_or(value, |(key, _)| key))
+            .is_some_and(is_sensitive_key);
+
+        if is_sensitive_flag && !arg.contains('=') {
+            redacted.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        redacted.push(redact_stdio_value(arg));
+    }
+
+    redacted
+}
+
+pub fn redact_upstream_resource_uri(uri: &str) -> String {
+    let Some(rest) = uri.strip_prefix("lab://upstream/") else {
+        return redact_url(uri);
+    };
+    let Some(slash_pos) = rest.find('/') else {
+        return "lab://upstream/[redacted]".to_string();
+    };
+    let upstream_name = &rest[..slash_pos];
+    let original_uri = &rest[slash_pos + 1..];
+    // Preserve non-sensitive pagination/id query params so observability can
+    // still distinguish resources; only `is_sensitive_key` entries are masked.
+    let redacted_original = redact_uri_or_path(original_uri);
+    format!("lab://upstream/{upstream_name}/{redacted_original}")
+}
+
+fn redact_uri_or_path(value: &str) -> String {
+    if let Ok(parsed) = Url::parse(value) {
+        return redact_parsed_url(parsed);
+    }
+    let (path, query) = match value.split_once('?') {
+        Some((path, rest)) => (path.split('#').next().unwrap_or(path), Some(rest)),
+        None => (value.split('#').next().unwrap_or(value), None),
+    };
+    match query.map(redact_query_pairs) {
+        Some(q) if !q.is_empty() => format!("{path}?{q}"),
+        _ => path.to_string(),
+    }
+}
+
+fn redact_parsed_url(mut parsed: Url) -> String {
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    let redacted_query = parsed.query().map(redact_query_pairs);
+    parsed.set_query(redacted_query.as_deref());
+    parsed.set_fragment(None);
+    parsed.to_string()
+}
+
+fn redact_query_pairs(query: &str) -> String {
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| {
+            let (key, value) = pair.split_once('=').map_or((pair, ""), |(k, v)| (k, v));
+            if is_sensitive_key(key) {
+                format!("{key}=[redacted]")
+            } else if value.is_empty() {
+                key.to_string()
+            } else {
+                format!("{key}={value}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_stdio_args_masks_split_form_secret_flags() {
+        let args = vec![
+            "npx".to_string(),
+            "--api-key".to_string(),
+            "super-secret".to_string(),
+            "--token=abc123".to_string(),
+        ];
+
+        assert_eq!(
+            redact_stdio_args(&args),
+            vec![
+                "npx".to_string(),
+                "--api-key".to_string(),
+                "[redacted]".to_string(),
+                "--token=[redacted]".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn redact_url_masks_credentials_and_sensitive_query_values() {
+        assert_eq!(
+            redact_url("http://user:pass@example.com/callback?token=secret&mode=1"),
+            "http://example.com/callback?token=[redacted]&mode=1"
+        );
+    }
+
+    #[test]
+    fn redact_upstream_resource_uri_masks_embedded_credentials() {
+        assert_eq!(
+            redact_upstream_resource_uri(
+                "lab://upstream/demo/https://user:pass@example.com/path?token=secret"
+            ),
+            "lab://upstream/demo/https://example.com/path?token=[redacted]"
+        );
+    }
+
+    #[test]
+    fn redact_upstream_resource_uri_preserves_non_sensitive_query_params() {
+        assert_eq!(
+            redact_upstream_resource_uri(
+                "lab://upstream/demo/https://example.com/items?page=2&limit=50"
+            ),
+            "lab://upstream/demo/https://example.com/items?page=2&limit=50"
+        );
+    }
+
+    #[test]
+    fn redact_upstream_resource_uri_mixed_query_keys() {
+        assert_eq!(
+            redact_upstream_resource_uri(
+                "lab://upstream/demo/https://example.com/items?page=2&api_key=abc"
+            ),
+            "lab://upstream/demo/https://example.com/items?page=2&api_key=[redacted]"
+        );
+    }
+}

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -204,6 +204,10 @@ pub struct UpstreamEntry {
     pub prompt_count: usize,
     /// Last successfully discovered upstream resource count.
     pub resource_count: usize,
+    /// Cached upstream prompt names from the last successful list operation.
+    pub prompt_names: Vec<String>,
+    /// Cached upstream resource URIs from the last successful list operation.
+    pub resource_uris: Vec<String>,
     /// Current tool-discovery/tool-call health state.
     pub tool_health: UpstreamHealth,
     /// Current prompt capability health state.

--- a/crates/lab/src/mcp.rs
+++ b/crates/lab/src/mcp.rs
@@ -2,6 +2,8 @@
 //! the Model Context Protocol. See `crates/lab/src/mcp/CLAUDE.md` for
 //! the full rulebook on dispatch, envelopes, and the shared catalog.
 
+pub mod catalog;
+pub mod elicitation;
 pub mod envelope;
 pub mod error;
 pub mod logging;

--- a/crates/lab/src/mcp/catalog.rs
+++ b/crates/lab/src/mcp/catalog.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use super::server::LabMcpServer;
+use crate::dispatch::upstream::pool::UpstreamPool;
+use crate::mcp::prompts::list_all as list_builtin_prompts;
+
+#[cfg(test)]
+use std::collections::BTreeSet;
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CatalogSnapshot {
+    pub(crate) tools: BTreeSet<String>,
+    pub(crate) resources: BTreeSet<String>,
+    pub(crate) prompts: BTreeSet<String>,
+}
+
+pub(crate) fn upstream_name_for_uri(uri: &str) -> Option<&str> {
+    let rest = uri.strip_prefix("lab://upstream/")?;
+    let slash_pos = rest.find('/')?;
+    Some(&rest[..slash_pos])
+}
+
+impl LabMcpServer {
+    pub(crate) async fn current_upstream_pool(&self) -> Option<Arc<UpstreamPool>> {
+        match &self.gateway_manager {
+            Some(manager) => manager.current_pool().await,
+            None => None,
+        }
+    }
+
+    pub(crate) async fn service_visible_on_mcp(&self, service: &str) -> bool {
+        if matches!(self.device_role, Some(crate::config::DeviceRole::NonMaster)) {
+            return false;
+        }
+        match &self.gateway_manager {
+            Some(manager) => manager.surface_enabled_for_service(service, "mcp").await,
+            None => true,
+        }
+    }
+
+    pub(crate) async fn action_allowed_on_mcp(&self, service: &str, action: &str) -> bool {
+        match &self.gateway_manager {
+            Some(manager) => {
+                manager
+                    .mcp_action_allowed_for_service(service, action)
+                    .await
+            }
+            None => true,
+        }
+    }
+
+    pub(crate) async fn allowed_mcp_actions(&self, service: &str) -> Option<Vec<String>> {
+        match &self.gateway_manager {
+            Some(manager) => manager.allowed_mcp_actions_for_service(service).await,
+            None => None,
+        }
+    }
+
+    pub(crate) fn builtin_prompt_names(&self) -> Vec<String> {
+        list_builtin_prompts()
+            .prompts
+            .iter()
+            .map(|prompt| prompt.name.to_string())
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn builtin_resource_identifiers(&self) -> BTreeSet<String> {
+        let mut resources = BTreeSet::from(["lab://catalog".to_string()]);
+        for svc in self.registry.services() {
+            if self.service_visible_on_mcp(svc.name).await {
+                resources.insert(format!("lab://{}/actions", svc.name));
+            }
+        }
+        resources
+    }
+
+    pub(crate) async fn catalog_json(&self) -> anyhow::Result<Value> {
+        let mut catalog = crate::catalog::build_catalog(&self.registry);
+        let mut services = Vec::new();
+        for mut service in catalog.services {
+            if !self.service_visible_on_mcp(&service.name).await {
+                continue;
+            }
+            if let Some(allowed_actions) = self.allowed_mcp_actions(&service.name).await
+                && !allowed_actions.is_empty()
+            {
+                service
+                    .actions
+                    .retain(|action| allowed_actions.contains(&action.name));
+            }
+            services.push(service);
+        }
+        catalog.services = services;
+        Ok(serde_json::to_value(catalog)?)
+    }
+
+    pub(crate) async fn service_actions_json(&self, service: &str) -> anyhow::Result<Value> {
+        if !self.service_visible_on_mcp(service).await {
+            anyhow::bail!("unknown service: {service}");
+        }
+
+        let catalog = crate::catalog::build_catalog(&self.registry);
+        let mut entry = catalog
+            .services
+            .into_iter()
+            .find(|entry| entry.name == service)
+            .ok_or_else(|| anyhow::anyhow!("unknown service: {service}"))?;
+
+        if let Some(allowed_actions) = self.allowed_mcp_actions(service).await
+            && !allowed_actions.is_empty()
+        {
+            entry
+                .actions
+                .retain(|action| allowed_actions.contains(&action.name));
+        }
+
+        Ok(serde_json::to_value(entry.actions)?)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn snapshot_catalog(&self) -> CatalogSnapshot {
+        let mut tools = BTreeSet::new();
+        for svc in self.registry.services() {
+            if self.service_visible_on_mcp(svc.name).await {
+                tools.insert(svc.name.to_string());
+            }
+        }
+
+        if let Some(pool) = self.current_upstream_pool().await {
+            for tool in pool.healthy_tools().await {
+                let name = tool.tool.name.to_string();
+                if !tools.contains(&name) {
+                    tools.insert(name);
+                }
+            }
+        }
+
+        let mut resources = self.builtin_resource_identifiers().await;
+        if let Some(pool) = self.current_upstream_pool().await {
+            for (upstream_name, uris) in pool.cached_upstream_resource_uris().await {
+                for uri in uris {
+                    resources.insert(format!("lab://upstream/{upstream_name}/{uri}"));
+                }
+            }
+        }
+
+        let builtin_prompt_names = self.builtin_prompt_names();
+        let builtin_prompt_refs: Vec<&str> =
+            builtin_prompt_names.iter().map(String::as_str).collect();
+        let mut prompts: BTreeSet<String> = builtin_prompt_names.iter().cloned().collect();
+        if let Some(pool) = self.current_upstream_pool().await {
+            for prompt_name in pool
+                .cached_upstream_prompt_names(&builtin_prompt_refs)
+                .await
+            {
+                prompts.insert(prompt_name);
+            }
+        }
+
+        CatalogSnapshot {
+            tools,
+            resources,
+            prompts,
+        }
+    }
+}

--- a/crates/lab/src/mcp/elicitation.rs
+++ b/crates/lab/src/mcp/elicitation.rs
@@ -1,0 +1,74 @@
+use rmcp::RoleServer;
+use rmcp::model::{
+    CreateElicitationRequestParams, ElicitationAction, ElicitationSchema, PrimitiveSchema,
+};
+use rmcp::service::RequestContext;
+use serde_json::Value;
+
+/// Outcome of an elicitation confirmation request.
+pub(crate) enum ElicitResult {
+    /// User confirmed the destructive action.
+    Confirmed,
+    /// User explicitly declined.
+    Declined,
+    /// User cancelled (closed the dialog without choosing).
+    Cancelled,
+    /// MCP client does not support the elicitation capability.
+    NotSupported,
+    /// The client advertised elicitation support, but the RPC failed.
+    Failed,
+}
+
+/// Ask the MCP client to confirm a destructive action via elicitation.
+///
+/// Sends a form with a single required `confirm: boolean` field.
+/// Returns `NotSupported` if the client's capabilities do not include elicitation.
+pub(crate) async fn elicit_confirm(
+    context: &RequestContext<RoleServer>,
+    service: &str,
+    action: &str,
+) -> ElicitResult {
+    if context.peer.supported_elicitation_modes().is_empty() {
+        return ElicitResult::NotSupported;
+    }
+
+    let Ok(schema) = ElicitationSchema::builder()
+        .required_property(
+            "confirm",
+            PrimitiveSchema::Boolean(rmcp::model::BooleanSchema::default()),
+        )
+        .build()
+    else {
+        return ElicitResult::NotSupported;
+    };
+
+    let params = CreateElicitationRequestParams::FormElicitationParams {
+        meta: None,
+        message: format!(
+            "Action `{service}.{action}` is destructive and cannot be undone. \
+             Set `confirm` to true to proceed."
+        ),
+        requested_schema: schema,
+    };
+
+    match context.peer.create_elicitation(params).await {
+        Ok(result) => match result.action {
+            ElicitationAction::Accept => {
+                let confirmed = result
+                    .content
+                    .as_ref()
+                    .and_then(|v| v.get("confirm"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if confirmed {
+                    ElicitResult::Confirmed
+                } else {
+                    ElicitResult::Declined
+                }
+            }
+            ElicitationAction::Decline => ElicitResult::Declined,
+            ElicitationAction::Cancel => ElicitResult::Cancelled,
+        },
+        Err(_) => ElicitResult::Failed,
+    }
+}

--- a/crates/lab/src/mcp/upstream.rs
+++ b/crates/lab/src/mcp/upstream.rs
@@ -1,8 +1,108 @@
-//! Re-export upstream types from the shared dispatch layer.
-//!
-//! The canonical implementation lives in `crate::dispatch::upstream`.
-//! This re-export exists so that existing `crate::mcp::upstream::*`
-//! references continue to resolve without a full codebase rename.
+use rmcp::model::{CallToolResult, Content};
+use serde_json::Value;
 
-#[allow(unused_imports)]
-pub use crate::dispatch::upstream::{pool, types};
+use crate::mcp::envelope::{build_error, build_error_extra};
+
+pub(crate) fn static_kind(s: &str) -> &'static str {
+    match s {
+        "unknown_action" => "unknown_action",
+        "unknown_subaction" => "unknown_subaction",
+        "missing_param" => "missing_param",
+        "invalid_param" => "invalid_param",
+        "unknown_instance" => "unknown_instance",
+        "auth_failed" => "auth_failed",
+        "not_found" => "not_found",
+        "rate_limited" => "rate_limited",
+        "validation_failed" => "validation_failed",
+        "network_error" => "network_error",
+        "server_error" => "server_error",
+        "decode_error" => "decode_error",
+        "confirmation_required" => "confirmation_required",
+        "upstream_error" => "upstream_error",
+        _ => "internal_error",
+    }
+}
+
+pub(crate) fn normalize_upstream_result(
+    service: &str,
+    action: &str,
+    result: CallToolResult,
+) -> (CallToolResult, &'static str, bool) {
+    if result.is_error != Some(true) {
+        return (result, "ok", false);
+    }
+
+    let Some(text) = result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|content| content.text.as_str())
+    else {
+        let envelope = build_error(
+            service,
+            action,
+            "upstream_error",
+            "upstream returned a non-text error payload",
+        );
+        return (
+            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            "upstream_error",
+            true,
+        );
+    };
+
+    let Ok(parsed) = serde_json::from_str::<Value>(text) else {
+        let envelope = build_error(service, action, "upstream_error", text);
+        return (
+            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            "upstream_error",
+            true,
+        );
+    };
+
+    let error_obj = parsed
+        .get("error")
+        .and_then(Value::as_object)
+        .or_else(|| parsed.as_object());
+
+    let Some(error_obj) = error_obj else {
+        let envelope = build_error(service, action, "upstream_error", text);
+        return (
+            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            "upstream_error",
+            true,
+        );
+    };
+
+    let kind = error_obj
+        .get("kind")
+        .and_then(Value::as_str)
+        .map(static_kind)
+        .unwrap_or("upstream_error");
+    let message = error_obj
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or(text);
+
+    let extra = serde_json::Map::from_iter(
+        error_obj
+            .iter()
+            .filter(|(key, _)| *key != "kind" && *key != "message")
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+
+    let envelope = if extra.is_empty() {
+        build_error(service, action, kind, message)
+    } else {
+        build_error_extra(service, action, kind, message, &Value::Object(extra))
+    };
+
+    (
+        CallToolResult::error(vec![Content::text(envelope.to_string())]),
+        kind,
+        matches!(
+            kind,
+            "upstream_error" | "network_error" | "server_error" | "decode_error" | "internal_error"
+        ),
+    )
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,13 @@ changes rather than internal refactors.
   patterns for callback-relay style clients such as Codex.
 
 ### Changed
+- **Breaking (HTTP API):** `gateway.add`, `gateway.update`, `gateway.remove`, and
+  `gateway.reload` are now marked destructive. HTTP and MCP callers must include
+  `"confirm": true` in `params` or the request is rejected with
+  `kind: "confirmation_required"` (HTTP 422). The in-repo `gateway-admin` UI is
+  already updated; any third-party HTTP consumer must add the confirm flag. See
+  `docs/GATEWAY.md` for the updated contract and `docs/ERRORS.md` for the
+  envelope shape.
 - Changed the hosted OAuth flow to advertise and serve `lab` as the auth server
   directly instead of relying on the old external issuer/JWKS configuration.
 - Changed Google authorization requests to request offline access with consent

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -268,6 +268,9 @@ Full details in [OAUTH.md](./OAUTH.md).
 | `LAB_AUTH_ACCESS_TOKEN_TTL_SECS` | no | Override lab-issued JWT access token lifetime. Defaults to `3600`. |
 | `LAB_AUTH_REFRESH_TOKEN_TTL_SECS` | no | Override refresh token lifetime. Defaults to `2592000` (30 days). |
 | `LAB_AUTH_CODE_TTL_SECS` | no | Override authorization code lifetime. Defaults to `300`. |
+| `LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `POST /register`. Defaults to `20`. |
+| `LAB_AUTH_AUTHORIZE_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `/authorize` and hosted browser-login initiation. Defaults to `60`. |
+| `LAB_AUTH_MAX_PENDING_OAUTH_STATES` | no | Maximum non-expired authorization and browser-login states kept in the auth store. Defaults to `1024`. |
 
 ### config.toml
 
@@ -282,6 +285,9 @@ google_scopes = ["openid", "email", "profile"]
 access_token_ttl_secs = 3600
 refresh_token_ttl_secs = 2592000
 auth_code_ttl_secs = 300
+register_requests_per_minute = 20
+authorize_requests_per_minute = 60
+max_pending_oauth_states = 1024
 ```
 
 Environment variables override `[auth]` values field-by-field.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -239,6 +239,15 @@ Rules:
 - HTTP and MCP must agree on the semantic kind
 - HTTP may use transport-appropriate status codes, but the JSON body remains structured
 - HTTP must not invent a second vocabulary for the same failure class
+- auth/session/logout/token routes must either use this envelope directly or
+  document a protocol-required exception in the owning auth docs
+
+Auth-specific rule:
+
+- session-store, database, provider, and signing-key failures are internal
+  failures, not "logged out" outcomes
+- handlers must not downgrade store/provider outages into successful
+  unauthenticated responses
 
 ## HTTP Status Mapping
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -60,6 +60,20 @@ Additional MCP-only flow-control cases may include:
 - `elicitation_declined`
 - `elicitation_unsupported`
 
+### Auth Protocol Exception
+
+`invalid_grant` is a documented auth-route exception for OAuth protocol
+failures. It is emitted by the auth server for invalid, expired, reused, or
+mismatched authorization codes and refresh tokens.
+
+- surface: HTTP auth routes only
+- status: `400 Bad Request`
+- contract owner: `docs/OAUTH.md`
+
+This kind does not replace the canonical shared SDK taxonomy for service
+dispatch. It exists because OAuth token endpoints have a protocol-level error
+vocabulary that callers expect.
+
 ### HTTP-Only Dispatcher Kinds
 
 The following kinds are emitted exclusively by the HTTP surface. MCP handles the same guard differently (via elicitation), and CLI handles it via `--yes` / `-y`.
@@ -262,6 +276,7 @@ Default mapping expectations:
 - `unknown_action` -> `400 Bad Request`
 - `unknown_instance` -> `400 Bad Request`
 - `confirmation_required` -> `422 Unprocessable Entity`
+- `invalid_grant` -> `400 Bad Request`
 - `network_error` -> `502 Bad Gateway`
 - `server_error` -> `502 Bad Gateway`
 - `upstream_error` -> `502 Bad Gateway`

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -90,6 +90,14 @@ Every mutating action follows the same sequence:
 4. atomically swap the runtime handle
 5. notify connected MCP peers when tool/resource/prompt catalogs changed
 
+Observability requirements for that reconcile:
+
+- log intent before config mutation begins
+- log each phase transition (`config_write`, `pool_build`, `swap`, `notify`)
+- log outcome with success/failure and elapsed time
+- redact credential-bearing URLs, commands, args, and token-derived values in
+  both logs and returned management views
+
 ## Examples
 
 ### CLI

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -97,6 +97,11 @@ Important constraints:
 
 - `relay-local` binds only to `127.0.0.1:<port>` on the browser machine
 - it forwards only the final callback request
+- it forwards only a callback-safe header allowlist; `Cookie`,
+  `Authorization`, and similar ambient credentials are stripped
+- it mirrors only a callback-safe response header allowlist; `Set-Cookie` and
+  other credential-bearing response headers are not relayed back through the
+  localhost helper
 - it does not mint tokens, store PKCE state, or complete the OAuth exchange itself
 - the real client listener must already be running and reachable before the callback arrives
 
@@ -199,6 +204,39 @@ Current constraints:
 - refresh grants are rejected if the local token is not backed by an upstream refresh token
 - refresh tokens do not rotate in this batch
 - `/revoke` is not implemented in this batch
+- successful and failed `/token` responses must send `Cache-Control: no-store`
+  and `Pragma: no-cache`
+
+### Auth Failure Semantics
+
+`lab` distinguishes unauthenticated callers from internal auth outages.
+
+Rules:
+
+- `/auth/session` returns an unauthenticated result only when the request truly
+  lacks a valid session
+- auth store, signing-key, provider, or persistence failures stay 5xx-class and
+  use canonical error envelopes
+- `/auth/logout` failures are surfaced as structured errors rather than being
+  treated as best-effort success
+- provider-facing logs must preserve stable `kind` classification when transport,
+  status, decode, or grant failures happen
+
+### Frontend Expectations
+
+The web UI and server-side frontend adapter must treat auth state as a three-way
+ distinction:
+
+- `loading`
+- `unauthenticated`
+- `auth_error`
+
+They must also:
+
+- capture response `x-request-id` values on failures
+- avoid showing a hosted-login CTA unless hosted login is actually available
+- invalidate or refresh cached session state when later requests fail with
+  `auth_failed` or CSRF-style auth errors
 
 ## RFC 9728 Protected Resource Metadata
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -27,6 +27,9 @@ OAuth mode is configured through env vars and/or `config.toml`. Env vars take pr
 | `LAB_AUTH_ALLOWED_REDIRECT_URIS` | no | Comma-separated redirect URI patterns allowed for dynamic client registration in addition to loopback callbacks. |
 | `LAB_GOOGLE_CALLBACK_PATH` | no | Callback path appended to `LAB_PUBLIC_URL`. Defaults to `/auth/google/callback`. |
 | `LAB_GOOGLE_SCOPES` | no | Comma-separated Google scopes. Defaults to `openid,email,profile`. |
+| `LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `POST /register`. Defaults to `20`. |
+| `LAB_AUTH_AUTHORIZE_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `/authorize` and browser login initiation. Defaults to `60`. |
+| `LAB_AUTH_MAX_PENDING_OAUTH_STATES` | no | Maximum non-expired pending authorization + browser-login states stored at once. Defaults to `1024`. |
 
 ## Startup Behavior
 
@@ -59,6 +62,8 @@ Registration rules in the initial launch:
 - loopback redirect URIs are always accepted
 - optional non-loopback redirect URI patterns can be allowed with `LAB_AUTH_ALLOWED_REDIRECT_URIS` or `[auth].allowed_client_redirect_uris`
 - unlisted public HTTPS redirect URIs are rejected
+- `POST /register`, `/authorize`, and hosted browser-login initiation are process-locally rate limited
+- new login/authorization state is rejected once the pending non-expired state cap is reached
 
 Flow summary:
 
@@ -246,7 +251,8 @@ They must also:
 - capture response `x-request-id` values on failures
 - avoid showing a hosted-login CTA unless hosted login is actually available
 - invalidate or refresh cached session state when later requests fail with
-  `auth_failed` or CSRF-style auth errors
+  `auth_failed` or a CSRF-style `validation_failed` response
+- not treat unrelated validation failures as implicit logout/session-expiry events
 
 ### OAuth Error Kinds
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -222,6 +222,16 @@ Rules:
 - provider-facing logs must preserve stable `kind` classification when transport,
   status, decode, or grant failures happen
 
+Browser-session introspection semantics:
+
+- `GET /auth/session` returns `200` with `authenticated: false` only for a true
+  logged-out outcome
+- the same payload includes `login_available` so browser clients can suppress
+  the hosted-login CTA when OAuth browser login is not configured
+- internal failures from session lookup, persistence, signing, or provider
+  coordination remain structured 5xx responses instead of collapsing into
+  `authenticated: false`
+
 ### Frontend Expectations
 
 The web UI and server-side frontend adapter must treat auth state as a three-way
@@ -237,6 +247,17 @@ They must also:
 - avoid showing a hosted-login CTA unless hosted login is actually available
 - invalidate or refresh cached session state when later requests fail with
   `auth_failed` or CSRF-style auth errors
+
+### OAuth Error Kinds
+
+Most auth-route failures use the canonical error envelope described in
+`docs/ERRORS.md`.
+
+Documented auth-specific exception:
+
+- `invalid_grant` remains a stable OAuth token/authorization error for
+  authorization-code and refresh-token redemption failures such as expired,
+  unknown, or mismatched grants
 
 ## RFC 9728 Protected Resource Metadata
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -103,6 +103,17 @@ Optional when applicable:
 - `operation = "health"`
 - `kind` on failure
 
+This same contract applies to auth-adjacent HTTP handlers that are part of the
+product surface, including:
+
+- `/auth/session`
+- `/auth/logout`
+- `/v1/device/oauth/relay/start`
+- OAuth authorize/callback/token handlers where `lab` itself is the actor
+
+Those routes must not silently bypass the normal dispatch schema just because
+they are not mounted under `/v1/{service}`.
+
 ### Local Log Ingest Boundary
 
 The local-master `logs` subsystem is a shared observability consumer, not a replacement for dispatch logging.
@@ -152,6 +163,29 @@ This applies to all shared request helpers, including:
 
 `HttpClient` logs must inherit the caller span from CLI, MCP, or HTTP dispatch.
 
+### Outbound RMCP Client Requests
+
+Outbound RMCP client operations are part of the same observability contract as
+shared HTTP requests.
+
+Every proxied upstream RMCP operation must emit:
+
+- one start event before the outbound RPC
+- one finish event on success
+- one error event on failure or timeout
+
+Required fields:
+
+- `upstream`
+- `capability`
+- `operation`
+- `elapsed_ms` on finish/error
+
+When the call originates from API or HTTP MCP, the RMCP events must inherit the
+surrounding caller context, including `request_id` when present. Timeouts must
+be logged as explicit failures rather than disappearing into generic disconnect
+noise.
+
 ### Health Probes
 
 Health probes are not normal business actions and must be distinguishable in logs.
@@ -170,6 +204,17 @@ Destructive actions must log:
 - outcome after execution
 
 Intent logs must make it clear which action is about to mutate state. Outcome logs must indicate success or failure.
+
+Gateway reconcile actions are destructive in this contract:
+
+- `gateway.add`
+- `gateway.update`
+- `gateway.remove`
+- `gateway.reload`
+
+Those actions must also log reconcile phase transitions and outcome details
+without exposing credential-bearing URLs, commands, tokens, or secret env
+values.
 
 ## Required Fields
 
@@ -191,6 +236,8 @@ Additional fields when applicable:
 - `instance`
 - `request_id`
 - `operation`
+- `upstream`
+- `capability`
 
 ### Request Events
 
@@ -229,6 +276,8 @@ The practical result must be:
 - outbound request logs can be tied back to the invoking surface
 - HTTP-originated requests can be tied back to a `request_id`
 - multi-instance requests can be tied back to an `instance`
+- outbound RMCP proxy activity can be tied back to the invoking surface and
+  request when one exists
 
 For device-runtime uploads, operators must be able to correlate:
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -186,6 +186,13 @@ surrounding caller context, including `request_id` when present. Timeouts must
 be logged as explicit failures rather than disappearing into generic disconnect
 noise.
 
+For negotiated RMCP logging notifications sent back to MCP clients:
+
+- reuse the same `surface/service/action/elapsed_ms[/kind]` payload shape as local dispatch logs
+- omit `kind` on success notifications
+- preserve the caller-derived failure severity (`warning` for caller/user errors,
+  `error` for internal or upstream failures)
+
 ### Health Probes
 
 Health probes are not normal business actions and must be distinguishable in logs.

--- a/docs/RMCP.md
+++ b/docs/RMCP.md
@@ -78,7 +78,8 @@ Notes:
 Rules:
 
 - both transports expose the same server behavior
-- stdio remains the default local transport
+- `lab serve` defaults to HTTP unless CLI, env, or config selects stdio
+- stdio remains available for explicit local child-process sessions via `lab serve mcp --stdio`
 - HTTP MCP is mounted inside the Axum application under a dedicated MCP path such as `/mcp`
 - the Axum API continues to own non-MCP HTTP routes such as `/health`, `/ready`, and `/v1/...`
 - HTTP transport configuration must not fork the catalog or discovery model

--- a/docs/RMCP.md
+++ b/docs/RMCP.md
@@ -205,12 +205,22 @@ Rules:
 
 - advertise logging capability in server info when available
 - honor negotiated log level handling where RMCP supports it
+- map negotiated levels onto the same dispatch outcome vocabulary used by local
+  tracing (`success -> info`, caller/user errors -> warning, internal/upstream
+  failures -> error)
 - emit sanitized log notifications only; never send tokens, cookies, auth
   headers, raw credential-bearing URLs, or secret env values
 - reuse the same action/service/upstream context and redaction rules that apply
   to local structured logs
 - logging notifications supplement local tracing; they do not replace required
   server-side observability
+
+Current implementation notes:
+
+- prompt/resource/tool read paths do not recompute catalog snapshots or fan out
+  list-changed notifications on every request
+- gateway-driven upstream catalog changes are propagated through the dedicated
+  peer notifier instead of piggybacking on ordinary request traffic
 
 ## Resource and Prompt Ownership
 

--- a/docs/RMCP.md
+++ b/docs/RMCP.md
@@ -60,6 +60,7 @@ The baseline posture is:
 | `client` | required in practice | `lab` must be able to act as an outbound MCP client and gateway |
 | `auth` | required | needed for outbound OAuth MCP clients and protected HTTP MCP deployments |
 | `transport-streamable-http-client` | required in practice | required for outbound MCP gateway/client work over HTTP |
+| logging capability | required in practice | `lab` emits sanitized RMCP log notifications when the client negotiates logging |
 
 Notes:
 
@@ -115,6 +116,13 @@ Rules:
 - continue to dispatch service operations through `action` + `params`
 - do not explode the tool list into one tool per endpoint or one tool per action
 - prompts and resources may be richer than tools, but they must still derive from the same shared catalog and dispatch ownership model
+
+Prompt and resource operations must carry the same observability posture as tool
+dispatch:
+
+- structured dispatch logs for list/read/get operations
+- stable error-kind handling where applicable
+- request correlation preserved through the surrounding caller context
 
 ## Handler and Macro Contract
 
@@ -187,6 +195,21 @@ Rules:
 
 - outbound RMCP client and auth support are first-class capabilities because `lab` must connect to and proxy other MCP servers
 - if outbound MCP clients are added, their credentials and token lifecycle must still follow `lab`'s own config and secret-handling rules
+
+## Logging Capability Contract
+
+`lab` implements RMCP logging capability as a first-class server feature.
+
+Rules:
+
+- advertise logging capability in server info when available
+- honor negotiated log level handling where RMCP supports it
+- emit sanitized log notifications only; never send tokens, cookies, auth
+  headers, raw credential-bearing URLs, or secret env values
+- reuse the same action/service/upstream context and redaction rules that apply
+  to local structured logs
+- logging notifications supplement local tracing; they do not replace required
+  server-side observability
 
 ## Resource and Prompt Ownership
 

--- a/docs/TRANSPORT.md
+++ b/docs/TRANSPORT.md
@@ -21,6 +21,10 @@ LAB_MCP_TRANSPORT=stdio lab serve
 
 No network listener is opened. No host, port, or auth configuration is needed.
 
+This default is contractual: code, CLI help, tests, and operator docs must all
+agree that `stdio` is the default transport unless changed intentionally in one
+coordinated update.
+
 ## Streamable HTTP (Default)
 
 The HTTP transport mounts the MCP protocol at `/mcp` inside the axum HTTP server, alongside the
@@ -98,6 +102,11 @@ Auth methods (see [OAUTH.md](./OAUTH.md) for details):
 - **OAuth mode** via `LAB_AUTH_MODE=oauth`, `LAB_PUBLIC_URL`, and Google client credentials.
 - Both can be active simultaneously. Static bearer is checked first.
 - If neither auth method is configured, the router permits local loopback requests only; non-loopback binds are rejected by the safety gate below.
+
+Auth-adjacent routes mounted on this server, including `/auth/session`,
+`/auth/logout`, `/authorize`, `/auth/google/callback`, and `/token`, remain
+part of the same request-id and structured-error contract even when their
+payloads are not normal `/v1/{service}` dispatches.
 
 ### Safety Gate
 

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -264,6 +264,11 @@ At startup, lab connects to all configured upstreams in parallel. Each upstream 
 
 Failed upstreams are marked unhealthy. Healthy upstreams continue operating. A single failed upstream does not prevent others from connecting.
 
+After startup, proxied RMCP operations continue to use explicit per-RPC
+timeouts. Tool calls, prompt reads, resource reads, and discovery/listing
+operations must fail closed with logged timeout/error events rather than
+blocking indefinitely behind one hung upstream.
+
 ```text
 upstream discovery succeeded  upstream=remote-lab tool_count=12
 upstream discovery failed     upstream=broken-server error="connection refused"
@@ -325,7 +330,9 @@ Each upstream has independent health tracking.
 
 - Connection errors
 - Tool call errors (`is_error` responses)
+- Prompt and resource proxy errors
 - Dropped connections
+- Timeouts
 - Response size cap exceeded
 
 ### Recovery
@@ -370,6 +377,10 @@ lab://upstream/remote-lab/lab://radarr/actions
 - `read_resource()` strips the prefix, identifies the upstream by name, and forwards the read.
 
 Failed resource listings from individual upstreams are logged as warnings. Other upstreams continue to serve.
+
+The same graceful-degradation rule applies to prompt/resource discovery and
+reads: one upstream failure must not prevent healthy upstreams from serving
+partial results.
 
 ## What Is Exposed Where
 


### PR DESCRIPTION
## Summary
- harden OAuth relay, token/session auth handling, and frontend browser-session state so auth outages stay observable instead of masquerading as logout
- add RMCP logging capability, prompt/resource dispatch parity, upstream timeout/breaker/redaction improvements, and destructive gateway confirmation alignment
- update docs/tests for the new observability and auth contract, including frontend request-id handling and gateway auth recovery tests

## Verification
- cargo fmt --all
- cargo test --workspace --all-features --tests --no-fail-fast
- cargo build --workspace --all-features
- cargo test -p lab-auth token::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml api::router::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml oauth::local_relay -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml dispatch::gateway::dispatch::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml dispatch::gateway::manager::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml dispatch::upstream::pool::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml mcp::server::tests -- --nocapture
- cargo test --manifest-path crates/lab/Cargo.toml cli::serve::tests -- --nocapture
- pnpm --dir apps/gateway-admin exec sh -lc 'node --test --experimental-strip-types "lib/server/**/*.test.ts" "lib/api/**/*.test.ts"'
- pnpm --dir apps/gateway-admin exec tsc --noEmit
- pnpm --dir apps/gateway-admin build

## Residual Risk
- cargo clippy --workspace --all-features --tests -- -D warnings still fails on pre-existing repo-wide lint debt outside this remediation scope, mostly in existing `lab-auth` / `lab-apis` test code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies logging and auth observability across the HTTP gateway, admin, and MCP so auth failures surface as structured errors with request IDs instead of silent logouts. Adds guarded OAuth flows, destructive‑action confirmation, tighter redaction, and normalized upstream error handling.

- **New Features**
  - Structured auth errors with kinds and request IDs across `/auth/session`, `/auth/logout`, OAuth relay, gateway, and backend; unauthenticated session responses include `login_available`; admin shows error details (with request IDs), suppresses hosted-login when unavailable, refreshes the browser session only on auth/CSRF failures, and clears local state on logout failures.
  - OAuth hardening: safe header allowlists in the local relay; token responses add `Cache-Control: no-store` and `Pragma: no-cache`; new `AuthError` kinds (`network_error`, `server_error`, `decode_error`) with `Retry-After` parsing; rate limits for `/register` and `/authorize`; cap on pending OAuth states.
  - Gateway: mutating actions are destructive, emit reconcile phase logs, and redact target URLs/stdio args/resource URIs while preserving non‑sensitive query params; admin sends `confirm=true` for destructive mutations.
  - MCP: negotiated logging; per‑RPC timeouts; catalog snapshots cache prompt/resource identifiers; upstream errors normalized to shared kinds for consistent envelopes.

- **Migration**
  - HTTP callers must send `params.confirm=true` for `gateway.add`, `gateway.update`, `gateway.remove`, and `gateway.reload`. MCP uses elicitation to confirm.
  - Admin/API consumers should handle new session fields: `login_available` and `auth_error` (`message`, optional `kind` and `requestId`).

<sup>Written for commit 04379b05f4cf176f102676bfbc6a4db503606b50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Gateway destructive actions (`gateway.add`, `gateway.update`, `gateway.remove`, `gateway.reload`) now require `"confirm": true` in request parameters; requests without confirmation are rejected with HTTP 422.

* **New Features**
  * Added rate limiting for OAuth registration, authorization, and browser-login operations.
  * Enhanced auth error handling with improved messages and request ID tracking for debugging.
  * Three-way auth state support with better error classification.

* **Documentation**
  * Updated configuration, gateway, and OAuth documentation with new rate-limit settings and auth requirements.
  * Enhanced observability and error contract documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->