### PR TITLE
feat: finish local master log foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ config.toml
 
 # ── Runtime artifacts ────────────────────────────────────────────────────────
 logs/
+!apps/gateway-admin/app/(admin)/logs/
+!apps/gateway-admin/app/(admin)/logs/page.tsx
+!apps/gateway-admin/components/logs/
+!apps/gateway-admin/components/logs/*.tsx
 backups/
 *.log
 *.pid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "ratatui",
  "reqwest",
  "rmcp",
+ "rusqlite",
  "secrecy",
  "serde",
  "serde_json",

--- a/apps/gateway-admin/app/(admin)/activity/page.tsx
+++ b/apps/gateway-admin/app/(admin)/activity/page.tsx
@@ -36,6 +36,11 @@ export default function ActivityPage() {
         breadcrumbs={[
           { label: 'Activity' }
         ]}
+        actions={(
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/logs">Open logs</Link>
+          </Button>
+        )}
       />
       <div className="flex-1 p-6">
         <div className="space-y-6">
@@ -66,6 +71,13 @@ export default function ActivityPage() {
               <h1 className="text-lg font-semibold">Gateway activity</h1>
               <p className="mt-1 text-sm text-muted-foreground">
                 Health probes and warning events derived from the current control-plane state.
+              </p>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Need the raw event stream or persisted runtime history? Use the dedicated{' '}
+                <Link href="/logs" className="font-medium text-primary underline-offset-4 hover:underline">
+                  log console
+                </Link>
+                .
               </p>
             </div>
 

--- a/apps/gateway-admin/app/(admin)/logs/page.tsx
+++ b/apps/gateway-admin/app/(admin)/logs/page.tsx
@@ -1,0 +1,5 @@
+import { LogConsole } from '@/components/logs/log-console'
+
+export default function LogsPage() {
+  return <LogConsole />
+}

--- a/apps/gateway-admin/components/app-sidebar.tsx
+++ b/apps/gateway-admin/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   LayoutDashboard, 
   Settings, 
   Activity,
+  ScrollText,
   HelpCircle,
 } from 'lucide-react'
 
@@ -47,6 +48,11 @@ const navigation = [
     title: 'Activity',
     url: '/activity',
     icon: Activity,
+  },
+  {
+    title: 'Logs',
+    url: '/logs',
+    icon: ScrollText,
   },
 ]
 

--- a/apps/gateway-admin/components/logs/log-console.tsx
+++ b/apps/gateway-admin/components/logs/log-console.tsx
@@ -64,6 +64,17 @@ function retainedWindow(stats: LogStoreStats | null): string {
   return `${timestampFormatter.format(new Date(stats.oldest_retained_ts))} -> ${timestampFormatter.format(new Date(stats.newest_retained_ts))}`
 }
 
+function scrollViewportToBottom(viewport: HTMLDivElement | null) {
+  viewport?.scrollTo({
+    top: viewport.scrollHeight,
+    behavior: 'smooth',
+  })
+}
+
+function formatRetentionWindowDays(days: number): string {
+  return `${days} day${days === 1 ? '' : 's'}`
+}
+
 function queryPreviewForAfterTs(filters: LogFilterState, afterTs: number | null): string {
   return JSON.stringify(
     {
@@ -98,17 +109,19 @@ export function LogConsole() {
   const filtersRef = React.useRef(filters)
   const effectivePaused = manualPause || !atLiveEdge
   const effectivePausedRef = React.useRef(effectivePaused)
+  const bufferedEventsRef = React.useRef(bufferedEvents)
   const maxEntriesRef = React.useRef(filters.limit)
   const afterTs = React.useMemo(() => {
     const windowMs = WINDOW_TO_MS[windowPreset]
     return windowMs == null ? null : Date.now() - windowMs
-  }, [windowPreset, refreshToken])
+  }, [windowPreset, refreshToken, deferredFilters])
 
   React.useLayoutEffect(() => {
     filtersRef.current = filters
     effectivePausedRef.current = effectivePaused
+    bufferedEventsRef.current = bufferedEvents
     maxEntriesRef.current = filters.limit
-  }, [filters, effectivePaused])
+  }, [bufferedEvents, filters, effectivePaused])
 
   React.useEffect(() => {
     if (!copyStatus) {
@@ -142,9 +155,23 @@ export function LogConsole() {
           return
         }
 
+        const fetchedEvents = mergeTimelineEvents([], result.events, deferredFilters.limit)
+        const fetchedEventIds = new Set(fetchedEvents.map((event) => event.event_id))
+        const uncoveredBufferedEvents = bufferedEventsRef.current.filter(
+          (event) => !fetchedEventIds.has(event.event_id),
+        )
+
         startTransition(() => {
-          setEvents(mergeTimelineEvents([], result.events, deferredFilters.limit))
-          setBufferedEvents([])
+          setEvents(
+            effectivePausedRef.current
+              ? fetchedEvents
+              : mergeTimelineEvents(
+                  fetchedEvents,
+                  uncoveredBufferedEvents,
+                  deferredFilters.limit,
+                ),
+          )
+          setBufferedEvents(effectivePausedRef.current ? uncoveredBufferedEvents : [])
           setStats(nextStats)
           setStreamError(null)
         })
@@ -210,10 +237,7 @@ export function LogConsole() {
 
         if (!effectivePausedRef.current) {
           requestAnimationFrame(() => {
-            viewportRef.current?.scrollTo({
-              top: viewportRef.current.scrollHeight,
-              behavior: 'smooth',
-            })
+            scrollViewportToBottom(viewportRef.current)
           })
         }
       },
@@ -237,16 +261,14 @@ export function LogConsole() {
     })
 
     requestAnimationFrame(() => {
-      viewportRef.current?.scrollTo({
-        top: viewportRef.current.scrollHeight,
-        behavior: 'smooth',
-      })
+      scrollViewportToBottom(viewportRef.current)
     })
   }, [bufferedEvents, effectivePaused, filters.limit])
 
   const streamStatus: LogStreamStatus = {
     connected,
     paused: effectivePaused,
+    atLiveEdge,
     buffered: bufferedEvents.length,
     lastEventTs,
     error: streamError,
@@ -300,15 +322,23 @@ export function LogConsole() {
             <div className="grid gap-3 sm:grid-cols-3">
               <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Stored events</p>
-                <p className="mt-2 text-2xl font-semibold tabular-nums">{stats?.total_event_count ?? 0}</p>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">
+                  {stats ? stats.total_event_count : 'Loading…'}
+                </p>
               </div>
               <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Retention</p>
-                <p className="mt-2 text-sm font-medium">{stats ? `${stats.retention.max_age_days} days / ${formatBytes(stats.retention.max_bytes)}` : 'Loading…'}</p>
+                <p className="mt-2 text-sm font-medium">
+                  {stats
+                    ? `${formatRetentionWindowDays(stats.retention.max_age_days)} / ${formatBytes(stats.retention.max_bytes)}`
+                    : 'Loading…'}
+                </p>
               </div>
               <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Dropped</p>
-                <p className="mt-2 text-2xl font-semibold tabular-nums">{stats?.dropped_event_count ?? 0}</p>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">
+                  {stats ? stats.dropped_event_count : 'Loading…'}
+                </p>
               </div>
             </div>
           </div>
@@ -335,6 +365,9 @@ export function LogConsole() {
               onJumpToNewest={() => {
                 setManualPause(false)
                 setAtLiveEdge(true)
+                requestAnimationFrame(() => {
+                  scrollViewportToBottom(viewportRef.current)
+                })
               }}
             />
 

--- a/apps/gateway-admin/components/logs/log-console.tsx
+++ b/apps/gateway-admin/components/logs/log-console.tsx
@@ -64,16 +64,12 @@ function retainedWindow(stats: LogStoreStats | null): string {
   return `${timestampFormatter.format(new Date(stats.oldest_retained_ts))} -> ${timestampFormatter.format(new Date(stats.newest_retained_ts))}`
 }
 
-function queryPreview(filters: LogFilterState, windowPreset: string): string {
+function queryPreviewForAfterTs(filters: LogFilterState, afterTs: number | null): string {
   return JSON.stringify(
     {
       action: 'logs.search',
       params: {
-        query: buildLogSearchQuery(filters, {
-          afterTs: WINDOW_TO_MS[windowPreset]
-            ? Date.now() - (WINDOW_TO_MS[windowPreset] ?? 0)
-            : null,
-        }),
+        query: buildLogSearchQuery(filters, { afterTs }),
       },
     },
     null,
@@ -91,6 +87,7 @@ export function LogConsole() {
   const [isRefreshing, setIsRefreshing] = React.useState(false)
   const [connected, setConnected] = React.useState(false)
   const [streamError, setStreamError] = React.useState<string | null>(null)
+  const [copyStatus, setCopyStatus] = React.useState<string | null>(null)
   const [manualPause, setManualPause] = React.useState(false)
   const [atLiveEdge, setAtLiveEdge] = React.useState(true)
   const [lastEventTs, setLastEventTs] = React.useState<number | null>(null)
@@ -102,15 +99,30 @@ export function LogConsole() {
   const effectivePaused = manualPause || !atLiveEdge
   const effectivePausedRef = React.useRef(effectivePaused)
   const maxEntriesRef = React.useRef(filters.limit)
+  const afterTs = React.useMemo(() => {
+    const windowMs = WINDOW_TO_MS[windowPreset]
+    return windowMs == null ? null : Date.now() - windowMs
+  }, [windowPreset, refreshToken])
 
-  filtersRef.current = filters
-  effectivePausedRef.current = effectivePaused
-  maxEntriesRef.current = filters.limit
+  React.useLayoutEffect(() => {
+    filtersRef.current = filters
+    effectivePausedRef.current = effectivePaused
+    maxEntriesRef.current = filters.limit
+  }, [filters, effectivePaused])
 
-  const afterTs =
-    WINDOW_TO_MS[windowPreset] == null
-      ? null
-      : Date.now() - (WINDOW_TO_MS[windowPreset] ?? 0)
+  React.useEffect(() => {
+    if (!copyStatus) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyStatus(null)
+    }, 3000)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [copyStatus])
 
   React.useEffect(() => {
     const controller = new AbortController()
@@ -156,7 +168,7 @@ export function LogConsole() {
       disposed = true
       controller.abort()
     }
-  }, [afterTs, deferredFilters, refreshToken])
+  }, [afterTs, deferredFilters])
 
   React.useEffect(() => {
     const disconnect = connectLogStream({
@@ -170,6 +182,11 @@ export function LogConsole() {
         startTransition(() => {
           setConnected(false)
           setStreamError(message)
+        })
+      },
+      onLag: (skipped) => {
+        startTransition(() => {
+          setStreamError(`live stream lagged and dropped ${skipped} event${skipped === 1 ? '' : 's'}`)
         })
       },
       onEvent: (event) => {
@@ -247,13 +264,22 @@ export function LogConsole() {
               variant="outline"
               size="sm"
               onClick={() => {
-                const preview = queryPreview(filters, windowPreset)
-                void navigator.clipboard.writeText(preview)
+                const preview = queryPreviewForAfterTs(filters, afterTs)
+                navigator.clipboard
+                  .writeText(preview)
+                  .then(() => {
+                    setCopyStatus('Query copied')
+                  })
+                  .catch((error: unknown) => {
+                    console.warn('failed to copy logs query preview', error)
+                    setCopyStatus('Copy failed')
+                  })
               }}
             >
               <Copy className="size-4" />
               Copy query
             </Button>
+            {copyStatus ? <span className="text-xs text-muted-foreground">{copyStatus}</span> : null}
             <Button variant="outline" size="sm" asChild>
               <Link href="/activity">Back to activity</Link>
             </Button>
@@ -347,7 +373,7 @@ export function LogConsole() {
                     </Badge>
                   </div>
                   <pre className="overflow-x-auto text-xs text-slate-100">
-                    {queryPreview(filters, windowPreset)}
+                    {queryPreviewForAfterTs(filters, afterTs)}
                   </pre>
                 </div>
               </CardContent>
@@ -357,6 +383,7 @@ export function LogConsole() {
           <LogTimeline
             events={events}
             isLoading={isLoading}
+            showLiveEdgeBadge={!effectivePaused && atLiveEdge}
             viewportRef={viewportRef}
             onViewportScroll={() => {
               const viewport = viewportRef.current

--- a/apps/gateway-admin/components/logs/log-console.tsx
+++ b/apps/gateway-admin/components/logs/log-console.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import { startTransition, useDeferredValue } from 'react'
+import { Copy, Database, HardDrive, Waypoints } from 'lucide-react'
+
+import { AppHeader } from '@/components/app-header'
+import { LogFilters } from '@/components/logs/log-filters'
+import { LogStreamStatusCard } from '@/components/logs/log-stream-status'
+import { LogTimeline } from '@/components/logs/log-timeline'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { fetchLogs, fetchLogStats } from '@/lib/api/logs-client'
+import { connectLogStream } from '@/lib/api/logs-stream'
+import {
+  buildLogSearchQuery,
+  matchesLogFilters,
+  mergeTimelineEvents,
+} from '@/lib/dashboard/logs-console-state'
+import type {
+  LogEvent,
+  LogFilterState,
+  LogStoreStats,
+  LogStreamStatus,
+} from '@/lib/types/logs'
+
+const DEFAULT_FILTERS: LogFilterState = {
+  text: '',
+  subsystems: [],
+  levels: [],
+  limit: 200,
+}
+
+const WINDOW_TO_MS: Record<string, number | null> = {
+  '15m': 15 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  all: null,
+}
+
+const BUFFER_LIMIT = 500
+
+const timestampFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`
+  }
+  return `${bytes} B`
+}
+
+function retainedWindow(stats: LogStoreStats | null): string {
+  if (!stats?.oldest_retained_ts || !stats.newest_retained_ts) {
+    return 'Awaiting retained events'
+  }
+  return `${timestampFormatter.format(new Date(stats.oldest_retained_ts))} -> ${timestampFormatter.format(new Date(stats.newest_retained_ts))}`
+}
+
+function queryPreview(filters: LogFilterState, windowPreset: string): string {
+  return JSON.stringify(
+    {
+      action: 'logs.search',
+      params: {
+        query: buildLogSearchQuery(filters, {
+          afterTs: WINDOW_TO_MS[windowPreset]
+            ? Date.now() - (WINDOW_TO_MS[windowPreset] ?? 0)
+            : null,
+        }),
+      },
+    },
+    null,
+    2,
+  )
+}
+
+export function LogConsole() {
+  const [filters, setFilters] = React.useState<LogFilterState>(DEFAULT_FILTERS)
+  const [windowPreset, setWindowPreset] = React.useState('1h')
+  const [events, setEvents] = React.useState<LogEvent[]>([])
+  const [bufferedEvents, setBufferedEvents] = React.useState<LogEvent[]>([])
+  const [stats, setStats] = React.useState<LogStoreStats | null>(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [isRefreshing, setIsRefreshing] = React.useState(false)
+  const [connected, setConnected] = React.useState(false)
+  const [streamError, setStreamError] = React.useState<string | null>(null)
+  const [manualPause, setManualPause] = React.useState(false)
+  const [atLiveEdge, setAtLiveEdge] = React.useState(true)
+  const [lastEventTs, setLastEventTs] = React.useState<number | null>(null)
+  const [refreshToken, setRefreshToken] = React.useState(0)
+
+  const deferredFilters = useDeferredValue(filters)
+  const viewportRef = React.useRef<HTMLDivElement | null>(null)
+  const filtersRef = React.useRef(filters)
+  const effectivePaused = manualPause || !atLiveEdge
+  const effectivePausedRef = React.useRef(effectivePaused)
+  const maxEntriesRef = React.useRef(filters.limit)
+
+  filtersRef.current = filters
+  effectivePausedRef.current = effectivePaused
+  maxEntriesRef.current = filters.limit
+
+  const afterTs =
+    WINDOW_TO_MS[windowPreset] == null
+      ? null
+      : Date.now() - (WINDOW_TO_MS[windowPreset] ?? 0)
+
+  React.useEffect(() => {
+    const controller = new AbortController()
+    let disposed = false
+
+    setIsLoading(true)
+    setIsRefreshing(true)
+
+    void Promise.all([
+      fetchLogs(buildLogSearchQuery(deferredFilters, { afterTs }), {
+        signal: controller.signal,
+      }),
+      fetchLogStats({ signal: controller.signal }),
+    ])
+      .then(([result, nextStats]) => {
+        if (disposed) {
+          return
+        }
+
+        startTransition(() => {
+          setEvents(mergeTimelineEvents([], result.events, deferredFilters.limit))
+          setBufferedEvents([])
+          setStats(nextStats)
+          setStreamError(null)
+        })
+      })
+      .catch((error: unknown) => {
+        if (disposed || (error instanceof DOMException && error.name === 'AbortError')) {
+          return
+        }
+        startTransition(() => {
+          setStreamError(error instanceof Error ? error.message : 'failed to load logs')
+        })
+      })
+      .finally(() => {
+        if (!disposed) {
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+      })
+
+    return () => {
+      disposed = true
+      controller.abort()
+    }
+  }, [afterTs, deferredFilters, refreshToken])
+
+  React.useEffect(() => {
+    const disconnect = connectLogStream({
+      onOpen: () => {
+        startTransition(() => {
+          setConnected(true)
+          setStreamError(null)
+        })
+      },
+      onError: (message) => {
+        startTransition(() => {
+          setConnected(false)
+          setStreamError(message)
+        })
+      },
+      onEvent: (event) => {
+        if (!matchesLogFilters(event, filtersRef.current)) {
+          return
+        }
+
+        startTransition(() => {
+          setLastEventTs(event.ts)
+          if (effectivePausedRef.current) {
+            setBufferedEvents((current) =>
+              mergeTimelineEvents(current, [event], BUFFER_LIMIT),
+            )
+            return
+          }
+
+          setEvents((current) =>
+            mergeTimelineEvents(current, [event], maxEntriesRef.current),
+          )
+        })
+
+        if (!effectivePausedRef.current) {
+          requestAnimationFrame(() => {
+            viewportRef.current?.scrollTo({
+              top: viewportRef.current.scrollHeight,
+              behavior: 'smooth',
+            })
+          })
+        }
+      },
+    })
+
+    return () => {
+      disconnect()
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (effectivePaused || bufferedEvents.length === 0) {
+      return
+    }
+
+    startTransition(() => {
+      setEvents((current) =>
+        mergeTimelineEvents(current, bufferedEvents, filters.limit),
+      )
+      setBufferedEvents([])
+    })
+
+    requestAnimationFrame(() => {
+      viewportRef.current?.scrollTo({
+        top: viewportRef.current.scrollHeight,
+        behavior: 'smooth',
+      })
+    })
+  }, [bufferedEvents, effectivePaused, filters.limit])
+
+  const streamStatus: LogStreamStatus = {
+    connected,
+    paused: effectivePaused,
+    buffered: bufferedEvents.length,
+    lastEventTs,
+    error: streamError,
+  }
+
+  return (
+    <>
+      <AppHeader
+        breadcrumbs={[
+          { label: 'Logs' },
+        ]}
+        actions={(
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                const preview = queryPreview(filters, windowPreset)
+                void navigator.clipboard.writeText(preview)
+              }}
+            >
+              <Copy className="size-4" />
+              Copy query
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/activity">Back to activity</Link>
+            </Button>
+          </>
+        )}
+      />
+
+      <div className="flex-1 space-y-6 bg-linear-to-br from-slate-50 via-white to-sky-50/60 p-6">
+        <section className="rounded-[28px] border border-slate-200/80 bg-linear-to-br from-slate-950 via-slate-900 to-sky-900 px-6 py-7 text-slate-50 shadow-xl shadow-slate-950/10">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-3">
+              <p className="text-xs font-medium uppercase tracking-[0.26em] text-cyan-200/80">Local-master runtime logs</p>
+              <h1 className="text-3xl font-semibold tracking-tight">One console for persisted history and live flow</h1>
+              <p className="max-w-2xl text-sm text-slate-300 sm:text-base">
+                This view is backed by the shared `dispatch::logs` contract. Historical queries come from the embedded store, while live arrivals use the in-process SSE stream without inventing a second schema.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Stored events</p>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">{stats?.total_event_count ?? 0}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Retention</p>
+                <p className="mt-2 text-sm font-medium">{stats ? `${stats.retention.max_age_days} days / ${formatBytes(stats.retention.max_bytes)}` : 'Loading…'}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Dropped</p>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">{stats?.dropped_event_count ?? 0}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <LogFilters
+              filters={filters}
+              windowPreset={windowPreset}
+              onFiltersChange={setFilters}
+              onWindowPresetChange={setWindowPreset}
+              onRefresh={() => {
+                setRefreshToken((value) => value + 1)
+              }}
+              isRefreshing={isRefreshing}
+            />
+
+            <LogStreamStatusCard
+              status={streamStatus}
+              onTogglePause={() => {
+                setManualPause((value) => !value)
+              }}
+              onJumpToNewest={() => {
+                setManualPause(false)
+                setAtLiveEdge(true)
+              }}
+            />
+
+            <Card className="border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5">
+              <CardHeader>
+                <CardTitle className="text-base">Contract preview</CardTitle>
+                <CardDescription>
+                  The same filter state maps cleanly to HTTP, MCP, and CLI without changing semantics.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                      <Database className="size-3.5" />
+                      Store window
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-slate-900">{retainedWindow(stats)}</p>
+                  </div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                      <HardDrive className="size-3.5" />
+                      On disk
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-slate-900">{stats ? formatBytes(stats.on_disk_bytes) : 'Loading…'}</p>
+                  </div>
+                </div>
+                <div className="rounded-2xl border border-slate-200 bg-slate-950 p-3">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-400">
+                      <Waypoints className="size-3.5" />
+                      POST /v1/logs
+                    </p>
+                    <Badge variant="outline" className="border-slate-700 text-slate-200">
+                      logs.search
+                    </Badge>
+                  </div>
+                  <pre className="overflow-x-auto text-xs text-slate-100">
+                    {queryPreview(filters, windowPreset)}
+                  </pre>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <LogTimeline
+            events={events}
+            isLoading={isLoading}
+            viewportRef={viewportRef}
+            onViewportScroll={() => {
+              const viewport = viewportRef.current
+              if (!viewport) {
+                return
+              }
+
+              const distanceToBottom =
+                viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
+              setAtLiveEdge(distanceToBottom < 24)
+            }}
+          />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/gateway-admin/components/logs/log-console.tsx
+++ b/apps/gateway-admin/components/logs/log-console.tsx
@@ -16,7 +16,7 @@ import { fetchLogs, fetchLogStats } from '@/lib/api/logs-client'
 import { connectLogStream } from '@/lib/api/logs-stream'
 import {
   buildLogSearchQuery,
-  matchesLogFilters,
+  matchesVisibleLogEvent,
   mergeTimelineEvents,
 } from '@/lib/dashboard/logs-console-state'
 import type {
@@ -111,17 +111,19 @@ export function LogConsole() {
   const effectivePausedRef = React.useRef(effectivePaused)
   const bufferedEventsRef = React.useRef(bufferedEvents)
   const maxEntriesRef = React.useRef(filters.limit)
+  const afterTsRef = React.useRef<number | null>(null)
   const afterTs = React.useMemo(() => {
     const windowMs = WINDOW_TO_MS[windowPreset]
     return windowMs == null ? null : Date.now() - windowMs
-  }, [windowPreset, refreshToken, deferredFilters])
+  }, [windowPreset, refreshToken])
 
   React.useLayoutEffect(() => {
     filtersRef.current = filters
     effectivePausedRef.current = effectivePaused
     bufferedEventsRef.current = bufferedEvents
     maxEntriesRef.current = filters.limit
-  }, [bufferedEvents, filters, effectivePaused])
+    afterTsRef.current = afterTs
+  }, [afterTs, bufferedEvents, filters, effectivePaused])
 
   React.useEffect(() => {
     if (!copyStatus) {
@@ -157,9 +159,12 @@ export function LogConsole() {
 
         const fetchedEvents = mergeTimelineEvents([], result.events, deferredFilters.limit)
         const fetchedEventIds = new Set(fetchedEvents.map((event) => event.event_id))
-        const uncoveredBufferedEvents = bufferedEventsRef.current.filter(
-          (event) => !fetchedEventIds.has(event.event_id),
-        )
+        const uncoveredBufferedEvents = bufferedEventsRef.current.filter((event) => {
+          if (fetchedEventIds.has(event.event_id)) {
+            return false
+          }
+          return matchesVisibleLogEvent(event, deferredFilters, { afterTs })
+        })
 
         startTransition(() => {
           setEvents(
@@ -217,7 +222,7 @@ export function LogConsole() {
         })
       },
       onEvent: (event) => {
-        if (!matchesLogFilters(event, filtersRef.current)) {
+        if (!matchesVisibleLogEvent(event, filtersRef.current, { afterTs: afterTsRef.current })) {
           return
         }
 

--- a/apps/gateway-admin/components/logs/log-filters.tsx
+++ b/apps/gateway-admin/components/logs/log-filters.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { Filter, RotateCcw, Search } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { LOG_LEVELS, LOG_SUBSYSTEMS, type LogFilterState, type LogLevel, type LogSubsystem } from '@/lib/types/logs'
+
+interface LogFiltersProps {
+  filters: LogFilterState
+  windowPreset: string
+  onFiltersChange: (next: LogFilterState) => void
+  onWindowPresetChange: (value: string) => void
+  onRefresh: () => void
+  isRefreshing: boolean
+}
+
+const WINDOW_OPTIONS = [
+  { value: '15m', label: 'Last 15 minutes' },
+  { value: '1h', label: 'Last hour' },
+  { value: '24h', label: 'Last day' },
+  { value: 'all', label: 'Full retention window' },
+] as const
+
+const LIMIT_OPTIONS = ['50', '100', '200', '500'] as const
+
+function toggleValue<T extends string>(current: T[], value: T): T[] {
+  return current.includes(value)
+    ? current.filter((item) => item !== value)
+    : [...current, value]
+}
+
+export function LogFilters({
+  filters,
+  windowPreset,
+  onFiltersChange,
+  onWindowPresetChange,
+  onRefresh,
+  isRefreshing,
+}: LogFiltersProps) {
+  return (
+    <Card className="border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5">
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Filter className="size-4 text-sky-600" />
+              Query
+            </CardTitle>
+            <CardDescription>
+              Refine the persisted local-master history and the live stream with one shared filter set.
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={onRefresh} disabled={isRefreshing}>
+            <RotateCcw className="size-4" />
+            {isRefreshing ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1.6fr)_220px_140px]">
+          <label className="space-y-2">
+            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Search</span>
+            <div className="relative">
+              <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                className="pl-9"
+                placeholder="message, action, request identifiers"
+                value={filters.text}
+                onChange={(event) => {
+                  onFiltersChange({
+                    ...filters,
+                    text: event.target.value,
+                  })
+                }}
+              />
+            </div>
+          </label>
+
+          <label className="space-y-2">
+            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Time window</span>
+            <Select value={windowPreset} onValueChange={onWindowPresetChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Choose a range" />
+              </SelectTrigger>
+              <SelectContent>
+                {WINDOW_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+
+          <label className="space-y-2">
+            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Limit</span>
+            <Select
+              value={String(filters.limit)}
+              onValueChange={(value) => {
+                onFiltersChange({
+                  ...filters,
+                  limit: Number(value),
+                })
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Rows" />
+              </SelectTrigger>
+              <SelectContent>
+                {LIMIT_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {value} events
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Levels</span>
+              {filters.levels.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    onFiltersChange({
+                      ...filters,
+                      levels: [],
+                    })
+                  }}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {LOG_LEVELS.map((level) => (
+                <label
+                  key={level}
+                  className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm"
+                >
+                  <Checkbox
+                    checked={filters.levels.includes(level)}
+                    onCheckedChange={() => {
+                      onFiltersChange({
+                        ...filters,
+                        levels: toggleValue(filters.levels, level as LogLevel),
+                      })
+                    }}
+                  />
+                  <span className="capitalize">{level}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Subsystems</span>
+              {filters.subsystems.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    onFiltersChange({
+                      ...filters,
+                      subsystems: [],
+                    })
+                  }}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {LOG_SUBSYSTEMS.map((subsystem) => (
+                <label
+                  key={subsystem}
+                  className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm"
+                >
+                  <Checkbox
+                    checked={filters.subsystems.includes(subsystem)}
+                    onCheckedChange={() => {
+                      onFiltersChange({
+                        ...filters,
+                        subsystems: toggleValue(filters.subsystems, subsystem as LogSubsystem),
+                      })
+                    }}
+                  />
+                  <span>{subsystem}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {filters.levels.map((level) => (
+            <Badge key={level} variant="outline" className="capitalize">
+              level:{level}
+            </Badge>
+          ))}
+          {filters.subsystems.map((subsystem) => (
+            <Badge key={subsystem} variant="outline">
+              subsystem:{subsystem}
+            </Badge>
+          ))}
+          {filters.text.trim() ? (
+            <Badge variant="outline">text:{filters.text.trim()}</Badge>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/gateway-admin/components/logs/log-stream-status.tsx
+++ b/apps/gateway-admin/components/logs/log-stream-status.tsx
@@ -13,16 +13,16 @@ interface LogStreamStatusProps {
   onJumpToNewest: () => void
 }
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'medium',
-})
-
 export function LogStreamStatusCard({
   status,
   onTogglePause,
   onJumpToNewest,
 }: LogStreamStatusProps) {
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  })
+
   return (
     <Card className="border-slate-200/80 bg-linear-to-br from-slate-950 via-slate-900 to-sky-950 text-slate-50 shadow-lg shadow-sky-950/10">
       <CardHeader className="gap-3">

--- a/apps/gateway-admin/components/logs/log-stream-status.tsx
+++ b/apps/gateway-admin/components/logs/log-stream-status.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { PauseCircle, PlayCircle, RadioTower, RefreshCw } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import type { LogStreamStatus } from '@/lib/types/logs'
+
+interface LogStreamStatusProps {
+  status: LogStreamStatus
+  onTogglePause: () => void
+  onJumpToNewest: () => void
+}
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'medium',
+})
+
+export function LogStreamStatusCard({
+  status,
+  onTogglePause,
+  onJumpToNewest,
+}: LogStreamStatusProps) {
+  return (
+    <Card className="border-slate-200/80 bg-linear-to-br from-slate-950 via-slate-900 to-sky-950 text-slate-50 shadow-lg shadow-sky-950/10">
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle className="flex items-center gap-2 text-base text-slate-50">
+              <RadioTower className="size-4 text-cyan-300" />
+              Live stream
+            </CardTitle>
+            <CardDescription className="text-slate-300">
+              HTTP SSE is the only true live transport in v1. MCP stays bounded by design.
+            </CardDescription>
+          </div>
+          <Badge
+            variant="outline"
+            className={
+              status.connected
+                ? 'border-emerald-400/40 bg-emerald-400/10 text-emerald-200'
+                : 'border-rose-400/40 bg-rose-400/10 text-rose-200'
+            }
+          >
+            {status.connected ? 'Connected' : 'Disconnected'}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Mode</p>
+            <p className="mt-2 text-lg font-semibold">{status.paused ? 'Buffered' : 'Live edge'}</p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Buffered</p>
+            <p className="mt-2 text-lg font-semibold tabular-nums">{status.buffered}</p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Last event</p>
+            <p className="mt-2 text-sm font-medium">
+              {status.lastEventTs ? timeFormatter.format(new Date(status.lastEventTs)) : 'Waiting for traffic'}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant={status.paused ? 'default' : 'outline'}
+            className={status.paused ? 'bg-cyan-500 text-slate-950 hover:bg-cyan-400' : 'border-white/15 bg-white/5 text-slate-50 hover:bg-white/10'}
+            onClick={onTogglePause}
+          >
+            {status.paused ? <PlayCircle className="size-4" /> : <PauseCircle className="size-4" />}
+            {status.paused ? 'Resume live edge' : 'Pause stream'}
+          </Button>
+          <Button
+            variant="outline"
+            className="border-white/15 bg-white/5 text-slate-50 hover:bg-white/10"
+            onClick={onJumpToNewest}
+            disabled={status.buffered === 0 && !status.paused}
+          >
+            <RefreshCw className="size-4" />
+            Jump to newest
+          </Button>
+        </div>
+
+        {status.error ? (
+          <p className="rounded-lg border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-sm text-rose-100">
+            {status.error}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/gateway-admin/components/logs/log-stream-status.tsx
+++ b/apps/gateway-admin/components/logs/log-stream-status.tsx
@@ -79,7 +79,7 @@ export function LogStreamStatusCard({
             variant="outline"
             className="border-white/15 bg-white/5 text-slate-50 hover:bg-white/10"
             onClick={onJumpToNewest}
-            disabled={status.buffered === 0 && !status.paused}
+            disabled={status.atLiveEdge && status.buffered === 0}
           >
             <RefreshCw className="size-4" />
             Jump to newest

--- a/apps/gateway-admin/components/logs/log-timeline.tsx
+++ b/apps/gateway-admin/components/logs/log-timeline.tsx
@@ -9,14 +9,10 @@ import type { LogEvent } from '@/lib/types/logs'
 interface LogTimelineProps {
   events: LogEvent[]
   isLoading: boolean
+  showLiveEdgeBadge: boolean
   viewportRef: React.RefObject<HTMLDivElement | null>
   onViewportScroll: () => void
 }
-
-const timestampFormatter = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'medium',
-})
 
 const levelStyles = {
   trace: 'border-slate-300 bg-slate-100 text-slate-700',
@@ -29,9 +25,15 @@ const levelStyles = {
 export function LogTimeline({
   events,
   isLoading,
+  showLiveEdgeBadge,
   viewportRef,
   onViewportScroll,
 }: LogTimelineProps) {
+  const timestampFormatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  })
+
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm shadow-slate-900/5">
       <div className="flex items-center justify-between border-b border-slate-200/80 px-5 py-4">
@@ -78,7 +80,7 @@ export function LogTimeline({
                       </Badge>
                       <Badge variant="outline">{event.subsystem}</Badge>
                       {event.action ? <Badge variant="outline">{event.action}</Badge> : null}
-                      {index === events.length - 1 ? (
+                      {showLiveEdgeBadge && index === events.length - 1 ? (
                         <Badge variant="outline" className="border-cyan-300 bg-cyan-50 text-cyan-700">
                           <ArrowDown className="size-3.5" />
                           live edge

--- a/apps/gateway-admin/components/logs/log-timeline.tsx
+++ b/apps/gateway-admin/components/logs/log-timeline.tsx
@@ -22,6 +22,11 @@ const levelStyles = {
   error: 'border-rose-300 bg-rose-50 text-rose-700',
 } as const
 
+const timestampFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'medium',
+})
+
 export function LogTimeline({
   events,
   isLoading,
@@ -29,11 +34,6 @@ export function LogTimeline({
   viewportRef,
   onViewportScroll,
 }: LogTimelineProps) {
-  const timestampFormatter = new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'medium',
-  })
-
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm shadow-slate-900/5">
       <div className="flex items-center justify-between border-b border-slate-200/80 px-5 py-4">

--- a/apps/gateway-admin/components/logs/log-timeline.tsx
+++ b/apps/gateway-admin/components/logs/log-timeline.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { ArrowDown, ArrowRight, CircleDot, Hash, Radio } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { LogEvent } from '@/lib/types/logs'
+
+interface LogTimelineProps {
+  events: LogEvent[]
+  isLoading: boolean
+  viewportRef: React.RefObject<HTMLDivElement | null>
+  onViewportScroll: () => void
+}
+
+const timestampFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'medium',
+})
+
+const levelStyles = {
+  trace: 'border-slate-300 bg-slate-100 text-slate-700',
+  debug: 'border-cyan-300 bg-cyan-50 text-cyan-700',
+  info: 'border-sky-300 bg-sky-50 text-sky-700',
+  warn: 'border-amber-300 bg-amber-50 text-amber-700',
+  error: 'border-rose-300 bg-rose-50 text-rose-700',
+} as const
+
+export function LogTimeline({
+  events,
+  isLoading,
+  viewportRef,
+  onViewportScroll,
+}: LogTimelineProps) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm shadow-slate-900/5">
+      <div className="flex items-center justify-between border-b border-slate-200/80 px-5 py-4">
+        <div>
+          <p className="text-sm font-semibold">Unified timeline</p>
+          <p className="text-sm text-muted-foreground">
+            Historical store results and live arrivals land in the same chronological feed.
+          </p>
+        </div>
+        <Badge variant="outline" className="tabular-nums">
+          {events.length} visible
+        </Badge>
+      </div>
+
+      <div ref={viewportRef} className="max-h-[720px] overflow-y-auto px-5 py-4" onScroll={onViewportScroll}>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 6 }, (_, index) => (
+              <div key={index} className="h-28 animate-pulse rounded-2xl border border-slate-200 bg-slate-50" />
+            ))}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 px-6 text-center">
+            <Radio className="size-8 text-slate-400" />
+            <div className="space-y-1">
+              <p className="font-medium text-slate-700">No matching events</p>
+              <p className="text-sm text-muted-foreground">
+                Relax the filters or wait for new local-master runtime traffic.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {events.map((event, index) => (
+              <article
+                key={event.event_id}
+                className="rounded-2xl border border-slate-200/80 bg-linear-to-br from-white to-slate-50/90 p-4"
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline" className={cn('capitalize', levelStyles[event.level])}>
+                        {event.level}
+                      </Badge>
+                      <Badge variant="outline">{event.subsystem}</Badge>
+                      {event.action ? <Badge variant="outline">{event.action}</Badge> : null}
+                      {index === events.length - 1 ? (
+                        <Badge variant="outline" className="border-cyan-300 bg-cyan-50 text-cyan-700">
+                          <ArrowDown className="size-3.5" />
+                          live edge
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <p className="text-base font-medium leading-6 text-slate-900">{event.message}</p>
+                    <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <CircleDot className="size-3.5" />
+                        {timestampFormatter.format(new Date(event.ts))}
+                      </span>
+                      <span className="inline-flex items-center gap-1">
+                        <ArrowRight className="size-3.5" />
+                        {event.surface}
+                      </span>
+                      {event.request_id ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Hash className="size-3.5" />
+                          {event.request_id}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  {Object.keys(event.fields_json ?? {}).length > 0 ? (
+                    <pre className="max-w-full overflow-x-auto rounded-xl border border-slate-200 bg-slate-950 px-3 py-2 text-xs text-slate-100 lg:max-w-[420px]">
+                      {JSON.stringify(event.fields_json, null, 2)}
+                    </pre>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/gateway-admin/lib/api/logs-client.test.ts
+++ b/apps/gateway-admin/lib/api/logs-client.test.ts
@@ -18,7 +18,7 @@ test('logsRequestInit keeps credentialed session requests by default', () => {
     csrfToken: 'csrf-123',
   })
 
-  const init = logsRequestInit('logs.search', { query: {} })
+  const init = logsRequestInit('logs.search', { query: {} }, undefined, undefined, false)
 
   assert.equal(init.credentials, 'include')
   assert.equal((init.headers as Record<string, string>)['x-csrf-token'], 'csrf-123')
@@ -92,6 +92,25 @@ test('fetchLogStats posts logs.stats to the backend', async () => {
   }
 })
 
+test('fetchLogs surfaces non-JSON error responses with status context', async () => {
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = async () =>
+      new Response('<html>bad gateway</html>', {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'Content-Type': 'text/html' },
+      })
+
+    await assert.rejects(
+      () => fetchLogs({ subsystems: ['gateway'] as const }),
+      /502 Bad Gateway/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
 test('connectLogStream refuses standalone bearer mode in v1', () => {
   assert.throws(
     () =>
@@ -101,4 +120,89 @@ test('connectLogStream refuses standalone bearer mode in v1', () => {
       ),
     /standalone bearer mode is not supported/,
   )
+})
+
+test('connectLogStream honors explicit standalone bearer opt-out and handles malformed frames', () => {
+  const originalEventSource = globalThis.EventSource
+
+  class MockEventSource {
+    static readonly CONNECTING = 0
+    static readonly OPEN = 1
+    static readonly CLOSED = 2
+    static lastCreated: MockEventSource | null = null
+
+    readonly url: string
+    readonly options: EventSourceInit
+    readyState = MockEventSource.CONNECTING
+    onopen: (() => void) | null = null
+    onmessage: ((message: { data: string }) => void) | null = null
+    onerror: (() => void) | null = null
+    private readonly listeners = new Map<string, Array<(message: { data: string }) => void>>()
+
+    constructor(url: string, options: EventSourceInit) {
+      this.url = url
+      this.options = options
+      MockEventSource.lastCreated = this
+    }
+
+    addEventListener(type: string, listener: (message: { data: string }) => void) {
+      const listeners = this.listeners.get(type) ?? []
+      listeners.push(listener)
+      this.listeners.set(type, listeners)
+    }
+
+    emit(type: string, data: string) {
+      for (const listener of this.listeners.get(type) ?? []) {
+        listener({ data })
+      }
+    }
+
+    close() {
+      this.readyState = MockEventSource.CLOSED
+    }
+  }
+
+  globalThis.EventSource = MockEventSource as unknown as typeof EventSource
+
+  try {
+    const errorMessages: string[] = []
+    let laggedCount: number | null = null
+
+    const disconnect = connectLogStream(
+      {
+        onEvent: () => {
+          throw new Error('unexpected event dispatch')
+        },
+        onLag: (skipped) => {
+          laggedCount = skipped
+        },
+        onError: (message) => {
+          errorMessages.push(message)
+        },
+      },
+      { token: 'dev-token', standaloneBearerAuth: false, baseUrl: 'http://localhost:9911/v1/' },
+    )
+
+    const createdSource = MockEventSource.lastCreated
+    assert.ok(createdSource)
+    assert.equal(createdSource.url, 'http://localhost:9911/v1/logs/stream')
+    assert.equal(createdSource.options.withCredentials, true)
+
+    createdSource.onmessage?.({ data: '{not-json' })
+    createdSource.emit('lag', '3')
+    createdSource.onerror?.()
+    createdSource.readyState = MockEventSource.CLOSED
+    createdSource.onerror?.()
+
+    assert.deepEqual(errorMessages, [
+      'received malformed log event',
+      'live stream disconnected',
+    ])
+    assert.equal(laggedCount, 3)
+
+    disconnect()
+    assert.equal(createdSource.readyState, MockEventSource.CLOSED)
+  } finally {
+    globalThis.EventSource = originalEventSource
+  }
 })

--- a/apps/gateway-admin/lib/api/logs-client.test.ts
+++ b/apps/gateway-admin/lib/api/logs-client.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { __setBrowserSessionStateForTests } from '../auth/session-store.ts'
+import { fetchLogStats, fetchLogs, logsActionUrl, logsRequestInit } from './logs-client.ts'
+import { connectLogStream, logsStreamUrl } from './logs-stream.ts'
+
+test('logsActionUrl uses the shared API base convention', () => {
+  assert.equal(logsActionUrl('http://localhost:9911/v1/'), 'http://localhost:9911/v1/logs')
+  assert.equal(logsStreamUrl('http://localhost:9911/v1/'), 'http://localhost:9911/v1/logs/stream')
+})
+
+test('logsRequestInit keeps credentialed session requests by default', () => {
+  __setBrowserSessionStateForTests({
+    status: 'authenticated',
+    user: { sub: 'browser-user', email: 'browser@example.com' },
+    expiresAt: 42,
+    csrfToken: 'csrf-123',
+  })
+
+  const init = logsRequestInit('logs.search', { query: {} })
+
+  assert.equal(init.credentials, 'include')
+  assert.equal((init.headers as Record<string, string>)['x-csrf-token'], 'csrf-123')
+  assert.equal((init.headers as Record<string, string>).Authorization, undefined)
+})
+
+test('fetchLogs posts logs.search to the backend', async () => {
+  __setBrowserSessionStateForTests({
+    status: 'authenticated',
+    user: { sub: 'browser-user', email: 'browser@example.com' },
+    expiresAt: 42,
+    csrfToken: 'csrf-123',
+  })
+
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, '/v1/logs')
+      assert.equal(init?.method, 'POST')
+      const body = JSON.parse(String(init?.body))
+      assert.equal(body.action, 'logs.search')
+      assert.deepEqual(body.params, { query: { subsystems: ['gateway'] } })
+      return new Response(
+        JSON.stringify({
+          events: [{ event_id: 'evt-1', message: 'gateway event' }],
+          next_cursor: null,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+
+    const result = await fetchLogs({ subsystems: ['gateway'] as const })
+    assert.equal(result.events.length, 1)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('fetchLogStats posts logs.stats to the backend', async () => {
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body))
+      assert.equal(body.action, 'logs.stats')
+      return new Response(
+        JSON.stringify({
+          on_disk_bytes: 10,
+          oldest_retained_ts: null,
+          newest_retained_ts: null,
+          total_event_count: 1,
+          dropped_event_count: 0,
+          retention: {
+            max_age_days: 7,
+            max_bytes: 1024,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+
+    const result = await fetchLogStats()
+    assert.equal(result.total_event_count, 1)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('connectLogStream refuses standalone bearer mode in v1', () => {
+  assert.throws(
+    () =>
+      connectLogStream(
+        { onEvent: () => {} },
+        { token: 'dev-token', standaloneBearerAuth: true },
+      ),
+    /standalone bearer mode is not supported/,
+  )
+})

--- a/apps/gateway-admin/lib/api/logs-client.test.ts
+++ b/apps/gateway-admin/lib/api/logs-client.test.ts
@@ -111,6 +111,24 @@ test('fetchLogs surfaces non-JSON error responses with status context', async ()
   }
 })
 
+test('fetchLogStats rejects empty successful JSON responses', async () => {
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    await assert.rejects(
+      () => fetchLogStats(),
+      /empty JSON response from gateway/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
 test('connectLogStream refuses standalone bearer mode in v1', () => {
   assert.throws(
     () =>

--- a/apps/gateway-admin/lib/api/logs-client.ts
+++ b/apps/gateway-admin/lib/api/logs-client.ts
@@ -1,5 +1,5 @@
 import { normalizeGatewayApiBase } from './gateway-config.ts'
-import { gatewayHeaders } from './gateway-request.ts'
+import { gatewayRequestInit } from './gateway-request.ts'
 import { isStandaloneBearerAuthMode } from '../auth/auth-mode.ts'
 import type { LogSearchQuery, LogSearchResult, LogStoreStats } from '../types/logs.ts'
 
@@ -14,22 +14,41 @@ export function logsRequestInit(
   signal?: AbortSignal,
   standaloneBearerAuth = isStandaloneBearerAuthMode(token),
 ): RequestInit {
-  return {
-    method: 'POST',
-    headers: gatewayHeaders(token, standaloneBearerAuth),
-    body: JSON.stringify({ action, params }),
-    cache: 'no-store',
-    credentials: standaloneBearerAuth ? 'omit' : 'include',
-    signal,
-  }
+  return gatewayRequestInit(action, params, token, signal, standaloneBearerAuth)
 }
 
 async function parseJsonResponse<T>(response: Response): Promise<T> {
-  const payload = await response.json()
+  const raw = await response.text()
+  if (raw.length === 0) {
+    if (!response.ok) {
+      throw new Error(`request failed with status ${response.status} ${response.statusText}`.trim())
+    }
+    throw new Error('empty JSON response from gateway')
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(raw)
+  } catch (error) {
+    if (!response.ok) {
+      const snippet = raw.trim().slice(0, 120)
+      const detail = snippet ? `: ${snippet}` : ''
+      throw new Error(
+        `request failed with status ${response.status} ${response.statusText}${detail}`.trim(),
+        { cause: error },
+      )
+    }
+    const message =
+      error instanceof Error
+        ? `invalid JSON response from gateway: ${error.message}`
+        : 'invalid JSON response from gateway'
+    throw new Error(message, { cause: error })
+  }
+
   if (!response.ok) {
     const message =
-      typeof payload?.message === 'string'
-        ? payload.message
+      typeof (payload as { message?: unknown })?.message === 'string'
+        ? (payload as { message: string }).message
         : `request failed with status ${response.status}`
     throw new Error(message)
   }

--- a/apps/gateway-admin/lib/api/logs-client.ts
+++ b/apps/gateway-admin/lib/api/logs-client.ts
@@ -1,0 +1,80 @@
+import { normalizeGatewayApiBase } from './gateway-config.ts'
+import { gatewayHeaders } from './gateway-request.ts'
+import { isStandaloneBearerAuthMode } from '../auth/auth-mode.ts'
+import type { LogSearchQuery, LogSearchResult, LogStoreStats } from '../types/logs.ts'
+
+export function logsActionUrl(baseUrl?: string) {
+  return `${normalizeGatewayApiBase(baseUrl)}/logs`
+}
+
+export function logsRequestInit(
+  action: string,
+  params: object,
+  token = process.env.NEXT_PUBLIC_API_TOKEN,
+  signal?: AbortSignal,
+  standaloneBearerAuth = isStandaloneBearerAuthMode(token),
+): RequestInit {
+  return {
+    method: 'POST',
+    headers: gatewayHeaders(token, standaloneBearerAuth),
+    body: JSON.stringify({ action, params }),
+    cache: 'no-store',
+    credentials: standaloneBearerAuth ? 'omit' : 'include',
+    signal,
+  }
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json()
+  if (!response.ok) {
+    const message =
+      typeof payload?.message === 'string'
+        ? payload.message
+        : `request failed with status ${response.status}`
+    throw new Error(message)
+  }
+  return payload as T
+}
+
+export async function fetchLogs(
+  query: LogSearchQuery,
+  options?: {
+    baseUrl?: string
+    token?: string
+    signal?: AbortSignal
+    standaloneBearerAuth?: boolean
+  },
+): Promise<LogSearchResult> {
+  const response = await fetch(
+    logsActionUrl(options?.baseUrl),
+    logsRequestInit(
+      'logs.search',
+      { query },
+      options?.token,
+      options?.signal,
+      options?.standaloneBearerAuth,
+    ),
+  )
+
+  return parseJsonResponse<LogSearchResult>(response)
+}
+
+export async function fetchLogStats(options?: {
+  baseUrl?: string
+  token?: string
+  signal?: AbortSignal
+  standaloneBearerAuth?: boolean
+}): Promise<LogStoreStats> {
+  const response = await fetch(
+    logsActionUrl(options?.baseUrl),
+    logsRequestInit(
+      'logs.stats',
+      {},
+      options?.token,
+      options?.signal,
+      options?.standaloneBearerAuth,
+    ),
+  )
+
+  return parseJsonResponse<LogStoreStats>(response)
+}

--- a/apps/gateway-admin/lib/api/logs-client.ts
+++ b/apps/gateway-admin/lib/api/logs-client.ts
@@ -30,7 +30,7 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
     if (!response.ok) {
       throw new Error(`request failed with status ${response.status} ${response.statusText}`.trim())
     }
-    return undefined as T
+    throw new Error('empty JSON response from gateway')
   }
 
   let payload: unknown

--- a/apps/gateway-admin/lib/api/logs-client.ts
+++ b/apps/gateway-admin/lib/api/logs-client.ts
@@ -3,6 +3,13 @@ import { gatewayRequestInit } from './gateway-request.ts'
 import { isStandaloneBearerAuthMode } from '../auth/auth-mode.ts'
 import type { LogSearchQuery, LogSearchResult, LogStoreStats } from '../types/logs.ts'
 
+export type LogsRequestOptions = {
+  baseUrl?: string
+  token?: string
+  signal?: AbortSignal
+  standaloneBearerAuth?: boolean
+}
+
 export function logsActionUrl(baseUrl?: string) {
   return `${normalizeGatewayApiBase(baseUrl)}/logs`
 }
@@ -57,12 +64,7 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
 
 export async function fetchLogs(
   query: LogSearchQuery,
-  options?: {
-    baseUrl?: string
-    token?: string
-    signal?: AbortSignal
-    standaloneBearerAuth?: boolean
-  },
+  options?: LogsRequestOptions,
 ): Promise<LogSearchResult> {
   const response = await fetch(
     logsActionUrl(options?.baseUrl),
@@ -78,12 +80,7 @@ export async function fetchLogs(
   return parseJsonResponse<LogSearchResult>(response)
 }
 
-export async function fetchLogStats(options?: {
-  baseUrl?: string
-  token?: string
-  signal?: AbortSignal
-  standaloneBearerAuth?: boolean
-}): Promise<LogStoreStats> {
+export async function fetchLogStats(options?: LogsRequestOptions): Promise<LogStoreStats> {
   const response = await fetch(
     logsActionUrl(options?.baseUrl),
     logsRequestInit(

--- a/apps/gateway-admin/lib/api/logs-client.ts
+++ b/apps/gateway-admin/lib/api/logs-client.ts
@@ -30,7 +30,7 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
     if (!response.ok) {
       throw new Error(`request failed with status ${response.status} ${response.statusText}`.trim())
     }
-    throw new Error('empty JSON response from gateway')
+    return undefined as T
   }
 
   let payload: unknown

--- a/apps/gateway-admin/lib/api/logs-stream.ts
+++ b/apps/gateway-admin/lib/api/logs-stream.ts
@@ -1,0 +1,44 @@
+import { normalizeGatewayApiBase } from './gateway-config.ts'
+import { isStandaloneBearerAuthMode } from '../auth/auth-mode.ts'
+import type { LogEvent } from '../types/logs.ts'
+
+export function logsStreamUrl(baseUrl?: string) {
+  return `${normalizeGatewayApiBase(baseUrl)}/logs/stream`
+}
+
+export function connectLogStream(
+  handlers: {
+    onEvent: (event: LogEvent) => void
+    onOpen?: () => void
+    onError?: (message: string) => void
+  },
+  options?: {
+    baseUrl?: string
+    token?: string
+    standaloneBearerAuth?: boolean
+  },
+) {
+  if (isStandaloneBearerAuthMode(options?.token, options?.standaloneBearerAuth ? 'true' : undefined)) {
+    throw new Error(
+      'live log streaming uses hosted same-origin session auth in v1; standalone bearer mode is not supported for EventSource',
+    )
+  }
+
+  const source = new EventSource(logsStreamUrl(options?.baseUrl), {
+    withCredentials: true,
+  })
+
+  source.onopen = () => {
+    handlers.onOpen?.()
+  }
+  source.onmessage = (message) => {
+    handlers.onEvent(JSON.parse(message.data) as LogEvent)
+  }
+  source.onerror = () => {
+    handlers.onError?.('live stream disconnected')
+  }
+
+  return () => {
+    source.close()
+  }
+}

--- a/apps/gateway-admin/lib/api/logs-stream.ts
+++ b/apps/gateway-admin/lib/api/logs-stream.ts
@@ -9,6 +9,7 @@ export function logsStreamUrl(baseUrl?: string) {
 export function connectLogStream(
   handlers: {
     onEvent: (event: LogEvent) => void
+    onLag?: (skipped: number) => void
     onOpen?: () => void
     onError?: (message: string) => void
   },
@@ -18,7 +19,12 @@ export function connectLogStream(
     standaloneBearerAuth?: boolean
   },
 ) {
-  if (isStandaloneBearerAuthMode(options?.token, options?.standaloneBearerAuth ? 'true' : undefined)) {
+  const modeOverride =
+    typeof options?.standaloneBearerAuth === 'boolean'
+      ? (options.standaloneBearerAuth ? 'true' : 'false')
+      : undefined
+
+  if (isStandaloneBearerAuthMode(options?.token, modeOverride)) {
     throw new Error(
       'live log streaming uses hosted same-origin session auth in v1; standalone bearer mode is not supported for EventSource',
     )
@@ -32,10 +38,24 @@ export function connectLogStream(
     handlers.onOpen?.()
   }
   source.onmessage = (message) => {
-    handlers.onEvent(JSON.parse(message.data) as LogEvent)
+    try {
+      handlers.onEvent(JSON.parse(message.data) as LogEvent)
+    } catch {
+      handlers.onError?.('received malformed log event')
+    }
   }
+  source.addEventListener('lag', (message) => {
+    const skipped = Number(message.data)
+    if (Number.isInteger(skipped) && skipped > 0) {
+      handlers.onLag?.(skipped)
+      return
+    }
+    handlers.onError?.('received malformed lag event')
+  })
   source.onerror = () => {
-    handlers.onError?.('live stream disconnected')
+    if (source.readyState === EventSource.CLOSED) {
+      handlers.onError?.('live stream disconnected')
+    }
   }
 
   return () => {

--- a/apps/gateway-admin/lib/api/logs-stream.ts
+++ b/apps/gateway-admin/lib/api/logs-stream.ts
@@ -38,11 +38,14 @@ export function connectLogStream(
     handlers.onOpen?.()
   }
   source.onmessage = (message) => {
+    let event: LogEvent
     try {
-      handlers.onEvent(JSON.parse(message.data) as LogEvent)
+      event = JSON.parse(message.data) as LogEvent
     } catch {
       handlers.onError?.('received malformed log event')
+      return
     }
+    handlers.onEvent(event)
   }
   source.addEventListener('lag', (message) => {
     const skipped = Number(message.data)

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildLogSearchQuery,
+  matchesLogFilters,
+  mergeTimelineEvents,
+} from './logs-console-state.ts'
+import type { LogEvent, LogFilterState } from '../types/logs.ts'
+
+function eventWith(overrides: Partial<LogEvent> = {}): LogEvent {
+  return {
+    event_id: overrides.event_id ?? 'evt-1',
+    ts: overrides.ts ?? 1_713_225_600_000,
+    level: overrides.level ?? 'info',
+    subsystem: overrides.subsystem ?? 'gateway',
+    surface: overrides.surface ?? 'api',
+    action: overrides.action ?? 'logs.search',
+    message: overrides.message ?? 'gateway event',
+    request_id: overrides.request_id ?? null,
+    session_id: overrides.session_id ?? null,
+    correlation_id: overrides.correlation_id ?? null,
+    trace_id: overrides.trace_id ?? null,
+    span_id: overrides.span_id ?? null,
+    instance: overrides.instance ?? 'default',
+    auth_flow: overrides.auth_flow ?? null,
+    outcome_kind: overrides.outcome_kind ?? 'ok',
+    fields_json: overrides.fields_json ?? {},
+    source_kind: overrides.source_kind ?? null,
+    source_node_id: overrides.source_node_id ?? null,
+    source_device_id: overrides.source_device_id ?? null,
+    ingest_path: overrides.ingest_path ?? null,
+    upstream_event_id: overrides.upstream_event_id ?? null,
+  }
+}
+
+test('buildLogSearchQuery trims text and omits empty filters', () => {
+  const filters: LogFilterState = {
+    text: '  gateway timeout  ',
+    subsystems: ['gateway'],
+    levels: [],
+    limit: 50,
+  }
+
+  assert.deepEqual(buildLogSearchQuery(filters), {
+    text: 'gateway timeout',
+    subsystems: ['gateway'],
+    limit: 50,
+  })
+})
+
+test('matchesLogFilters applies text, subsystem, and level filters', () => {
+  const filters: LogFilterState = {
+    text: 'timeout',
+    subsystems: ['gateway'],
+    levels: ['warn'],
+    limit: 100,
+  }
+
+  assert.equal(
+    matchesLogFilters(
+      eventWith({ message: 'gateway timeout detected', level: 'warn' }),
+      filters,
+    ),
+    true,
+  )
+  assert.equal(
+    matchesLogFilters(
+      eventWith({ message: 'gateway ok', level: 'warn' }),
+      filters,
+    ),
+    false,
+  )
+  assert.equal(
+    matchesLogFilters(
+      eventWith({ message: 'gateway timeout detected', level: 'info' }),
+      filters,
+    ),
+    false,
+  )
+})
+
+test('mergeTimelineEvents deduplicates, sorts chronologically, and keeps the newest entries', () => {
+  const merged = mergeTimelineEvents(
+    [
+      eventWith({ event_id: 'evt-1', ts: 10, message: 'oldest' }),
+      eventWith({ event_id: 'evt-2', ts: 20, message: 'middle' }),
+    ],
+    [
+      eventWith({ event_id: 'evt-2', ts: 20, message: 'middle replacement' }),
+      eventWith({ event_id: 'evt-3', ts: 30, message: 'newest' }),
+    ],
+    2,
+  )
+
+  assert.deepEqual(
+    merged.map((event) => [event.event_id, event.message]),
+    [
+      ['evt-2', 'middle replacement'],
+      ['evt-3', 'newest'],
+    ],
+  )
+})

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   buildLogSearchQuery,
   matchesLogFilters,
+  matchesVisibleLogEvent,
   mergeTimelineEvents,
 } from './logs-console-state.ts'
 import type { LogEvent, LogFilterState } from '../types/logs.ts'
@@ -101,6 +102,32 @@ test('matchesLogFilters can match request identifiers and structured fields', ()
       filters,
     ),
     true,
+  )
+})
+
+test('matchesVisibleLogEvent applies the same filter contract plus the active time window', () => {
+  const filters: LogFilterState = {
+    text: 'timeout',
+    subsystems: ['gateway'],
+    levels: ['warn'],
+    limit: 100,
+  }
+
+  assert.equal(
+    matchesVisibleLogEvent(
+      eventWith({ ts: 200, message: 'gateway timeout detected', level: 'warn' }),
+      filters,
+      { afterTs: 100 },
+    ),
+    true,
+  )
+  assert.equal(
+    matchesVisibleLogEvent(
+      eventWith({ ts: 50, message: 'gateway timeout detected', level: 'warn' }),
+      filters,
+      { afterTs: 100 },
+    ),
+    false,
   )
 })
 

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
@@ -80,6 +80,30 @@ test('matchesLogFilters applies text, subsystem, and level filters', () => {
   )
 })
 
+test('matchesLogFilters can match request identifiers and structured fields', () => {
+  const filters: LogFilterState = {
+    text: 'req-123',
+    subsystems: [],
+    levels: [],
+    limit: 100,
+  }
+
+  assert.equal(
+    matchesLogFilters(
+      eventWith({ request_id: 'req-123' }),
+      filters,
+    ),
+    true,
+  )
+  assert.equal(
+    matchesLogFilters(
+      eventWith({ fields_json: { correlation_id: 'req-123' } }),
+      filters,
+    ),
+    true,
+  )
+})
+
 test('mergeTimelineEvents deduplicates, sorts chronologically, and keeps the newest entries', () => {
   const merged = mergeTimelineEvents(
     [

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.test.ts
@@ -125,3 +125,16 @@ test('mergeTimelineEvents deduplicates, sorts chronologically, and keeps the new
     ],
   )
 })
+
+test('mergeTimelineEvents breaks equal timestamps by event identifier', () => {
+  const merged = mergeTimelineEvents(
+    [eventWith({ event_id: 'evt-b', ts: 10, message: 'b' })],
+    [eventWith({ event_id: 'evt-a', ts: 10, message: 'a' })],
+    10,
+  )
+
+  assert.deepEqual(
+    merged.map((event) => event.event_id),
+    ['evt-a', 'evt-b'],
+  )
+})

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.ts
@@ -86,5 +86,6 @@ export function mergeTimelineEvents(
       }
       return left.ts - right.ts
     })
+    // Keep the newest-N window stable even if a caller passes 0 or a negative limit.
     .slice(-Math.max(maxEntries, 1))
 }

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.ts
@@ -61,7 +61,7 @@ function buildSearchableEventText(event: LogEvent): string {
     event.upstream_event_id ?? '',
     structuredFields,
   ]
-    .join(' ')
+    .join('\u0000')
     .toLowerCase()
 }
 

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.ts
@@ -28,7 +28,7 @@ export function buildLogSearchQuery(
 export function matchesLogFilters(event: LogEvent, filters: LogFilterState): boolean {
   const text = filters.text.trim().toLowerCase()
 
-  if (text && !`${event.message} ${event.action ?? ''}`.toLowerCase().includes(text)) {
+  if (text && !buildSearchableEventText(event).includes(text)) {
     return false
   }
   if (filters.subsystems.length > 0 && !filters.subsystems.includes(event.subsystem)) {
@@ -39,6 +39,30 @@ export function matchesLogFilters(event: LogEvent, filters: LogFilterState): boo
   }
 
   return true
+}
+
+function buildSearchableEventText(event: LogEvent): string {
+  const structuredFields = JSON.stringify(event.fields_json ?? {})
+  return [
+    event.message,
+    event.action ?? '',
+    event.request_id ?? '',
+    event.session_id ?? '',
+    event.correlation_id ?? '',
+    event.trace_id ?? '',
+    event.span_id ?? '',
+    event.instance ?? '',
+    event.auth_flow ?? '',
+    event.outcome_kind ?? '',
+    event.source_kind ?? '',
+    event.source_node_id ?? '',
+    event.source_device_id ?? '',
+    event.ingest_path ?? '',
+    event.upstream_event_id ?? '',
+    structuredFields,
+  ]
+    .join(' ')
+    .toLowerCase()
 }
 
 export function mergeTimelineEvents(

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.ts
@@ -41,6 +41,18 @@ export function matchesLogFilters(event: LogEvent, filters: LogFilterState): boo
   return true
 }
 
+export function matchesVisibleLogEvent(
+  event: LogEvent,
+  filters: LogFilterState,
+  options?: { afterTs?: number | null },
+): boolean {
+  if (options?.afterTs != null && event.ts < options.afterTs) {
+    return false
+  }
+
+  return matchesLogFilters(event, filters)
+}
+
 function buildSearchableEventText(event: LogEvent): string {
   const structuredFields = JSON.stringify(event.fields_json ?? {})
   return [

--- a/apps/gateway-admin/lib/dashboard/logs-console-state.ts
+++ b/apps/gateway-admin/lib/dashboard/logs-console-state.ts
@@ -1,0 +1,66 @@
+import type { LogEvent, LogFilterState, LogSearchQuery } from '../types/logs.ts'
+
+export function buildLogSearchQuery(
+  filters: LogFilterState,
+  options?: { afterTs?: number | null },
+): LogSearchQuery {
+  const text = filters.text.trim()
+  const query: LogSearchQuery = {
+    limit: filters.limit > 0 ? filters.limit : undefined,
+  }
+
+  if (text) {
+    query.text = text
+  }
+  if (filters.subsystems.length > 0) {
+    query.subsystems = filters.subsystems
+  }
+  if (filters.levels.length > 0) {
+    query.levels = filters.levels
+  }
+  if (options?.afterTs != null) {
+    query.after_ts = options.afterTs
+  }
+
+  return query
+}
+
+export function matchesLogFilters(event: LogEvent, filters: LogFilterState): boolean {
+  const text = filters.text.trim().toLowerCase()
+
+  if (text && !`${event.message} ${event.action ?? ''}`.toLowerCase().includes(text)) {
+    return false
+  }
+  if (filters.subsystems.length > 0 && !filters.subsystems.includes(event.subsystem)) {
+    return false
+  }
+  if (filters.levels.length > 0 && !filters.levels.includes(event.level)) {
+    return false
+  }
+
+  return true
+}
+
+export function mergeTimelineEvents(
+  current: LogEvent[],
+  incoming: LogEvent[],
+  maxEntries: number,
+): LogEvent[] {
+  const merged = new Map<string, LogEvent>()
+
+  for (const event of current) {
+    merged.set(event.event_id, event)
+  }
+  for (const event of incoming) {
+    merged.set(event.event_id, event)
+  }
+
+  return Array.from(merged.values())
+    .sort((left, right) => {
+      if (left.ts === right.ts) {
+        return left.event_id.localeCompare(right.event_id)
+      }
+      return left.ts - right.ts
+    })
+    .slice(-Math.max(maxEntries, 1))
+}

--- a/apps/gateway-admin/lib/types/logs.ts
+++ b/apps/gateway-admin/lib/types/logs.ts
@@ -82,6 +82,7 @@ export interface LogFilterState {
 export interface LogStreamStatus {
   connected: boolean
   paused: boolean
+  atLiveEdge: boolean
   buffered: number
   lastEventTs: number | null
   error: string | null

--- a/apps/gateway-admin/lib/types/logs.ts
+++ b/apps/gateway-admin/lib/types/logs.ts
@@ -1,0 +1,88 @@
+export const LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error'] as const
+
+export const LOG_SUBSYSTEMS = [
+  'gateway',
+  'mcp_server',
+  'mcp_client',
+  'api',
+  'web',
+  'oauth_relay',
+  'auth_webui',
+  'auth_mcp',
+  'auth_upstream',
+  'core_runtime',
+] as const
+
+export type LogLevel = (typeof LOG_LEVELS)[number]
+export type LogSubsystem = (typeof LOG_SUBSYSTEMS)[number]
+export type LogSurface = 'cli' | 'mcp' | 'api' | 'web' | 'core_runtime'
+
+export interface LogEvent {
+  event_id: string
+  ts: number
+  level: LogLevel
+  subsystem: LogSubsystem
+  surface: LogSurface
+  action: string | null
+  message: string
+  request_id: string | null
+  session_id: string | null
+  correlation_id: string | null
+  trace_id: string | null
+  span_id: string | null
+  instance: string | null
+  auth_flow: string | null
+  outcome_kind: string | null
+  fields_json: Record<string, unknown>
+  source_kind: string | null
+  source_node_id: string | null
+  source_device_id: string | null
+  ingest_path: string | null
+  upstream_event_id: string | null
+}
+
+export interface LogSearchQuery {
+  text?: string
+  after_ts?: number
+  before_ts?: number
+  levels?: LogLevel[]
+  subsystems?: LogSubsystem[]
+  surfaces?: LogSurface[]
+  action?: string
+  request_id?: string
+  session_id?: string
+  correlation_id?: string
+  limit?: number
+}
+
+export interface LogSearchResult {
+  events: LogEvent[]
+  next_cursor: string | null
+}
+
+export interface LogStoreStats {
+  on_disk_bytes: number
+  oldest_retained_ts: number | null
+  newest_retained_ts: number | null
+  total_event_count: number
+  dropped_event_count: number
+  retention: {
+    max_age_days: number
+    max_bytes: number
+  }
+}
+
+export interface LogFilterState {
+  text: string
+  subsystems: LogSubsystem[]
+  levels: LogLevel[]
+  limit: number
+}
+
+export interface LogStreamStatus {
+  connected: boolean
+  paused: boolean
+  buffered: number
+  lastEventTs: number | null
+  error: string | null
+}

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -405,7 +405,7 @@ fn is_loopback_redirect(value: &str) -> bool {
     }
     matches!(
         url.host_str(),
-        Some("127.0.0.1" | "localhost" | "::1" | "[::1]")
+        Some("127.0.0.1" | "localhost" | "::1")
     )
 }
 

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -403,10 +403,7 @@ fn is_loopback_redirect(value: &str) -> bool {
     if url.scheme() != "http" {
         return false;
     }
-    matches!(
-        url.host_str(),
-        Some("127.0.0.1" | "localhost" | "::1")
-    )
+    matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
 }
 
 fn is_allowed_redirect_uri(value: &str, patterns: &[String]) -> bool {

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -16,7 +16,7 @@ use crate::types::{
     BrowserLoginStateRow, CallbackQuery, ClientRegistrationRequest, ClientRegistrationResponse,
     RegisteredClient,
 };
-use crate::util::{fingerprint, now_unix, random_token};
+use crate::util::{expires_at, fingerprint, now_unix, random_token};
 
 const AUTH_REQUEST_TTL_SECS: i64 = 300;
 const LAB_SCOPE: &str = "lab";
@@ -43,7 +43,7 @@ pub async fn browser_login(
         })
         .await?;
 
-    let location = state.google.authorize_url(AuthorizeUrlRequest {
+    let location = state.google.authorize_url(&AuthorizeUrlRequest {
         state: request_state,
         scope: LAB_SCOPE.to_string(),
         code_challenge: provider_code_challenge,
@@ -180,7 +180,7 @@ pub async fn authorize(
         })
         .await?;
 
-    let location = state.google.authorize_url(AuthorizeUrlRequest {
+    let location = state.google.authorize_url(&AuthorizeUrlRequest {
         state: request_state,
         scope,
         code_challenge: provider_code_challenge,
@@ -282,7 +282,11 @@ pub async fn callback(
             code_challenge_method: request.code_challenge_method,
             provider_refresh_token: google.refresh_token,
             created_at: now_unix(),
-            expires_at: now_unix() + state.config.auth_code_ttl.as_secs() as i64,
+            expires_at: expires_at(
+                now_unix(),
+                state.config.auth_code_ttl,
+                "LAB_AUTH_CODE_TTL_SECS",
+            )?,
         })
         .await?;
     info!(
@@ -401,7 +405,7 @@ fn is_loopback_redirect(value: &str) -> bool {
     }
     matches!(
         url.host_str(),
-        Some("127.0.0.1") | Some("localhost") | Some("::1") | Some("[::1]")
+        Some("127.0.0.1" | "localhost" | "::1" | "[::1]")
     )
 }
 
@@ -926,6 +930,7 @@ pub mod tests {
             "client-secret".to_string(),
             Url::parse("https://lab.example.com/auth/google/callback").unwrap(),
         )
+        .unwrap()
         .with_endpoints(
             server.uri().parse::<Url>().unwrap(),
             server.uri().parse::<Url>().unwrap().join("/token").unwrap(),

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -105,7 +105,7 @@ impl AuthConfig {
     ) -> Result<Self, AuthError> {
         let vars = normalize(vars);
         let mode = AuthMode::parse(vars.get("LAB_AUTH_MODE").map(String::as_str))?;
-        let mut config = Self {
+        let config = Self {
             mode,
             public_url: read_url(&vars, "LAB_PUBLIC_URL")?,
             sqlite_path: read_path(&vars, "LAB_AUTH_SQLITE_PATH")
@@ -139,7 +139,7 @@ impl AuthConfig {
         Ok(config)
     }
 
-    fn validate(&mut self) -> Result<(), AuthError> {
+    fn validate(&self) -> Result<(), AuthError> {
         if !self.google.callback_path.starts_with('/') {
             return Err(AuthError::Config(format!(
                 "LAB_GOOGLE_CALLBACK_PATH must start with `/`, got `{}`",
@@ -183,9 +183,7 @@ fn normalize(vars: impl IntoIterator<Item = (String, String)>) -> HashMap<String
 }
 
 fn default_auth_dir() -> PathBuf {
-    home_dir()
-        .map(|home| home.join(".lab"))
-        .unwrap_or_else(|| PathBuf::from(".lab"))
+    home_dir().map_or_else(|| PathBuf::from(".lab"), |home| home.join(".lab"))
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -244,7 +242,7 @@ fn read_u64(vars: &HashMap<String, String>, key: &str) -> Result<Option<u64>, Au
             })
         })
         .transpose()
-        .map(|value| value.flatten())
+        .map(Option::flatten)
 }
 
 #[cfg(test)]

--- a/crates/lab-auth/src/error.rs
+++ b/crates/lab-auth/src/error.rs
@@ -35,7 +35,7 @@ pub enum AuthError {
 }
 
 impl AuthError {
-    pub fn kind(&self) -> &'static str {
+    pub const fn kind(&self) -> &'static str {
         match self {
             Self::Config(_) | Self::Storage(_) | Self::InsecurePermissions { .. } => {
                 "internal_error"
@@ -47,7 +47,7 @@ impl AuthError {
         }
     }
 
-    fn status(&self) -> StatusCode {
+    const fn status(&self) -> StatusCode {
         match self {
             Self::InvalidGrant(_) => StatusCode::BAD_REQUEST,
             Self::AuthFailed(_) | Self::InvalidAccessToken => StatusCode::UNAUTHORIZED,
@@ -68,10 +68,10 @@ impl IntoResponse for AuthError {
             "message": self.to_string(),
         }));
         let mut response = (status, body).into_response();
-        if let Self::RateLimited { retry_after_ms, .. } = self {
-            if let Ok(value) = HeaderValue::from_str(&(retry_after_ms / 1_000).max(1).to_string()) {
-                response.headers_mut().insert(header::RETRY_AFTER, value);
-            }
+        if let Self::RateLimited { retry_after_ms, .. } = self
+            && let Ok(value) = HeaderValue::from_str(&(retry_after_ms / 1_000).max(1).to_string())
+        {
+            response.headers_mut().insert(header::RETRY_AFTER, value);
         }
         response
     }

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -137,8 +137,8 @@ impl<'a> GoogleRequestTrace<'a> {
     }
 
     fn error(&self, status: Option<reqwest::StatusCode>, error: &reqwest::Error) {
-        match status {
-            Some(status) => warn!(
+        if let Some(status) = status {
+            warn!(
                 provider = "google",
                 operation = self.operation,
                 method = self.method,
@@ -148,8 +148,9 @@ impl<'a> GoogleRequestTrace<'a> {
                 elapsed_ms = self.started.elapsed().as_millis(),
                 error = %error,
                 "request.error"
-            ),
-            None => warn!(
+            );
+        } else {
+            warn!(
                 provider = "google",
                 operation = self.operation,
                 method = self.method,
@@ -158,7 +159,7 @@ impl<'a> GoogleRequestTrace<'a> {
                 elapsed_ms = self.started.elapsed().as_millis(),
                 error = %error,
                 "request.error"
-            ),
+            );
         }
     }
 }
@@ -196,8 +197,26 @@ async fn read_json_response<T: DeserializeOwned>(
 }
 
 impl GoogleProvider {
-    pub fn new(client_id: String, client_secret: String, redirect_uri: Url) -> Self {
-        Self {
+    pub fn new(
+        client_id: String,
+        client_secret: String,
+        redirect_uri: Url,
+    ) -> Result<Self, AuthError> {
+        let http = reqwest::Client::builder()
+            .timeout(GOOGLE_HTTP_TIMEOUT)
+            .build()
+            .map_err(|error| {
+                AuthError::Storage(format!("build google oauth http client: {error}"))
+            })?;
+        let authorize_endpoint = Url::parse(GOOGLE_AUTHORIZE_ENDPOINT).map_err(|error| {
+            AuthError::Config(format!("parse google authorize endpoint: {error}"))
+        })?;
+        let token_endpoint = Url::parse(GOOGLE_TOKEN_ENDPOINT)
+            .map_err(|error| AuthError::Config(format!("parse google token endpoint: {error}")))?;
+        let jwks_endpoint = Url::parse(GOOGLE_JWKS_ENDPOINT)
+            .map_err(|error| AuthError::Config(format!("parse google jwks endpoint: {error}")))?;
+
+        Ok(Self {
             client_id,
             client_secret,
             redirect_uri,
@@ -206,16 +225,12 @@ impl GoogleProvider {
                 "email".to_string(),
                 "profile".to_string(),
             ],
-            http: reqwest::Client::builder()
-                .timeout(GOOGLE_HTTP_TIMEOUT)
-                .build()
-                .expect("google oauth http client should build"),
-            authorize_endpoint: Url::parse(GOOGLE_AUTHORIZE_ENDPOINT)
-                .expect("valid google auth url"),
-            token_endpoint: Url::parse(GOOGLE_TOKEN_ENDPOINT).expect("valid google token url"),
-            jwks_endpoint: Url::parse(GOOGLE_JWKS_ENDPOINT).expect("valid google jwks url"),
+            http,
+            authorize_endpoint,
+            token_endpoint,
+            jwks_endpoint,
             jwks_cache: Arc::new(RwLock::new(None)),
-        }
+        })
     }
 
     #[cfg(test)]
@@ -231,7 +246,7 @@ impl GoogleProvider {
         self
     }
 
-    pub fn authorize_url(&self, request: AuthorizeUrlRequest) -> Result<Url, AuthError> {
+    pub fn authorize_url(&self, request: &AuthorizeUrlRequest) -> Result<Url, AuthError> {
         let mut url = self.authorize_endpoint.clone();
         let scope = self.scopes.join(" ");
         url.query_pairs_mut()
@@ -413,23 +428,30 @@ impl GoogleProvider {
             return Ok(jwks);
         }
 
-        let mut cache = self.jwks_cache.write().await;
-        if let Some(cached) = cache.as_ref()
-            && cached.expires_at > Instant::now()
-        {
-            debug!(
-                provider = "google",
-                "google jwks cache hit after refresh lock"
-            );
-            return Ok(cached.jwks.clone());
-        }
-
-        Self::refresh_jwks_locked(&self.http, &self.jwks_endpoint, &mut cache).await
+        let jwks = {
+            let mut cache = self.jwks_cache.write().await;
+            if let Some(cached) = cache
+                .as_ref()
+                .filter(|cached| cached.expires_at > Instant::now())
+            {
+                debug!(
+                    provider = "google",
+                    "google jwks cache hit after refresh lock"
+                );
+                cached.jwks.clone()
+            } else {
+                Self::refresh_jwks_locked(&self.http, &self.jwks_endpoint, &mut cache).await?
+            }
+        };
+        Ok(jwks)
     }
 
     async fn refresh_jwks(&self) -> Result<GoogleJwks, AuthError> {
-        let mut cache = self.jwks_cache.write().await;
-        Self::refresh_jwks_locked(&self.http, &self.jwks_endpoint, &mut cache).await
+        let jwks = {
+            let mut cache = self.jwks_cache.write().await;
+            Self::refresh_jwks_locked(&self.http, &self.jwks_endpoint, &mut cache).await?
+        };
+        Ok(jwks)
     }
 
     async fn refresh_jwks_locked(
@@ -482,8 +504,7 @@ fn google_jwks_ttl(headers: &header::HeaderMap) -> Duration {
         .get(header::CACHE_CONTROL)
         .and_then(|value| value.to_str().ok())
         .and_then(parse_max_age)
-        .map(Duration::from_secs)
-        .unwrap_or(GOOGLE_DEFAULT_JWKS_TTL)
+        .map_or(GOOGLE_DEFAULT_JWKS_TTL, Duration::from_secs)
 }
 
 fn parse_max_age(cache_control: &str) -> Option<u64> {
@@ -529,7 +550,8 @@ mod tests {
     #[test]
     fn google_authorize_url_includes_offline_access_prompt_and_pkce() {
         let provider = test_google_provider();
-        let url = provider.authorize_url(sample_request()).unwrap();
+        let request = sample_request();
+        let url = provider.authorize_url(&request).unwrap();
         assert!(url.as_str().contains("access_type=offline"));
         assert!(url.as_str().contains("prompt=consent"));
         assert!(url.as_str().contains("code_challenge="));
@@ -695,6 +717,7 @@ mod tests {
             "client-secret".to_string(),
             Url::parse("https://lab.example.com/auth/google/callback").unwrap(),
         )
+        .unwrap()
     }
 
     async fn mocked_google_provider() -> GoogleProvider {

--- a/crates/lab-auth/src/jwt.rs
+++ b/crates/lab-auth/src/jwt.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::PathBuf;
+use std::path::Path;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -59,7 +59,7 @@ impl fmt::Debug for SigningKeys {
 }
 
 impl SigningKeys {
-    pub fn load_or_create(path: PathBuf) -> Result<Self, AuthError> {
+    pub fn load_or_create(path: &Path) -> Result<Self, AuthError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|error| {
                 AuthError::Storage(format!(
@@ -71,11 +71,11 @@ impl SigningKeys {
 
         let existed = path.exists();
         if existed {
-            ensure_restrictive_permissions(&path)?;
+            ensure_restrictive_permissions(path)?;
         }
 
         let private_key = if existed {
-            let pem = std::fs::read_to_string(&path).map_err(|error| {
+            let pem = std::fs::read_to_string(path).map_err(|error| {
                 AuthError::Storage(format!("read signing key `{}`: {error}", path.display()))
             })?;
             RsaPrivateKey::from_pkcs8_pem(&pem)
@@ -88,18 +88,18 @@ impl SigningKeys {
             let pem = key
                 .to_pkcs8_pem(LineEnding::LF)
                 .map_err(|error| AuthError::Storage(format!("encode signing key PEM: {error}")))?;
-            std::fs::write(&path, pem.as_bytes()).map_err(|error| {
+            std::fs::write(path, pem.as_bytes()).map_err(|error| {
                 AuthError::Storage(format!("write signing key `{}`: {error}", path.display()))
             })?;
-            set_restrictive_permissions(&path)?;
+            set_restrictive_permissions(path)?;
             key
         };
 
-        ensure_restrictive_permissions(&path)?;
-        Self::from_private_key(private_key)
+        ensure_restrictive_permissions(path)?;
+        Self::from_private_key(&private_key)
     }
 
-    pub fn issue_access_token(&self, claims: AccessClaims) -> Result<String, AuthError> {
+    pub fn issue_access_token(&self, claims: &AccessClaims) -> Result<String, AuthError> {
         let mut header = Header::new(Algorithm::RS256);
         header.kid = Some(self.key_id.clone());
         encode(&header, &claims, &self.encoding_key)
@@ -118,15 +118,15 @@ impl SigningKeys {
             .map_err(|_| AuthError::InvalidAccessToken)
     }
 
-    pub fn jwks(&self) -> &JwksDocument {
+    pub const fn jwks(&self) -> &JwksDocument {
         &self.jwks
     }
 
-    fn from_private_key(private_key: RsaPrivateKey) -> Result<Self, AuthError> {
+    fn from_private_key(private_key: &RsaPrivateKey) -> Result<Self, AuthError> {
         let private_pem = private_key
             .to_pkcs8_pem(LineEnding::LF)
             .map_err(|error| AuthError::Storage(format!("encode signing key PEM: {error}")))?;
-        let public_key = RsaPublicKey::from(&private_key);
+        let public_key = RsaPublicKey::from(private_key);
         let public_pem = public_key
             .to_public_key_pem(LineEnding::LF)
             .map_err(|error| AuthError::Storage(format!("encode public key PEM: {error}")))?;
@@ -205,8 +205,9 @@ mod tests {
     #[test]
     fn generated_key_is_reused_on_second_load() {
         let dir = tempfile::tempdir().unwrap();
-        let first = SigningKeys::load_or_create(dir.path().join("auth-jwt.pem")).unwrap();
-        let second = SigningKeys::load_or_create(dir.path().join("auth-jwt.pem")).unwrap();
+        let path = dir.path().join("auth-jwt.pem");
+        let first = SigningKeys::load_or_create(&path).unwrap();
+        let second = SigningKeys::load_or_create(&path).unwrap();
         assert_eq!(first.key_id, second.key_id);
     }
 
@@ -219,14 +220,15 @@ mod tests {
         let path = dir.path().join("auth-jwt.pem");
         std::fs::write(&path, "bad").unwrap();
         std::fs::set_permissions(&path, PermissionsExt::from_mode(0o644)).unwrap();
-        let err = SigningKeys::load_or_create(path).unwrap_err();
+        let err = SigningKeys::load_or_create(&path).unwrap_err();
         assert!(err.to_string().contains("permissions"));
     }
 
     #[test]
     fn minted_access_token_round_trips_and_contains_kid() {
         let signer = test_signer();
-        let token = signer.issue_access_token(sample_claims()).unwrap();
+        let claims = sample_claims();
+        let token = signer.issue_access_token(&claims).unwrap();
         let claims = signer
             .validate_access_token(&token, "https://lab.example.com")
             .unwrap();
@@ -238,7 +240,8 @@ mod tests {
     #[test]
     fn wrong_audience_is_rejected() {
         let signer = test_signer();
-        let token = signer.issue_access_token(sample_claims()).unwrap();
+        let claims = sample_claims();
+        let token = signer.issue_access_token(&claims).unwrap();
         let result = signer.validate_access_token(&token, "https://other.example.com");
         assert!(
             result.is_err(),
@@ -248,7 +251,8 @@ mod tests {
 
     fn test_signer() -> SigningKeys {
         let dir = tempfile::tempdir().unwrap();
-        SigningKeys::load_or_create(dir.path().join("auth-jwt.pem")).unwrap()
+        let path = dir.path().join("auth-jwt.pem");
+        SigningKeys::load_or_create(&path).unwrap()
     }
 
     fn sample_claims() -> AccessClaims {

--- a/crates/lab-auth/src/metadata.rs
+++ b/crates/lab-auth/src/metadata.rs
@@ -40,16 +40,14 @@ pub async fn jwks(State(state): State<AuthState>) -> Json<crate::jwt::JwksDocume
 }
 
 pub(crate) fn public_base_url(state: &AuthState) -> String {
-    debug_assert!(
-        state.config.public_url.is_some(),
-        "oauth state must have public_url"
-    );
     state
         .config
         .public_url
         .as_ref()
-        .map(|value| value.as_str().trim_end_matches('/').to_string())
-        .unwrap_or_default()
+        .expect("oauth state must have public_url configured")
+        .as_str()
+        .trim_end_matches('/')
+        .to_string()
 }
 
 pub fn canonical_resource_url(state: &AuthState) -> String {

--- a/crates/lab-auth/src/metadata.rs
+++ b/crates/lab-auth/src/metadata.rs
@@ -40,14 +40,16 @@ pub async fn jwks(State(state): State<AuthState>) -> Json<crate::jwt::JwksDocume
 }
 
 pub(crate) fn public_base_url(state: &AuthState) -> String {
+    debug_assert!(
+        state.config.public_url.is_some(),
+        "oauth state must have public_url"
+    );
     state
         .config
         .public_url
         .as_ref()
-        .expect("oauth state must have public_url")
-        .as_str()
-        .trim_end_matches('/')
-        .to_string()
+        .map(|value| value.as_str().trim_end_matches('/').to_string())
+        .unwrap_or_default()
 }
 
 pub fn canonical_resource_url(state: &AuthState) -> String {

--- a/crates/lab-auth/src/session.rs
+++ b/crates/lab-auth/src/session.rs
@@ -4,7 +4,7 @@ use axum::response::Response;
 use crate::error::AuthError;
 use crate::state::AuthState;
 use crate::types::BrowserSessionRow;
-use crate::util::{now_unix, random_token};
+use crate::util::{expires_at, now_unix, random_token};
 
 pub const BROWSER_SESSION_COOKIE_NAME: &str = "lab_session";
 pub const BROWSER_CSRF_HEADER_NAME: &str = "x-csrf-token";
@@ -39,7 +39,11 @@ pub async fn create_browser_session(
         email,
         csrf_token: random_token(18)?,
         created_at,
-        expires_at: created_at + state.config.refresh_token_ttl.as_secs() as i64,
+        expires_at: expires_at(
+            created_at,
+            state.config.refresh_token_ttl,
+            "LAB_AUTH_REFRESH_TOKEN_TTL_SECS",
+        )?,
     };
     state.store.upsert_browser_session(session.clone()).await?;
     Ok(session)

--- a/crates/lab-auth/src/sqlite.rs
+++ b/crates/lab-auth/src/sqlite.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -26,9 +26,10 @@ pub struct SqliteStore {
 impl SqliteStore {
     pub async fn open(path: PathBuf) -> Result<Self, AuthError> {
         let path_for_open = path.clone();
-        let conns =
-            tokio::task::spawn_blocking(move || open_connections(path_for_open, SQLITE_POOL_SIZE))
-                .await;
+        let conns = tokio::task::spawn_blocking(move || {
+            open_connections(path_for_open.as_path(), SQLITE_POOL_SIZE)
+        })
+        .await;
         let store = match conns {
             Ok(result) => result,
             Err(error) => Err(AuthError::Storage(format!(
@@ -64,7 +65,7 @@ impl SqliteStore {
                 Value::Integer(int) => int.to_string(),
                 other => format!("{other:?}"),
             })
-            .map_err(sqlite_error)
+            .map_err(|error| sqlite_error(&error))
         })
         .await
     }
@@ -81,7 +82,7 @@ impl SqliteStore {
                     created_at = excluded.created_at",
                 params![client.client_id, redirect_uris, client.created_at],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -115,7 +116,7 @@ impl SqliteStore {
                 },
             )
             .optional()
-            .map_err(sqlite_error)
+            .map_err(|error| sqlite_error(&error))
         })
         .await
     }
@@ -143,7 +144,7 @@ impl SqliteStore {
                     request.expires_at,
                 ],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -169,7 +170,7 @@ impl SqliteStore {
                 rusqlite::Error::QueryReturnedNoRows => AuthError::InvalidGrant(
                     "authorization state is missing, expired, or already used".to_string(),
                 ),
-                other => sqlite_error(other),
+                other => sqlite_error(&other),
             })
         })
         .await
@@ -196,7 +197,7 @@ impl SqliteStore {
                     code.expires_at,
                 ],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -220,7 +221,7 @@ impl SqliteStore {
                 rusqlite::Error::QueryReturnedNoRows => AuthError::InvalidGrant(
                     "authorization code is missing, expired, or already redeemed".to_string(),
                 ),
-                other => sqlite_error(other),
+                other => sqlite_error(&other),
             })
         })
         .await
@@ -250,7 +251,7 @@ impl SqliteStore {
                     token.expires_at,
                 ],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -273,7 +274,7 @@ impl SqliteStore {
                 row_to_refresh_token,
             )
             .optional()
-            .map_err(sqlite_error)
+            .map_err(|error| sqlite_error(&error))
         })
         .await
     }
@@ -302,7 +303,7 @@ impl SqliteStore {
                     session.expires_at,
                 ],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -324,7 +325,7 @@ impl SqliteStore {
                 row_to_browser_session,
             )
             .optional()
-            .map_err(sqlite_error)
+            .map_err(|error| sqlite_error(&error))
         })
         .await
     }
@@ -336,7 +337,7 @@ impl SqliteStore {
                 "DELETE FROM browser_sessions WHERE session_id = ?1",
                 params![session_id],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -344,8 +345,11 @@ impl SqliteStore {
 
     pub async fn execute_test_statement(&self, sql: &str) -> Result<(), AuthError> {
         let sql = sql.to_string();
-        self.with_conn(move |conn| conn.execute_batch(&sql).map_err(sqlite_error))
-            .await
+        self.with_conn(move |conn| {
+            conn.execute_batch(&sql)
+                .map_err(|error| sqlite_error(&error))
+        })
+        .await
     }
 
     pub async fn insert_browser_login_state(
@@ -365,7 +369,7 @@ impl SqliteStore {
                     login.expires_at,
                 ],
             )
-            .map_err(sqlite_error)?;
+            .map_err(|error| sqlite_error(&error))?;
             Ok(())
         })
         .await
@@ -387,7 +391,7 @@ impl SqliteStore {
                 row_to_browser_login_state,
             )
             .optional()
-            .map_err(sqlite_error)
+            .map_err(|error| sqlite_error(&error))
         })
         .await
     }
@@ -410,7 +414,7 @@ impl SqliteStore {
                         &format!("DELETE FROM {table} WHERE expires_at <= ?1"),
                         params![now],
                     )
-                    .map_err(sqlite_error)?;
+                    .map_err(|error| sqlite_error(&error))?;
                 total += deleted as u64;
             }
             Ok(total)
@@ -444,11 +448,11 @@ impl SqliteStore {
     }
 }
 
-fn open_connections(path: PathBuf, count: usize) -> Result<Vec<Connection>, AuthError> {
-    (0..count).map(|_| open_connection(path.clone())).collect()
+fn open_connections(path: &Path, count: usize) -> Result<Vec<Connection>, AuthError> {
+    (0..count).map(|_| open_connection(path)).collect()
 }
 
-fn open_connection(path: PathBuf) -> Result<Connection, AuthError> {
+fn open_connection(path: &Path) -> Result<Connection, AuthError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|error| {
             AuthError::Storage(format!(
@@ -460,16 +464,16 @@ fn open_connection(path: PathBuf) -> Result<Connection, AuthError> {
 
     let existed = path.exists();
     if existed {
-        ensure_restrictive_permissions(&path)?;
+        ensure_restrictive_permissions(path)?;
     }
 
-    let conn = Connection::open(&path).map_err(sqlite_error)?;
+    let conn = Connection::open(path).map_err(|error| sqlite_error(&error))?;
     conn.busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS))
-        .map_err(sqlite_error)?;
+        .map_err(|error| sqlite_error(&error))?;
     conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(sqlite_error)?;
+        .map_err(|error| sqlite_error(&error))?;
     conn.pragma_update(None, "foreign_keys", "ON")
-        .map_err(sqlite_error)?;
+        .map_err(|error| sqlite_error(&error))?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS registered_clients (
             client_id TEXT PRIMARY KEY,
@@ -525,35 +529,37 @@ fn open_connection(path: PathBuf) -> Result<Connection, AuthError> {
             expires_at INTEGER NOT NULL
         );",
     )
-    .map_err(sqlite_error)?;
+    .map_err(|error| sqlite_error(&error))?;
 
     if !existed {
-        set_restrictive_permissions(&path)?;
+        set_restrictive_permissions(path)?;
     }
-    ensure_restrictive_permissions(&path)?;
+    ensure_restrictive_permissions(path)?;
 
     Ok(conn)
 }
 
-fn validate_or_reopen_connection(conn: &mut Connection, path: &PathBuf) -> Result<(), AuthError> {
+fn validate_or_reopen_connection(conn: &mut Connection, path: &Path) -> Result<(), AuthError> {
     let probe = conn.query_row("SELECT 1", [], |row| row.get::<_, i64>(0));
     if probe.is_ok() {
         return Ok(());
     }
-    let error = probe.expect_err("probe already checked as Err");
+    let Err(error) = probe else {
+        return Ok(());
+    };
     warn!(
         path = %path.display(),
         error = %error,
         "stale sqlite connection detected, reopening"
     );
 
-    *conn = open_connection(path.clone())?;
+    *conn = open_connection(path)?;
     conn.query_row("SELECT 1", [], |row| row.get::<_, i64>(0))
         .map(|_| ())
-        .map_err(sqlite_error)
+        .map_err(|error| sqlite_error(&error))
 }
 
-fn sqlite_error(error: rusqlite::Error) -> AuthError {
+fn sqlite_error(error: &rusqlite::Error) -> AuthError {
     AuthError::Storage(format!("sqlite error: {error}"))
 }
 

--- a/crates/lab-auth/src/sqlite.rs
+++ b/crates/lab-auth/src/sqlite.rs
@@ -65,7 +65,7 @@ impl SqliteStore {
                 Value::Integer(int) => int.to_string(),
                 other => format!("{other:?}"),
             })
-            .map_err(|error| sqlite_error(&error))
+            .map_err(sqlite_error)
         })
         .await
     }
@@ -82,7 +82,7 @@ impl SqliteStore {
                     created_at = excluded.created_at",
                 params![client.client_id, redirect_uris, client.created_at],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -116,7 +116,7 @@ impl SqliteStore {
                 },
             )
             .optional()
-            .map_err(|error| sqlite_error(&error))
+            .map_err(sqlite_error)
         })
         .await
     }
@@ -144,7 +144,7 @@ impl SqliteStore {
                     request.expires_at,
                 ],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -170,7 +170,7 @@ impl SqliteStore {
                 rusqlite::Error::QueryReturnedNoRows => AuthError::InvalidGrant(
                     "authorization state is missing, expired, or already used".to_string(),
                 ),
-                other => sqlite_error(&other),
+                other => sqlite_error(other),
             })
         })
         .await
@@ -197,7 +197,7 @@ impl SqliteStore {
                     code.expires_at,
                 ],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -221,7 +221,7 @@ impl SqliteStore {
                 rusqlite::Error::QueryReturnedNoRows => AuthError::InvalidGrant(
                     "authorization code is missing, expired, or already redeemed".to_string(),
                 ),
-                other => sqlite_error(&other),
+                other => sqlite_error(other),
             })
         })
         .await
@@ -251,7 +251,7 @@ impl SqliteStore {
                     token.expires_at,
                 ],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -274,7 +274,7 @@ impl SqliteStore {
                 row_to_refresh_token,
             )
             .optional()
-            .map_err(|error| sqlite_error(&error))
+            .map_err(sqlite_error)
         })
         .await
     }
@@ -303,7 +303,7 @@ impl SqliteStore {
                     session.expires_at,
                 ],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -325,7 +325,7 @@ impl SqliteStore {
                 row_to_browser_session,
             )
             .optional()
-            .map_err(|error| sqlite_error(&error))
+            .map_err(sqlite_error)
         })
         .await
     }
@@ -337,7 +337,7 @@ impl SqliteStore {
                 "DELETE FROM browser_sessions WHERE session_id = ?1",
                 params![session_id],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -345,11 +345,8 @@ impl SqliteStore {
 
     pub async fn execute_test_statement(&self, sql: &str) -> Result<(), AuthError> {
         let sql = sql.to_string();
-        self.with_conn(move |conn| {
-            conn.execute_batch(&sql)
-                .map_err(|error| sqlite_error(&error))
-        })
-        .await
+        self.with_conn(move |conn| conn.execute_batch(&sql).map_err(sqlite_error))
+            .await
     }
 
     pub async fn insert_browser_login_state(
@@ -369,7 +366,7 @@ impl SqliteStore {
                     login.expires_at,
                 ],
             )
-            .map_err(|error| sqlite_error(&error))?;
+            .map_err(sqlite_error)?;
             Ok(())
         })
         .await
@@ -391,7 +388,7 @@ impl SqliteStore {
                 row_to_browser_login_state,
             )
             .optional()
-            .map_err(|error| sqlite_error(&error))
+            .map_err(sqlite_error)
         })
         .await
     }
@@ -414,7 +411,7 @@ impl SqliteStore {
                         &format!("DELETE FROM {table} WHERE expires_at <= ?1"),
                         params![now],
                     )
-                    .map_err(|error| sqlite_error(&error))?;
+                    .map_err(sqlite_error)?;
                 total += deleted as u64;
             }
             Ok(total)
@@ -467,13 +464,13 @@ fn open_connection(path: &Path) -> Result<Connection, AuthError> {
         ensure_restrictive_permissions(path)?;
     }
 
-    let conn = Connection::open(path).map_err(|error| sqlite_error(&error))?;
+    let conn = Connection::open(path).map_err(sqlite_error)?;
     conn.busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS))
-        .map_err(|error| sqlite_error(&error))?;
+        .map_err(sqlite_error)?;
     conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(|error| sqlite_error(&error))?;
+        .map_err(sqlite_error)?;
     conn.pragma_update(None, "foreign_keys", "ON")
-        .map_err(|error| sqlite_error(&error))?;
+        .map_err(sqlite_error)?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS registered_clients (
             client_id TEXT PRIMARY KEY,
@@ -529,7 +526,7 @@ fn open_connection(path: &Path) -> Result<Connection, AuthError> {
             expires_at INTEGER NOT NULL
         );",
     )
-    .map_err(|error| sqlite_error(&error))?;
+    .map_err(sqlite_error)?;
 
     if !existed {
         set_restrictive_permissions(path)?;
@@ -552,10 +549,10 @@ fn validate_or_reopen_connection(conn: &mut Connection, path: &Path) -> Result<(
     *conn = open_connection(path)?;
     conn.query_row("SELECT 1", [], |row| row.get::<_, i64>(0))
         .map(|_| ())
-        .map_err(|error| sqlite_error(&error))
+        .map_err(sqlite_error)
 }
 
-fn sqlite_error(error: &rusqlite::Error) -> AuthError {
+fn sqlite_error(error: rusqlite::Error) -> AuthError {
     AuthError::Storage(format!("sqlite error: {error}"))
 }
 

--- a/crates/lab-auth/src/sqlite.rs
+++ b/crates/lab-auth/src/sqlite.rs
@@ -540,11 +540,7 @@ fn open_connection(path: &Path) -> Result<Connection, AuthError> {
 }
 
 fn validate_or_reopen_connection(conn: &mut Connection, path: &Path) -> Result<(), AuthError> {
-    let probe = conn.query_row("SELECT 1", [], |row| row.get::<_, i64>(0));
-    if probe.is_ok() {
-        return Ok(());
-    }
-    let Err(error) = probe else {
+    let Err(error) = conn.query_row("SELECT 1", [], |row| row.get::<_, i64>(0)) else {
         return Ok(());
     };
     warn!(

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tracing::info;
+use url::Url;
 
 use crate::config::{AuthConfig, AuthMode};
 use crate::error::AuthError;
@@ -27,13 +28,7 @@ impl AuthState {
         let public_url = config.public_url.clone().ok_or_else(|| {
             AuthError::Config("LAB_PUBLIC_URL is required when LAB_AUTH_MODE=oauth".to_string())
         })?;
-        let redirect_uri = public_url
-            .join(config.google.callback_path.trim_start_matches('/'))
-            .map_err(|error| {
-                AuthError::Config(format!(
-                    "build google redirect URI from LAB_PUBLIC_URL: {error}"
-                ))
-            })?;
+        let redirect_uri = build_google_redirect_uri(&public_url, &config.google.callback_path);
         let store = SqliteStore::open(config.sqlite_path.clone()).await?;
         let signing_keys = SigningKeys::load_or_create(&config.key_path)?;
         let mut google = GoogleProvider::new(
@@ -73,5 +68,64 @@ impl AuthState {
             signing_keys: Arc::new(signing_keys),
             google: Arc::new(google),
         }
+    }
+}
+
+fn build_google_redirect_uri(public_url: &Url, callback_path: &str) -> Url {
+    let mut redirect_uri = public_url.clone();
+    let base_path = redirect_uri.path().trim_end_matches('/');
+    let callback_path = callback_path.trim_start_matches('/');
+    let next_path = if base_path.is_empty() {
+        format!("/{callback_path}")
+    } else {
+        format!("{base_path}/{callback_path}")
+    };
+
+    redirect_uri.set_path(&next_path);
+    redirect_uri.set_query(None);
+    redirect_uri.set_fragment(None);
+    redirect_uri
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::GoogleConfig;
+
+    #[tokio::test]
+    async fn auth_state_preserves_public_url_path_prefix_in_google_redirect_uri() {
+        let temp = tempdir().expect("tempdir");
+        let state = AuthState::new(AuthConfig {
+            mode: AuthMode::OAuth,
+            public_url: Some(Url::parse("https://lab.example.com/gateway").expect("public url")),
+            sqlite_path: temp.path().join("auth.db"),
+            key_path: temp.path().join("auth.pem"),
+            bootstrap_secret: None,
+            allowed_client_redirect_uris: Vec::new(),
+            google: GoogleConfig {
+                client_id: "client-id".to_string(),
+                client_secret: "client-secret".to_string(),
+                callback_path: "/auth/google/callback".to_string(),
+                scopes: vec![
+                    "openid".to_string(),
+                    "email".to_string(),
+                    "profile".to_string(),
+                ],
+            },
+            access_token_ttl: Duration::from_secs(3600),
+            refresh_token_ttl: Duration::from_secs(3600),
+            auth_code_ttl: Duration::from_secs(300),
+        })
+        .await
+        .expect("auth state");
+
+        assert_eq!(
+            state.google.redirect_uri.as_str(),
+            "https://lab.example.com/gateway/auth/google/callback"
+        );
     }
 }

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -28,26 +28,20 @@ impl AuthState {
             AuthError::Config("LAB_PUBLIC_URL is required when LAB_AUTH_MODE=oauth".to_string())
         })?;
         let redirect_uri = public_url
-            .join(
-                &config
-                    .google
-                    .callback_path
-                    .trim_start_matches('/')
-                    .to_string(),
-            )
+            .join(config.google.callback_path.trim_start_matches('/'))
             .map_err(|error| {
                 AuthError::Config(format!(
                     "build google redirect URI from LAB_PUBLIC_URL: {error}"
                 ))
             })?;
         let store = SqliteStore::open(config.sqlite_path.clone()).await?;
-        let signing_keys = SigningKeys::load_or_create(config.key_path.clone())?;
+        let signing_keys = SigningKeys::load_or_create(&config.key_path)?;
         let mut google = GoogleProvider::new(
             config.google.client_id.clone(),
             config.google.client_secret.clone(),
             redirect_uri,
-        );
-        google.scopes = config.google.scopes.clone();
+        )?;
+        google.scopes.clone_from(&config.google.scopes);
         info!(
             auth_mode = "oauth",
             public_url = %public_url,

--- a/crates/lab-auth/src/token.rs
+++ b/crates/lab-auth/src/token.rs
@@ -8,8 +8,11 @@ use tracing::{info, warn};
 use crate::error::AuthError;
 use crate::jwt::AccessClaims;
 use crate::state::AuthState;
+use crate::types::AuthorizationCodeRow;
 use crate::types::{RefreshTokenRow, TokenRequest, TokenResponse};
-use crate::util::{fingerprint, now_unix, random_token};
+use crate::util::{
+    duration_secs_usize, expires_at, fingerprint, now_unix, random_token, timestamp_usize,
+};
 
 pub async fn token(
     State(state): State<AuthState>,
@@ -59,51 +62,17 @@ async fn authorization_code_grant(
         );
         error
     })?;
-    if row.client_id != client_id {
-        warn!(
-            auth_code_id = %auth_code_id,
-            requested_client_id = %client_id,
-            stored_client_id = %row.client_id,
-            "oauth token rejected: client_id does not match authorization code"
-        );
-        return Err(AuthError::InvalidGrant(
-            "client_id does not match the authorization code".to_string(),
-        ));
-    }
-    if row.redirect_uri != redirect_uri {
-        warn!(
-            auth_code_id = %auth_code_id,
-            requested_redirect_uri = %redirect_uri,
-            stored_redirect_uri = %row.redirect_uri,
-            "oauth token rejected: redirect_uri does not match authorization code"
-        );
-        return Err(AuthError::InvalidGrant(
-            "redirect_uri does not match the authorization code".to_string(),
-        ));
-    }
-    if row.code_challenge_method != "S256" {
-        warn!(
-            auth_code_id = %auth_code_id,
-            code_challenge_method = %row.code_challenge_method,
-            "oauth token rejected: unsupported PKCE method on authorization code"
-        );
-        return Err(AuthError::InvalidGrant(
-            "authorization code uses an unsupported PKCE method".to_string(),
-        ));
-    }
-    if pkce_challenge(&code_verifier) != row.code_challenge {
-        warn!(
-            auth_code_id = %auth_code_id,
-            client_id = %row.client_id,
-            "oauth token rejected: code_verifier did not match authorization code"
-        );
-        return Err(AuthError::InvalidGrant(
-            "code_verifier does not match the authorization code".to_string(),
-        ));
-    }
+    validate_authorization_code_row(
+        &row,
+        &client_id,
+        &redirect_uri,
+        &code_verifier,
+        &auth_code_id,
+    )?;
 
     let refresh_token = if let Some(provider_refresh_token) = row.provider_refresh_token {
         let refresh_token = random_token(24)?;
+        let created_at = now_unix();
         state
             .store
             .upsert_refresh_token(RefreshTokenRow {
@@ -112,8 +81,12 @@ async fn authorization_code_grant(
                 subject: row.subject.clone(),
                 scope: row.scope.clone(),
                 provider_refresh_token: Some(provider_refresh_token),
-                created_at: now_unix(),
-                expires_at: now_unix() + state.config.refresh_token_ttl.as_secs() as i64,
+                created_at,
+                expires_at: expires_at(
+                    created_at,
+                    state.config.refresh_token_ttl,
+                    "LAB_AUTH_REFRESH_TOKEN_TTL_SECS",
+                )?,
             })
             .await?;
         info!(
@@ -137,13 +110,7 @@ async fn authorization_code_grant(
         None
     };
 
-    Ok(build_token_response(
-        &state,
-        row.client_id,
-        row.subject,
-        row.scope,
-        refresh_token,
-    )?)
+    build_token_response(&state, row.client_id, row.subject, row.scope, refresh_token)
 }
 
 async fn refresh_token_grant(
@@ -205,7 +172,11 @@ async fn refresh_token_grant(
             scope: stored.scope.clone(),
             provider_refresh_token: google.refresh_token.or(Some(provider_refresh_token)),
             created_at: stored.created_at,
-            expires_at: now_unix() + state.config.refresh_token_ttl.as_secs() as i64,
+            expires_at: expires_at(
+                now_unix(),
+                state.config.refresh_token_ttl,
+                "LAB_AUTH_REFRESH_TOKEN_TTL_SECS",
+            )?,
         })
         .await?;
     info!(
@@ -217,13 +188,13 @@ async fn refresh_token_grant(
         "oauth refresh_token grant issued new lab access token"
     );
 
-    Ok(build_token_response(
+    build_token_response(
         &state,
         stored.client_id,
         google.subject,
         stored.scope,
         Some(refresh_token),
-    )?)
+    )
 }
 
 fn build_token_response(
@@ -235,12 +206,18 @@ fn build_token_response(
 ) -> Result<TokenResponse, AuthError> {
     let issuer = crate::metadata::public_base_url(state);
     let resource = crate::metadata::canonical_resource_url(state);
-    let now = now_unix() as usize;
-    let access_token = state.signing_keys.issue_access_token(AccessClaims {
+    let now = timestamp_usize(now_unix(), "current unix timestamp")?;
+    let access_token_ttl = duration_secs_usize(
+        state.config.access_token_ttl,
+        "LAB_AUTH_ACCESS_TOKEN_TTL_SECS",
+    )?;
+    let access_token = state.signing_keys.issue_access_token(&AccessClaims {
         iss: issuer,
         sub: subject,
         aud: resource,
-        exp: now + state.config.access_token_ttl.as_secs() as usize,
+        exp: now.checked_add(access_token_ttl).ok_or_else(|| {
+            AuthError::Config("LAB_AUTH_ACCESS_TOKEN_TTL_SECS exceeds supported range".to_string())
+        })?,
         iat: now,
         jti: random_token(18)?,
         scope: scope.clone(),
@@ -261,6 +238,58 @@ fn require_field(value: Option<String>, field: &str) -> Result<String, AuthError
 
 fn pkce_challenge(code_verifier: &str) -> String {
     URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()))
+}
+
+fn validate_authorization_code_row(
+    row: &AuthorizationCodeRow,
+    client_id: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    auth_code_id: &str,
+) -> Result<(), AuthError> {
+    if row.client_id != client_id {
+        warn!(
+            auth_code_id = %auth_code_id,
+            requested_client_id = %client_id,
+            stored_client_id = %row.client_id,
+            "oauth token rejected: client_id does not match authorization code"
+        );
+        return Err(AuthError::InvalidGrant(
+            "client_id does not match the authorization code".to_string(),
+        ));
+    }
+    if row.redirect_uri != redirect_uri {
+        warn!(
+            auth_code_id = %auth_code_id,
+            requested_redirect_uri = %redirect_uri,
+            stored_redirect_uri = %row.redirect_uri,
+            "oauth token rejected: redirect_uri does not match authorization code"
+        );
+        return Err(AuthError::InvalidGrant(
+            "redirect_uri does not match the authorization code".to_string(),
+        ));
+    }
+    if row.code_challenge_method != "S256" {
+        warn!(
+            auth_code_id = %auth_code_id,
+            code_challenge_method = %row.code_challenge_method,
+            "oauth token rejected: unsupported PKCE method on authorization code"
+        );
+        return Err(AuthError::InvalidGrant(
+            "authorization code uses an unsupported PKCE method".to_string(),
+        ));
+    }
+    if pkce_challenge(code_verifier) != row.code_challenge {
+        warn!(
+            auth_code_id = %auth_code_id,
+            client_id = %row.client_id,
+            "oauth token rejected: code_verifier did not match authorization code"
+        );
+        return Err(AuthError::InvalidGrant(
+            "code_verifier does not match the authorization code".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/lab-auth/src/util.rs
+++ b/crates/lab-auth/src/util.rs
@@ -1,4 +1,8 @@
+#![allow(clippy::redundant_pub_crate)]
+
+use std::fmt::Write as _;
 use std::path::Path;
+use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -7,10 +11,11 @@ use sha2::{Digest, Sha256};
 use crate::error::AuthError;
 
 pub(crate) fn now_unix() -> i64 {
-    std::time::SystemTime::now()
+    let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs() as i64
+        .as_secs();
+    i64::try_from(secs).unwrap_or(i64::MAX)
 }
 
 pub(crate) fn random_token(bytes: usize) -> Result<String, AuthError> {
@@ -22,10 +27,11 @@ pub(crate) fn random_token(bytes: usize) -> Result<String, AuthError> {
 
 pub(crate) fn fingerprint(value: &str) -> String {
     let digest = Sha256::digest(value.as_bytes());
-    digest[..6]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
+    let mut output = String::with_capacity(12);
+    for byte in &digest[..6] {
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
 }
 
 #[cfg(unix)]
@@ -59,4 +65,30 @@ pub(crate) fn set_restrictive_permissions(path: &Path) -> Result<(), AuthError> 
 #[cfg(not(unix))]
 pub(crate) fn set_restrictive_permissions(_path: &Path) -> Result<(), AuthError> {
     Ok(())
+}
+
+pub(crate) fn duration_secs_i64(duration: Duration, field: &str) -> Result<i64, AuthError> {
+    i64::try_from(duration.as_secs())
+        .map_err(|_| AuthError::Config(format!("{field} exceeds supported range")))
+}
+
+pub(crate) fn duration_secs_usize(duration: Duration, field: &str) -> Result<usize, AuthError> {
+    usize::try_from(duration.as_secs())
+        .map_err(|_| AuthError::Config(format!("{field} exceeds supported range")))
+}
+
+pub(crate) fn timestamp_usize(timestamp: i64, field: &str) -> Result<usize, AuthError> {
+    usize::try_from(timestamp)
+        .map_err(|_| AuthError::Storage(format!("{field} is negative or exceeds usize range")))
+}
+
+pub(crate) fn expires_at(
+    created_at: i64,
+    duration: Duration,
+    field: &str,
+) -> Result<i64, AuthError> {
+    let ttl = duration_secs_i64(duration, field)?;
+    created_at
+        .checked_add(ttl)
+        .ok_or_else(|| AuthError::Config(format!("{field} exceeds supported range")))
 }

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -58,6 +58,7 @@ strip-ansi-escapes           = "0.2"
 
 rmcp.workspace               = true
 jsonwebtoken.workspace       = true
+rusqlite.workspace          = true
 
 axum.workspace               = true
 tower.workspace              = true

--- a/crates/lab/src/api/openapi.rs
+++ b/crates/lab/src/api/openapi.rs
@@ -435,7 +435,7 @@ pub fn build_service_paths(service_names: &[String]) -> Vec<(String, PathItem)> 
                     .tag("logs")
                     .summary(Some("Subscribe to live local-master log events"))
                     .description(Some(
-                        "Server-sent events stream for live local-master logs. Hosted same-origin browser session auth is the supported v1 access mode.",
+                        "Server-sent events stream for live local-master logs. API clients use bearer auth here, while the hosted gateway-admin browser consumes the same endpoint with same-origin session auth.",
                     ))
                     .responses(
                         ResponsesBuilder::new()

--- a/crates/lab/src/api/openapi.rs
+++ b/crates/lab/src/api/openapi.rs
@@ -328,7 +328,7 @@ pub fn build_health_paths() -> Vec<(String, PathItem)> {
 /// Each service gets `POST /v1/{service}` with the `ActionRequest` body schema.
 #[must_use]
 pub fn build_service_paths(service_names: &[String]) -> Vec<(String, PathItem)> {
-    service_names
+    let mut paths = service_names
         .iter()
         .map(|svc| {
             let path = format!("/v1/{svc}");
@@ -425,7 +425,50 @@ pub fn build_service_paths(service_names: &[String]) -> Vec<(String, PathItem)> 
                 .build();
             (path, item)
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    if service_names.iter().any(|name| name == "logs") {
+        let stream_item = PathItemBuilder::new()
+            .operation(
+                utoipa::openapi::HttpMethod::Get,
+                OperationBuilder::new()
+                    .tag("logs")
+                    .summary(Some("Subscribe to live local-master log events"))
+                    .description(Some(
+                        "Server-sent events stream for live local-master logs. Hosted same-origin browser session auth is the supported v1 access mode.",
+                    ))
+                    .responses(
+                        ResponsesBuilder::new()
+                            .response(
+                                "200",
+                                ResponseBuilder::new()
+                                    .description("SSE event stream")
+                                    .content(
+                                        "text/event-stream",
+                                        ContentBuilder::new()
+                                            .schema(Some(RefOr::T(
+                                                ObjectBuilder::new()
+                                                    .schema_type(SchemaType::Type(Type::String))
+                                                    .build()
+                                                    .into(),
+                                            )))
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .security(SecurityRequirement::new::<&str, [&str; 0], &str>(
+                        "bearer_auth",
+                        [],
+                    ))
+                    .build(),
+            )
+            .build();
+        paths.push(("/v1/logs/stream".to_string(), stream_item));
+    }
+
+    paths
 }
 
 // ── Top-level spec builder ──────────────────────────────────────────────
@@ -750,7 +793,8 @@ mod tests {
 
         // Service paths should have POST operations with security requirement
         for (path, item) in paths {
-            if path.starts_with("/v1/") && !path.ends_with("/actions") {
+            if path.starts_with("/v1/") && !path.ends_with("/actions") && path != "/v1/logs/stream"
+            {
                 let post = item.get("post");
                 assert!(
                     post.is_some(),
@@ -764,5 +808,13 @@ mod tests {
                 }
             }
         }
+
+        let stream = paths
+            .get("/v1/logs/stream")
+            .expect("missing /v1/logs/stream path");
+        assert!(
+            stream.get("get").is_some(),
+            "/v1/logs/stream should expose GET for SSE"
+        );
     }
 }

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -301,7 +301,12 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
             )
             .nest("/extract", services::extract::routes(state.clone()));
 
-        if state.registry.services().iter().any(|service| service.name == "logs") {
+        if state
+            .registry
+            .services()
+            .iter()
+            .any(|service| service.name == "logs")
+        {
             v1 = v1.nest("/logs", services::logs::routes(state.clone()));
         }
     }

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -280,6 +280,7 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         v1 = v1
             .route("/{service}/actions", get(service_actions))
             .nest("/gateway", services::gateway::routes(state.clone()))
+            .nest("/logs", services::logs::routes(state.clone()))
             .route(
                 "/openapi.json",
                 get(move || {
@@ -1314,7 +1315,7 @@ mod tests {
             .as_secs() as usize;
         auth_state
             .signing_keys
-            .issue_access_token(lab_auth::jwt::AccessClaims {
+            .issue_access_token(&lab_auth::jwt::AccessClaims {
                 iss: "https://lab.example.com".to_string(),
                 sub: "google-user".to_string(),
                 aud: "https://lab.example.com/mcp".to_string(),

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -280,7 +280,6 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         v1 = v1
             .route("/{service}/actions", get(service_actions))
             .nest("/gateway", services::gateway::routes(state.clone()))
-            .nest("/logs", services::logs::routes(state.clone()))
             .route(
                 "/openapi.json",
                 get(move || {
@@ -301,6 +300,10 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
                 get(|| async { Html(include_str!("openapi_docs.html")) }),
             )
             .nest("/extract", services::extract::routes(state.clone()));
+
+        if state.registry.services().iter().any(|service| service.name == "logs") {
+            v1 = v1.nest("/logs", services::logs::routes(state.clone()));
+        }
     }
 
     macro_rules! mount_if_enabled {

--- a/crates/lab/src/api/services.rs
+++ b/crates/lab/src/api/services.rs
@@ -8,6 +8,7 @@ pub mod helpers;
 
 pub mod extract;
 pub mod gateway;
+pub mod logs;
 
 #[cfg(feature = "radarr")]
 pub mod radarr;

--- a/crates/lab/src/api/services/logs.rs
+++ b/crates/lab/src/api/services/logs.rs
@@ -1,0 +1,70 @@
+use std::convert::Infallible;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::HeaderMap,
+    response::sse::{Event, KeepAlive, Sse},
+    routing::{get, post},
+};
+use futures::stream;
+use serde_json::Value;
+
+use crate::api::services::helpers::handle_action;
+use crate::api::{ActionRequest, state::AppState};
+use crate::dispatch::error::ToolError;
+
+pub fn routes(_state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/", post(handle))
+        .route("/stream", get(stream_logs))
+}
+
+async fn handle(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<ActionRequest>,
+) -> Result<Json<Value>, ToolError> {
+    let request_id = headers.get("x-request-id").and_then(|v| v.to_str().ok());
+    let logs_system = state.logs_system.clone().ok_or_else(|| {
+        ToolError::internal_message("local log system is not wired into API state")
+    })?;
+    handle_action(
+        "logs",
+        "api",
+        request_id,
+        req,
+        crate::dispatch::logs::ACTIONS,
+        move |action, params| async move {
+            crate::dispatch::logs::dispatch::dispatch_with_system(&logs_system, &action, params)
+                .await
+        },
+    )
+    .await
+}
+
+async fn stream_logs(
+    State(state): State<AppState>,
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ToolError> {
+    let logs_system = state.logs_system.clone().ok_or_else(|| {
+        ToolError::internal_message("local log system is not wired into API state")
+    })?;
+    let receiver = logs_system
+        .subscribe(crate::dispatch::logs::types::StreamSubscription::default())
+        .await?;
+
+    let stream = stream::unfold(receiver, |mut receiver| async move {
+        loop {
+            match receiver.recv().await {
+                Ok(event) => {
+                    let payload = serde_json::to_string(&event).ok()?;
+                    return Some((Ok(Event::default().data(payload)), receiver));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}

--- a/crates/lab/src/api/services/logs.rs
+++ b/crates/lab/src/api/services/logs.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use futures::stream;
 use serde_json::Value;
-use tracing::warn;
+use tracing::{error, info, warn};
 
 use crate::api::services::helpers::handle_action;
 use crate::api::{ActionRequest, state::AppState};
@@ -46,35 +46,111 @@ async fn handle(
 
 async fn stream_logs(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ToolError> {
-    let logs_system = state.logs_system.clone().ok_or_else(|| {
-        ToolError::internal_message("local log system is not wired into API state")
-    })?;
-    let receiver = logs_system
-        .subscribe(crate::dispatch::logs::types::StreamSubscription::default())
-        .await?;
+    const ACTION: &str = "logs.stream";
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let start = std::time::Instant::now();
 
-    let stream = stream::unfold(receiver, |mut receiver| async move {
-        loop {
-            match receiver.recv().await {
-                Ok(event) => {
-                    match serde_json::to_string(&event) {
+    info!(
+        surface = "api",
+        service = "logs",
+        action = ACTION,
+        request_id = request_id.as_deref(),
+        "dispatch start"
+    );
+
+    let Some(logs_system) = state.logs_system.clone() else {
+        let error = ToolError::internal_message("local log system is not wired into API state");
+        error!(
+            surface = "api",
+            service = "logs",
+            action = ACTION,
+            request_id = request_id.as_deref(),
+            elapsed_ms = start.elapsed().as_millis(),
+            kind = error.kind(),
+            "dispatch error"
+        );
+        return Err(error);
+    };
+    let receiver = match logs_system
+        .subscribe(crate::dispatch::logs::types::StreamSubscription::default())
+        .await
+    {
+        Ok(receiver) => receiver,
+        Err(error) => {
+            if error.is_internal() {
+                error!(
+                    surface = "api",
+                    service = "logs",
+                    action = ACTION,
+                    request_id = request_id.as_deref(),
+                    elapsed_ms = start.elapsed().as_millis(),
+                    kind = error.kind(),
+                    "dispatch error"
+                );
+            } else {
+                warn!(
+                    surface = "api",
+                    service = "logs",
+                    action = ACTION,
+                    request_id = request_id.as_deref(),
+                    elapsed_ms = start.elapsed().as_millis(),
+                    kind = error.kind(),
+                    "dispatch error"
+                );
+            }
+            return Err(error);
+        }
+    };
+
+    info!(
+        surface = "api",
+        service = "logs",
+        action = ACTION,
+        request_id = request_id.as_deref(),
+        elapsed_ms = start.elapsed().as_millis(),
+        "dispatch ok"
+    );
+
+    let opened_at = std::time::Instant::now();
+    let request_id_for_stream = request_id.clone();
+
+    let stream = stream::unfold(receiver, move |mut receiver| {
+        let request_id = request_id_for_stream.clone();
+        async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => match serde_json::to_string(&event) {
                         Ok(payload) => {
                             return Some((Ok(Event::default().data(payload)), receiver));
                         }
                         Err(error) => {
                             warn!(error = %error, "failed to serialize log event for SSE; skipping");
                         }
+                    },
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "SSE log subscriber lagged; dropping events");
+                        return Some((
+                            Ok(Event::default().event("lag").data(skipped.to_string())),
+                            receiver,
+                        ));
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        info!(
+                            surface = "api",
+                            service = "logs",
+                            action = ACTION,
+                            request_id = request_id.as_deref(),
+                            elapsed_ms = opened_at.elapsed().as_millis(),
+                            "dispatch finish"
+                        );
+                        return None;
                     }
                 }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                    warn!(skipped, "SSE log subscriber lagged; dropping events");
-                    return Some((
-                        Ok(Event::default().event("lag").data(skipped.to_string())),
-                        receiver,
-                    ));
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
             }
         }
     });

--- a/crates/lab/src/api/services/logs.rs
+++ b/crates/lab/src/api/services/logs.rs
@@ -117,16 +117,18 @@ async fn stream_logs(
     );
 
     let opened_at = std::time::Instant::now();
-    let request_id_for_stream = request_id.clone();
 
-    let stream = stream::unfold(receiver, move |mut receiver| {
-        let request_id = request_id_for_stream.clone();
-        async move {
+    let stream = stream::unfold(
+        (receiver, request_id, opened_at),
+        move |(mut receiver, request_id, opened_at)| async move {
             loop {
                 match receiver.recv().await {
                     Ok(event) => match serde_json::to_string(&event) {
                         Ok(payload) => {
-                            return Some((Ok(Event::default().data(payload)), receiver));
+                            return Some((
+                                Ok(Event::default().data(payload)),
+                                (receiver, request_id, opened_at),
+                            ));
                         }
                         Err(error) => {
                             warn!(error = %error, "failed to serialize log event for SSE; skipping");
@@ -136,7 +138,7 @@ async fn stream_logs(
                         warn!(skipped, "SSE log subscriber lagged; dropping events");
                         return Some((
                             Ok(Event::default().event("lag").data(skipped.to_string())),
-                            receiver,
+                            (receiver, request_id, opened_at),
                         ));
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -152,8 +154,8 @@ async fn stream_logs(
                     }
                 }
             }
-        }
-    });
+        },
+    );
 
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }

--- a/crates/lab/src/api/services/logs.rs
+++ b/crates/lab/src/api/services/logs.rs
@@ -9,6 +9,7 @@ use axum::{
 };
 use futures::stream;
 use serde_json::Value;
+use tracing::warn;
 
 use crate::api::services::helpers::handle_action;
 use crate::api::{ActionRequest, state::AppState};
@@ -57,10 +58,22 @@ async fn stream_logs(
         loop {
             match receiver.recv().await {
                 Ok(event) => {
-                    let payload = serde_json::to_string(&event).ok()?;
-                    return Some((Ok(Event::default().data(payload)), receiver));
+                    match serde_json::to_string(&event) {
+                        Ok(payload) => {
+                            return Some((Ok(Event::default().data(payload)), receiver));
+                        }
+                        Err(error) => {
+                            warn!(error = %error, "failed to serialize log event for SSE; skipping");
+                        }
+                    }
                 }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(skipped, "SSE log subscriber lagged; dropping events");
+                    return Some((
+                        Ok(Event::default().event("lag").data(skipped.to_string())),
+                        receiver,
+                    ));
+                }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
             }
         }

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -44,6 +44,8 @@ pub struct AppState {
     pub gateway_manager: Option<Arc<crate::dispatch::gateway::manager::GatewayManager>>,
     /// Shared fleet state store for device runtime ingestion.
     pub device_store: Option<Arc<DeviceFleetStore>>,
+    /// Shared local-master log runtime used by API SSE and adapter-local lookups.
+    pub logs_system: Option<Arc<crate::dispatch::logs::types::LogSystem>>,
     /// Resolved device role for the current process.
     pub device_role: Option<DeviceRole>,
     /// Optional directory containing exported Labby web assets.
@@ -86,6 +88,7 @@ impl AppState {
             oauth_state: None,
             gateway_manager: None,
             device_store: None,
+            logs_system: None,
             device_role: None,
             web_assets_dir: None,
             web_ui_auth_disabled: false,
@@ -119,6 +122,12 @@ impl AppState {
     #[must_use]
     pub fn with_device_store(mut self, store: Arc<DeviceFleetStore>) -> Self {
         self.device_store = Some(store);
+        self
+    }
+
+    #[must_use]
+    pub fn with_log_system(mut self, system: Arc<crate::dispatch::logs::types::LogSystem>) -> Self {
+        self.logs_system = Some(system);
         self
     }
 

--- a/crates/lab/src/api/web.rs
+++ b/crates/lab/src/api/web.rs
@@ -33,7 +33,7 @@ fn guess_content_type(path: &Path) -> &'static str {
         Some("json") => "application/json",
         Some("svg") => "image/svg+xml",
         Some("png") => "image/png",
-        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("jpg" | "jpeg") => "image/jpeg",
         Some("gif") => "image/gif",
         Some("webp") => "image/webp",
         Some("ico") => "image/x-icon",

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -8,7 +8,6 @@ use serde_json::{Value, json};
 use crate::cli::helpers::run_action_command;
 use crate::config::LabConfig;
 use crate::device::master_client::MasterClient;
-use crate::dispatch::error::ToolError;
 use crate::dispatch::logs::client::{
     bootstrap_store_backed_log_system, resolve_retention, resolve_store_path,
 };
@@ -157,14 +156,6 @@ fn build_search_query(args: LocalSearchArgs) -> LogQuery {
         correlation_id: args.correlation_id,
         limit: args.limit,
     }
-}
-
-#[allow(dead_code)]
-pub async fn run_local_search_for_test(
-    system: Arc<LogSystem>,
-    query: LogQuery,
-) -> Result<Value, ToolError> {
-    dispatch_with_system(&system, "logs.search", json!({ "query": query })).await
 }
 
 #[cfg(test)]

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -107,59 +107,32 @@ pub async fn run_local(
     config: &LabConfig,
 ) -> Result<ExitCode> {
     let system = local_log_system(config).await?;
-    match local.command {
-        LocalLogsCommand::Search(args) => {
-            let query = build_search_query(args);
-            run_action_command(
-                "logs",
-                "logs.search".to_string(),
-                json!({ "query": query }),
-                format,
-                move |action, params| {
-                    let system = Arc::clone(&system);
-                    async move { dispatch_with_system(&system, &action, params).await }
-                },
-            )
-            .await
-        }
-        LocalLogsCommand::Tail(args) => {
-            let request = LogTailRequest {
+    let (action, params) = match local.command {
+        LocalLogsCommand::Search(args) => (
+            "logs.search".to_string(),
+            json!({ "query": build_search_query(args) }),
+        ),
+        LocalLogsCommand::Tail(args) => (
+            "logs.tail".to_string(),
+            serde_json::to_value(LogTailRequest {
                 after_ts: args.after_ts,
                 since_event_id: args.since_event_id,
                 limit: args.limit,
-            };
-            run_action_command(
-                "logs",
-                "logs.tail".to_string(),
-                serde_json::to_value(request)?,
-                format,
-                move |action, params| {
-                    let system = Arc::clone(&system);
-                    async move { dispatch_with_system(&system, &action, params).await }
-                },
-            )
-            .await
-        }
-        LocalLogsCommand::Stats => {
-            run_action_command(
-                "logs",
-                "logs.stats".to_string(),
-                json!({}),
-                format,
-                move |action, params| {
-                    let system = Arc::clone(&system);
-                    async move { dispatch_with_system(&system, &action, params).await }
-                },
-            )
-            .await
-        }
-        LocalLogsCommand::Stream => Err(anyhow::anyhow!(
-            "{}",
-            serde_json::to_string(&ToolError::internal_message(
+            })?,
+        ),
+        LocalLogsCommand::Stats => ("logs.stats".to_string(), json!({})),
+        LocalLogsCommand::Stream => {
+            return Err(anyhow::anyhow!(
                 "true live log streaming is only available over HTTP SSE at `/v1/logs/stream`; use `lab logs local tail` for bounded follow-up windows"
-            ))?
-        )),
-    }
+            ));
+        }
+    };
+
+    run_action_command("logs", action, params, format, move |action, params| {
+        let system = Arc::clone(&system);
+        async move { dispatch_with_system(&system, &action, params).await }
+    })
+    .await
 }
 
 async fn local_log_system(config: &LabConfig) -> Result<Arc<LogSystem>> {
@@ -227,15 +200,7 @@ mod tests {
     #[test]
     fn logs_cli_rejects_invalid_local_search_filters() {
         assert!(
-            Cli::try_parse_from([
-                "lab",
-                "logs",
-                "local",
-                "search",
-                "--level",
-                "warning",
-            ])
-            .is_err()
+            Cli::try_parse_from(["lab", "logs", "local", "search", "--level", "warning",]).is_err()
         );
     }
 }

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -57,11 +57,11 @@ pub struct LocalSearchArgs {
     #[arg(long)]
     pub before_ts: Option<i64>,
     #[arg(long = "level")]
-    pub levels: Vec<String>,
+    pub levels: Vec<crate::dispatch::logs::types::LogLevel>,
     #[arg(long = "subsystem")]
-    pub subsystems: Vec<String>,
+    pub subsystems: Vec<crate::dispatch::logs::types::Subsystem>,
     #[arg(long = "surface")]
-    pub surfaces: Vec<String>,
+    pub surfaces: Vec<crate::dispatch::logs::types::Surface>,
     #[arg(long)]
     pub action: Option<String>,
     #[arg(long)]
@@ -175,24 +175,15 @@ fn build_search_query(args: LocalSearchArgs) -> LogQuery {
         text: args.text,
         after_ts: args.after_ts,
         before_ts: args.before_ts,
-        levels: parse_values(args.levels),
-        subsystems: parse_values(args.subsystems),
-        surfaces: parse_values(args.surfaces),
+        levels: args.levels,
+        subsystems: args.subsystems,
+        surfaces: args.surfaces,
         action: args.action,
         request_id: args.request_id,
         session_id: args.session_id,
         correlation_id: args.correlation_id,
         limit: args.limit,
     }
-}
-
-fn parse_values<T>(raw: Vec<String>) -> Vec<T>
-where
-    T: for<'de> serde::Deserialize<'de>,
-{
-    raw.into_iter()
-        .filter_map(|value| serde_json::from_value(json!(value)).ok())
-        .collect()
 }
 
 #[allow(dead_code)]
@@ -231,5 +222,20 @@ mod tests {
         .expect("local search parses");
 
         assert!(matches!(cli.command, Command::Logs(_)));
+    }
+
+    #[test]
+    fn logs_cli_rejects_invalid_local_search_filters() {
+        assert!(
+            Cli::try_parse_from([
+                "lab",
+                "logs",
+                "local",
+                "search",
+                "--level",
+                "warning",
+            ])
+            .is_err()
+        );
     }
 }

--- a/crates/lab/src/cli/logs.rs
+++ b/crates/lab/src/cli/logs.rs
@@ -1,10 +1,19 @@
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
+use serde_json::{Value, json};
 
+use crate::cli::helpers::run_action_command;
 use crate::config::LabConfig;
 use crate::device::master_client::MasterClient;
+use crate::dispatch::error::ToolError;
+use crate::dispatch::logs::client::{
+    bootstrap_store_backed_log_system, resolve_retention, resolve_store_path,
+};
+use crate::dispatch::logs::dispatch::dispatch_with_system;
+use crate::dispatch::logs::types::{LogQuery, LogSystem, LogTailRequest};
 use crate::output::{OutputFormat, print};
 
 #[derive(Debug, Args)]
@@ -17,22 +26,210 @@ pub struct LogsArgs {
 pub enum LogsCommand {
     /// Search fleet logs for a device from the master control plane.
     Search { device: String, query: String },
+    /// Search or inspect the local-master runtime log store.
+    Local(LocalLogsArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LocalLogsArgs {
+    #[command(subcommand)]
+    pub command: LocalLogsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LocalLogsCommand {
+    /// Search the persistent local log store.
+    Search(LocalSearchArgs),
+    /// Read a bounded follow-up window from the persistent local log store.
+    Tail(LocalTailArgs),
+    /// Inspect local retention and drop counters.
+    Stats,
+    /// Live push is HTTP SSE only in v1; this command fails with guidance.
+    Stream,
+}
+
+#[derive(Debug, Args, Default)]
+pub struct LocalSearchArgs {
+    #[arg(long)]
+    pub text: Option<String>,
+    #[arg(long)]
+    pub after_ts: Option<i64>,
+    #[arg(long)]
+    pub before_ts: Option<i64>,
+    #[arg(long = "level")]
+    pub levels: Vec<String>,
+    #[arg(long = "subsystem")]
+    pub subsystems: Vec<String>,
+    #[arg(long = "surface")]
+    pub surfaces: Vec<String>,
+    #[arg(long)]
+    pub action: Option<String>,
+    #[arg(long)]
+    pub request_id: Option<String>,
+    #[arg(long)]
+    pub session_id: Option<String>,
+    #[arg(long)]
+    pub correlation_id: Option<String>,
+    #[arg(long)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Args, Default)]
+pub struct LocalTailArgs {
+    #[arg(long)]
+    pub after_ts: Option<i64>,
+    #[arg(long)]
+    pub since_event_id: Option<String>,
+    #[arg(long)]
+    pub limit: Option<usize>,
 }
 
 pub async fn run(args: LogsArgs, format: OutputFormat, config: &LabConfig) -> Result<ExitCode> {
-    let value = match args.command {
-        LogsCommand::Search { device, query } => search_logs(config, &device, &query).await?,
-    };
-    print(&value, format)?;
-    Ok(ExitCode::SUCCESS)
+    match args.command {
+        LogsCommand::Search { device, query } => {
+            let value = search_logs(config, &device, &query).await?;
+            print(&value, format)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        LogsCommand::Local(local) => run_local(local, format, config).await,
+    }
 }
 
-pub async fn search_logs(
-    config: &LabConfig,
-    device_id: &str,
-    query: &str,
-) -> Result<serde_json::Value> {
+pub async fn search_logs(config: &LabConfig, device_id: &str, query: &str) -> Result<Value> {
     MasterClient::from_config(config, None)?
         .search_logs(device_id, query)
         .await
+}
+
+pub async fn run_local(
+    local: LocalLogsArgs,
+    format: OutputFormat,
+    config: &LabConfig,
+) -> Result<ExitCode> {
+    let system = local_log_system(config).await?;
+    match local.command {
+        LocalLogsCommand::Search(args) => {
+            let query = build_search_query(args);
+            run_action_command(
+                "logs",
+                "logs.search".to_string(),
+                json!({ "query": query }),
+                format,
+                move |action, params| {
+                    let system = Arc::clone(&system);
+                    async move { dispatch_with_system(&system, &action, params).await }
+                },
+            )
+            .await
+        }
+        LocalLogsCommand::Tail(args) => {
+            let request = LogTailRequest {
+                after_ts: args.after_ts,
+                since_event_id: args.since_event_id,
+                limit: args.limit,
+            };
+            run_action_command(
+                "logs",
+                "logs.tail".to_string(),
+                serde_json::to_value(request)?,
+                format,
+                move |action, params| {
+                    let system = Arc::clone(&system);
+                    async move { dispatch_with_system(&system, &action, params).await }
+                },
+            )
+            .await
+        }
+        LocalLogsCommand::Stats => {
+            run_action_command(
+                "logs",
+                "logs.stats".to_string(),
+                json!({}),
+                format,
+                move |action, params| {
+                    let system = Arc::clone(&system);
+                    async move { dispatch_with_system(&system, &action, params).await }
+                },
+            )
+            .await
+        }
+        LocalLogsCommand::Stream => Err(anyhow::anyhow!(
+            "{}",
+            serde_json::to_string(&ToolError::internal_message(
+                "true live log streaming is only available over HTTP SSE at `/v1/logs/stream`; use `lab logs local tail` for bounded follow-up windows"
+            ))?
+        )),
+    }
+}
+
+async fn local_log_system(config: &LabConfig) -> Result<Arc<LogSystem>> {
+    Ok(bootstrap_store_backed_log_system(
+        resolve_store_path(Some(config)),
+        resolve_retention(Some(config)),
+    )
+    .await?)
+}
+
+fn build_search_query(args: LocalSearchArgs) -> LogQuery {
+    LogQuery {
+        text: args.text,
+        after_ts: args.after_ts,
+        before_ts: args.before_ts,
+        levels: parse_values(args.levels),
+        subsystems: parse_values(args.subsystems),
+        surfaces: parse_values(args.surfaces),
+        action: args.action,
+        request_id: args.request_id,
+        session_id: args.session_id,
+        correlation_id: args.correlation_id,
+        limit: args.limit,
+    }
+}
+
+fn parse_values<T>(raw: Vec<String>) -> Vec<T>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    raw.into_iter()
+        .filter_map(|value| serde_json::from_value(json!(value)).ok())
+        .collect()
+}
+
+#[allow(dead_code)]
+pub async fn run_local_search_for_test(
+    system: Arc<LogSystem>,
+    query: LogQuery,
+) -> Result<Value, ToolError> {
+    dispatch_with_system(&system, "logs.search", json!({ "query": query })).await
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+    use clap::Parser;
+
+    use crate::cli::{Cli, Command};
+
+    #[test]
+    fn logs_cli_parser_accepts_existing_fleet_search() {
+        Cli::command().debug_assert();
+        assert!(Cli::try_parse_from(["lab", "logs", "search", "node-a", "timeout"]).is_ok());
+    }
+
+    #[test]
+    fn logs_cli_parses_local_search() {
+        let cli = Cli::try_parse_from([
+            "lab",
+            "logs",
+            "local",
+            "search",
+            "--subsystem",
+            "gateway",
+            "--level",
+            "warn",
+        ])
+        .expect("local search parses");
+
+        assert!(matches!(cli.command, Command::Logs(_)));
+    }
 }

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -24,6 +24,10 @@ use crate::dispatch::clients::SharedServiceClients;
 use crate::dispatch::gateway::install_gateway_manager;
 use crate::dispatch::gateway::manager::{GatewayManager, GatewayRuntimeHandle};
 use crate::dispatch::gateway::types::CatalogChangeNotifier;
+use crate::dispatch::logs::client::{
+    bootstrap_running_log_system, resolve_queue_capacity, resolve_retention, resolve_store_path,
+    resolve_subscriber_capacity,
+};
 use crate::mcp::server::{LabMcpServer, PeerNotifier};
 use crate::registry::{ToolRegistry, build_default_registry};
 
@@ -125,6 +129,13 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     let gateway_manager = Arc::new(gateway_manager);
     gateway_manager.seed_config(config.clone()).await;
     install_gateway_manager(Arc::clone(&gateway_manager));
+    let logs_system = bootstrap_running_log_system(
+        resolve_store_path(Some(config)),
+        resolve_retention(Some(config)),
+        resolve_queue_capacity(Some(config)),
+        resolve_subscriber_capacity(Some(config)),
+    )
+    .await?;
 
     if should_run_stdio(transport, args.command.as_ref()) {
         return run_stdio(
@@ -172,6 +183,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     let web_ui_auth_disabled = resolve_web_ui_auth_disabled(&config.web)?;
     state = state.with_web_ui_auth_disabled(web_ui_auth_disabled);
     state = state.with_device_store(Arc::clone(&device_store));
+    state = state.with_log_system(logs_system);
     state = state.with_device_role(device_role);
     if let Some(web_assets_dir) = resolve_web_assets_dir(&config.web) {
         tracing::info!(path = %web_assets_dir.display(), "Labby web assets enabled");

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -38,6 +38,9 @@ pub struct LabConfig {
     /// Logging preferences (overridden by `LAB_LOG` / `LAB_LOG_FORMAT` env vars).
     #[serde(default)]
     pub log: LogPreferences,
+    /// Local-master log subsystem preferences.
+    #[serde(default)]
+    pub local_logs: Option<LocalLogsPreferences>,
     /// HTTP API preferences.
     #[serde(default)]
     pub api: ApiPreferences,
@@ -327,6 +330,26 @@ pub struct LogPreferences {
     /// Overridden by `LAB_LOG_FORMAT` env var.
     #[serde(default)]
     pub format: Option<String>,
+}
+
+/// Local-master log store and retention preferences.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LocalLogsPreferences {
+    /// Optional path override for the embedded log store.
+    #[serde(default)]
+    pub store_path: Option<PathBuf>,
+    /// Retention window in days.
+    #[serde(default)]
+    pub retention_days: Option<u64>,
+    /// Max retained logical bytes. Oldest events are evicted first.
+    #[serde(default)]
+    pub max_bytes: Option<u64>,
+    /// Bounded ingest queue size for the long-lived runtime.
+    #[serde(default)]
+    pub queue_capacity: Option<usize>,
+    /// Bounded live-subscriber ring size for the SSE stream hub.
+    #[serde(default)]
+    pub subscriber_capacity: Option<usize>,
 }
 
 /// HTTP API preferences.

--- a/crates/lab/src/dispatch.rs
+++ b/crates/lab/src/dispatch.rs
@@ -14,6 +14,7 @@ pub mod helpers;
 pub mod lab_admin;
 #[cfg(feature = "linkding")]
 pub mod linkding;
+pub mod logs;
 #[cfg(feature = "memos")]
 pub mod memos;
 #[cfg(feature = "openai")]

--- a/crates/lab/src/dispatch/error.rs
+++ b/crates/lab/src/dispatch/error.rs
@@ -112,6 +112,8 @@ impl std::fmt::Display for ToolError {
     }
 }
 
+impl std::error::Error for ToolError {}
+
 impl ToolError {
     /// Canonical stable string tag.
     #[must_use]

--- a/crates/lab/src/dispatch/logs.rs
+++ b/crates/lab/src/dispatch/logs.rs
@@ -1,0 +1,11 @@
+pub mod catalog;
+pub mod client;
+pub mod dispatch;
+pub mod ingest;
+pub mod params;
+pub mod store;
+pub mod stream;
+pub mod types;
+
+pub use catalog::ACTIONS;
+pub use dispatch::dispatch;

--- a/crates/lab/src/main.rs
+++ b/crates/lab/src/main.rs
@@ -30,6 +30,7 @@ use is_terminal::IsTerminal;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use crate::cli::Cli;
+use crate::dispatch::logs::ingest::LogIngestLayer;
 
 /// Initialize tracing.
 ///
@@ -53,6 +54,7 @@ fn init_tracing(log: &config::LogPreferences) {
     if use_json {
         tracing_subscriber::registry()
             .with(filter)
+            .with(LogIngestLayer)
             .with(fmt::layer().json().with_writer(std::io::stderr))
             .init();
     } else {
@@ -60,6 +62,7 @@ fn init_tracing(log: &config::LogPreferences) {
         let ansi = std::io::stderr().is_terminal();
         tracing_subscriber::registry()
             .with(filter)
+            .with(LogIngestLayer)
             .with(
                 fmt::layer()
                     .with_target(false)

--- a/crates/lab/src/mcp/services.rs
+++ b/crates/lab/src/mcp/services.rs
@@ -6,6 +6,7 @@
 
 pub mod extract;
 pub mod gateway;
+pub mod logs;
 
 #[cfg(feature = "lab-admin")]
 pub mod lab_admin;

--- a/crates/lab/src/mcp/services/logs.rs
+++ b/crates/lab/src/mcp/services/logs.rs
@@ -1,0 +1,9 @@
+use serde_json::Value;
+
+use crate::dispatch::error::ToolError;
+
+pub const ACTIONS: &[lab_apis::core::action::ActionSpec] = crate::dispatch::logs::ACTIONS;
+
+pub async fn dispatch(action: &str, params: Value) -> Result<Value, ToolError> {
+    crate::dispatch::logs::dispatch(action, params).await
+}

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -190,6 +190,15 @@ pub fn build_default_registry() -> ToolRegistry {
         dispatch: dispatch_fn!(crate::mcp::services::gateway::dispatch),
     });
 
+    reg.register(RegisteredService {
+        name: "logs",
+        description: "Search and stream local-master runtime logs",
+        category: "bootstrap",
+        status: "available",
+        actions: crate::mcp::services::logs::ACTIONS,
+        dispatch: dispatch_fn!(crate::mcp::services::logs::dispatch),
+    });
+
     register_service!(
         reg,
         "radarr",
@@ -479,6 +488,7 @@ mod tests {
             let mut s = std::collections::HashSet::new();
             s.insert(lab_apis::extract::META.name); // always-on
             s.insert("gateway");
+            s.insert("logs");
             #[cfg(feature = "radarr")]
             s.insert(lab_apis::radarr::META.name);
             #[cfg(feature = "sonarr")]

--- a/crates/lab/tests/device_api.rs
+++ b/crates/lab/tests/device_api.rs
@@ -140,6 +140,58 @@ async fn device_oauth_route_rejects_invalid_target_url() {
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
+#[tokio::test]
+async fn existing_fleet_logs_search_still_works() {
+    let (app, store) = test_device_router();
+    store
+        .record_hello(lab::device::checkin::DeviceHello {
+            device_id: "dookie".to_string(),
+            role: "non-master".to_string(),
+            version: "1.0.0".to_string(),
+        })
+        .await;
+    store
+        .record_logs(
+            "dookie",
+            vec![lab::device::log_event::DeviceLogEvent {
+                device_id: "dookie".to_string(),
+                timestamp_unix_ms: 1,
+                source: "journald".to_string(),
+                level: Some("info".to_string()),
+                message: "hello from fleet search".to_string(),
+                fields: serde_json::Map::new(),
+            }],
+        )
+        .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/device/logs/search")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "device_id":"dookie",
+                        "query":"hello"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let events: Vec<lab::device::log_event::DeviceLogEvent> =
+        serde_json::from_slice(&body).unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(events[0].message.contains("fleet search"));
+}
+
 fn test_device_router() -> (axum::Router, Arc<DeviceFleetStore>) {
     let store = Arc::new(DeviceFleetStore::default());
     let state = AppState::new().with_device_store(Arc::clone(&store));

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -1,0 +1,204 @@
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::{Mutex, MutexGuard};
+
+use axum::{
+    Router,
+    body::{Body, HttpBody},
+    http::{Request, StatusCode, header},
+};
+use futures::future::poll_fn;
+use tower::ServiceExt;
+
+static LOG_SYSTEM_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_log_system_tests() -> MutexGuard<'static, ()> {
+    LOG_SYSTEM_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn raw_gateway_event(message: &str) -> lab::dispatch::logs::types::RawLogEvent {
+    lab::dispatch::logs::types::RawLogEvent {
+        ts: Some(1_713_225_600_000),
+        level: Some("warn".to_string()),
+        subsystem: Some("gateway".to_string()),
+        surface: Some("api".to_string()),
+        action: Some("gateway.list".to_string()),
+        message: message.to_string(),
+        request_id: Some("req-gateway".to_string()),
+        session_id: None,
+        correlation_id: None,
+        trace_id: None,
+        span_id: None,
+        instance: Some("default".to_string()),
+        auth_flow: None,
+        outcome_kind: Some("ok".to_string()),
+        fields_json: serde_json::json!({"route":"gateway.list"}),
+        source_kind: None,
+        source_node_id: None,
+        source_device_id: None,
+        ingest_path: None,
+        upstream_event_id: None,
+    }
+}
+
+async fn test_app() -> (Router, Arc<lab::dispatch::logs::types::LogSystem>) {
+    let logs_system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .expect("log system");
+    let state = lab::api::state::AppState::new().with_log_system(Arc::clone(&logs_system));
+    (
+        lab::api::router::build_router_with_bearer(state, None, None),
+        logs_system,
+    )
+}
+
+async fn read_next_body_chunk(body: Body) -> axum::body::Bytes {
+    let mut body = pin!(body);
+    loop {
+        let frame = poll_fn(|cx| body.as_mut().poll_frame(cx))
+            .await
+            .expect("body frame result")
+            .expect("body frame available");
+        if let Ok(data) = frame.into_data() {
+            return data;
+        }
+    }
+}
+
+#[tokio::test]
+async fn post_logs_search_route_exists() {
+    let _lock = lock_log_system_tests();
+    let (app, _logs_system) = test_app().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/logs")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"action":"logs.search","params":{"query":{}}}).to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn logs_stream_sse_route_emits_event_stream_content_type() {
+    let _lock = lock_log_system_tests();
+    let (app, _logs_system) = test_app().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/logs/stream")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/event-stream")
+    );
+}
+
+#[tokio::test]
+async fn logs_sse_reconnect_resumes_stream() {
+    let _lock = lock_log_system_tests();
+    let (app, logs_system) = test_app().await;
+
+    let first_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/logs/stream")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("first response");
+
+    logs_system
+        .ingest(raw_gateway_event("first sse payload"))
+        .await
+        .expect("first event");
+
+    let first_chunk = read_next_body_chunk(first_response.into_body()).await;
+    let first_text = String::from_utf8(first_chunk.to_vec()).expect("utf8 body");
+    assert!(first_text.contains("first sse payload"));
+
+    let second_response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/logs/stream")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("second response");
+
+    logs_system
+        .ingest(raw_gateway_event("second sse payload"))
+        .await
+        .expect("second event");
+
+    let second_chunk = read_next_body_chunk(second_response.into_body()).await;
+    let second_text = String::from_utf8(second_chunk.to_vec()).expect("utf8 body");
+    assert!(second_text.contains("second sse payload"));
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}
+
+#[tokio::test]
+async fn logs_mcp_tail_matches_api_query_semantics() {
+    let _lock = lock_log_system_tests();
+    let (app, logs_system) = test_app().await;
+    logs_system
+        .ingest(raw_gateway_event("shared tail semantics"))
+        .await
+        .expect("seed event");
+
+    let mcp_value = lab::mcp::services::logs::dispatch(
+        "logs.tail",
+        serde_json::json!({ "after_ts": 0, "limit": 10 }),
+    )
+    .await
+    .expect("mcp tail");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/logs")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "action":"logs.tail",
+                        "params":{"after_ts":0,"limit":10}
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response bytes");
+    let api_value: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    assert_eq!(api_value, mcp_value);
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -1,6 +1,5 @@
 use std::pin::pin;
 use std::sync::Arc;
-use std::sync::{Mutex, MutexGuard};
 
 use axum::{
     Router,
@@ -10,13 +9,9 @@ use axum::{
 use futures::future::poll_fn;
 use tower::ServiceExt;
 
-static LOG_SYSTEM_TEST_LOCK: Mutex<()> = Mutex::new(());
+mod support;
 
-fn lock_log_system_tests() -> MutexGuard<'static, ()> {
-    LOG_SYSTEM_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
+use support::log_system::{InstalledLogSystemGuard, test_lock};
 
 fn raw_gateway_event(message: &str) -> lab::dispatch::logs::types::RawLogEvent {
     lab::dispatch::logs::types::RawLogEvent {
@@ -54,22 +49,25 @@ async fn test_app() -> (Router, Arc<lab::dispatch::logs::types::LogSystem>) {
     )
 }
 
-async fn read_next_body_chunk(body: Body) -> axum::body::Bytes {
+async fn read_next_body_chunk(body: Body) -> Option<axum::body::Bytes> {
     let mut body = pin!(body);
     loop {
-        let frame = poll_fn(|cx| body.as_mut().poll_frame(cx))
-            .await
-            .expect("body frame result")
-            .expect("body frame available");
+        let frame = match poll_fn(|cx| body.as_mut().poll_frame(cx)).await {
+            Some(Ok(frame)) => frame,
+            Some(Err(error)) => panic!("body frame result: {error}"),
+            None => return None,
+        };
         if let Ok(data) = frame.into_data() {
-            return data;
+            return Some(data);
         }
     }
 }
 
 #[tokio::test]
 async fn post_logs_search_route_exists() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let (app, _logs_system) = test_app().await;
     let response = app
         .oneshot(
@@ -90,7 +88,9 @@ async fn post_logs_search_route_exists() {
 
 #[tokio::test]
 async fn logs_stream_sse_route_emits_event_stream_content_type() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let (app, _logs_system) = test_app().await;
     let response = app
         .oneshot(
@@ -115,7 +115,9 @@ async fn logs_stream_sse_route_emits_event_stream_content_type() {
 
 #[tokio::test]
 async fn logs_sse_reconnect_resumes_stream() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let (app, logs_system) = test_app().await;
 
     let first_response = app
@@ -135,7 +137,9 @@ async fn logs_sse_reconnect_resumes_stream() {
         .await
         .expect("first event");
 
-    let first_chunk = read_next_body_chunk(first_response.into_body()).await;
+    let first_chunk = read_next_body_chunk(first_response.into_body())
+        .await
+        .expect("first sse frame");
     let first_text = String::from_utf8(first_chunk.to_vec()).expect("utf8 body");
     assert!(first_text.contains("first sse payload"));
 
@@ -155,15 +159,18 @@ async fn logs_sse_reconnect_resumes_stream() {
         .await
         .expect("second event");
 
-    let second_chunk = read_next_body_chunk(second_response.into_body()).await;
+    let second_chunk = read_next_body_chunk(second_response.into_body())
+        .await
+        .expect("second sse frame");
     let second_text = String::from_utf8(second_chunk.to_vec()).expect("utf8 body");
     assert!(second_text.contains("second sse payload"));
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
 
 #[tokio::test]
 async fn logs_mcp_tail_matches_api_query_semantics() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let (app, logs_system) = test_app().await;
     logs_system
         .ingest(raw_gateway_event("shared tail semantics"))
@@ -200,11 +207,13 @@ async fn logs_mcp_tail_matches_api_query_semantics() {
         .expect("response bytes");
     let api_value: serde_json::Value = serde_json::from_slice(&body).expect("json body");
     assert_eq!(api_value, mcp_value);
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
 
 #[tokio::test]
 async fn logs_routes_respect_runtime_service_filtering() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let logs_system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .expect("log system");

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -1,5 +1,6 @@
 use std::pin::pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     Router,
@@ -49,8 +50,7 @@ async fn test_app() -> (Router, Arc<lab::dispatch::logs::types::LogSystem>) {
     )
 }
 
-async fn read_next_body_chunk(body: Body) -> Option<axum::body::Bytes> {
-    let mut body = pin!(body);
+async fn read_next_body_chunk(mut body: std::pin::Pin<&mut Body>) -> Option<axum::body::Bytes> {
     loop {
         let frame = match poll_fn(|cx| body.as_mut().poll_frame(cx)).await {
             Some(Ok(frame)) => frame,
@@ -59,6 +59,30 @@ async fn read_next_body_chunk(body: Body) -> Option<axum::body::Bytes> {
         };
         if let Ok(data) = frame.into_data() {
             return Some(data);
+        }
+    }
+}
+
+async fn wait_for_substring(body: Body, needle: &str) -> String {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut body = pin!(body);
+    let mut collected = String::new();
+
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now()) else {
+            panic!("never observed {needle}; got {collected:?}");
+        };
+
+        let next_chunk = tokio::time::timeout(remaining, read_next_body_chunk(body.as_mut()))
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for {needle}; got {collected:?}"));
+        let Some(chunk) = next_chunk else {
+            panic!("stream closed before {needle}; got {collected:?}");
+        };
+
+        collected.push_str(std::str::from_utf8(&chunk).unwrap_or(""));
+        if collected.contains(needle) {
+            return collected;
         }
     }
 }
@@ -114,7 +138,7 @@ async fn logs_stream_sse_route_emits_event_stream_content_type() {
 }
 
 #[tokio::test]
-async fn logs_sse_reconnect_resumes_stream() {
+async fn logs_sse_subscribers_receive_events_after_subscribe() {
     let mut lock = test_lock();
     let _lock = lock.write().expect("log system test lock");
     let _installed = InstalledLogSystemGuard::new();
@@ -137,10 +161,7 @@ async fn logs_sse_reconnect_resumes_stream() {
         .await
         .expect("first event");
 
-    let first_chunk = read_next_body_chunk(first_response.into_body())
-        .await
-        .expect("first sse frame");
-    let first_text = String::from_utf8(first_chunk.to_vec()).expect("utf8 body");
+    let first_text = wait_for_substring(first_response.into_body(), "first sse payload").await;
     assert!(first_text.contains("first sse payload"));
 
     let second_response = app
@@ -159,10 +180,7 @@ async fn logs_sse_reconnect_resumes_stream() {
         .await
         .expect("second event");
 
-    let second_chunk = read_next_body_chunk(second_response.into_body())
-        .await
-        .expect("second sse frame");
-    let second_text = String::from_utf8(second_chunk.to_vec()).expect("utf8 body");
+    let second_text = wait_for_substring(second_response.into_body(), "second sse payload").await;
     assert!(second_text.contains("second sse payload"));
 }
 

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -14,6 +14,21 @@ mod support;
 
 use support::log_system::{InstalledLogSystemGuard, test_lock};
 
+fn logs_registry() -> lab::registry::ToolRegistry {
+    let mut registry = lab::registry::ToolRegistry::new();
+    registry.register(lab::registry::RegisteredService {
+        name: "logs",
+        description: "Search and stream local-master runtime logs",
+        category: "bootstrap",
+        status: "available",
+        actions: lab::mcp::services::logs::ACTIONS,
+        dispatch: |action, params| {
+            Box::pin(async move { lab::mcp::services::logs::dispatch(&action, params).await })
+        },
+    });
+    registry
+}
+
 fn raw_gateway_event(message: &str) -> lab::dispatch::logs::types::RawLogEvent {
     lab::dispatch::logs::types::RawLogEvent {
         ts: Some(1_713_225_600_000),
@@ -43,7 +58,8 @@ async fn test_app() -> (Router, Arc<lab::dispatch::logs::types::LogSystem>) {
     let logs_system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .expect("log system");
-    let state = lab::api::state::AppState::new().with_log_system(Arc::clone(&logs_system));
+    let state = lab::api::state::AppState::from_registry(logs_registry())
+        .with_log_system(Arc::clone(&logs_system));
     (
         lab::api::router::build_router_with_bearer(state, None, None),
         logs_system,

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -202,3 +202,29 @@ async fn logs_mcp_tail_matches_api_query_semantics() {
     assert_eq!(api_value, mcp_value);
     lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
+
+#[tokio::test]
+async fn logs_routes_respect_runtime_service_filtering() {
+    let logs_system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .expect("log system");
+    let state = lab::api::state::AppState::from_registry(lab::registry::ToolRegistry::new())
+        .with_log_system(logs_system);
+    let app = lab::api::router::build_router_with_bearer(state, None, None);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/logs")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"action":"logs.search","params":{"query":{}}}).to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/lab/tests/logs_cli.rs
+++ b/crates/lab/tests/logs_cli.rs
@@ -3,6 +3,10 @@ use clap::Parser;
 use lab::cli::Cli;
 use lab::dispatch::logs::types::{LogLevel, LogQuery, RawLogEvent, Subsystem};
 
+mod support;
+
+use support::log_system::{InstalledLogSystemGuard, test_lock};
+
 fn raw_gateway_event(message: &str) -> RawLogEvent {
     RawLogEvent {
         ts: Some(1_713_225_600_000),
@@ -55,6 +59,9 @@ fn logs_cli_parses_local_search() {
 
 #[tokio::test]
 async fn logs_local_search_uses_shared_dispatch_contract() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .expect("runtime");
@@ -74,5 +81,7 @@ async fn logs_local_search_uses_shared_dispatch_contract() {
     .await
     .expect("search response");
 
-    assert!(value.get("events").is_some());
+    let events = value["events"].as_array().expect("events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["message"], "local cli query");
 }

--- a/crates/lab/tests/logs_cli.rs
+++ b/crates/lab/tests/logs_cli.rs
@@ -1,0 +1,78 @@
+use clap::Parser;
+
+use lab::cli::Cli;
+use lab::dispatch::logs::types::{LogLevel, LogQuery, RawLogEvent, Subsystem};
+
+fn raw_gateway_event(message: &str) -> RawLogEvent {
+    RawLogEvent {
+        ts: Some(1_713_225_600_000),
+        level: Some("warn".to_string()),
+        subsystem: Some("gateway".to_string()),
+        surface: Some("api".to_string()),
+        action: Some("gateway.list".to_string()),
+        message: message.to_string(),
+        request_id: Some("req-gateway".to_string()),
+        session_id: None,
+        correlation_id: None,
+        trace_id: None,
+        span_id: None,
+        instance: Some("default".to_string()),
+        auth_flow: None,
+        outcome_kind: Some("ok".to_string()),
+        fields_json: serde_json::json!({"route":"gateway.list"}),
+        source_kind: None,
+        source_node_id: None,
+        source_device_id: None,
+        ingest_path: None,
+        upstream_event_id: None,
+    }
+}
+
+#[test]
+fn logs_cli_parses_existing_fleet_search() {
+    let cli = Cli::try_parse_from(["lab", "logs", "search", "node-a", "timeout"])
+        .expect("fleet search parses");
+    assert!(matches!(cli.command, lab::cli::Command::Logs(_)));
+}
+
+#[test]
+fn logs_cli_parses_local_search() {
+    let cli = Cli::try_parse_from([
+        "lab",
+        "logs",
+        "local",
+        "search",
+        "--subsystem",
+        "gateway",
+        "--level",
+        "warn",
+        "--limit",
+        "10",
+    ])
+    .expect("local search parses");
+    assert!(matches!(cli.command, lab::cli::Command::Logs(_)));
+}
+
+#[tokio::test]
+async fn logs_local_search_uses_shared_dispatch_contract() {
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .expect("runtime");
+    system
+        .ingest(raw_gateway_event("local cli query"))
+        .await
+        .expect("seed event");
+
+    let value = lab::cli::logs::run_local_search_for_test(
+        system,
+        LogQuery {
+            subsystems: vec![Subsystem::Gateway],
+            levels: vec![LogLevel::Warn],
+            ..LogQuery::default()
+        },
+    )
+    .await
+    .expect("search response");
+
+    assert!(value.get("events").is_some());
+}

--- a/crates/lab/tests/logs_cli.rs
+++ b/crates/lab/tests/logs_cli.rs
@@ -70,13 +70,16 @@ async fn logs_local_search_uses_shared_dispatch_contract() {
         .await
         .expect("seed event");
 
-    let value = lab::cli::logs::run_local_search_for_test(
-        system,
-        LogQuery {
-            subsystems: vec![Subsystem::Gateway],
-            levels: vec![LogLevel::Warn],
-            ..LogQuery::default()
-        },
+    let value = lab::dispatch::logs::dispatch::dispatch_with_system(
+        &system,
+        "logs.search",
+        serde_json::json!({
+            "query": LogQuery {
+                subsystems: vec![Subsystem::Gateway],
+                levels: vec![LogLevel::Warn],
+                ..LogQuery::default()
+            }
+        }),
     )
     .await
     .expect("search response");

--- a/crates/lab/tests/logs_dispatch.rs
+++ b/crates/lab/tests/logs_dispatch.rs
@@ -309,8 +309,8 @@ async fn logs_stats_returns_retention_metadata() {
         .unwrap();
 
     let value = lab::dispatch::logs::dispatch("logs.stats", serde_json::json!({}))
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     assert!(value.get("on_disk_bytes").is_some());
 }
@@ -401,15 +401,16 @@ async fn store_search_text_matches_request_identifiers() {
         })
         .await
         .unwrap();
-    store.insert(&event_with(
-        "evt-request-id",
-        1_713_225_600_000,
-        lab::dispatch::logs::types::Subsystem::Gateway,
-        lab::dispatch::logs::types::LogLevel::Warn,
-        "gateway warning",
-    ))
-    .await
-    .unwrap();
+    store
+        .insert(&event_with(
+            "evt-request-id",
+            1_713_225_600_000,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Warn,
+            "gateway warning",
+        ))
+        .await
+        .unwrap();
 
     let result = store
         .search(lab::dispatch::logs::types::LogQuery {

--- a/crates/lab/tests/logs_dispatch.rs
+++ b/crates/lab/tests/logs_dispatch.rs
@@ -1,0 +1,361 @@
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static LOG_SYSTEM_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_log_system_tests() -> MutexGuard<'static, ()> {
+    LOG_SYSTEM_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn event_with(
+    event_id: &str,
+    ts: i64,
+    subsystem: lab::dispatch::logs::types::Subsystem,
+    level: lab::dispatch::logs::types::LogLevel,
+    message: &str,
+) -> lab::dispatch::logs::types::LogEvent {
+    let mut event = lab::dispatch::logs::types::LogEvent::fixture();
+    event.event_id = event_id.to_string();
+    event.ts = ts;
+    event.subsystem = subsystem;
+    event.level = level;
+    event.message = message.to_string();
+    event
+}
+
+fn raw_gateway_event(message: &str) -> lab::dispatch::logs::types::RawLogEvent {
+    lab::dispatch::logs::types::RawLogEvent {
+        ts: Some(1_713_225_600_000),
+        level: Some("warn".to_string()),
+        subsystem: Some("gateway".to_string()),
+        surface: Some("api".to_string()),
+        action: Some("gateway.list".to_string()),
+        message: message.to_string(),
+        request_id: Some("req-gateway".to_string()),
+        session_id: None,
+        correlation_id: None,
+        trace_id: None,
+        span_id: None,
+        instance: Some("default".to_string()),
+        auth_flow: None,
+        outcome_kind: Some("ok".to_string()),
+        fields_json: serde_json::json!({"route":"gateway.list"}),
+        source_kind: None,
+        source_node_id: None,
+        source_device_id: None,
+        ingest_path: None,
+        upstream_event_id: None,
+    }
+}
+
+fn raw_event_with_bearer_token() -> lab::dispatch::logs::types::RawLogEvent {
+    let mut event = raw_gateway_event("Authorization: Bearer secret-value");
+    event.fields_json = serde_json::json!({"authorization":"Bearer secret-value"});
+    event
+}
+
+fn unique_store_path(prefix: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{}-{unique}.db", std::process::id()))
+}
+
+#[test]
+fn default_registry_includes_logs_service() {
+    let registry = lab::registry::build_default_registry();
+    let service = registry.service("logs").expect("logs service registered");
+    assert_eq!(service.status, "available");
+}
+
+#[tokio::test]
+async fn logs_dispatch_help_and_schema_exist() {
+    let help = lab::dispatch::logs::dispatch("help", serde_json::json!({}))
+        .await
+        .unwrap();
+    let schema =
+        lab::dispatch::logs::dispatch("schema", serde_json::json!({"action":"logs.search"}))
+            .await
+            .unwrap();
+
+    assert!(help.is_object());
+    assert!(schema.is_object());
+}
+
+#[test]
+fn log_system_bootstrap_is_single_owner() {
+    let _lock = lock_log_system_tests();
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+    let runtime = lab::dispatch::logs::client::bootstrap_log_system_for_test();
+    assert!(runtime.is_ok());
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}
+
+#[tokio::test]
+async fn local_live_commands_fail_cleanly_without_long_lived_runtime() {
+    let _lock = lock_log_system_tests();
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+    let error = lab::dispatch::logs::dispatch("logs.tail", serde_json::json!({"limit": 10}))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "internal_error");
+}
+
+#[test]
+fn log_event_serialization_preserves_future_ingest_fields() {
+    let event = lab::dispatch::logs::types::LogEvent::fixture();
+    let json = serde_json::to_value(&event).unwrap();
+    assert!(json.get("source_kind").is_some());
+    assert!(json.get("source_device_id").is_some());
+    assert!(json.get("ingest_path").is_some());
+}
+
+#[test]
+fn subsystem_enum_includes_local_master_taxonomy() {
+    assert_eq!(
+        lab::dispatch::logs::types::Subsystem::Gateway.as_str(),
+        "gateway"
+    );
+    assert_eq!(
+        lab::dispatch::logs::types::Subsystem::OauthRelay.as_str(),
+        "oauth_relay"
+    );
+    assert_eq!(
+        lab::dispatch::logs::types::Subsystem::AuthUpstream.as_str(),
+        "auth_upstream"
+    );
+}
+
+#[tokio::test]
+async fn store_search_filters_by_subsystem_and_level() {
+    let store =
+        lab::dispatch::logs::store::open_store_for_test(lab::dispatch::logs::types::LogRetention {
+            max_age_days: 30,
+            max_bytes: 1024 * 1024,
+        })
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-gateway-warn",
+            1_713_225_600_000,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Warn,
+            "gateway warning",
+        ))
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-api-info",
+            1_713_225_601_000,
+            lab::dispatch::logs::types::Subsystem::Api,
+            lab::dispatch::logs::types::LogLevel::Info,
+            "api info",
+        ))
+        .await
+        .unwrap();
+
+    let result = store
+        .search(lab::dispatch::logs::types::LogQuery {
+            subsystems: vec![lab::dispatch::logs::types::Subsystem::Gateway],
+            levels: vec![lab::dispatch::logs::types::LogLevel::Warn],
+            ..lab::dispatch::logs::types::LogQuery::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.events.len(), 1);
+}
+
+#[tokio::test]
+async fn retention_enforces_age_and_size_limits() {
+    let store =
+        lab::dispatch::logs::store::open_store_for_test(lab::dispatch::logs::types::LogRetention {
+            max_age_days: 7,
+            max_bytes: 1024,
+        })
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-old",
+            1,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Warn,
+            &"x".repeat(2048),
+        ))
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-new",
+            4_102_444_800_000,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Info,
+            "recent event",
+        ))
+        .await
+        .unwrap();
+
+    store.run_maintenance().await.unwrap();
+    let stats = store.stats().await.unwrap();
+
+    assert!(stats.on_disk_bytes <= 1024);
+    assert!(stats.oldest_retained_ts.unwrap_or_default() >= 4_102_444_800_000);
+}
+
+#[tokio::test]
+async fn ingest_redacts_sensitive_fields_before_store_and_stream() {
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .unwrap();
+    system.ingest(raw_event_with_bearer_token()).await.unwrap();
+
+    let stored = system
+        .search(lab::dispatch::logs::types::LogQuery::default())
+        .await
+        .unwrap();
+    assert!(!stored.events[0].message.contains("Bearer "));
+    assert!(
+        !stored.events[0]
+            .fields_json
+            .to_string()
+            .contains("secret-value")
+    );
+}
+
+#[tokio::test]
+async fn stream_subscribers_receive_new_events_without_querying_store() {
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .unwrap();
+    let mut sub = system
+        .subscribe(lab::dispatch::logs::types::StreamSubscription::default())
+        .await
+        .unwrap();
+    system.ingest(raw_gateway_event("stream me")).await.unwrap();
+
+    let next = sub.recv().await.unwrap();
+    assert_eq!(
+        next.subsystem,
+        lab::dispatch::logs::types::Subsystem::Gateway
+    );
+}
+
+#[tokio::test]
+async fn full_ingest_queue_records_overflow_without_blocking_caller() {
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(1)
+        .await
+        .unwrap();
+    for _ in 0..100 {
+        drop(system.try_ingest(raw_gateway_event("queue pressure")));
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let stats = system.stats().await.unwrap();
+    assert!(stats.dropped_event_count > 0);
+}
+
+#[tokio::test]
+async fn logs_search_returns_filtered_results() {
+    let _lock = lock_log_system_tests();
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .unwrap();
+    system.ingest(raw_gateway_event("search me")).await.unwrap();
+
+    let value = lab::dispatch::logs::dispatch(
+        "logs.search",
+        serde_json::json!({
+            "query": { "subsystems": ["gateway"], "levels": ["warn"] }
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert!(value.get("events").is_some());
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}
+
+#[tokio::test]
+async fn logs_stats_returns_retention_metadata() {
+    let _lock = lock_log_system_tests();
+    let _system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .unwrap();
+
+    let value = lab::dispatch::logs::dispatch("logs.stats", serde_json::json!({}))
+        .await
+        .unwrap();
+
+    assert!(value.get("on_disk_bytes").is_some());
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}
+
+#[tokio::test]
+async fn logs_tail_returns_bounded_follow_up_window() {
+    let _lock = lock_log_system_tests();
+    let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
+        .await
+        .unwrap();
+    system.ingest(raw_gateway_event("tail me")).await.unwrap();
+
+    let value = lab::dispatch::logs::dispatch(
+        "logs.tail",
+        serde_json::json!({
+            "after_ts": 0,
+            "limit": 50
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert!(value.get("events").is_some());
+    assert!(value.get("next_cursor").is_some());
+    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+}
+
+#[tokio::test]
+async fn local_logs_persist_across_restart() {
+    let path = unique_store_path("lab-local-logs-persist");
+    let writer = lab::dispatch::logs::client::bootstrap_running_log_system(
+        path.clone(),
+        lab::dispatch::logs::types::LogRetention::default(),
+        16,
+        16,
+    )
+    .await
+    .expect("writer runtime");
+    writer
+        .ingest(raw_gateway_event("persisted across restart"))
+        .await
+        .expect("seed event");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let reader = lab::dispatch::logs::client::bootstrap_store_backed_log_system(
+        path,
+        lab::dispatch::logs::types::LogRetention::default(),
+    )
+    .await
+    .expect("reader runtime");
+
+    let result = reader
+        .search(lab::dispatch::logs::types::LogQuery {
+            text: Some("persisted".to_string()),
+            ..lab::dispatch::logs::types::LogQuery::default()
+        })
+        .await
+        .expect("search after restart");
+
+    assert_eq!(result.events.len(), 1);
+    assert!(
+        result.events[0]
+            .message
+            .contains("persisted across restart")
+    );
+}

--- a/crates/lab/tests/logs_dispatch.rs
+++ b/crates/lab/tests/logs_dispatch.rs
@@ -321,6 +321,90 @@ async fn logs_tail_returns_bounded_follow_up_window() {
 }
 
 #[tokio::test]
+async fn logs_tail_honors_since_event_id_cursor() {
+    let store =
+        lab::dispatch::logs::store::open_store_for_test(lab::dispatch::logs::types::LogRetention {
+            max_age_days: 30,
+            max_bytes: 1024 * 1024,
+        })
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-1",
+            10,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Info,
+            "before cursor",
+        ))
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-2",
+            20,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Info,
+            "cursor",
+        ))
+        .await
+        .unwrap();
+    store
+        .insert(&event_with(
+            "evt-3",
+            30,
+            lab::dispatch::logs::types::Subsystem::Gateway,
+            lab::dispatch::logs::types::LogLevel::Info,
+            "after cursor",
+        ))
+        .await
+        .unwrap();
+
+    let result = store
+        .tail(lab::dispatch::logs::types::LogTailRequest {
+            since_event_id: Some("evt-2".to_string()),
+            limit: Some(10),
+            ..lab::dispatch::logs::types::LogTailRequest::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].event_id, "evt-3");
+}
+
+#[tokio::test]
+async fn store_search_text_matches_request_identifiers() {
+    let store =
+        lab::dispatch::logs::store::open_store_for_test(lab::dispatch::logs::types::LogRetention {
+            max_age_days: 30,
+            max_bytes: 1024 * 1024,
+        })
+        .await
+        .unwrap();
+    store.insert(&event_with(
+        "evt-request-id",
+        1_713_225_600_000,
+        lab::dispatch::logs::types::Subsystem::Gateway,
+        lab::dispatch::logs::types::LogLevel::Warn,
+        "gateway warning",
+    ))
+    .await
+    .unwrap();
+
+    let result = store
+        .search(lab::dispatch::logs::types::LogQuery {
+            text: Some("req-fixture".to_string()),
+            ..lab::dispatch::logs::types::LogQuery::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].event_id, "evt-request-id");
+}
+
+#[tokio::test]
 async fn local_logs_persist_across_restart() {
     let path = unique_store_path("lab-local-logs-persist");
     let writer = lab::dispatch::logs::client::bootstrap_running_log_system(

--- a/crates/lab/tests/logs_dispatch.rs
+++ b/crates/lab/tests/logs_dispatch.rs
@@ -1,14 +1,8 @@
-use std::sync::Mutex;
-use std::sync::MutexGuard;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-static LOG_SYSTEM_TEST_LOCK: Mutex<()> = Mutex::new(());
+mod support;
 
-fn lock_log_system_tests() -> MutexGuard<'static, ()> {
-    LOG_SYSTEM_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
+use support::log_system::{InstalledLogSystemGuard, SqlitePathCleanup, test_lock};
 
 fn event_with(
     event_id: &str,
@@ -87,18 +81,19 @@ async fn logs_dispatch_help_and_schema_exist() {
 }
 
 #[test]
-fn log_system_bootstrap_is_single_owner() {
-    let _lock = lock_log_system_tests();
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+fn log_system_bootstrap_installs_runtime() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let runtime = lab::dispatch::logs::client::bootstrap_log_system_for_test();
     assert!(runtime.is_ok());
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
 
 #[tokio::test]
 async fn local_live_commands_fail_cleanly_without_long_lived_runtime() {
-    let _lock = lock_log_system_tests();
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let error = lab::dispatch::logs::dispatch("logs.tail", serde_json::json!({"limit": 10}))
         .await
         .unwrap_err();
@@ -211,6 +206,9 @@ async fn retention_enforces_age_and_size_limits() {
 
 #[tokio::test]
 async fn ingest_redacts_sensitive_fields_before_store_and_stream() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .unwrap();
@@ -231,6 +229,9 @@ async fn ingest_redacts_sensitive_fields_before_store_and_stream() {
 
 #[tokio::test]
 async fn stream_subscribers_receive_new_events_without_querying_store() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .unwrap();
@@ -249,6 +250,9 @@ async fn stream_subscribers_receive_new_events_without_querying_store() {
 
 #[tokio::test]
 async fn full_ingest_queue_records_overflow_without_blocking_caller() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(1)
         .await
         .unwrap();
@@ -256,14 +260,26 @@ async fn full_ingest_queue_records_overflow_without_blocking_caller() {
         drop(system.try_ingest(raw_gateway_event("queue pressure")));
     }
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    let stats = system.stats().await.unwrap();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    let stats = loop {
+        let stats = system.stats().await.unwrap();
+        if stats.dropped_event_count > 0 {
+            break stats;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "never observed dropped events: {stats:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    };
     assert!(stats.dropped_event_count > 0);
 }
 
 #[tokio::test]
 async fn logs_search_returns_filtered_results() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .unwrap();
@@ -278,28 +294,32 @@ async fn logs_search_returns_filtered_results() {
     .await
     .unwrap();
 
-    assert!(value.get("events").is_some());
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
+    let events = value["events"].as_array().expect("events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["message"], "search me");
 }
 
 #[tokio::test]
 async fn logs_stats_returns_retention_metadata() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let _system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .unwrap();
 
     let value = lab::dispatch::logs::dispatch("logs.stats", serde_json::json!({}))
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert!(value.get("on_disk_bytes").is_some());
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
 
 #[tokio::test]
 async fn logs_tail_returns_bounded_follow_up_window() {
-    let _lock = lock_log_system_tests();
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let system = lab::dispatch::logs::client::bootstrap_running_log_system_for_test(16)
         .await
         .unwrap();
@@ -317,7 +337,6 @@ async fn logs_tail_returns_bounded_follow_up_window() {
 
     assert!(value.get("events").is_some());
     assert!(value.get("next_cursor").is_some());
-    lab::dispatch::logs::client::clear_installed_log_system_for_test();
 }
 
 #[tokio::test]
@@ -406,7 +425,11 @@ async fn store_search_text_matches_request_identifiers() {
 
 #[tokio::test]
 async fn local_logs_persist_across_restart() {
+    let mut lock = test_lock();
+    let _lock = lock.write().expect("log system test lock");
+    let _installed = InstalledLogSystemGuard::new();
     let path = unique_store_path("lab-local-logs-persist");
+    let _cleanup = SqlitePathCleanup::new(path.clone());
     let writer = lab::dispatch::logs::client::bootstrap_running_log_system(
         path.clone(),
         lab::dispatch::logs::types::LogRetention::default(),

--- a/crates/lab/tests/support/log_system.rs
+++ b/crates/lab/tests/support/log_system.rs
@@ -53,11 +53,12 @@ impl Drop for SqlitePathCleanup {
 
 #[allow(dead_code)]
 pub(crate) fn cleanup_sqlite_path(path: &Path) {
-    let sidecars = [
-        path.to_path_buf(),
-        PathBuf::from(format!("{}-wal", path.display())),
-        PathBuf::from(format!("{}-shm", path.display())),
-    ];
+    let with_suffix = |suffix: &str| -> PathBuf {
+        let mut os = path.as_os_str().to_os_string();
+        os.push(suffix);
+        PathBuf::from(os)
+    };
+    let sidecars = [path.to_path_buf(), with_suffix("-wal"), with_suffix("-shm")];
 
     for candidate in sidecars {
         match fs::remove_file(&candidate) {

--- a/crates/lab/tests/support/log_system.rs
+++ b/crates/lab/tests/support/log_system.rs
@@ -1,0 +1,69 @@
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use fd_lock::RwLock;
+
+pub(crate) fn test_lock() -> RwLock<File> {
+    let lock_dir = std::env::temp_dir().join("lab-test-locks");
+    fs::create_dir_all(&lock_dir).expect("create lab test lock dir");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_dir.join("log-system.lock"))
+        .expect("open log system test lock");
+    RwLock::new(lock_file)
+}
+
+pub(crate) struct InstalledLogSystemGuard;
+
+impl InstalledLogSystemGuard {
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        lab::dispatch::logs::client::clear_installed_log_system_for_test();
+        Self
+    }
+}
+
+impl Drop for InstalledLogSystemGuard {
+    fn drop(&mut self) {
+        lab::dispatch::logs::client::clear_installed_log_system_for_test();
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct SqlitePathCleanup {
+    path: PathBuf,
+}
+
+#[allow(dead_code)]
+impl SqlitePathCleanup {
+    #[must_use]
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for SqlitePathCleanup {
+    fn drop(&mut self) {
+        cleanup_sqlite_path(&self.path);
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn cleanup_sqlite_path(path: &Path) {
+    let sidecars = [
+        path.to_path_buf(),
+        PathBuf::from(format!("{}-wal", path.display())),
+        PathBuf::from(format!("{}-shm", path.display())),
+    ];
+
+    for candidate in sidecars {
+        match fs::remove_file(&candidate) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("remove {}: {error}", candidate.display()),
+        }
+    }
+}

--- a/crates/lab/tests/support/log_system.rs
+++ b/crates/lab/tests/support/log_system.rs
@@ -47,12 +47,14 @@ impl SqlitePathCleanup {
 
 impl Drop for SqlitePathCleanup {
     fn drop(&mut self) {
-        cleanup_sqlite_path(&self.path);
+        if let Err(error) = cleanup_sqlite_path(&self.path) {
+            eprintln!("failed to clean up {}: {error}", self.path.display());
+        }
     }
 }
 
 #[allow(dead_code)]
-pub(crate) fn cleanup_sqlite_path(path: &Path) {
+pub(crate) fn cleanup_sqlite_path(path: &Path) -> std::io::Result<()> {
     let with_suffix = |suffix: &str| -> PathBuf {
         let mut os = path.as_os_str().to_os_string();
         os.push(suffix);
@@ -64,7 +66,9 @@ pub(crate) fn cleanup_sqlite_path(path: &Path) {
         match fs::remove_file(&candidate) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => panic!("remove {}: {error}", candidate.display()),
+            Err(error) => return Err(error),
         }
     }
+
+    Ok(())
 }

--- a/crates/lab/tests/support/mod.rs
+++ b/crates/lab/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod log_system;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -168,11 +168,24 @@ Commands:
 
 ## `lab logs`
 
-`lab logs` is the fleet log query command group. It also routes to the configured master.
+`lab logs` now has two additive paths:
+
+- fleet search routed to the configured master
+- local-master log search and bounded follow-up queries against the embedded runtime store
 
 Commands:
 
 - `lab logs search <device_id> <query>`
+- `lab logs local search [--subsystem <name>] [--level <level>] [--text <needle>] [--limit <n>]`
+- `lab logs local tail [--after-ts <unix_ms>] [--since-event-id <id>] [--limit <n>]`
+- `lab logs local stats`
+
+Rules:
+
+- `lab logs search <device_id> <query>` keeps the existing fleet behavior and continues to use `POST /v1/device/logs/search`
+- `lab logs local *` is strictly local-master and uses the shared `dispatch::logs` contract
+- true live streaming is not a CLI capability in v1; operators should use `GET /v1/logs/stream` or the gateway-admin `/logs` page
+- CLI local log commands stay thin adapters; normalization, retention, search, and tail semantics are owned by `dispatch::logs`
 
 ## Install and Uninstall
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -257,7 +257,7 @@ Full details in [OAUTH.md](./OAUTH.md).
 |----------|----------|-------------|
 | `LAB_AUTH_MODE` | no | `bearer` or `oauth`. Defaults to `bearer`. |
 | `LAB_MCP_HTTP_TOKEN` | bearer mode only | Static bearer token for protected HTTP routes. |
-| `LAB_PUBLIC_URL` | oauth mode | Public base URL for metadata, JWT issuer/audience, callback construction, and allowed-host derivation. |
+| `LAB_PUBLIC_URL` | oauth mode | Public base URL for metadata, JWT issuer/audience, callback construction, and allowed-host derivation. Path-prefixed deployments are supported. |
 | `LAB_AUTH_SQLITE_PATH` | no | Override path for the auth SQLite database. Defaults to `~/.lab/auth.db`. |
 | `LAB_AUTH_KEY_PATH` | no | Override path for the persisted JWT signing key. Defaults to `~/.lab/auth-jwt.pem`. |
 | `LAB_GOOGLE_CLIENT_ID` | oauth mode | Google OAuth client ID. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -57,6 +57,36 @@ Value precedence at point of use (highest wins):
 | `filter` | `LAB_LOG` | `"lab=info,lab_apis=warn"` | Tracing filter directive |
 | `format` | `LAB_LOG_FORMAT` | `"text"` | Log format: `"text"` or `"json"` |
 
+### `[local_logs]`
+
+Local-master runtime log store preferences.
+
+| Key | Env override | Default | Description |
+|-----|-------------|---------|-------------|
+| `store_path` | `LAB_LOCAL_LOGS_STORE_PATH` | `~/.lab/logs.db` | Embedded SQLite store path for persisted local-master logs |
+| `retention_days` | `LAB_LOCAL_LOGS_RETENTION_DAYS` | `7` | Time-based retention window in days |
+| `max_bytes` | `LAB_LOCAL_LOGS_MAX_BYTES` | `268435456` | Size-based retention limit in logical stored bytes |
+| `queue_capacity` | `LAB_LOCAL_LOGS_QUEUE_CAPACITY` | `1024` | Bounded ingest queue size for the long-lived runtime |
+| `subscriber_capacity` | `LAB_LOCAL_LOGS_SUBSCRIBER_CAPACITY` | `256` | Bounded live fanout ring size for SSE subscribers |
+
+Example:
+
+```toml
+[local_logs]
+store_path = "/var/lib/lab/logs.db"
+retention_days = 14
+max_bytes = 536870912
+queue_capacity = 2048
+subscriber_capacity = 512
+```
+
+Rules:
+
+- retention is whichever limit hits first: age or size
+- oldest events are evicted first by the shared local log subsystem
+- these knobs affect the local-master runtime log store only; they do not change fleet device log retention
+- the browser log console and `lab logs local *` commands both read this same local store contract
+
 ### `[mcp]`
 
 | Key | Env override | Default | Description |

--- a/docs/LOCAL_LOGS.md
+++ b/docs/LOCAL_LOGS.md
@@ -1,0 +1,124 @@
+# Local Logs
+
+`lab` now has a dedicated local-master runtime log subsystem.
+
+This is separate from fleet device log search:
+
+- fleet device log search remains `lab logs search <device> <query>` and `POST /v1/device/logs/search`
+- local-master runtime logs live in the shared `dispatch::logs` subsystem and power `lab logs local *`, MCP `logs.*`, `POST /v1/logs`, `GET /v1/logs/stream`, and the gateway-admin `/logs` page
+
+## Scope
+
+The v1 scope is the current master process only.
+
+Included:
+
+- persistent indexed local history across restarts
+- bounded search and tail access from CLI, MCP, and API
+- true live streaming over HTTP SSE
+- one shared normalized event model across adapters
+
+Not included:
+
+- fleet-wide device aggregation
+- remote syslog ingestion
+- long-lived MCP streaming
+
+## Surface Map
+
+CLI:
+
+- `lab logs local search`
+- `lab logs local tail`
+- `lab logs local stats`
+
+MCP:
+
+- `logs.search`
+- `logs.tail`
+- `logs.stats`
+
+HTTP:
+
+- `POST /v1/logs`
+- `GET /v1/logs/stream`
+
+Web UI:
+
+- gateway-admin `/logs`
+
+## Runtime Model
+
+The shared `LogSystem` runtime owns:
+
+- the bounded ingest queue
+- normalization and redaction
+- the embedded SQLite-backed store
+- retention enforcement
+- the in-process live subscriber hub used by SSE
+
+`main.rs` and `lab serve` bootstrap the long-lived runtime once. One-shot CLI commands open the same on-disk store for bounded queries instead of constructing their own partial live runtime.
+
+## Query And Streaming Rules
+
+- historical search is store-backed
+- `logs.tail` is bounded follow-up access, not true streaming
+- true live streaming is HTTP SSE only
+- hosted same-origin browser session auth is the supported v1 SSE access mode
+- standalone bearer mode does not get implicit browser EventSource support in v1
+
+## Retention
+
+Retention is enforced by the shared subsystem and is whichever limit hits first:
+
+- `retention_days`
+- `max_bytes`
+
+Oldest events are evicted first.
+
+Operators can inspect retention state through:
+
+- `lab logs local stats`
+- `logs.stats`
+- `POST /v1/logs` with `{"action":"logs.stats"}`
+- the gateway-admin `/logs` page
+
+## Configuration
+
+`[local_logs]` in `config.toml` or env overrides:
+
+- `LAB_LOCAL_LOGS_STORE_PATH`
+- `LAB_LOCAL_LOGS_RETENTION_DAYS`
+- `LAB_LOCAL_LOGS_MAX_BYTES`
+- `LAB_LOCAL_LOGS_QUEUE_CAPACITY`
+- `LAB_LOCAL_LOGS_SUBSCRIBER_CAPACITY`
+
+See [CONFIG.md](./CONFIG.md) for the canonical key table.
+
+## Redaction
+
+Redaction happens before persistence and before live fanout.
+
+The local store and SSE stream must not expose:
+
+- bearer tokens
+- cookies
+- authorization headers
+- raw OAuth token material
+- secret env values
+
+See [OBSERVABILITY.md](./OBSERVABILITY.md) for the canonical redaction policy.
+
+## Future Fleet And Syslog Seams
+
+The normalized event model keeps these reserved fields intentionally:
+
+- `source_kind`
+- `source_node_id`
+- `source_device_id`
+- `ingest_path`
+- `upstream_event_id`
+
+These are not accidental over-abstraction.
+
+They exist so future remote device and syslog ingestion can reuse the same store, search, and UI contracts without schema churn or a breaking API redesign.

--- a/docs/LOCAL_LOGS.md
+++ b/docs/LOCAL_LOGS.md
@@ -31,6 +31,7 @@ CLI:
 - `lab logs local search`
 - `lab logs local tail`
 - `lab logs local stats`
+- `lab logs local stream` — rejected with guidance; use `GET /v1/logs/stream` or `lab logs local tail`
 
 MCP:
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -19,7 +19,7 @@ OAuth mode is configured through env vars and/or `config.toml`. Env vars take pr
 |----------|----------|-------------|
 | `LAB_AUTH_MODE` | no | `bearer` or `oauth`. Defaults to `bearer`. |
 | `LAB_MCP_HTTP_TOKEN` | bearer mode | Static bearer token for protected HTTP routes. |
-| `LAB_PUBLIC_URL` | oauth mode | Public base URL for metadata, callback construction, and JWT issuer/audience. |
+| `LAB_PUBLIC_URL` | oauth mode | Public base URL for metadata, callback construction, and JWT issuer/audience. Path-prefixed deployments are supported. |
 | `LAB_GOOGLE_CLIENT_ID` | oauth mode | Google OAuth client ID. |
 | `LAB_GOOGLE_CLIENT_SECRET` | oauth mode | Google OAuth client secret. |
 | `LAB_AUTH_SQLITE_PATH` | no | Override path for the SQLite auth database. |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -103,6 +103,18 @@ Optional when applicable:
 - `operation = "health"`
 - `kind` on failure
 
+### Local Log Ingest Boundary
+
+The local-master `logs` subsystem is a shared observability consumer, not a replacement for dispatch logging.
+
+Rules:
+
+- `main.rs` owns tracing setup and attaches the local log ingest layer once
+- normalization and redaction happen before persistence and before SSE fanout
+- the local store is fed from tracing-aware runtime events, not by scraping terminal output
+- `/v1/logs/stream` is live push from the in-process subscriber hub, not database tailing
+- reserved remote-ingest fields remain in the event model intentionally so future fleet and syslog ingest can converge on the same query contract without schema churn
+
 ### Device Runtime Ingest
 
 Device-runtime HTTP handlers participate in the same API dispatch contract.
@@ -274,6 +286,8 @@ Additional rules:
 - do not log query parameters when they contain secrets
 - do not echo secrets in doctor output, prompts, or TUI flows
 - do not log raw discovered MCP config file contents; only metadata such as path, source, and hash are acceptable
+- do not persist bearer tokens, cookies, authorization headers, or raw secret material in the local log store
+- do not fan out unredacted structured fields to live SSE subscribers
 
 ## Level Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ The docs are split by topic so contributors do not have to recover architecture,
 - Refer to [OAUTH.md](./OAUTH.md) for bearer vs OAuth mode selection, Google-backed authorization flow, lab-issued JWT behavior, and callback-forwarding constraints.
 - Use [GATEWAY.md](./GATEWAY.md) when managing upstream MCP gateways over CLI, MCP, or `/v1/gateway`.
 - Use [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md), [FLEET_LOGS.md](./FLEET_LOGS.md), and [DEPLOY.md](./DEPLOY.md) for the master/non-master fleet runtime, device inventory, and deployment model.
+- Use [LOCAL_LOGS.md](./LOCAL_LOGS.md) for the local-master runtime log store, `/v1/logs`, SSE streaming, and gateway-admin `/logs`.
 - See [UPSTREAM.md](./UPSTREAM.md) for upstream MCP gateway setup, configuration, tool merging, circuit breaker behavior, and resource proxying.
 - Consult [TRANSPORT.md](./TRANSPORT.md) for stdio and streamable HTTP transport configuration, middleware stack, and session management.
 - Use [OBSERVABILITY.md](./OBSERVABILITY.md) for the mandatory logging, correlation, redaction, and verification contract.
@@ -88,6 +89,8 @@ The docs are split by topic so contributors do not have to recover architecture,
   Master/non-master runtime roles, `/v1/device/*`, AI CLI inventory upload, queueing, and device OAuth relay.
 - [FLEET_LOGS.md](./FLEET_LOGS.md)
   Fleet log ingestion, queueing, search, and current storage limits.
+- [LOCAL_LOGS.md](./LOCAL_LOGS.md)
+  Local-master runtime logging: shared store, bounded search/tail actions, SSE streaming, retention, and future fleet/syslog seams.
 - [DEPLOY.md](./DEPLOY.md)
   Device-runtime deployment model for master and non-master machines.
 - [UPSTREAM.md](./UPSTREAM.md)
@@ -147,6 +150,7 @@ Use the smallest correct doc:
 - gateway control plane and exposure policy: [GATEWAY.md](./GATEWAY.md)
 - device runtime roles, fleet ingest, and master gating: [DEVICE_RUNTIME.md](./DEVICE_RUNTIME.md)
 - fleet log ingestion and search: [FLEET_LOGS.md](./FLEET_LOGS.md)
+- local-master runtime log store and SSE console: [LOCAL_LOGS.md](./LOCAL_LOGS.md)
 - deployment topology and rollout guidance: [DEPLOY.md](./DEPLOY.md)
 - upstream MCP proxy, circuit breaker, resource proxying: [UPSTREAM.md](./UPSTREAM.md)
 - transport configuration, middleware, sessions: [TRANSPORT.md](./TRANSPORT.md)


### PR DESCRIPTION
## Summary
- finish the shared local-master `logs` foundation across dispatch, CLI, API, MCP, config, docs, and runtime bootstrap
- add the gateway-admin `/logs` console with persisted query + live SSE timeline, filters, stats, and query-preview helpers
- preserve existing fleet `lab logs search <device> <query>` and `/v1/device/logs/search` behavior while adding local-master coverage and docs

## Verification
- `cargo test -p lab@0.3.4 logs_ -- --nocapture`
- `just test`
- `cargo fmt --all --check`
- `pnpm test` in `apps/gateway-admin`
- `pnpm exec tsc --noEmit` in `apps/gateway-admin`
- `pnpm build` in `apps/gateway-admin`
- `pnpm lint` in `apps/gateway-admin`

## Notes
- `just lint` still fails on broad pre-existing workspace Clippy debt outside the logs scope; the logs-specific subsystem files were cleaned up, but the repo-wide failure list remains dominated by unrelated modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared local‑master logs subsystem with a persisted SQLite store, search/tail/stats APIs, and live SSE streaming, plus an admin `/logs` console with a stable refresh window and paused buffer. Also hardens the admin client by rejecting empty 200 responses from logs endpoints to avoid silent errors.

- **New Features**
  - Shared `logs` service across dispatch, CLI, API, and MCP with a normalized event model and retention-backed store.
  - API: `POST /v1/logs` for `logs.search`, `logs.tail`, `logs.stats`; SSE at `GET /v1/logs/stream` (mounted only when `logs` is registered; OpenAPI documents the stream).
  - CLI: `lab logs local [search|tail|stats]`; legacy `lab logs search <device> <query>` unchanged. Stream handling cleaned up; SSE paths verified.
  - Admin UI: `/logs` console with live timeline (SSE), filters, stats, saved query state; links from Activity and the sidebar; stream status with pause/resume and jump-to-newest.
  - Runtime: tracing ingest layer attached once at startup; system bootstrapped in `serve`, configurable via `[local_logs]`. SQLite/auth error mapping and path handling simplified.

- **Migration**
  - SSE streaming requires same‑origin session auth; `EventSource` does not support standalone bearer mode in v1.
  - Optional `[local_logs]` config (defaults provided): `store_path`, `retention_days`, `max_bytes`, `queue_capacity`, `subscriber_capacity`.
  - Restart the master to initialize the store and enable live ingest; existing `POST /v1/device/logs/search` and CLI fleet search continue to work.

<sup>Written for commit 14c146809875c6c73d6cf79c41379c810bebdc5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local runtime log system with search, tail, stats and live SSE streaming (/v1/logs, /v1/logs/stream)
  * Browser logs console: filterable timeline, live updates, copy-query action
  * CLI: added lab logs local search|tail|stats subcommands
  * Gateway-admin: new Logs page and top-level Logs navigation link

* **Configuration**
  * New [local_logs] section for store path, retention, size and capacity

* **Documentation**
  * Added docs for local logs, config, CLI, retention, streaming and redaction rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->