### PR TITLE
feat(logs): rebuild dispatch/logs submodules lost in PR #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ logs/
 !apps/gateway-admin/app/(admin)/logs/page.tsx
 !apps/gateway-admin/components/logs/
 !apps/gateway-admin/components/logs/*.tsx
+!crates/lab/src/dispatch/logs/
+!crates/lab/src/dispatch/logs/*.rs
 backups/
 *.log
 *.pid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-scalar",
+ "uuid",
  "wiremock",
 ]
 
@@ -5393,6 +5394,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rand         = "0.9"
 rusqlite     = { version = "0.37", features = ["bundled"] }
 sha2         = "0.10"
 percent-encoding = "2.3"
+uuid         = { version = "1", features = ["v4", "serde"] }
 
 # http server (lab binary only)
 axum         = { version = "0.8", features = ["macros", "json", "tokio", "http2"] }

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -59,6 +59,7 @@ strip-ansi-escapes           = "0.2"
 rmcp.workspace               = true
 jsonwebtoken.workspace       = true
 rusqlite.workspace          = true
+uuid.workspace               = true
 
 axum.workspace               = true
 tower.workspace              = true

--- a/crates/lab/src/dispatch/logs/catalog.rs
+++ b/crates/lab/src/dispatch/logs/catalog.rs
@@ -1,0 +1,4 @@
+// Stub — replaced by Task 7.
+use lab_apis::core::action::ActionSpec;
+
+pub const ACTIONS: &[ActionSpec] = &[];

--- a/crates/lab/src/dispatch/logs/catalog.rs
+++ b/crates/lab/src/dispatch/logs/catalog.rs
@@ -1,4 +1,80 @@
-// Stub — replaced by Task 7.
-use lab_apis::core::action::ActionSpec;
+//! Action catalog for the local-master `logs` service.
+//!
+//! Single authoritative source for MCP, CLI, and API adapters. All actions
+//! are read-only — `destructive: false` everywhere.
 
-pub const ACTIONS: &[ActionSpec] = &[];
+use lab_apis::core::action::{ActionSpec, ParamSpec};
+
+pub const ACTIONS: &[ActionSpec] = &[
+    ActionSpec {
+        name: "help",
+        description: "Show this action catalog",
+        destructive: false,
+        returns: "Catalog",
+        params: &[],
+    },
+    ActionSpec {
+        name: "schema",
+        description: "Return the parameter schema for a named action",
+        destructive: false,
+        returns: "Schema",
+        params: &[ParamSpec {
+            name: "action",
+            ty: "string",
+            required: true,
+            description: "Action name to describe",
+        }],
+    },
+    ActionSpec {
+        name: "logs.search",
+        description: "Search persisted log events with filters",
+        destructive: false,
+        returns: "Value",
+        params: &[ParamSpec {
+            name: "query",
+            ty: "json",
+            required: false,
+            description: "LogQuery filter object (text, levels, subsystems, surfaces, ts range, …)",
+        }],
+    },
+    ActionSpec {
+        name: "logs.tail",
+        description: "Bounded follow-up read from the persisted store",
+        destructive: false,
+        returns: "Value",
+        params: &[
+            ParamSpec {
+                name: "after_ts",
+                ty: "integer",
+                required: false,
+                description: "Return events strictly after this ms-since-epoch timestamp",
+            },
+            ParamSpec {
+                name: "since_event_id",
+                ty: "string",
+                required: false,
+                description: "Return events strictly after this event_id cursor",
+            },
+            ParamSpec {
+                name: "limit",
+                ty: "integer",
+                required: false,
+                description: "Max events to return (default 500, max 10000)",
+            },
+        ],
+    },
+    ActionSpec {
+        name: "logs.stats",
+        description: "Return retention metadata and drop counters",
+        destructive: false,
+        returns: "Value",
+        params: &[],
+    },
+    ActionSpec {
+        name: "logs.stream",
+        description: "Live push is HTTP SSE only; dispatch returns guidance",
+        destructive: false,
+        returns: "Value",
+        params: &[],
+    },
+];

--- a/crates/lab/src/dispatch/logs/client.rs
+++ b/crates/lab/src/dispatch/logs/client.rs
@@ -1,55 +1,172 @@
-// Stub — replaced by Task 9.
-use std::path::PathBuf;
-use std::sync::Arc;
+//! LogSystem bootstrap + env/config resolution.
 
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use super::ingest::{self, IngestCounters};
+use super::store::LogStore;
+use super::stream::StreamHub;
 use super::types::{LogRetention, LogSystem};
 use crate::config::LabConfig;
 use crate::dispatch::error::ToolError;
+use crate::dispatch::helpers::env_non_empty;
 
-pub fn clear_installed_log_system_for_test() {}
+// ── Process-global installed LogSystem ────────────────────────────────────────
 
-pub fn require_system() -> Result<Arc<LogSystem>, ToolError> {
-    Err(ToolError::internal_message("log system stub (Task 9)"))
+static INSTALLED: OnceLock<RwLock<Option<Arc<LogSystem>>>> = OnceLock::new();
+
+fn installed_slot() -> &'static RwLock<Option<Arc<LogSystem>>> {
+    INSTALLED.get_or_init(|| RwLock::new(None))
 }
 
+fn install(system: Arc<LogSystem>) {
+    let slot = installed_slot();
+    let mut w = slot.write().expect("installed log system lock poisoned");
+    *w = Some(system);
+}
+
+pub fn require_system() -> Result<Arc<LogSystem>, ToolError> {
+    let slot = installed_slot();
+    let r = slot.read().expect("installed log system lock poisoned");
+    r.as_ref().cloned().ok_or_else(|| {
+        ToolError::internal_message("local log system is not installed in this process")
+    })
+}
+
+pub fn clear_installed_log_system_for_test() {
+    let slot = installed_slot();
+    let mut w = slot.write().expect("installed log system lock poisoned");
+    *w = None;
+}
+
+// ── Bootstraps ────────────────────────────────────────────────────────────────
+
 pub async fn bootstrap_running_log_system(
-    _p: PathBuf,
-    _r: LogRetention,
-    _q: usize,
-    _s: usize,
+    store_path: PathBuf,
+    retention: LogRetention,
+    queue_capacity: usize,
+    subscriber_capacity: usize,
 ) -> anyhow::Result<Arc<LogSystem>> {
-    unimplemented!("bootstrap_running_log_system stub (Task 9)")
+    let store = Arc::new(LogStore::open(store_path, retention).await?);
+    let hub = Arc::new(StreamHub::new(subscriber_capacity));
+    let (handle, counters) =
+        ingest::spawn_writer(Arc::clone(&store), Arc::clone(&hub), queue_capacity);
+
+    let system = Arc::new(LogSystem {
+        store,
+        hub,
+        ingest: handle,
+        counters,
+    });
+    install(Arc::clone(&system));
+    Ok(system)
 }
 
 pub async fn bootstrap_store_backed_log_system(
-    _p: PathBuf,
-    _r: LogRetention,
+    store_path: PathBuf,
+    retention: LogRetention,
 ) -> anyhow::Result<Arc<LogSystem>> {
-    unimplemented!("bootstrap_store_backed_log_system stub (Task 9)")
+    let store = Arc::new(LogStore::open(store_path, retention).await?);
+    let hub = Arc::new(StreamHub::new(1));
+    let counters = Arc::new(IngestCounters::new());
+    let handle = ingest::readonly_handle(Arc::clone(&counters));
+
+    Ok(Arc::new(LogSystem {
+        store,
+        hub,
+        ingest: handle,
+        counters,
+    }))
 }
 
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
 #[doc(hidden)]
-pub async fn bootstrap_running_log_system_for_test(_q: usize) -> anyhow::Result<Arc<LogSystem>> {
-    unimplemented!("bootstrap_running_log_system_for_test stub (Task 9)")
+pub async fn bootstrap_running_log_system_for_test(
+    queue_capacity: usize,
+) -> anyhow::Result<Arc<LogSystem>> {
+    let path = unique_test_store_path();
+    bootstrap_running_log_system(path, LogRetention::default(), queue_capacity, 32).await
 }
 
 #[doc(hidden)]
 pub fn bootstrap_log_system_for_test() -> anyhow::Result<Arc<LogSystem>> {
-    unimplemented!("bootstrap_log_system_for_test stub (Task 9)")
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(bootstrap_running_log_system_for_test(16))
 }
 
-pub fn resolve_store_path(_c: Option<&LabConfig>) -> PathBuf {
-    PathBuf::new()
+fn unique_test_store_path() -> PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "lab-logs-test-bootstrap-{}-{unique}.db",
+        std::process::id()
+    ))
 }
 
-pub fn resolve_retention(_c: Option<&LabConfig>) -> LogRetention {
-    LogRetention::default()
+// ── Config resolvers ──────────────────────────────────────────────────────────
+
+const DEFAULT_DB_PATH_REL: &str = ".lab/logs.db";
+
+pub fn resolve_store_path(config: Option<&LabConfig>) -> PathBuf {
+    if let Some(env) = env_non_empty("LAB_LOGS_STORE_PATH") {
+        return PathBuf::from(env);
+    }
+    if let Some(cfg) = config.and_then(|c| c.local_logs.as_ref()) {
+        if let Some(p) = &cfg.store_path {
+            return p.clone();
+        }
+    }
+    default_store_path()
 }
 
-pub fn resolve_queue_capacity(_c: Option<&LabConfig>) -> usize {
-    4096
+fn default_store_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(DEFAULT_DB_PATH_REL)
 }
 
-pub fn resolve_subscriber_capacity(_c: Option<&LabConfig>) -> usize {
-    1024
+pub fn resolve_retention(config: Option<&LabConfig>) -> LogRetention {
+    let base = config
+        .and_then(|c| c.local_logs.as_ref())
+        .map(|c| LogRetention {
+            max_age_days: c.retention_days.unwrap_or(LogRetention::default().max_age_days),
+            max_bytes: c.max_bytes.unwrap_or(LogRetention::default().max_bytes),
+        })
+        .unwrap_or_default();
+
+    LogRetention {
+        max_age_days: env_non_empty("LAB_LOGS_RETENTION_DAYS")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(base.max_age_days),
+        max_bytes: env_non_empty("LAB_LOGS_MAX_BYTES")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(base.max_bytes),
+    }
+}
+
+pub fn resolve_queue_capacity(config: Option<&LabConfig>) -> usize {
+    env_non_empty("LAB_LOGS_QUEUE_CAPACITY")
+        .and_then(|s| s.parse().ok())
+        .or_else(|| {
+            config
+                .and_then(|c| c.local_logs.as_ref())
+                .and_then(|c| c.queue_capacity)
+        })
+        .unwrap_or(4096)
+}
+
+pub fn resolve_subscriber_capacity(config: Option<&LabConfig>) -> usize {
+    env_non_empty("LAB_LOGS_SUBSCRIBER_CAPACITY")
+        .and_then(|s| s.parse().ok())
+        .or_else(|| {
+            config
+                .and_then(|c| c.local_logs.as_ref())
+                .and_then(|c| c.subscriber_capacity)
+        })
+        .unwrap_or(1024)
 }

--- a/crates/lab/src/dispatch/logs/client.rs
+++ b/crates/lab/src/dispatch/logs/client.rs
@@ -1,0 +1,55 @@
+// Stub — replaced by Task 9.
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::types::{LogRetention, LogSystem};
+use crate::config::LabConfig;
+use crate::dispatch::error::ToolError;
+
+pub fn clear_installed_log_system_for_test() {}
+
+pub fn require_system() -> Result<Arc<LogSystem>, ToolError> {
+    Err(ToolError::internal_message("log system stub (Task 9)"))
+}
+
+pub async fn bootstrap_running_log_system(
+    _p: PathBuf,
+    _r: LogRetention,
+    _q: usize,
+    _s: usize,
+) -> anyhow::Result<Arc<LogSystem>> {
+    unimplemented!("bootstrap_running_log_system stub (Task 9)")
+}
+
+pub async fn bootstrap_store_backed_log_system(
+    _p: PathBuf,
+    _r: LogRetention,
+) -> anyhow::Result<Arc<LogSystem>> {
+    unimplemented!("bootstrap_store_backed_log_system stub (Task 9)")
+}
+
+#[doc(hidden)]
+pub async fn bootstrap_running_log_system_for_test(_q: usize) -> anyhow::Result<Arc<LogSystem>> {
+    unimplemented!("bootstrap_running_log_system_for_test stub (Task 9)")
+}
+
+#[doc(hidden)]
+pub fn bootstrap_log_system_for_test() -> anyhow::Result<Arc<LogSystem>> {
+    unimplemented!("bootstrap_log_system_for_test stub (Task 9)")
+}
+
+pub fn resolve_store_path(_c: Option<&LabConfig>) -> PathBuf {
+    PathBuf::new()
+}
+
+pub fn resolve_retention(_c: Option<&LabConfig>) -> LogRetention {
+    LogRetention::default()
+}
+
+pub fn resolve_queue_capacity(_c: Option<&LabConfig>) -> usize {
+    4096
+}
+
+pub fn resolve_subscriber_capacity(_c: Option<&LabConfig>) -> usize {
+    1024
+}

--- a/crates/lab/src/dispatch/logs/dispatch.rs
+++ b/crates/lab/src/dispatch/logs/dispatch.rs
@@ -1,0 +1,17 @@
+// Stub — replaced by Task 10.
+use serde_json::Value;
+
+use super::types::LogSystem;
+use crate::dispatch::error::ToolError;
+
+pub async fn dispatch(_action: &str, _params: Value) -> Result<Value, ToolError> {
+    unimplemented!("dispatch stub (Task 10)")
+}
+
+pub async fn dispatch_with_system(
+    _system: &LogSystem,
+    _action: &str,
+    _params: Value,
+) -> Result<Value, ToolError> {
+    unimplemented!("dispatch_with_system stub (Task 10)")
+}

--- a/crates/lab/src/dispatch/logs/dispatch.rs
+++ b/crates/lab/src/dispatch/logs/dispatch.rs
@@ -17,7 +17,15 @@ pub async fn dispatch(action: &str, params: Value) -> Result<Value, ToolError> {
             action_schema(ACTIONS, a)
         }
         other => {
-            validate_action(other)?;
+            // Validate the action name before requiring an installed system,
+            // so `unknown_action` surfaces even when no LogSystem is available.
+            if !ACTIONS.iter().any(|a| a.name == other) {
+                return Err(ToolError::UnknownAction {
+                    message: format!("unknown action `{other}` for service `logs`"),
+                    valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
+                    hint: None,
+                });
+            }
             let system = client::require_system()?;
             dispatch_with_system(&system, other, params).await
         }
@@ -35,77 +43,21 @@ pub async fn dispatch_with_system(
             let a = require_str(&params, "action")?;
             action_schema(ACTIONS, a)
         }
-        "logs.search" => {
-            let q = parse_search_params(params)?;
-            let result = system.search(q).await?;
-            to_json(result)
-        }
-        "logs.tail" => {
-            let r = parse_tail_params(params)?;
-            let result = system.tail(r).await?;
-            to_json(result)
-        }
-        "logs.stats" => {
-            let stats = system.stats().await?;
-            to_json(stats)
-        }
+        "logs.search" => to_json(system.search(parse_search_params(params)?).await?),
+        "logs.tail" => to_json(system.tail(parse_tail_params(params)?).await?),
+        "logs.stats" => to_json(system.stats().await?),
         "logs.stream" => Err(ToolError::Sdk {
             sdk_kind: "not_found".to_string(),
             message:
                 "live push is HTTP SSE only; connect to GET /v1/logs/stream to receive events"
                     .to_string(),
         }),
-        unknown => Err(unknown_action_error(unknown)),
+        unknown => Err(ToolError::UnknownAction {
+            message: format!("unknown action `{unknown}` for service `logs`"),
+            valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
+            hint: None,
+        }),
     }
-}
-
-fn validate_action(action: &str) -> Result<(), ToolError> {
-    if ACTIONS.iter().any(|a| a.name == action) {
-        Ok(())
-    } else {
-        Err(unknown_action_error(action))
-    }
-}
-
-fn unknown_action_error(action: &str) -> ToolError {
-    let valid: Vec<String> = ACTIONS.iter().map(|a| a.name.to_string()).collect();
-    let hint = closest(&valid, action);
-    ToolError::UnknownAction {
-        message: format!("unknown action `{action}` for service `logs`"),
-        valid,
-        hint,
-    }
-}
-
-fn closest(valid: &[String], action: &str) -> Option<String> {
-    valid
-        .iter()
-        .filter(|v| v.len().abs_diff(action.len()) <= 2)
-        .min_by_key(|v| levenshtein(v, action))
-        .filter(|v| levenshtein(v, action) <= 3)
-        .cloned()
-}
-
-fn levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    if a.is_empty() {
-        return b.len();
-    }
-    if b.is_empty() {
-        return a.len();
-    }
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut curr = vec![0; b.len() + 1];
-    for i in 1..=a.len() {
-        curr[0] = i;
-        for j in 1..=b.len() {
-            let cost = usize::from(a[i - 1] != b[j - 1]);
-            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[b.len()]
 }
 
 #[cfg(test)]

--- a/crates/lab/src/dispatch/logs/dispatch.rs
+++ b/crates/lab/src/dispatch/logs/dispatch.rs
@@ -1,17 +1,137 @@
-// Stub — replaced by Task 10.
+//! Top-level action router for the `logs` dispatch service.
+
 use serde_json::Value;
 
+use super::catalog::ACTIONS;
+use super::client;
+use super::params::{parse_search_params, parse_tail_params};
 use super::types::LogSystem;
 use crate::dispatch::error::ToolError;
+use crate::dispatch::helpers::{action_schema, help_payload, require_str, to_json};
 
-pub async fn dispatch(_action: &str, _params: Value) -> Result<Value, ToolError> {
-    unimplemented!("dispatch stub (Task 10)")
+pub async fn dispatch(action: &str, params: Value) -> Result<Value, ToolError> {
+    match action {
+        "help" => Ok(help_payload("logs", ACTIONS)),
+        "schema" => {
+            let a = require_str(&params, "action")?;
+            action_schema(ACTIONS, a)
+        }
+        other => {
+            validate_action(other)?;
+            let system = client::require_system()?;
+            dispatch_with_system(&system, other, params).await
+        }
+    }
 }
 
 pub async fn dispatch_with_system(
-    _system: &LogSystem,
-    _action: &str,
-    _params: Value,
+    system: &LogSystem,
+    action: &str,
+    params: Value,
 ) -> Result<Value, ToolError> {
-    unimplemented!("dispatch_with_system stub (Task 10)")
+    match action {
+        "help" => Ok(help_payload("logs", ACTIONS)),
+        "schema" => {
+            let a = require_str(&params, "action")?;
+            action_schema(ACTIONS, a)
+        }
+        "logs.search" => {
+            let q = parse_search_params(params)?;
+            let result = system.search(q).await?;
+            to_json(result)
+        }
+        "logs.tail" => {
+            let r = parse_tail_params(params)?;
+            let result = system.tail(r).await?;
+            to_json(result)
+        }
+        "logs.stats" => {
+            let stats = system.stats().await?;
+            to_json(stats)
+        }
+        "logs.stream" => Err(ToolError::Sdk {
+            sdk_kind: "not_found".to_string(),
+            message:
+                "live push is HTTP SSE only; connect to GET /v1/logs/stream to receive events"
+                    .to_string(),
+        }),
+        unknown => Err(unknown_action_error(unknown)),
+    }
+}
+
+fn validate_action(action: &str) -> Result<(), ToolError> {
+    if ACTIONS.iter().any(|a| a.name == action) {
+        Ok(())
+    } else {
+        Err(unknown_action_error(action))
+    }
+}
+
+fn unknown_action_error(action: &str) -> ToolError {
+    let valid: Vec<String> = ACTIONS.iter().map(|a| a.name.to_string()).collect();
+    let hint = closest(&valid, action);
+    ToolError::UnknownAction {
+        message: format!("unknown action `{action}` for service `logs`"),
+        valid,
+        hint,
+    }
+}
+
+fn closest(valid: &[String], action: &str) -> Option<String> {
+    valid
+        .iter()
+        .filter(|v| v.len().abs_diff(action.len()) <= 2)
+        .min_by_key(|v| levenshtein(v, action))
+        .filter(|v| levenshtein(v, action) <= 3)
+        .cloned()
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0; b.len() + 1];
+    for i in 1..=a.len() {
+        curr[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn help_returns_catalog_object() {
+        let v = dispatch("help", serde_json::json!({})).await.unwrap();
+        assert!(v.is_object());
+        assert_eq!(v["service"], "logs");
+    }
+
+    #[tokio::test]
+    async fn schema_returns_action_shape() {
+        let v = dispatch("schema", serde_json::json!({"action": "logs.search"}))
+            .await
+            .unwrap();
+        assert!(v.is_object());
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_kind() {
+        let e = dispatch("logs.serch", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "unknown_action");
+    }
 }

--- a/crates/lab/src/dispatch/logs/ingest.rs
+++ b/crates/lab/src/dispatch/logs/ingest.rs
@@ -10,9 +10,18 @@ use super::stream::StreamHub;
 use super::types::{LogEvent, LogLevel, RawLogEvent, Subsystem, Surface};
 use crate::dispatch::error::ToolError;
 
+/// Milliseconds since the Unix epoch, clamped to a signed 64-bit range.
+pub(super) fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+/// Counters for ingest-queue health. Only drops are exported via `stats`;
+/// accepted-event totals would be redundant with the store row count.
 pub struct IngestCounters {
     dropped: AtomicU64,
-    total: AtomicU64,
 }
 
 impl IngestCounters {
@@ -20,7 +29,6 @@ impl IngestCounters {
     pub fn new() -> Self {
         Self {
             dropped: AtomicU64::new(0),
-            total: AtomicU64::new(0),
         }
     }
 
@@ -31,10 +39,6 @@ impl IngestCounters {
 
     pub fn record_drop(&self) {
         self.dropped.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn record_accepted(&self) {
-        self.total.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -65,7 +69,6 @@ impl IngestHandle {
         let event = canonicalize(raw);
         store.insert(&event).await?;
         hub.publish(event);
-        self.counters.record_accepted();
         Ok(())
     }
 
@@ -76,17 +79,14 @@ impl IngestHandle {
             ));
         };
         match tx.try_send(raw) {
-            Ok(()) => {
-                self.counters.record_accepted();
-                Ok(())
-            }
+            Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => {
                 self.counters.record_drop();
                 Ok(())
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => Err(ToolError::internal_message(
-                "log ingest channel closed",
-            )),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(ToolError::internal_message("log ingest channel closed"))
+            }
         }
     }
 }
@@ -131,16 +131,11 @@ pub fn spawn_writer(
 fn canonicalize(mut raw: RawLogEvent) -> LogEvent {
     raw.message = redact_bearer(&raw.message);
 
-    let ts = raw.ts.unwrap_or_else(|| {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0)
-    });
+    let ts = raw.ts.unwrap_or_else(now_ms);
     let level = raw
         .level
         .as_deref()
-        .and_then(parse_level)
+        .and_then(LogLevel::parse)
         .unwrap_or(LogLevel::Info);
     let subsystem = raw
         .subsystem
@@ -179,17 +174,6 @@ fn canonicalize(mut raw: RawLogEvent) -> LogEvent {
         ingest_path: raw.ingest_path.or_else(|| Some("tracing".to_string())),
         upstream_event_id: raw.upstream_event_id,
     }
-}
-
-fn parse_level(s: &str) -> Option<LogLevel> {
-    Some(match s.to_ascii_lowercase().as_str() {
-        "trace" => LogLevel::Trace,
-        "debug" => LogLevel::Debug,
-        "info" | "information" => LogLevel::Info,
-        "warn" | "warning" => LogLevel::Warn,
-        "error" | "err" => LogLevel::Error,
-        _ => return None,
-    })
 }
 
 fn redact_bearer(msg: &str) -> String {
@@ -275,23 +259,25 @@ where
         event.record(&mut visitor);
 
         let raw = RawLogEvent {
-            ts: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as i64)
-                    .unwrap_or(0),
+            ts: Some(now_ms()),
+            level: Some(
+                match *metadata.level() {
+                    tracing::Level::TRACE => "trace",
+                    tracing::Level::DEBUG => "debug",
+                    tracing::Level::INFO => "info",
+                    tracing::Level::WARN => "warn",
+                    tracing::Level::ERROR => "error",
+                }
+                .to_string(),
             ),
-            level: Some(match *metadata.level() {
-                tracing::Level::TRACE => "trace",
-                tracing::Level::DEBUG => "debug",
-                tracing::Level::INFO => "info",
-                tracing::Level::WARN => "warn",
-                tracing::Level::ERROR => "error",
-            }.to_string()),
-            subsystem: visitor.subsystem.or_else(|| Some("core_runtime".to_string())),
+            subsystem: visitor
+                .subsystem
+                .or_else(|| Some("core_runtime".to_string())),
             surface: visitor.surface,
             action: visitor.action,
-            message: visitor.message.unwrap_or_else(|| metadata.target().to_string()),
+            message: visitor
+                .message
+                .unwrap_or_else(|| metadata.target().to_string()),
             request_id: visitor.request_id,
             session_id: visitor.session_id,
             correlation_id: visitor.correlation_id,

--- a/crates/lab/src/dispatch/logs/ingest.rs
+++ b/crates/lab/src/dispatch/logs/ingest.rs
@@ -1,0 +1,63 @@
+// Stub — replaced by Task 6.
+use std::sync::Arc;
+
+use super::store::LogStore;
+use super::stream::StreamHub;
+use super::types::RawLogEvent;
+use crate::dispatch::error::ToolError;
+
+pub struct IngestHandle;
+
+impl IngestHandle {
+    pub async fn submit(&self, _r: RawLogEvent) -> Result<(), ToolError> {
+        unimplemented!("IngestHandle stub (Task 6)")
+    }
+    pub fn try_submit(&self, _r: RawLogEvent) -> Result<(), ToolError> {
+        unimplemented!("IngestHandle stub (Task 6)")
+    }
+}
+
+pub struct IngestCounters;
+
+impl IngestCounters {
+    pub fn new() -> Self {
+        Self
+    }
+    pub fn dropped(&self) -> u64 {
+        0
+    }
+}
+
+impl Default for IngestCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn spawn_writer(
+    _store: Arc<LogStore>,
+    _hub: Arc<StreamHub>,
+    _queue_capacity: usize,
+) -> (IngestHandle, Arc<IngestCounters>) {
+    unimplemented!("spawn_writer stub (Task 6)")
+}
+
+pub fn readonly_handle(_counters: Arc<IngestCounters>) -> IngestHandle {
+    IngestHandle
+}
+
+/// Tracing layer that forwards events into the installed LogSystem. Stub until Task 6.
+pub struct LogIngestLayer;
+
+impl<S> tracing_subscriber::Layer<S> for LogIngestLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_event(
+        &self,
+        _event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // No-op stub; real implementation in Task 6.
+    }
+}

--- a/crates/lab/src/dispatch/logs/ingest.rs
+++ b/crates/lab/src/dispatch/logs/ingest.rs
@@ -1,30 +1,40 @@
-// Stub — replaced by Task 6.
+//! Ingest pipeline: raw event → redact → enrich → store + stream.
+
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::mpsc;
 
 use super::store::LogStore;
 use super::stream::StreamHub;
-use super::types::RawLogEvent;
+use super::types::{LogEvent, LogLevel, RawLogEvent, Subsystem, Surface};
 use crate::dispatch::error::ToolError;
 
-pub struct IngestHandle;
-
-impl IngestHandle {
-    pub async fn submit(&self, _r: RawLogEvent) -> Result<(), ToolError> {
-        unimplemented!("IngestHandle stub (Task 6)")
-    }
-    pub fn try_submit(&self, _r: RawLogEvent) -> Result<(), ToolError> {
-        unimplemented!("IngestHandle stub (Task 6)")
-    }
+pub struct IngestCounters {
+    dropped: AtomicU64,
+    total: AtomicU64,
 }
 
-pub struct IngestCounters;
-
 impl IngestCounters {
+    #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {
+            dropped: AtomicU64::new(0),
+            total: AtomicU64::new(0),
+        }
     }
+
+    #[must_use]
     pub fn dropped(&self) -> u64 {
-        0
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    pub fn record_drop(&self) {
+        self.dropped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_accepted(&self) {
+        self.total.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -34,19 +44,197 @@ impl Default for IngestCounters {
     }
 }
 
+pub struct IngestHandle {
+    tx: Option<mpsc::Sender<RawLogEvent>>,
+    counters: Arc<IngestCounters>,
+}
+
+impl IngestHandle {
+    pub async fn submit(&self, raw: RawLogEvent) -> Result<(), ToolError> {
+        let Some(tx) = &self.tx else {
+            return Err(ToolError::internal_message(
+                "log system is read-only (no ingest writer)",
+            ));
+        };
+        tx.send(raw)
+            .await
+            .map_err(|_| ToolError::internal_message("log ingest channel closed"))?;
+        self.counters.record_accepted();
+        Ok(())
+    }
+
+    pub fn try_submit(&self, raw: RawLogEvent) -> Result<(), ToolError> {
+        let Some(tx) = &self.tx else {
+            return Err(ToolError::internal_message(
+                "log system is read-only (no ingest writer)",
+            ));
+        };
+        match tx.try_send(raw) {
+            Ok(()) => {
+                self.counters.record_accepted();
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.counters.record_drop();
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(ToolError::internal_message(
+                "log ingest channel closed",
+            )),
+        }
+    }
+}
+
+pub fn readonly_handle(counters: Arc<IngestCounters>) -> IngestHandle {
+    IngestHandle { tx: None, counters }
+}
+
 pub fn spawn_writer(
-    _store: Arc<LogStore>,
-    _hub: Arc<StreamHub>,
-    _queue_capacity: usize,
+    store: Arc<LogStore>,
+    hub: Arc<StreamHub>,
+    queue_capacity: usize,
 ) -> (IngestHandle, Arc<IngestCounters>) {
-    unimplemented!("spawn_writer stub (Task 6)")
+    let (tx, mut rx) = mpsc::channel::<RawLogEvent>(queue_capacity.max(1));
+    let counters = Arc::new(IngestCounters::new());
+    let handle = IngestHandle {
+        tx: Some(tx),
+        counters: Arc::clone(&counters),
+    };
+
+    tokio::spawn(async move {
+        while let Some(raw) = rx.recv().await {
+            let event = canonicalize(raw);
+            if let Err(err) = store.insert(&event).await {
+                tracing::warn!(target: "lab::dispatch::logs", ?err, "log store insert failed; event dropped");
+                continue;
+            }
+            hub.publish(event);
+        }
+    });
+
+    (handle, counters)
 }
 
-pub fn readonly_handle(_counters: Arc<IngestCounters>) -> IngestHandle {
-    IngestHandle
+// ── Canonicalization ─────────────────────────────────────────────────────────
+
+fn canonicalize(mut raw: RawLogEvent) -> LogEvent {
+    raw.message = redact_bearer(&raw.message);
+
+    let ts = raw.ts.unwrap_or_else(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0)
+    });
+    let level = raw
+        .level
+        .as_deref()
+        .and_then(parse_level)
+        .unwrap_or(LogLevel::Info);
+    let subsystem = raw
+        .subsystem
+        .as_deref()
+        .and_then(Subsystem::parse)
+        .unwrap_or(Subsystem::CoreRuntime);
+    let surface = raw
+        .surface
+        .as_deref()
+        .and_then(Surface::parse)
+        .unwrap_or(Surface::CoreRuntime);
+
+    let event_id = uuid::Uuid::new_v4().to_string();
+    let fields_json = scrub_json(raw.fields_json);
+
+    LogEvent {
+        event_id,
+        ts,
+        level,
+        subsystem,
+        surface,
+        action: raw.action,
+        message: raw.message,
+        request_id: raw.request_id,
+        session_id: raw.session_id,
+        correlation_id: raw.correlation_id,
+        trace_id: raw.trace_id,
+        span_id: raw.span_id,
+        instance: raw.instance,
+        auth_flow: raw.auth_flow,
+        outcome_kind: raw.outcome_kind,
+        fields_json,
+        source_kind: raw.source_kind,
+        source_node_id: raw.source_node_id,
+        source_device_id: raw.source_device_id,
+        ingest_path: raw.ingest_path.or_else(|| Some("tracing".to_string())),
+        upstream_event_id: raw.upstream_event_id,
+    }
 }
 
-/// Tracing layer that forwards events into the installed LogSystem. Stub until Task 6.
+fn parse_level(s: &str) -> Option<LogLevel> {
+    Some(match s.to_ascii_lowercase().as_str() {
+        "trace" => LogLevel::Trace,
+        "debug" => LogLevel::Debug,
+        "info" | "information" => LogLevel::Info,
+        "warn" | "warning" => LogLevel::Warn,
+        "error" | "err" => LogLevel::Error,
+        _ => return None,
+    })
+}
+
+fn redact_bearer(msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    let mut rest = msg;
+    while let Some(pos) = rest.find("Bearer ") {
+        out.push_str(&rest[..pos]);
+        out.push_str("Bearer <redacted>");
+        let after = &rest[pos + "Bearer ".len()..];
+        let tok_end = after
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(after.len());
+        rest = &after[tok_end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn scrub_json(v: serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, val) in map {
+                if looks_secret(&k) {
+                    out.insert(k, serde_json::Value::String("<redacted>".into()));
+                } else {
+                    out.insert(k, scrub_json(val));
+                }
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(scrub_json).collect())
+        }
+        serde_json::Value::String(s) => serde_json::Value::String(redact_bearer(&s)),
+        other => other,
+    }
+}
+
+fn looks_secret(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    k.contains("secret")
+        || k.contains("token")
+        || k.contains("password")
+        || k.contains("api_key")
+        || k.contains("apikey")
+        || k == "authorization"
+}
+
+// ── tracing Layer ────────────────────────────────────────────────────────────
+
+/// Tracing layer that forwards events into the installed LogSystem.
+///
+/// Implementation strategy: visit fields, build a RawLogEvent, and hand off
+/// via `LogSystem::try_ingest` (non-blocking). If no system is installed, the
+/// event is silently dropped.
 pub struct LogIngestLayer;
 
 impl<S> tracing_subscriber::Layer<S> for LogIngestLayer
@@ -55,9 +243,151 @@ where
 {
     fn on_event(
         &self,
-        _event: &tracing::Event<'_>,
+        event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        // No-op stub; real implementation in Task 6.
+        let metadata = event.metadata();
+
+        // Guard against self-log infinite loop: skip events from the logs subsystem itself.
+        if metadata.target().starts_with("lab::dispatch::logs") {
+            return;
+        }
+
+        let Ok(system) = super::client::require_system() else {
+            return;
+        };
+
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+
+        let raw = RawLogEvent {
+            ts: Some(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0),
+            ),
+            level: Some(match *metadata.level() {
+                tracing::Level::TRACE => "trace",
+                tracing::Level::DEBUG => "debug",
+                tracing::Level::INFO => "info",
+                tracing::Level::WARN => "warn",
+                tracing::Level::ERROR => "error",
+            }.to_string()),
+            subsystem: visitor.subsystem.or_else(|| Some("core_runtime".to_string())),
+            surface: visitor.surface,
+            action: visitor.action,
+            message: visitor.message.unwrap_or_else(|| metadata.target().to_string()),
+            request_id: visitor.request_id,
+            session_id: visitor.session_id,
+            correlation_id: visitor.correlation_id,
+            trace_id: None,
+            span_id: None,
+            instance: visitor.instance,
+            auth_flow: visitor.auth_flow,
+            outcome_kind: visitor.outcome_kind,
+            fields_json: serde_json::Value::Object(visitor.extra),
+            source_kind: None,
+            source_node_id: None,
+            source_device_id: None,
+            ingest_path: Some("tracing".to_string()),
+            upstream_event_id: None,
+        };
+
+        let _ = system.try_ingest(raw);
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    message: Option<String>,
+    subsystem: Option<String>,
+    surface: Option<String>,
+    action: Option<String>,
+    request_id: Option<String>,
+    session_id: Option<String>,
+    correlation_id: Option<String>,
+    instance: Option<String>,
+    auth_flow: Option<String>,
+    outcome_kind: Option<String>,
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl tracing::field::Visit for FieldVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.set_field(field.name(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.set_field(field.name(), format!("{value:?}"));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.extra.insert(
+            field.name().to_string(),
+            serde_json::Value::Number(value.into()),
+        );
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.extra.insert(
+            field.name().to_string(),
+            serde_json::Value::Number(value.into()),
+        );
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.extra
+            .insert(field.name().to_string(), serde_json::Value::Bool(value));
+    }
+}
+
+impl FieldVisitor {
+    fn set_field(&mut self, name: &str, value: String) {
+        match name {
+            "message" => self.message = Some(value),
+            "subsystem" => self.subsystem = Some(value),
+            "surface" => self.surface = Some(value),
+            "action" => self.action = Some(value),
+            "request_id" => self.request_id = Some(value),
+            "session_id" => self.session_id = Some(value),
+            "correlation_id" => self.correlation_id = Some(value),
+            "instance" => self.instance = Some(value),
+            "auth_flow" => self.auth_flow = Some(value),
+            "outcome_kind" => self.outcome_kind = Some(value),
+            _ => {
+                self.extra
+                    .insert(name.to_string(), serde_json::Value::String(value));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_bearer_replaces_token() {
+        let msg = "Authorization: Bearer secret-value";
+        let out = redact_bearer(msg);
+        assert!(!out.contains("secret-value"));
+        assert!(out.contains("Bearer <redacted>"));
+    }
+
+    #[test]
+    fn scrub_json_replaces_authorization_key() {
+        let v = serde_json::json!({"authorization":"Bearer secret-value","safe":"ok"});
+        let out = scrub_json(v).to_string();
+        assert!(!out.contains("secret-value"));
+        assert!(out.contains("\"safe\":\"ok\""));
+    }
+
+    #[test]
+    fn scrub_json_handles_nested_and_arrays() {
+        let v = serde_json::json!({"outer":{"api_key":"abc"},"list":["Bearer xyz"]});
+        let out = scrub_json(v).to_string();
+        assert!(!out.contains("\"abc\""));
+        assert!(!out.contains("Bearer xyz"));
     }
 }

--- a/crates/lab/src/dispatch/logs/ingest.rs
+++ b/crates/lab/src/dispatch/logs/ingest.rs
@@ -46,19 +46,25 @@ impl Default for IngestCounters {
 
 pub struct IngestHandle {
     tx: Option<mpsc::Sender<RawLogEvent>>,
+    /// Inline write-through path used by `submit` (await). The store and hub
+    /// are owned by the LogSystem and shared with the writer task, so this is
+    /// a cheap Arc clone.
+    inline: Option<(Arc<LogStore>, Arc<StreamHub>)>,
     counters: Arc<IngestCounters>,
 }
 
 impl IngestHandle {
     pub async fn submit(&self, raw: RawLogEvent) -> Result<(), ToolError> {
-        let Some(tx) = &self.tx else {
+        // Await-path: persist inline so callers see their write before returning.
+        // Non-await callers (the tracing layer) use `try_submit` instead.
+        let Some((store, hub)) = &self.inline else {
             return Err(ToolError::internal_message(
                 "log system is read-only (no ingest writer)",
             ));
         };
-        tx.send(raw)
-            .await
-            .map_err(|_| ToolError::internal_message("log ingest channel closed"))?;
+        let event = canonicalize(raw);
+        store.insert(&event).await?;
+        hub.publish(event);
         self.counters.record_accepted();
         Ok(())
     }
@@ -86,7 +92,11 @@ impl IngestHandle {
 }
 
 pub fn readonly_handle(counters: Arc<IngestCounters>) -> IngestHandle {
-    IngestHandle { tx: None, counters }
+    IngestHandle {
+        tx: None,
+        inline: None,
+        counters,
+    }
 }
 
 pub fn spawn_writer(
@@ -98,6 +108,7 @@ pub fn spawn_writer(
     let counters = Arc::new(IngestCounters::new());
     let handle = IngestHandle {
         tx: Some(tx),
+        inline: Some((Arc::clone(&store), Arc::clone(&hub))),
         counters: Arc::clone(&counters),
     };
 
@@ -182,11 +193,14 @@ fn parse_level(s: &str) -> Option<LogLevel> {
 }
 
 fn redact_bearer(msg: &str) -> String {
+    // Replace the entire "Bearer <token>" sequence with "<redacted-auth>" so the
+    // literal substring "Bearer " does not survive — asserted by
+    // tests/logs_dispatch.rs:221.
     let mut out = String::with_capacity(msg.len());
     let mut rest = msg;
     while let Some(pos) = rest.find("Bearer ") {
         out.push_str(&rest[..pos]);
-        out.push_str("Bearer <redacted>");
+        out.push_str("<redacted-auth>");
         let after = &rest[pos + "Bearer ".len()..];
         let tok_end = after
             .find(|c: char| c.is_whitespace())
@@ -372,7 +386,8 @@ mod tests {
         let msg = "Authorization: Bearer secret-value";
         let out = redact_bearer(msg);
         assert!(!out.contains("secret-value"));
-        assert!(out.contains("Bearer <redacted>"));
+        assert!(!out.contains("Bearer "));
+        assert!(out.contains("<redacted-auth>"));
     }
 
     #[test]

--- a/crates/lab/src/dispatch/logs/params.rs
+++ b/crates/lab/src/dispatch/logs/params.rs
@@ -1,0 +1,1 @@
+// Stub — replaced by Task 8.

--- a/crates/lab/src/dispatch/logs/params.rs
+++ b/crates/lab/src/dispatch/logs/params.rs
@@ -1,1 +1,75 @@
-// Stub — replaced by Task 8.
+//! Param coercion for logs dispatch actions.
+
+use serde_json::Value;
+
+use super::types::{LogQuery, LogTailRequest};
+use crate::dispatch::error::ToolError;
+
+pub fn parse_search_params(params: Value) -> Result<LogQuery, ToolError> {
+    let inner = match params {
+        Value::Object(mut map) => {
+            if let Some(q) = map.remove("query") {
+                q
+            } else {
+                Value::Object(map)
+            }
+        }
+        Value::Null => Value::Object(Default::default()),
+        other => other,
+    };
+    serde_json::from_value::<LogQuery>(inner).map_err(|e| ToolError::InvalidParam {
+        message: format!("invalid LogQuery: {e}"),
+        param: "query".to_string(),
+    })
+}
+
+pub fn parse_tail_params(params: Value) -> Result<LogTailRequest, ToolError> {
+    let inner = match params {
+        Value::Null => Value::Object(Default::default()),
+        other => other,
+    };
+    serde_json::from_value::<LogTailRequest>(inner).map_err(|e| ToolError::InvalidParam {
+        message: format!("invalid LogTailRequest: {e}"),
+        param: "params".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_accepts_wrapped_query() {
+        let p = serde_json::json!({"query":{"subsystems":["gateway"],"levels":["warn"]}});
+        let q = parse_search_params(p).unwrap();
+        assert_eq!(q.subsystems.len(), 1);
+        assert_eq!(q.levels.len(), 1);
+    }
+
+    #[test]
+    fn search_accepts_flat_query() {
+        let p = serde_json::json!({"subsystems":["gateway"]});
+        let q = parse_search_params(p).unwrap();
+        assert_eq!(q.subsystems.len(), 1);
+    }
+
+    #[test]
+    fn search_accepts_empty_object() {
+        let q = parse_search_params(serde_json::json!({})).unwrap();
+        assert!(q.subsystems.is_empty());
+    }
+
+    #[test]
+    fn tail_accepts_flat() {
+        let p = serde_json::json!({"after_ts":0,"limit":10});
+        let r = parse_tail_params(p).unwrap();
+        assert_eq!(r.after_ts, Some(0));
+        assert_eq!(r.limit, Some(10));
+    }
+
+    #[test]
+    fn search_rejects_garbage() {
+        let err = parse_search_params(serde_json::json!(42)).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+    }
+}

--- a/crates/lab/src/dispatch/logs/params.rs
+++ b/crates/lab/src/dispatch/logs/params.rs
@@ -6,15 +6,10 @@ use super::types::{LogQuery, LogTailRequest};
 use crate::dispatch::error::ToolError;
 
 pub fn parse_search_params(params: Value) -> Result<LogQuery, ToolError> {
+    // Accept both `{"query": {...}}` (wrapped) and `{...}` (flat); `null` too.
     let inner = match params {
-        Value::Object(mut map) => {
-            if let Some(q) = map.remove("query") {
-                q
-            } else {
-                Value::Object(map)
-            }
-        }
-        Value::Null => Value::Object(Default::default()),
+        Value::Object(mut map) => map.remove("query").unwrap_or(Value::Object(map)),
+        Value::Null => Value::Object(serde_json::Map::new()),
         other => other,
     };
     serde_json::from_value::<LogQuery>(inner).map_err(|e| ToolError::InvalidParam {
@@ -24,9 +19,10 @@ pub fn parse_search_params(params: Value) -> Result<LogQuery, ToolError> {
 }
 
 pub fn parse_tail_params(params: Value) -> Result<LogTailRequest, ToolError> {
-    let inner = match params {
-        Value::Null => Value::Object(Default::default()),
-        other => other,
+    let inner = if params.is_null() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        params
     };
     serde_json::from_value::<LogTailRequest>(inner).map_err(|e| ToolError::InvalidParam {
         message: format!("invalid LogTailRequest: {e}"),

--- a/crates/lab/src/dispatch/logs/store.rs
+++ b/crates/lab/src/dispatch/logs/store.rs
@@ -1,31 +1,433 @@
-// Stub — replaced by Task 4.
-use super::types::{LogQuery, LogRetention, LogSearchResult, LogStoreStats, LogTailRequest, LogTailResult};
+//! SQLite-backed persistence for captured log events.
+//!
+//! Single writer (the async writer task in `ingest`), many readers. WAL mode
+//! + shared `Mutex<Connection>` inside `spawn_blocking` keeps the API async
+//! without dragging in `sqlx`.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use rusqlite::{Connection, OpenFlags, params, params_from_iter};
+
+use super::types::{
+    LogEvent, LogLevel, LogQuery, LogRetention, LogSearchResult, LogStoreStats, LogTailRequest,
+    LogTailResult, Subsystem, Surface,
+};
 use crate::dispatch::error::ToolError;
 
-pub struct LogStore;
+const SCHEMA_SQL: &str = include_str!("store_schema.sql");
+
+pub struct LogStore {
+    pub(super) conn: Arc<Mutex<Connection>>,
+    pub(super) path: PathBuf,
+    pub(super) retention: LogRetention,
+}
 
 impl LogStore {
-    pub async fn search(&self, _q: LogQuery) -> Result<LogSearchResult, ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
+    pub async fn open(path: PathBuf, retention: LogRetention) -> Result<Self, ToolError> {
+        let conn_path = path.clone();
+        let conn = tokio::task::spawn_blocking(move || -> Result<Connection, rusqlite::Error> {
+            if let Some(parent) = conn_path.parent() {
+                std::fs::create_dir_all(parent).ok();
+            }
+            let flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE;
+            let conn = Connection::open_with_flags(&conn_path, flags)?;
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+            conn.pragma_update(None, "synchronous", "NORMAL")?;
+            conn.pragma_update(None, "temp_store", "MEMORY")?;
+            conn.pragma_update(None, "mmap_size", 134_217_728_i64)?;
+            conn.execute_batch(SCHEMA_SQL)?;
+            Ok(conn)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store open: {e}")))?;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            path,
+            retention,
+        })
     }
-    pub async fn tail(&self, _r: LogTailRequest) -> Result<LogTailResult, ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
+
+    pub async fn insert(&self, event: &LogEvent) -> Result<(), ToolError> {
+        let conn = Arc::clone(&self.conn);
+        let event = event.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+            let c = conn.lock().expect("log store mutex poisoned");
+            insert_event(&c, &event)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store insert join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store insert: {e}")))
     }
+
+    pub async fn search(&self, query: LogQuery) -> Result<LogSearchResult, ToolError> {
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || -> Result<LogSearchResult, rusqlite::Error> {
+            let c = conn.lock().expect("log store mutex poisoned");
+            run_search(&c, &query)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store search join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store search: {e}")))
+    }
+
+    pub async fn tail(&self, req: LogTailRequest) -> Result<LogTailResult, ToolError> {
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || -> Result<LogTailResult, rusqlite::Error> {
+            let c = conn.lock().expect("log store mutex poisoned");
+            run_tail(&c, &req)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store tail join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store tail: {e}")))
+    }
+
     pub async fn stats(&self) -> Result<LogStoreStats, ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
+        let conn = Arc::clone(&self.conn);
+        let retention = self.retention;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || -> Result<LogStoreStats, rusqlite::Error> {
+            let c = conn.lock().expect("log store mutex poisoned");
+            run_stats(&c, retention, &path)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store stats join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store stats: {e}")))
     }
+
     pub async fn run_maintenance(&self) -> Result<(), ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
-    }
-    pub async fn insert(&self, _e: &super::types::LogEvent) -> Result<(), ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
-    }
-    pub async fn open(_p: std::path::PathBuf, _r: LogRetention) -> Result<Self, ToolError> {
-        unimplemented!("LogStore stub (Task 4)")
+        let conn = Arc::clone(&self.conn);
+        let retention = self.retention;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+            let c = conn.lock().expect("log store mutex poisoned");
+            run_maintenance(&c, retention, &path)
+        })
+        .await
+        .map_err(|e| ToolError::internal_message(format!("log store maintenance join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store maintenance: {e}")))
     }
 }
 
 #[doc(hidden)]
-pub async fn open_store_for_test(_r: LogRetention) -> Result<LogStore, ToolError> {
-    unimplemented!("open_store_for_test stub (Task 4)")
+pub async fn open_store_for_test(retention: LogRetention) -> Result<LogStore, ToolError> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!(
+        "lab-logs-test-{}-{unique}.db",
+        std::process::id()
+    ));
+    LogStore::open(path, retention).await
+}
+
+// ── Insert ────────────────────────────────────────────────────────────────────
+
+fn insert_event(conn: &Connection, event: &LogEvent) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT OR IGNORE INTO log_events (
+            event_id, ts, level, subsystem, surface, action, message,
+            request_id, session_id, correlation_id, trace_id, span_id,
+            instance, auth_flow, outcome_kind, fields_json,
+            source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+        params![
+            event.event_id,
+            event.ts,
+            event.level.as_str(),
+            event.subsystem.as_str(),
+            event.surface.as_str(),
+            event.action,
+            event.message,
+            event.request_id,
+            event.session_id,
+            event.correlation_id,
+            event.trace_id,
+            event.span_id,
+            event.instance,
+            event.auth_flow,
+            event.outcome_kind,
+            event.fields_json.to_string(),
+            event.source_kind,
+            event.source_node_id,
+            event.source_device_id,
+            event.ingest_path,
+            event.upstream_event_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn level_from_str(s: &str) -> Option<LogLevel> {
+    Some(match s {
+        "trace" => LogLevel::Trace,
+        "debug" => LogLevel::Debug,
+        "info" => LogLevel::Info,
+        "warn" => LogLevel::Warn,
+        "error" => LogLevel::Error,
+        _ => return None,
+    })
+}
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+fn run_search(conn: &Connection, q: &LogQuery) -> Result<LogSearchResult, rusqlite::Error> {
+    let mut sql = String::from(
+        "SELECT event_id, ts, level, subsystem, surface, action, message,
+                request_id, session_id, correlation_id, trace_id, span_id,
+                instance, auth_flow, outcome_kind, fields_json,
+                source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
+         FROM log_events WHERE 1=1",
+    );
+    let mut args: Vec<rusqlite::types::Value> = Vec::new();
+
+    if let Some(after) = q.after_ts {
+        sql.push_str(" AND ts > ?");
+        args.push(after.into());
+    }
+    if let Some(before) = q.before_ts {
+        sql.push_str(" AND ts < ?");
+        args.push(before.into());
+    }
+    if !q.levels.is_empty() {
+        sql.push_str(" AND level IN (");
+        for (i, lv) in q.levels.iter().enumerate() {
+            if i > 0 {
+                sql.push(',');
+            }
+            sql.push('?');
+            args.push(lv.as_str().to_string().into());
+        }
+        sql.push(')');
+    }
+    if !q.subsystems.is_empty() {
+        sql.push_str(" AND subsystem IN (");
+        for (i, s) in q.subsystems.iter().enumerate() {
+            if i > 0 {
+                sql.push(',');
+            }
+            sql.push('?');
+            args.push(s.as_str().to_string().into());
+        }
+        sql.push(')');
+    }
+    if !q.surfaces.is_empty() {
+        sql.push_str(" AND surface IN (");
+        for (i, s) in q.surfaces.iter().enumerate() {
+            if i > 0 {
+                sql.push(',');
+            }
+            sql.push('?');
+            args.push(s.as_str().to_string().into());
+        }
+        sql.push(')');
+    }
+    if let Some(action) = &q.action {
+        sql.push_str(" AND action = ?");
+        args.push(action.clone().into());
+    }
+    if let Some(request_id) = &q.request_id {
+        sql.push_str(" AND request_id = ?");
+        args.push(request_id.clone().into());
+    }
+    if let Some(session_id) = &q.session_id {
+        sql.push_str(" AND session_id = ?");
+        args.push(session_id.clone().into());
+    }
+    if let Some(corr) = &q.correlation_id {
+        sql.push_str(" AND correlation_id = ?");
+        args.push(corr.clone().into());
+    }
+    if let Some(text) = &q.text {
+        sql.push_str(
+            " AND (message LIKE ? OR IFNULL(request_id,'') LIKE ? OR IFNULL(session_id,'') LIKE ? OR IFNULL(correlation_id,'') LIKE ?)",
+        );
+        let like = format!("%{text}%");
+        args.push(like.clone().into());
+        args.push(like.clone().into());
+        args.push(like.clone().into());
+        args.push(like.into());
+    }
+    sql.push_str(" ORDER BY ts DESC, event_id DESC");
+    let limit = q.limit.unwrap_or(500).min(10_000);
+    sql.push_str(&format!(" LIMIT {limit}"));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(args.iter()), row_to_event)?;
+    let events: Vec<LogEvent> = rows.collect::<Result<_, _>>()?;
+    let next_cursor = events.last().map(|e| e.event_id.clone());
+    Ok(LogSearchResult { events, next_cursor })
+}
+
+fn row_to_event(row: &rusqlite::Row<'_>) -> Result<LogEvent, rusqlite::Error> {
+    let level: String = row.get("level")?;
+    let subsystem: String = row.get("subsystem")?;
+    let surface: String = row.get("surface")?;
+    let fields_json: String = row.get("fields_json")?;
+    Ok(LogEvent {
+        event_id: row.get("event_id")?,
+        ts: row.get("ts")?,
+        level: level_from_str(&level).unwrap_or(LogLevel::Info),
+        subsystem: Subsystem::parse(&subsystem).unwrap_or(Subsystem::CoreRuntime),
+        surface: Surface::parse(&surface).unwrap_or(Surface::CoreRuntime),
+        action: row.get("action")?,
+        message: row.get("message")?,
+        request_id: row.get("request_id")?,
+        session_id: row.get("session_id")?,
+        correlation_id: row.get("correlation_id")?,
+        trace_id: row.get("trace_id")?,
+        span_id: row.get("span_id")?,
+        instance: row.get("instance")?,
+        auth_flow: row.get("auth_flow")?,
+        outcome_kind: row.get("outcome_kind")?,
+        fields_json: serde_json::from_str(&fields_json).unwrap_or(serde_json::Value::Null),
+        source_kind: row.get("source_kind")?,
+        source_node_id: row.get("source_node_id")?,
+        source_device_id: row.get("source_device_id")?,
+        ingest_path: row.get("ingest_path")?,
+        upstream_event_id: row.get("upstream_event_id")?,
+    })
+}
+
+// ── Tail ──────────────────────────────────────────────────────────────────────
+
+fn run_tail(conn: &Connection, req: &LogTailRequest) -> Result<LogTailResult, rusqlite::Error> {
+    let mut cursor_ts: Option<i64> = req.after_ts;
+    let mut cursor_event_id: Option<String> = None;
+    if let Some(ev_id) = &req.since_event_id {
+        let ts: Option<i64> = conn
+            .query_row(
+                "SELECT ts FROM log_events WHERE event_id = ?1",
+                params![ev_id],
+                |r| r.get(0),
+            )
+            .ok();
+        if let Some(t) = ts {
+            cursor_ts = Some(t);
+            cursor_event_id = Some(ev_id.clone());
+        }
+    }
+    let limit = req.limit.unwrap_or(500).min(10_000);
+
+    let (sql, args): (String, Vec<rusqlite::types::Value>) = match (cursor_ts, cursor_event_id) {
+        (Some(ts), Some(ev_id)) => (
+            "SELECT event_id, ts, level, subsystem, surface, action, message,
+                    request_id, session_id, correlation_id, trace_id, span_id,
+                    instance, auth_flow, outcome_kind, fields_json,
+                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
+             FROM log_events
+             WHERE ts > ?1 OR (ts = ?1 AND event_id > ?2)
+             ORDER BY ts ASC, event_id ASC
+             LIMIT ?3"
+                .into(),
+            vec![ts.into(), ev_id.into(), (limit as i64).into()],
+        ),
+        (Some(ts), None) => (
+            "SELECT event_id, ts, level, subsystem, surface, action, message,
+                    request_id, session_id, correlation_id, trace_id, span_id,
+                    instance, auth_flow, outcome_kind, fields_json,
+                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
+             FROM log_events
+             WHERE ts > ?1
+             ORDER BY ts ASC, event_id ASC
+             LIMIT ?2"
+                .into(),
+            vec![ts.into(), (limit as i64).into()],
+        ),
+        (None, _) => (
+            "SELECT event_id, ts, level, subsystem, surface, action, message,
+                    request_id, session_id, correlation_id, trace_id, span_id,
+                    instance, auth_flow, outcome_kind, fields_json,
+                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
+             FROM log_events
+             ORDER BY ts ASC, event_id ASC
+             LIMIT ?1"
+                .into(),
+            vec![(limit as i64).into()],
+        ),
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(args.iter()), row_to_event)?;
+    let events: Vec<LogEvent> = rows.collect::<Result<_, _>>()?;
+    let next_cursor = events.last().map(|e| e.event_id.clone());
+    Ok(LogTailResult { events, next_cursor })
+}
+
+// ── Stats ─────────────────────────────────────────────────────────────────────
+
+fn run_stats(
+    conn: &Connection,
+    retention: LogRetention,
+    path: &Path,
+) -> Result<LogStoreStats, rusqlite::Error> {
+    let (total_event_count, oldest_retained_ts, newest_retained_ts): (u64, Option<i64>, Option<i64>) =
+        conn.query_row(
+            "SELECT COUNT(*), MIN(ts), MAX(ts) FROM log_events",
+            [],
+            |row| Ok((row.get::<_, u64>(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+
+    let on_disk_bytes = sidecar_bytes(path);
+
+    Ok(LogStoreStats {
+        on_disk_bytes,
+        oldest_retained_ts,
+        newest_retained_ts,
+        total_event_count,
+        dropped_event_count: 0,
+        retention,
+    })
+}
+
+fn sidecar_bytes(path: &Path) -> u64 {
+    let mut total = 0u64;
+    for suffix in ["", "-wal", "-shm"] {
+        let p = if suffix.is_empty() {
+            path.to_path_buf()
+        } else {
+            let mut os = path.as_os_str().to_os_string();
+            os.push(suffix);
+            PathBuf::from(os)
+        };
+        if let Ok(meta) = std::fs::metadata(&p) {
+            total = total.saturating_add(meta.len());
+        }
+    }
+    total
+}
+
+// ── Maintenance ───────────────────────────────────────────────────────────────
+
+fn run_maintenance(
+    conn: &Connection,
+    retention: LogRetention,
+    path: &Path,
+) -> Result<(), rusqlite::Error> {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(i64::MAX);
+    let cutoff = now_ms.saturating_sub((retention.max_age_days as i64) * 86_400_000);
+    conn.execute("DELETE FROM log_events WHERE ts < ?1", params![cutoff])?;
+
+    for _ in 0..16 {
+        if sidecar_bytes(path) <= retention.max_bytes {
+            break;
+        }
+        let affected = conn.execute(
+            "DELETE FROM log_events WHERE rowid IN
+               (SELECT rowid FROM log_events ORDER BY ts ASC LIMIT 1024)",
+            [],
+        )?;
+        if affected == 0 {
+            break;
+        }
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;")?;
+    }
+    Ok(())
 }

--- a/crates/lab/src/dispatch/logs/store.rs
+++ b/crates/lab/src/dispatch/logs/store.rs
@@ -4,7 +4,7 @@
 //! + shared `Mutex<Connection>` inside `spawn_blocking` keeps the API async
 //! without dragging in `sqlx`.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use rusqlite::{Connection, OpenFlags, params, params_from_iter};
@@ -17,21 +17,26 @@ use crate::dispatch::error::ToolError;
 
 const SCHEMA_SQL: &str = include_str!("store_schema.sql");
 
+/// Column list shared by search + tail. Kept in sync with
+/// `row_to_event`'s `row.get(...)` names.
+const SELECT_COLS: &str = "event_id, ts, level, subsystem, surface, action, message,
+     request_id, session_id, correlation_id, trace_id, span_id,
+     instance, auth_flow, outcome_kind, fields_json,
+     source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id";
+
 pub struct LogStore {
-    pub(super) conn: Arc<Mutex<Connection>>,
-    pub(super) path: PathBuf,
-    pub(super) retention: LogRetention,
+    conn: Arc<Mutex<Connection>>,
+    retention: LogRetention,
 }
 
 impl LogStore {
     pub async fn open(path: PathBuf, retention: LogRetention) -> Result<Self, ToolError> {
-        let conn_path = path.clone();
         let conn = tokio::task::spawn_blocking(move || -> Result<Connection, rusqlite::Error> {
-            if let Some(parent) = conn_path.parent() {
+            if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
             let flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE;
-            let conn = Connection::open_with_flags(&conn_path, flags)?;
+            let conn = Connection::open_with_flags(&path, flags)?;
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "NORMAL")?;
             conn.pragma_update(None, "temp_store", "MEMORY")?;
@@ -40,74 +45,56 @@ impl LogStore {
             Ok(conn)
         })
         .await
-        .map_err(|e| ToolError::internal_message(format!("log store join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store open join: {e}")))?
         .map_err(|e| ToolError::internal_message(format!("log store open: {e}")))?;
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
-            path,
             retention,
         })
     }
 
     pub async fn insert(&self, event: &LogEvent) -> Result<(), ToolError> {
-        let conn = Arc::clone(&self.conn);
         let event = event.clone();
-        tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
-            let c = conn.lock().expect("log store mutex poisoned");
-            insert_event(&c, &event)
-        })
-        .await
-        .map_err(|e| ToolError::internal_message(format!("log store insert join: {e}")))?
-        .map_err(|e| ToolError::internal_message(format!("log store insert: {e}")))
+        self.blocking("insert", move |c| insert_event(c, &event))
+            .await
     }
 
     pub async fn search(&self, query: LogQuery) -> Result<LogSearchResult, ToolError> {
-        let conn = Arc::clone(&self.conn);
-        tokio::task::spawn_blocking(move || -> Result<LogSearchResult, rusqlite::Error> {
-            let c = conn.lock().expect("log store mutex poisoned");
-            run_search(&c, &query)
-        })
-        .await
-        .map_err(|e| ToolError::internal_message(format!("log store search join: {e}")))?
-        .map_err(|e| ToolError::internal_message(format!("log store search: {e}")))
+        self.blocking("search", move |c| run_search(c, &query)).await
     }
 
     pub async fn tail(&self, req: LogTailRequest) -> Result<LogTailResult, ToolError> {
-        let conn = Arc::clone(&self.conn);
-        tokio::task::spawn_blocking(move || -> Result<LogTailResult, rusqlite::Error> {
-            let c = conn.lock().expect("log store mutex poisoned");
-            run_tail(&c, &req)
-        })
-        .await
-        .map_err(|e| ToolError::internal_message(format!("log store tail join: {e}")))?
-        .map_err(|e| ToolError::internal_message(format!("log store tail: {e}")))
+        self.blocking("tail", move |c| run_tail(c, &req)).await
     }
 
     pub async fn stats(&self) -> Result<LogStoreStats, ToolError> {
-        let conn = Arc::clone(&self.conn);
         let retention = self.retention;
-        let path = self.path.clone();
-        tokio::task::spawn_blocking(move || -> Result<LogStoreStats, rusqlite::Error> {
-            let c = conn.lock().expect("log store mutex poisoned");
-            run_stats(&c, retention, &path)
-        })
-        .await
-        .map_err(|e| ToolError::internal_message(format!("log store stats join: {e}")))?
-        .map_err(|e| ToolError::internal_message(format!("log store stats: {e}")))
+        self.blocking("stats", move |c| run_stats(c, retention))
+            .await
     }
 
     pub async fn run_maintenance(&self) -> Result<(), ToolError> {
-        let conn = Arc::clone(&self.conn);
         let retention = self.retention;
-        let path = self.path.clone();
-        tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+        self.blocking("maintenance", move |c| run_maintenance(c, retention))
+            .await
+    }
+
+    /// Run a `Connection`-using closure on the blocking pool. Wraps the
+    /// repeated `spawn_blocking → lock → double map_err` pattern.
+    async fn blocking<T, F>(&self, label: &'static str, f: F) -> Result<T, ToolError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Connection) -> Result<T, rusqlite::Error> + Send + 'static,
+    {
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || {
             let c = conn.lock().expect("log store mutex poisoned");
-            run_maintenance(&c, retention, &path)
+            f(&c)
         })
         .await
-        .map_err(|e| ToolError::internal_message(format!("log store maintenance join: {e}")))?
-        .map_err(|e| ToolError::internal_message(format!("log store maintenance: {e}")))
+        .map_err(|e| ToolError::internal_message(format!("log store {label} join: {e}")))?
+        .map_err(|e| ToolError::internal_message(format!("log store {label}: {e}")))
     }
 }
 
@@ -162,27 +149,10 @@ fn insert_event(conn: &Connection, event: &LogEvent) -> Result<(), rusqlite::Err
     Ok(())
 }
 
-fn level_from_str(s: &str) -> Option<LogLevel> {
-    Some(match s {
-        "trace" => LogLevel::Trace,
-        "debug" => LogLevel::Debug,
-        "info" => LogLevel::Info,
-        "warn" => LogLevel::Warn,
-        "error" => LogLevel::Error,
-        _ => return None,
-    })
-}
-
 // ── Search ────────────────────────────────────────────────────────────────────
 
 fn run_search(conn: &Connection, q: &LogQuery) -> Result<LogSearchResult, rusqlite::Error> {
-    let mut sql = String::from(
-        "SELECT event_id, ts, level, subsystem, surface, action, message,
-                request_id, session_id, correlation_id, trace_id, span_id,
-                instance, auth_flow, outcome_kind, fields_json,
-                source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
-         FROM log_events WHERE 1=1",
-    );
+    let mut sql = format!("SELECT {SELECT_COLS} FROM log_events WHERE 1=1");
     let mut args: Vec<rusqlite::types::Value> = Vec::new();
 
     if let Some(after) = q.after_ts {
@@ -193,39 +163,24 @@ fn run_search(conn: &Connection, q: &LogQuery) -> Result<LogSearchResult, rusqli
         sql.push_str(" AND ts < ?");
         args.push(before.into());
     }
-    if !q.levels.is_empty() {
-        sql.push_str(" AND level IN (");
-        for (i, lv) in q.levels.iter().enumerate() {
-            if i > 0 {
-                sql.push(',');
-            }
-            sql.push('?');
-            args.push(lv.as_str().to_string().into());
-        }
-        sql.push(')');
-    }
-    if !q.subsystems.is_empty() {
-        sql.push_str(" AND subsystem IN (");
-        for (i, s) in q.subsystems.iter().enumerate() {
-            if i > 0 {
-                sql.push(',');
-            }
-            sql.push('?');
-            args.push(s.as_str().to_string().into());
-        }
-        sql.push(')');
-    }
-    if !q.surfaces.is_empty() {
-        sql.push_str(" AND surface IN (");
-        for (i, s) in q.surfaces.iter().enumerate() {
-            if i > 0 {
-                sql.push(',');
-            }
-            sql.push('?');
-            args.push(s.as_str().to_string().into());
-        }
-        sql.push(')');
-    }
+    append_in_clause(
+        &mut sql,
+        &mut args,
+        "level",
+        q.levels.iter().map(|l| l.as_str().to_string()),
+    );
+    append_in_clause(
+        &mut sql,
+        &mut args,
+        "subsystem",
+        q.subsystems.iter().map(|s| s.as_str().to_string()),
+    );
+    append_in_clause(
+        &mut sql,
+        &mut args,
+        "surface",
+        q.surfaces.iter().map(|s| s.as_str().to_string()),
+    );
     if let Some(action) = &q.action {
         sql.push_str(" AND action = ?");
         args.push(action.clone().into());
@@ -263,6 +218,29 @@ fn run_search(conn: &Connection, q: &LogQuery) -> Result<LogSearchResult, rusqli
     Ok(LogSearchResult { events, next_cursor })
 }
 
+fn append_in_clause<I>(
+    sql: &mut String,
+    args: &mut Vec<rusqlite::types::Value>,
+    column: &str,
+    values: I,
+) where
+    I: IntoIterator<Item = String>,
+{
+    let values: Vec<String> = values.into_iter().collect();
+    if values.is_empty() {
+        return;
+    }
+    sql.push_str(&format!(" AND {column} IN ("));
+    for (i, v) in values.into_iter().enumerate() {
+        if i > 0 {
+            sql.push(',');
+        }
+        sql.push('?');
+        args.push(v.into());
+    }
+    sql.push(')');
+}
+
 fn row_to_event(row: &rusqlite::Row<'_>) -> Result<LogEvent, rusqlite::Error> {
     let level: String = row.get("level")?;
     let subsystem: String = row.get("subsystem")?;
@@ -271,7 +249,7 @@ fn row_to_event(row: &rusqlite::Row<'_>) -> Result<LogEvent, rusqlite::Error> {
     Ok(LogEvent {
         event_id: row.get("event_id")?,
         ts: row.get("ts")?,
-        level: level_from_str(&level).unwrap_or(LogLevel::Info),
+        level: LogLevel::parse(&level).unwrap_or(LogLevel::Info),
         subsystem: Subsystem::parse(&subsystem).unwrap_or(Subsystem::CoreRuntime),
         surface: Surface::parse(&surface).unwrap_or(Surface::CoreRuntime),
         action: row.get("action")?,
@@ -311,45 +289,25 @@ fn run_tail(conn: &Connection, req: &LogTailRequest) -> Result<LogTailResult, ru
             cursor_event_id = Some(ev_id.clone());
         }
     }
-    let limit = req.limit.unwrap_or(500).min(10_000);
+    let limit = req.limit.unwrap_or(500).min(10_000) as i64;
 
-    let (sql, args): (String, Vec<rusqlite::types::Value>) = match (cursor_ts, cursor_event_id) {
-        (Some(ts), Some(ev_id)) => (
-            "SELECT event_id, ts, level, subsystem, surface, action, message,
-                    request_id, session_id, correlation_id, trace_id, span_id,
-                    instance, auth_flow, outcome_kind, fields_json,
-                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
-             FROM log_events
-             WHERE ts > ?1 OR (ts = ?1 AND event_id > ?2)
-             ORDER BY ts ASC, event_id ASC
-             LIMIT ?3"
-                .into(),
-            vec![ts.into(), ev_id.into(), (limit as i64).into()],
-        ),
-        (Some(ts), None) => (
-            "SELECT event_id, ts, level, subsystem, surface, action, message,
-                    request_id, session_id, correlation_id, trace_id, span_id,
-                    instance, auth_flow, outcome_kind, fields_json,
-                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
-             FROM log_events
-             WHERE ts > ?1
-             ORDER BY ts ASC, event_id ASC
-             LIMIT ?2"
-                .into(),
-            vec![ts.into(), (limit as i64).into()],
-        ),
-        (None, _) => (
-            "SELECT event_id, ts, level, subsystem, surface, action, message,
-                    request_id, session_id, correlation_id, trace_id, span_id,
-                    instance, auth_flow, outcome_kind, fields_json,
-                    source_kind, source_node_id, source_device_id, ingest_path, upstream_event_id
-             FROM log_events
-             ORDER BY ts ASC, event_id ASC
-             LIMIT ?1"
-                .into(),
-            vec![(limit as i64).into()],
-        ),
-    };
+    // NOTE: the `ts > ?1 OR (ts = ?1 AND event_id > ?2)` tiebreaker is what
+    // makes the `since_event_id` cursor ordering stable. Do not collapse.
+    let (where_clause, args): (&str, Vec<rusqlite::types::Value>) =
+        match (cursor_ts, cursor_event_id) {
+            (Some(ts), Some(ev_id)) => (
+                "WHERE ts > ?1 OR (ts = ?1 AND event_id > ?2)",
+                vec![ts.into(), ev_id.into(), limit.into()],
+            ),
+            (Some(ts), None) => ("WHERE ts > ?1", vec![ts.into(), limit.into()]),
+            (None, _) => ("", vec![limit.into()]),
+        };
+
+    let limit_placeholder = args.len();
+    let sql = format!(
+        "SELECT {SELECT_COLS} FROM log_events {where_clause} \
+         ORDER BY ts ASC, event_id ASC LIMIT ?{limit_placeholder}"
+    );
 
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(args.iter()), row_to_event)?;
@@ -363,7 +321,6 @@ fn run_tail(conn: &Connection, req: &LogTailRequest) -> Result<LogTailResult, ru
 fn run_stats(
     conn: &Connection,
     retention: LogRetention,
-    _path: &Path,
 ) -> Result<LogStoreStats, rusqlite::Error> {
     let (total_event_count, oldest_retained_ts, newest_retained_ts): (u64, Option<i64>, Option<i64>) =
         conn.query_row(
@@ -398,16 +355,13 @@ fn content_bytes(conn: &Connection) -> Result<u64, rusqlite::Error> {
 
 // ── Maintenance ───────────────────────────────────────────────────────────────
 
-fn run_maintenance(
-    conn: &Connection,
-    retention: LogRetention,
-    _path: &Path,
-) -> Result<(), rusqlite::Error> {
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+fn run_maintenance(conn: &Connection, retention: LogRetention) -> Result<(), rusqlite::Error> {
+    let now_ms = super::ingest::now_ms();
+    let age_ms = i64::try_from(retention.max_age_days)
+        .ok()
+        .and_then(|d| d.checked_mul(86_400_000))
         .unwrap_or(i64::MAX);
-    let cutoff = now_ms.saturating_sub((retention.max_age_days as i64) * 86_400_000);
+    let cutoff = now_ms.saturating_sub(age_ms);
     conn.execute("DELETE FROM log_events WHERE ts < ?1", params![cutoff])?;
 
     for _ in 0..64 {

--- a/crates/lab/src/dispatch/logs/store.rs
+++ b/crates/lab/src/dispatch/logs/store.rs
@@ -363,7 +363,7 @@ fn run_tail(conn: &Connection, req: &LogTailRequest) -> Result<LogTailResult, ru
 fn run_stats(
     conn: &Connection,
     retention: LogRetention,
-    path: &Path,
+    _path: &Path,
 ) -> Result<LogStoreStats, rusqlite::Error> {
     let (total_event_count, oldest_retained_ts, newest_retained_ts): (u64, Option<i64>, Option<i64>) =
         conn.query_row(
@@ -372,7 +372,7 @@ fn run_stats(
             |row| Ok((row.get::<_, u64>(0)?, row.get(1)?, row.get(2)?)),
         )?;
 
-    let on_disk_bytes = sidecar_bytes(path);
+    let on_disk_bytes = content_bytes(conn)?;
 
     Ok(LogStoreStats {
         on_disk_bytes,
@@ -384,21 +384,16 @@ fn run_stats(
     })
 }
 
-fn sidecar_bytes(path: &Path) -> u64 {
-    let mut total = 0u64;
-    for suffix in ["", "-wal", "-shm"] {
-        let p = if suffix.is_empty() {
-            path.to_path_buf()
-        } else {
-            let mut os = path.as_os_str().to_os_string();
-            os.push(suffix);
-            PathBuf::from(os)
-        };
-        if let Ok(meta) = std::fs::metadata(&p) {
-            total = total.saturating_add(meta.len());
-        }
-    }
-    total
+/// Sum of the logical content bytes retained (message + fields_json + small
+/// per-row overhead). This is what retention policies act on — NOT the
+/// physical SQLite file size, which has fixed overhead + WAL sidecar weight
+/// that can't be shrunk below a few KB regardless of content.
+fn content_bytes(conn: &Connection) -> Result<u64, rusqlite::Error> {
+    conn.query_row(
+        "SELECT COALESCE(SUM(LENGTH(message) + LENGTH(fields_json)), 0) FROM log_events",
+        [],
+        |row| row.get::<_, i64>(0).map(|n| n.max(0) as u64),
+    )
 }
 
 // ── Maintenance ───────────────────────────────────────────────────────────────
@@ -406,7 +401,7 @@ fn sidecar_bytes(path: &Path) -> u64 {
 fn run_maintenance(
     conn: &Connection,
     retention: LogRetention,
-    path: &Path,
+    _path: &Path,
 ) -> Result<(), rusqlite::Error> {
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -415,19 +410,18 @@ fn run_maintenance(
     let cutoff = now_ms.saturating_sub((retention.max_age_days as i64) * 86_400_000);
     conn.execute("DELETE FROM log_events WHERE ts < ?1", params![cutoff])?;
 
-    for _ in 0..16 {
-        if sidecar_bytes(path) <= retention.max_bytes {
+    for _ in 0..64 {
+        if content_bytes(conn)? <= retention.max_bytes {
             break;
         }
         let affected = conn.execute(
             "DELETE FROM log_events WHERE rowid IN
-               (SELECT rowid FROM log_events ORDER BY ts ASC LIMIT 1024)",
+               (SELECT rowid FROM log_events ORDER BY ts ASC LIMIT 256)",
             [],
         )?;
         if affected == 0 {
             break;
         }
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;")?;
     }
     Ok(())
 }

--- a/crates/lab/src/dispatch/logs/store.rs
+++ b/crates/lab/src/dispatch/logs/store.rs
@@ -1,0 +1,31 @@
+// Stub — replaced by Task 4.
+use super::types::{LogQuery, LogRetention, LogSearchResult, LogStoreStats, LogTailRequest, LogTailResult};
+use crate::dispatch::error::ToolError;
+
+pub struct LogStore;
+
+impl LogStore {
+    pub async fn search(&self, _q: LogQuery) -> Result<LogSearchResult, ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+    pub async fn tail(&self, _r: LogTailRequest) -> Result<LogTailResult, ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+    pub async fn stats(&self) -> Result<LogStoreStats, ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+    pub async fn run_maintenance(&self) -> Result<(), ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+    pub async fn insert(&self, _e: &super::types::LogEvent) -> Result<(), ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+    pub async fn open(_p: std::path::PathBuf, _r: LogRetention) -> Result<Self, ToolError> {
+        unimplemented!("LogStore stub (Task 4)")
+    }
+}
+
+#[doc(hidden)]
+pub async fn open_store_for_test(_r: LogRetention) -> Result<LogStore, ToolError> {
+    unimplemented!("open_store_for_test stub (Task 4)")
+}

--- a/crates/lab/src/dispatch/logs/store_schema.sql
+++ b/crates/lab/src/dispatch/logs/store_schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS log_events (
+    event_id          TEXT PRIMARY KEY,
+    ts                INTEGER NOT NULL,
+    level             TEXT NOT NULL,
+    subsystem         TEXT NOT NULL,
+    surface           TEXT NOT NULL,
+    action            TEXT,
+    message           TEXT NOT NULL,
+    request_id        TEXT,
+    session_id        TEXT,
+    correlation_id    TEXT,
+    trace_id          TEXT,
+    span_id           TEXT,
+    instance          TEXT,
+    auth_flow         TEXT,
+    outcome_kind      TEXT,
+    fields_json       TEXT NOT NULL DEFAULT '{}',
+    source_kind       TEXT,
+    source_node_id    TEXT,
+    source_device_id  TEXT,
+    ingest_path       TEXT,
+    upstream_event_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_log_events_ts         ON log_events(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_log_events_level_ts   ON log_events(level, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_log_events_subsys_ts  ON log_events(subsystem, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_log_events_request_id ON log_events(request_id);
+CREATE INDEX IF NOT EXISTS idx_log_events_session_id ON log_events(session_id);

--- a/crates/lab/src/dispatch/logs/stream.rs
+++ b/crates/lab/src/dispatch/logs/stream.rs
@@ -1,14 +1,31 @@
-// Stub — replaced by Task 5.
+//! Broadcast fanout hub for live log streaming.
+
+use tokio::sync::broadcast;
+
 use super::types::{LogEvent, LogStreamReceiver, StreamSubscription};
 
-pub struct StreamHub;
+pub struct StreamHub {
+    sender: broadcast::Sender<LogEvent>,
+}
 
 impl StreamHub {
-    pub fn new(_capacity: usize) -> Self {
-        Self
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity.max(1));
+        Self { sender }
     }
-    pub fn subscribe(&self, _s: StreamSubscription) -> LogStreamReceiver {
-        unimplemented!("StreamHub stub (Task 5)")
+
+    /// Publish an event to all live subscribers. Non-blocking; if there are
+    /// no subscribers, `send` returns `Err(SendError)` which we swallow.
+    pub fn publish(&self, event: LogEvent) {
+        let _ = self.sender.send(event);
     }
-    pub fn publish(&self, _e: LogEvent) {}
+
+    /// Create a new receiver. Filtering is applied on the receiver side so
+    /// the shared broadcast channel carries every event — a slow subscriber
+    /// cannot starve others.
+    #[must_use]
+    pub fn subscribe(&self, filter: StreamSubscription) -> LogStreamReceiver {
+        LogStreamReceiver::new(self.sender.subscribe(), filter)
+    }
 }

--- a/crates/lab/src/dispatch/logs/stream.rs
+++ b/crates/lab/src/dispatch/logs/stream.rs
@@ -1,0 +1,14 @@
+// Stub — replaced by Task 5.
+use super::types::{LogEvent, LogStreamReceiver, StreamSubscription};
+
+pub struct StreamHub;
+
+impl StreamHub {
+    pub fn new(_capacity: usize) -> Self {
+        Self
+    }
+    pub fn subscribe(&self, _s: StreamSubscription) -> LogStreamReceiver {
+        unimplemented!("StreamHub stub (Task 5)")
+    }
+    pub fn publish(&self, _e: LogEvent) {}
+}

--- a/crates/lab/src/dispatch/logs/types.rs
+++ b/crates/lab/src/dispatch/logs/types.rs
@@ -1,0 +1,413 @@
+//! Wire types and runtime façade for the local-master log subsystem.
+//!
+//! All types here are serialized to JSON at the HTTP/MCP boundary and MUST
+//! preserve the snake_case + lowercase casing pinned by the gateway-admin
+//! TypeScript consumer in `apps/gateway-admin/lib/types/logs.ts`.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::dispatch::error::ToolError;
+
+// ── Enums ────────────────────────────────────────────────────────────────────
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum,
+)]
+#[serde(rename_all = "lowercase")]
+#[clap(rename_all = "lowercase")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
+pub enum Subsystem {
+    Gateway,
+    McpServer,
+    McpClient,
+    Api,
+    Web,
+    OauthRelay,
+    AuthWebui,
+    AuthMcp,
+    AuthUpstream,
+    CoreRuntime,
+}
+
+impl Subsystem {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Gateway => "gateway",
+            Self::McpServer => "mcp_server",
+            Self::McpClient => "mcp_client",
+            Self::Api => "api",
+            Self::Web => "web",
+            Self::OauthRelay => "oauth_relay",
+            Self::AuthWebui => "auth_webui",
+            Self::AuthMcp => "auth_mcp",
+            Self::AuthUpstream => "auth_upstream",
+            Self::CoreRuntime => "core_runtime",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "gateway" => Self::Gateway,
+            "mcp_server" => Self::McpServer,
+            "mcp_client" => Self::McpClient,
+            "api" => Self::Api,
+            "web" => Self::Web,
+            "oauth_relay" => Self::OauthRelay,
+            "auth_webui" => Self::AuthWebui,
+            "auth_mcp" => Self::AuthMcp,
+            "auth_upstream" => Self::AuthUpstream,
+            "core_runtime" => Self::CoreRuntime,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
+pub enum Surface {
+    Cli,
+    Mcp,
+    Api,
+    Web,
+    CoreRuntime,
+}
+
+impl Surface {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+            Self::Api => "api",
+            Self::Web => "web",
+            Self::CoreRuntime => "core_runtime",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "cli" => Self::Cli,
+            "mcp" => Self::Mcp,
+            "api" => Self::Api,
+            "web" => Self::Web,
+            "core_runtime" => Self::CoreRuntime,
+            _ => return None,
+        })
+    }
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LogEvent {
+    pub event_id: String,
+    pub ts: i64,
+    pub level: LogLevel,
+    pub subsystem: Subsystem,
+    pub surface: Surface,
+    #[serde(default)]
+    pub action: Option<String>,
+    pub message: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    #[serde(default)]
+    pub span_id: Option<String>,
+    #[serde(default)]
+    pub instance: Option<String>,
+    #[serde(default)]
+    pub auth_flow: Option<String>,
+    #[serde(default)]
+    pub outcome_kind: Option<String>,
+    #[serde(default)]
+    pub fields_json: serde_json::Value,
+    #[serde(default)]
+    pub source_kind: Option<String>,
+    #[serde(default)]
+    pub source_node_id: Option<String>,
+    #[serde(default)]
+    pub source_device_id: Option<String>,
+    #[serde(default)]
+    pub ingest_path: Option<String>,
+    #[serde(default)]
+    pub upstream_event_id: Option<String>,
+}
+
+impl LogEvent {
+    #[must_use]
+    pub fn fixture() -> Self {
+        Self {
+            event_id: "evt-fixture".to_string(),
+            ts: 1_713_225_600_000,
+            level: LogLevel::Info,
+            subsystem: Subsystem::CoreRuntime,
+            surface: Surface::CoreRuntime,
+            action: Some("fixture.event".to_string()),
+            message: "fixture log event".to_string(),
+            request_id: Some("req-fixture".to_string()),
+            session_id: Some("sess-fixture".to_string()),
+            correlation_id: Some("corr-fixture".to_string()),
+            trace_id: Some("trace-fixture".to_string()),
+            span_id: Some("span-fixture".to_string()),
+            instance: Some("default".to_string()),
+            auth_flow: None,
+            outcome_kind: Some("ok".to_string()),
+            fields_json: serde_json::json!({}),
+            source_kind: Some("local".to_string()),
+            source_node_id: Some("node-local".to_string()),
+            source_device_id: Some("device-local".to_string()),
+            ingest_path: Some("tracing".to_string()),
+            upstream_event_id: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RawLogEvent {
+    #[serde(default)]
+    pub ts: Option<i64>,
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub subsystem: Option<String>,
+    #[serde(default)]
+    pub surface: Option<String>,
+    #[serde(default)]
+    pub action: Option<String>,
+    pub message: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    #[serde(default)]
+    pub span_id: Option<String>,
+    #[serde(default)]
+    pub instance: Option<String>,
+    #[serde(default)]
+    pub auth_flow: Option<String>,
+    #[serde(default)]
+    pub outcome_kind: Option<String>,
+    #[serde(default)]
+    pub fields_json: serde_json::Value,
+    #[serde(default)]
+    pub source_kind: Option<String>,
+    #[serde(default)]
+    pub source_node_id: Option<String>,
+    #[serde(default)]
+    pub source_device_id: Option<String>,
+    #[serde(default)]
+    pub ingest_path: Option<String>,
+    #[serde(default)]
+    pub upstream_event_id: Option<String>,
+}
+
+// ── Queries ──────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct LogQuery {
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub after_ts: Option<i64>,
+    #[serde(default)]
+    pub before_ts: Option<i64>,
+    #[serde(default)]
+    pub levels: Vec<LogLevel>,
+    #[serde(default)]
+    pub subsystems: Vec<Subsystem>,
+    #[serde(default)]
+    pub surfaces: Vec<Surface>,
+    #[serde(default)]
+    pub action: Option<String>,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct LogTailRequest {
+    #[serde(default)]
+    pub after_ts: Option<i64>,
+    #[serde(default)]
+    pub since_event_id: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+// ── Results ──────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LogSearchResult {
+    pub events: Vec<LogEvent>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LogTailResult {
+    pub events: Vec<LogEvent>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct LogRetention {
+    pub max_age_days: u64,
+    pub max_bytes: u64,
+}
+
+impl Default for LogRetention {
+    fn default() -> Self {
+        Self {
+            max_age_days: 7,
+            max_bytes: 256 * 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LogStoreStats {
+    pub on_disk_bytes: u64,
+    pub oldest_retained_ts: Option<i64>,
+    pub newest_retained_ts: Option<i64>,
+    pub total_event_count: u64,
+    pub dropped_event_count: u64,
+    pub retention: LogRetention,
+}
+
+// ── Stream ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StreamSubscription {
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub levels: Vec<LogLevel>,
+    #[serde(default)]
+    pub subsystems: Vec<Subsystem>,
+    #[serde(default)]
+    pub surfaces: Vec<Surface>,
+}
+
+pub struct LogStreamReceiver {
+    inner: broadcast::Receiver<LogEvent>,
+    filter: StreamSubscription,
+}
+
+impl LogStreamReceiver {
+    pub(super) fn new(inner: broadcast::Receiver<LogEvent>, filter: StreamSubscription) -> Self {
+        Self { inner, filter }
+    }
+
+    pub async fn recv(&mut self) -> Result<LogEvent, broadcast::error::RecvError> {
+        loop {
+            let event = self.inner.recv().await?;
+            if self.matches(&event) {
+                return Ok(event);
+            }
+        }
+    }
+
+    fn matches(&self, event: &LogEvent) -> bool {
+        let f = &self.filter;
+        if !f.levels.is_empty() && !f.levels.contains(&event.level) {
+            return false;
+        }
+        if !f.subsystems.is_empty() && !f.subsystems.contains(&event.subsystem) {
+            return false;
+        }
+        if !f.surfaces.is_empty() && !f.surfaces.contains(&event.surface) {
+            return false;
+        }
+        if let Some(needle) = &f.text {
+            if !event.message.contains(needle.as_str()) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+// ── Runtime façade ───────────────────────────────────────────────────────────
+
+pub struct LogSystem {
+    pub(super) store: Arc<super::store::LogStore>,
+    pub(super) hub: Arc<super::stream::StreamHub>,
+    pub(super) ingest: super::ingest::IngestHandle,
+    pub(super) counters: Arc<super::ingest::IngestCounters>,
+}
+
+impl LogSystem {
+    pub async fn ingest(&self, raw: RawLogEvent) -> Result<(), ToolError> {
+        self.ingest.submit(raw).await
+    }
+
+    pub fn try_ingest(&self, raw: RawLogEvent) -> Result<(), ToolError> {
+        self.ingest.try_submit(raw)
+    }
+
+    pub async fn search(&self, query: LogQuery) -> Result<LogSearchResult, ToolError> {
+        self.store.search(query).await
+    }
+
+    pub async fn tail(&self, req: LogTailRequest) -> Result<LogTailResult, ToolError> {
+        self.store.tail(req).await
+    }
+
+    pub async fn stats(&self) -> Result<LogStoreStats, ToolError> {
+        let mut stats = self.store.stats().await?;
+        stats.dropped_event_count = self.counters.dropped();
+        Ok(stats)
+    }
+
+    pub async fn subscribe(
+        &self,
+        sub: StreamSubscription,
+    ) -> Result<LogStreamReceiver, ToolError> {
+        Ok(self.hub.subscribe(sub))
+    }
+}

--- a/crates/lab/src/dispatch/logs/types.rs
+++ b/crates/lab/src/dispatch/logs/types.rs
@@ -37,6 +37,19 @@ impl LogLevel {
             Self::Error => "error",
         }
     }
+
+    /// Parse a case-insensitive level name. Recognizes standard aliases
+    /// (`warning`, `err`, `information`).
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s.to_ascii_lowercase().as_str() {
+            "trace" => Self::Trace,
+            "debug" => Self::Debug,
+            "info" | "information" => Self::Info,
+            "warn" | "warning" => Self::Warn,
+            "error" | "err" => Self::Error,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(


### PR DESCRIPTION
## Summary

Rebuilds the eight `crates/lab/src/dispatch/logs/` submodules that PR #17 ("feat: finish local master log foundation") merged as module declarations only — the actual implementation files were swallowed by the `.gitignore`'s global `logs/` rule and never committed. `origin/main` has been failing to compile since that merge (`E0583: file not found for module catalog|client|dispatch|ingest|params|store|stream|types`).

## What's in this PR

- **`.gitignore` fix**: negate `!crates/lab/src/dispatch/logs/` so rebuilt files aren't silently skipped (root cause of the original bug)
- **8 submodule files**: `types.rs`, `store.rs` (+ `store_schema.sql`), `ingest.rs`, `stream.rs`, `catalog.rs`, `params.rs`, `dispatch.rs`, `client.rs` — reconstructed from the committed test spec + call sites
- **3 cleanup passes**: post-`rust-pro` review applied simplify + lavra-review, netting −172 LOC

Reconstructed from ground-truth: `crates/lab/tests/logs_{dispatch,api,cli}.rs` (the 25-test spec that survived the original merge), `crates/lab/src/cli/logs.rs`, `crates/lab/src/api/services/logs.rs`, and the TypeScript wire types in `apps/gateway-admin/lib/types/logs.ts`.

## Architecture

- **Store**: `rusqlite 0.37 bundled` with WAL mode, `tokio::task::spawn_blocking` on an `Arc<Mutex<Connection>>` — no `sqlx` dep
- **Ingest**: `tracing_subscriber::Layer` (`LogIngestLayer`) capturing events → bounded `mpsc` → async writer task; bearer tokens + secret-shaped JSON keys redacted before persist AND before fanout
- **Stream**: `tokio::sync::broadcast` hub with receiver-side filtering so slow SSE subscribers can't starve others; `Lagged(n)` surfaces as an SSE `event: lag` frame
- **Dispatch**: the standard `dispatch` + `dispatch_with_system` pair; reuses shared `help_payload` / `action_schema` / `handle_action` helpers — no service-local reinvention
- **Lifecycle**: `bootstrap_running_log_system` (read+write) installs the `Arc<LogSystem>` into a process-global `OnceLock` so `dispatch::dispatch` can reach it without `AppState`; `bootstrap_store_backed_log_system` (read-only) for CLI one-shots

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo test` on the three logs test files — **25/25 pass** (17 + 5 + 3)
- `cargo clippy --all-features --all-targets -- -D warnings` on the 9 new files — **zero violations**
- Pre-commit hooks pass on every commit (no `--no-verify` used)

## Test plan

- [x] `cargo test -p lab --all-features --test logs_dispatch` → 17/17
- [x] `cargo test -p lab --all-features --test logs_api` → 5/5
- [x] `cargo test -p lab --all-features --test logs_cli` → 3/3
- [x] `cargo test --workspace --all-features` → only pre-existing oauth-redaction failure remains (documented out-of-scope)
- [x] Rebased cleanly onto current `origin/main`

## Ambiguity resolutions applied

Since the original source was lost, a few contract points had to be decided from the call sites:
1. Env var prefix: `LAB_LOGS_*`
2. `logs.stream` dispatch returns `sdk_kind: "not_found"` directing callers to HTTP SSE (rather than `unknown_action`)
3. Retention self-log guard via `target: "lab::dispatch::logs"` filter in the tracing layer
4. `StreamSubscription` filter fields mirror `LogQuery` (levels/subsystems/surfaces/text)
5. `LogSystem::ingest` (await) persists inline; `try_ingest` (sync) queues — both paths pinned by committed tests
6. `LogStoreStats.on_disk_bytes` = sum of retained content bytes (not physical file size) — required by the retention test at `tests/logs_dispatch.rs:203`

Full plan in `docs/superpowers/plans/2026-04-17-rebuild-logs-dispatch.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the `logs` dispatch service lost in PR #17 and fixes the `.gitignore` rule so the files are tracked. This restores compile on `main` and adds a persisted store, live streaming, and safe ingest with redaction.

- **New Features**
  - SQLite-backed store via `rusqlite` (WAL) with search, tail, stats, and retention.
  - Ingest pipeline with bearer/secret redaction and async writer; live broadcast hub with receiver-side filtering.
  - Dispatch actions (`help`, `schema`, `logs.search`, `logs.tail`, `logs.stats`, `logs.stream`) with param parsing and consistent error handling.
  - Bootstrap from env/config with a process-global install; `uuid`-based event IDs.

- **Bug Fixes**
  - Negated `.gitignore` to include `crates/lab/src/dispatch/logs/*.rs`.
  - Restored eight missing submodules and schema file; `main` builds clean and existing logs tests pass.

<sup>Written for commit fe543bef2656a385ba1c204d21b8fb912b0d4f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive logging system with search, tail, and real-time streaming capabilities
  * Added log statistics, retention policies, and automatic maintenance
  * Added UUID-based event identification and log ingest pipeline with automatic field scrubbing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->