### PR TITLE
feat(gateway-admin): begin Aurora transition for gateways

### DIFF
--- a/apps/gateway-admin/components/gateway/empty-state.tsx
+++ b/apps/gateway-admin/components/gateway/empty-state.tsx
@@ -1,6 +1,12 @@
 import { Cable, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import {
+  AURORA_DISPLAY_TITLE,
+  AURORA_MUTED_LABEL,
+  AURORA_STRONG_PANEL,
+  gatewayActionTone,
+} from './gateway-theme'
 
 interface EmptyStateProps {
   title: string
@@ -21,17 +27,21 @@ export function EmptyState({
   className 
 }: EmptyStateProps) {
   return (
-    <div className={cn('flex flex-col items-center justify-center py-16 px-4', className)}>
-      <div className="flex size-12 items-center justify-center rounded-full bg-muted">
-        {icon || <Cable className="size-6 text-muted-foreground" />}
+    <div className={cn(AURORA_STRONG_PANEL, 'flex flex-col items-center justify-center px-4 py-16 text-center', className)}>
+      <div className="flex size-14 items-center justify-center rounded-full border border-aurora-border-strong bg-[linear-gradient(180deg,rgba(18,40,56,0.96),rgba(14,31,44,0.98))] shadow-[0_10px_18px_rgba(0,0,0,0.16),var(--aurora-highlight-medium)]">
+        {icon || <Cable className="size-6 text-aurora-accent-strong" />}
       </div>
-      <h3 className="mt-4 text-lg font-medium">{title}</h3>
-      <p className="mt-1 text-sm text-muted-foreground text-center max-w-sm">
+      <p className={cn(AURORA_MUTED_LABEL, 'mt-5')}>Gateway fleet</p>
+      <h3 className={cn(AURORA_DISPLAY_TITLE, 'mt-2 text-xl font-semibold text-aurora-text-primary')}>{title}</h3>
+      <p className="mt-2 max-w-sm text-sm leading-6 text-aurora-text-muted">
         {description}
       </p>
       {action && (
-        <Button onClick={action.onClick} className="mt-6">
-          <Plus className="size-4 mr-2" />
+        <Button
+          onClick={action.onClick}
+          className={cn(gatewayActionTone('accent'), 'mt-6 border px-4 text-aurora-text-primary hover:bg-[#17364b] hover:text-aurora-text-primary')}
+        >
+          <Plus className="mr-2 size-4" />
           {action.label}
         </Button>
       )}

--- a/apps/gateway-admin/components/gateway/gateway-filters.test.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-filters.test.tsx
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { GatewayFilters } from './gateway-filters'
+
+test('gateway filters render aurora control surfaces and clear state affordance', () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(GatewayFilters, {
+      search: 'plex',
+      onSearchChange: () => {},
+      healthFilter: 'enabled',
+      onHealthFilterChange: () => {},
+      connectionFilter: 'connected',
+      onConnectionFilterChange: () => {},
+      typeFilter: 'http',
+      onTypeFilterChange: () => {},
+    }),
+  )
+
+  assert.match(markup, /bg-aurora-panel-medium/)
+  assert.match(markup, /bg-aurora-control-surface/)
+  assert.match(markup, /Search gateways/)
+  assert.match(markup, /Clear filters/i)
+})

--- a/apps/gateway-admin/components/gateway/gateway-filters.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-filters.tsx
@@ -10,6 +10,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import {
+  AURORA_CONTROL_SURFACE,
+  AURORA_MEDIUM_PANEL,
+  AURORA_MUTED_LABEL,
+  gatewayActionTone,
+} from './gateway-theme'
 
 export type HealthFilter =
   | 'all'
@@ -52,62 +59,93 @@ export function GatewayFilters({
   }
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-      <div className="relative w-full sm:max-w-sm sm:flex-1">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-        <Input
-          placeholder="Search gateways..."
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          className="pl-9"
-        />
+    <div className={cn(AURORA_MEDIUM_PANEL, 'space-y-4 p-4')}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className={AURORA_MUTED_LABEL}>Fleet controls</p>
+          <p className="text-sm text-aurora-text-muted">
+            Narrow the control-plane view without losing the dense operational table.
+          </p>
+        </div>
+        {hasFilters && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={clearFilters}
+            className={cn(
+              gatewayActionTone(),
+              'h-9 px-3 text-aurora-text-primary hover:bg-[#17364b] hover:text-aurora-text-primary',
+            )}
+          >
+            <X className="mr-1 size-4" />
+            Clear filters
+          </Button>
+        )}
       </div>
 
-      <div className="grid w-full gap-3 sm:w-auto sm:grid-cols-3">
-      <Select value={healthFilter} onValueChange={(v) => onHealthFilterChange(v as HealthFilter)}>
-        <SelectTrigger className="w-full sm:w-[160px]">
-          <SelectValue placeholder="State" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All states</SelectItem>
-          <SelectItem value="active">Active</SelectItem>
-          <SelectItem value="enabled">Enabled</SelectItem>
-          <SelectItem value="disabled">Deactivated</SelectItem>
-          <SelectItem value="configured">Configured</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.25fr)_repeat(3,minmax(0,188px))]">
+        <div className="space-y-1.5">
+          <p className={AURORA_MUTED_LABEL}>Search</p>
+          <div className="relative">
+            <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-aurora-text-muted" />
+            <Input
+              placeholder="Search gateways, commands, or endpoints"
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className={cn(
+                AURORA_CONTROL_SURFACE,
+                'h-11 border pl-9 text-aurora-text-primary placeholder:text-aurora-text-muted',
+              )}
+            />
+          </div>
+        </div>
 
-      <Select value={connectionFilter} onValueChange={(v) => onConnectionFilterChange(v as ConnectionFilter)}>
-        <SelectTrigger className="w-full sm:w-[160px]">
-          <SelectValue placeholder="Connection" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All connections</SelectItem>
-          <SelectItem value="connected">Connected</SelectItem>
-          <SelectItem value="disconnected">Disconnected</SelectItem>
-        </SelectContent>
-      </Select>
+        <div className="space-y-1.5">
+          <p className={AURORA_MUTED_LABEL}>State</p>
+          <Select value={healthFilter} onValueChange={(v) => onHealthFilterChange(v as HealthFilter)}>
+            <SelectTrigger className={cn(AURORA_CONTROL_SURFACE, 'h-11 w-full border text-aurora-text-primary')}>
+              <SelectValue placeholder="State" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All states</SelectItem>
+              <SelectItem value="active">Active</SelectItem>
+              <SelectItem value="enabled">Enabled</SelectItem>
+              <SelectItem value="disabled">Deactivated</SelectItem>
+              <SelectItem value="configured">Configured</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
 
-      <Select value={typeFilter} onValueChange={(v) => onTypeFilterChange(v as GatewayTypeFilter)}>
-        <SelectTrigger className="w-full sm:w-[140px]">
-          <SelectValue placeholder="Type" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All types</SelectItem>
-          <SelectItem value="lab">Lab</SelectItem>
-          <SelectItem value="custom">Custom</SelectItem>
-          <SelectItem value="http">HTTP</SelectItem>
-          <SelectItem value="stdio">stdio</SelectItem>
-        </SelectContent>
-      </Select>
+        <div className="space-y-1.5">
+          <p className={AURORA_MUTED_LABEL}>Connection</p>
+          <Select value={connectionFilter} onValueChange={(v) => onConnectionFilterChange(v as ConnectionFilter)}>
+            <SelectTrigger className={cn(AURORA_CONTROL_SURFACE, 'h-11 w-full border text-aurora-text-primary')}>
+              <SelectValue placeholder="Connection" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All connections</SelectItem>
+              <SelectItem value="connected">Connected</SelectItem>
+              <SelectItem value="disconnected">Disconnected</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <p className={AURORA_MUTED_LABEL}>Type</p>
+          <Select value={typeFilter} onValueChange={(v) => onTypeFilterChange(v as GatewayTypeFilter)}>
+            <SelectTrigger className={cn(AURORA_CONTROL_SURFACE, 'h-11 w-full border text-aurora-text-primary')}>
+              <SelectValue placeholder="Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              <SelectItem value="lab">Lab</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
+              <SelectItem value="http">HTTP</SelectItem>
+              <SelectItem value="stdio">stdio</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
-
-      {hasFilters && (
-        <Button variant="ghost" size="sm" onClick={clearFilters} className="h-9 self-start px-2 sm:self-auto">
-          <X className="size-4 mr-1" />
-          Clear
-        </Button>
-      )}
     </div>
   )
 }

--- a/apps/gateway-admin/components/gateway/gateway-list-content.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-list-content.tsx
@@ -19,7 +19,18 @@ import { DeleteGatewayDialog } from './delete-gateway-dialog'
 import { TestResultPanel } from './test-result-panel'
 import { useGateways, useGatewayMutations } from '@/lib/hooks/use-gateways'
 import type { Gateway, CreateGatewayInput, UpdateGatewayInput } from '@/lib/types/gateway'
-import { getErrorMessage } from '@/lib/utils'
+import { cn, getErrorMessage } from '@/lib/utils'
+import {
+  AURORA_DISPLAY_NUMBER,
+  AURORA_DISPLAY_TITLE,
+  AURORA_MEDIUM_PANEL,
+  AURORA_MUTED_LABEL,
+  AURORA_PAGE_FRAME,
+  AURORA_PAGE_SHELL,
+  AURORA_STRONG_PANEL,
+  AURORA_GATEWAY_STAT,
+  gatewayActionTone,
+} from './gateway-theme'
 
 export function GatewayListContent() {
   const { data: gateways, isLoading, error } = useGateways()
@@ -177,85 +188,116 @@ export function GatewayListContent() {
           { label: 'Gateways' }
         ]}
         actions={
-          <Button onClick={handleCreate}>
+          <Button
+            onClick={handleCreate}
+            className={cn(gatewayActionTone('accent'), 'border px-4 text-aurora-text-primary hover:bg-[#17364b] hover:text-aurora-text-primary')}
+          >
             <Plus className="size-4 mr-2" />
             Add Gateway
           </Button>
         }
       />
 
-      <div className="flex-1 p-6 space-y-6">
-        <div className="rounded-xl border bg-card/80 p-3 shadow-sm shadow-black/5">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm font-medium">
-              <Cable className="size-4 text-muted-foreground" />
-              <span className="tabular-nums">{summary.total}</span>
-              <span className="text-muted-foreground">configured</span>
+      <div className={`relative min-h-[calc(100vh-3.5rem)] w-full overflow-hidden bg-aurora-page-bg text-aurora-text-primary ${AURORA_PAGE_SHELL}`}>
+        <div className={cn(AURORA_PAGE_FRAME, 'gap-6')}>
+          <section className={cn(AURORA_MEDIUM_PANEL, 'space-y-5 p-5')}>
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="space-y-1">
+                <p className={AURORA_MUTED_LABEL}>Gateway fleet</p>
+                <h1 className={cn(AURORA_DISPLAY_TITLE, 'text-2xl font-semibold text-aurora-text-primary')}>
+                  Operational gateway control plane
+                </h1>
+                <p className="max-w-3xl text-sm leading-6 text-aurora-text-muted">
+                  Monitor connection health, surface exposure, and operator follow-up without changing the existing workflow.
+                </p>
+              </div>
+              <p className="max-w-sm text-sm leading-6 text-aurora-text-muted">
+                {summary.warnings} warning{summary.warnings === 1 ? '' : 's'} across all gateways.
+              </p>
             </div>
-            <div className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm font-medium">
-              <Activity className="size-4 text-emerald-500" />
-              <span className="tabular-nums">{summary.healthy}</span>
-              <span className="text-muted-foreground">healthy</span>
+
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className={AURORA_GATEWAY_STAT}>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className={AURORA_MUTED_LABEL}>Configured</p>
+                    <p className={cn(AURORA_DISPLAY_NUMBER, 'mt-2 text-3xl text-aurora-text-primary')}>{summary.total}</p>
+                  </div>
+                  <Cable className="size-5 text-aurora-text-muted" />
+                </div>
+              </div>
+              <div className={AURORA_GATEWAY_STAT}>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className={AURORA_MUTED_LABEL}>Healthy</p>
+                    <p className={cn(AURORA_DISPLAY_NUMBER, 'mt-2 text-3xl text-aurora-accent-strong')}>{summary.healthy}</p>
+                  </div>
+                  <Activity className="size-5 text-aurora-accent-strong" />
+                </div>
+              </div>
+              <div className={AURORA_GATEWAY_STAT}>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className={AURORA_MUTED_LABEL}>Disconnected</p>
+                    <p className={cn(AURORA_DISPLAY_NUMBER, 'mt-2 text-3xl text-aurora-warn')}>{summary.disconnected}</p>
+                  </div>
+                  <TriangleAlert className="size-5 text-aurora-warn" />
+                </div>
+              </div>
+              <div className={AURORA_GATEWAY_STAT}>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className={AURORA_MUTED_LABEL}>Discovered tools</p>
+                    <p className={cn(AURORA_DISPLAY_NUMBER, 'mt-2 text-3xl text-aurora-text-primary')}>{summary.tools}</p>
+                  </div>
+                  <Wrench className="size-5 text-aurora-accent-primary" />
+                </div>
+              </div>
             </div>
-            <div className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm font-medium">
-              <TriangleAlert className="size-4 text-amber-500" />
-              <span className="tabular-nums">{summary.disconnected}</span>
-              <span className="text-muted-foreground">disconnected</span>
-            </div>
-            <div className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm font-medium">
-              <Wrench className="size-4 text-primary" />
-              <span className="tabular-nums">{summary.tools}</span>
-              <span className="text-muted-foreground">tools</span>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {summary.warnings} warning{summary.warnings === 1 ? '' : 's'} across all gateways.
-            </p>
           </div>
-        </div>
 
-        {/* Filters */}
-        <GatewayFilters
-          search={search}
-          onSearchChange={setSearch}
-          healthFilter={healthFilter}
-          onHealthFilterChange={setHealthFilter}
-          connectionFilter={connectionFilter}
-          onConnectionFilterChange={setConnectionFilter}
-          typeFilter={typeFilter}
-          onTypeFilterChange={setTypeFilter}
-        />
+          <GatewayFilters
+            search={search}
+            onSearchChange={setSearch}
+            healthFilter={healthFilter}
+            onHealthFilterChange={setHealthFilter}
+            connectionFilter={connectionFilter}
+            onConnectionFilterChange={setConnectionFilter}
+            typeFilter={typeFilter}
+            onTypeFilterChange={setTypeFilter}
+          />
 
-        {/* Content */}
-        <div className="rounded-lg border bg-card">
-          {isLoading ? (
-            <GatewayTableSkeleton />
-          ) : error ? (
-            <div className="p-8 text-center">
-              <p className="text-destructive">Failed to load gateways</p>
-              <p className="text-sm text-muted-foreground mt-1">{error.message}</p>
-            </div>
-          ) : filteredGateways.length === 0 ? (
-            gateways?.length === 0 ? (
-              <EmptyState
-                title="No gateways configured"
-                description="Get started by adding your first MCP gateway connection to manage upstream gateway tools."
-                action={{ label: 'Add Gateway', onClick: handleCreate }}
-              />
+          <div>
+            {isLoading ? (
+              <GatewayTableSkeleton />
+            ) : error ? (
+              <div className={cn(AURORA_STRONG_PANEL, 'p-8 text-center')}>
+                <p className="text-aurora-error">Failed to load gateways</p>
+                <p className="mt-1 text-sm text-aurora-text-muted">{error.message}</p>
+              </div>
+            ) : filteredGateways.length === 0 ? (
+              gateways?.length === 0 ? (
+                <EmptyState
+                  title="No gateways configured"
+                  description="Get started by adding your first MCP gateway connection to manage upstream gateway tools."
+                  action={{ label: 'Add Gateway', onClick: handleCreate }}
+                />
+              ) : (
+                <EmptyState
+                  title="No matching gateways"
+                  description="Try adjusting your filters to find what you&apos;re looking for."
+                />
+              )
             ) : (
-              <EmptyState
-                title="No matching gateways"
-                description="Try adjusting your filters to find what you&apos;re looking for."
+              <GatewayTable
+                gateways={filteredGateways}
+                onEdit={handleEdit}
+                onTest={handleTest}
+                onReload={handleReload}
+                onDelete={setDeleteGateway}
               />
-            )
-          ) : (
-            <GatewayTable
-              gateways={filteredGateways}
-              onEdit={handleEdit}
-              onTest={handleTest}
-              onReload={handleReload}
-              onDelete={setDeleteGateway}
-            />
-          )}
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/gateway-admin/components/gateway/gateway-table.test.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-table.test.tsx
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { GatewayTable } from './gateway-table'
+import type { Gateway } from '@/lib/types/gateway'
+
+const gateway: Gateway = {
+  id: 'gw_1',
+  name: 'Plex Control Plane',
+  transport: 'http',
+  source: 'custom',
+  configured: true,
+  enabled: true,
+  config: {
+    url: 'https://plex.example.com/mcp',
+  },
+  status: {
+    healthy: true,
+    connected: true,
+    last_error: 'Reload required to apply policy changes.',
+    discovered_tool_count: 18,
+    exposed_tool_count: 14,
+    discovered_resource_count: 6,
+    exposed_resource_count: 4,
+    discovered_prompt_count: 3,
+    exposed_prompt_count: 2,
+  },
+  discovery: {
+    tools: [],
+    resources: [],
+    prompts: [],
+  },
+  warnings: [
+    {
+      code: 'policy_drift',
+      message: 'Tool exposure differs from the last successful sync.',
+      timestamp: '2026-04-17T13:00:00Z',
+    },
+  ],
+  created_at: '2026-04-16T12:00:00Z',
+  updated_at: '2026-04-17T12:00:00Z',
+}
+
+test('gateway table uses aurora lifted surfaces and muted operational pills', () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(GatewayTable, {
+      gateways: [gateway],
+      onEdit: () => {},
+      onTest: () => {},
+      onReload: () => {},
+      onDelete: () => {},
+    }),
+  )
+
+  assert.match(markup, /bg-aurora-panel-strong/)
+  assert.match(markup, /bg-aurora-control-surface/)
+  assert.match(markup, /text-aurora-text-primary/)
+  assert.match(markup, /text-aurora-warn/)
+})

--- a/apps/gateway-admin/components/gateway/gateway-table.tsx
+++ b/apps/gateway-admin/components/gateway/gateway-table.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { 
-  MoreHorizontal, 
-  Eye, 
-  Pencil, 
-  Play, 
-  RefreshCw, 
+import {
+  MoreHorizontal,
+  Eye,
+  Pencil,
+  Play,
+  RefreshCw,
   Trash2,
   FileText,
   MessageSquare,
@@ -30,12 +30,25 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 import { TransportBadge } from './transport-badge'
 import { WarningsPill } from './warnings-pill'
 import type { Gateway } from '@/lib/types/gateway'
 import { gatewayDetailHref } from '@/lib/api/gateway-config'
 import { buildGatewayEndpointPreview } from '@/lib/api/gateway-mobile'
 import { SurfaceRatio } from './surface-ratio'
+import {
+  AURORA_DISPLAY_TITLE,
+  AURORA_MUTED_LABEL,
+  AURORA_STRONG_PANEL,
+  AURORA_GATEWAY_CARD,
+  AURORA_GATEWAY_DISABLED_ROW,
+  AURORA_GATEWAY_MUTED_CARD,
+  AURORA_GATEWAY_ROW,
+  AURORA_GATEWAY_SUBTLE_SURFACE,
+  gatewayActionTone,
+  gatewayStatusTone,
+} from './gateway-theme'
 
 interface GatewayTableProps {
   gateways: Gateway[]
@@ -76,11 +89,16 @@ export function GatewayTable({
         {gateways.map((gateway) => {
           const supportsProbeControls = gateway.source !== 'lab_service'
           const isDisabled = gateway.source === 'lab_service' && !(gateway.enabled ?? true)
+          const statusTone = gatewayStatusTone(gateway.status.healthy, gateway.status.connected)
 
           return (
             <article
               key={gateway.id}
-              className={isDisabled ? 'rounded-xl border bg-muted/20 p-4 text-muted-foreground' : 'rounded-xl border bg-card p-4'}
+              className={cn(
+                isDisabled ? AURORA_GATEWAY_MUTED_CARD : AURORA_GATEWAY_CARD,
+                'p-4 text-aurora-text-primary',
+                isDisabled && 'text-[#8ea4b3]',
+              )}
             >
               <div className="flex items-start gap-3">
                 <div className="min-w-0 flex-1 space-y-3">
@@ -89,21 +107,25 @@ export function GatewayTable({
                       <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <Link
                           href={gatewayDetailHref(gateway.id)}
-                          className="min-w-0 max-w-full text-base font-semibold break-words hover:underline underline-offset-4"
+                          className={cn(
+                            AURORA_DISPLAY_TITLE,
+                            'min-w-0 max-w-full break-words text-base font-semibold text-aurora-text-primary hover:text-aurora-accent-strong hover:underline underline-offset-4',
+                          )}
                         >
                           {gateway.name}
                         </Link>
                         {isDisabled && (
-                          <Badge variant="secondary" className="text-[10px] uppercase">
+                          <Badge className="rounded-full border border-aurora-border-strong bg-[rgba(7,17,26,0.48)] text-[10px] uppercase tracking-[0.16em] text-aurora-text-muted">
                             Disabled
                           </Badge>
                         )}
                       </div>
                       <div className="flex flex-wrap items-center gap-2">
                         <span
-                          className={`size-2 rounded-full ${gateway.status.healthy && gateway.status.connected ? 'bg-emerald-500' : 'bg-rose-500'}`}
+                          className={cn('size-2 rounded-full', statusTone.dot)}
                           aria-hidden="true"
                         />
+                        <span className={cn(AURORA_MUTED_LABEL, 'tracking-[0.14em]', statusTone.text)}>{statusTone.label}</span>
                         <TransportBadge transport={gateway.transport} />
                         <WarningsPill warnings={gateway.warnings} />
                       </div>
@@ -111,7 +133,11 @@ export function GatewayTable({
 
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="size-8 shrink-0">
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className={cn(gatewayActionTone(), 'size-9 shrink-0 hover:bg-[#17364b] hover:text-aurora-text-primary')}
+                        >
                           <MoreHorizontal className="size-4" />
                           <span className="sr-only">More actions</span>
                         </Button>
@@ -152,7 +178,7 @@ export function GatewayTable({
                     </DropdownMenu>
                   </div>
 
-                  <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/20 p-3">
+                  <div className={cn(AURORA_GATEWAY_SUBTLE_SURFACE, 'flex flex-wrap items-center gap-2 p-3')}>
                     <SurfaceRatio
                       icon={Wrench}
                       label="Tools"
@@ -174,7 +200,7 @@ export function GatewayTable({
                   </div>
 
                   {gateway.status.last_error && (
-                    <p className="line-clamp-2 break-words text-xs text-warning">{gateway.status.last_error}</p>
+                    <p className="line-clamp-2 break-words text-xs text-aurora-warn">{gateway.status.last_error}</p>
                   )}
 
                   <div className="flex flex-wrap items-center gap-2">
@@ -182,7 +208,7 @@ export function GatewayTable({
                       <Button
                         variant="outline"
                         size="sm"
-                        className="h-8"
+                        className={cn(gatewayActionTone(), 'h-9 hover:bg-[#17364b] hover:text-aurora-text-primary')}
                         onClick={() => handleAction(gateway, 'test', onTest)}
                         disabled={isLoading(gateway.id, 'test')}
                       >
@@ -194,7 +220,7 @@ export function GatewayTable({
                       <Button
                         variant="outline"
                         size="sm"
-                        className="h-8"
+                        className={cn(gatewayActionTone(), 'h-9 hover:bg-[#17364b] hover:text-aurora-text-primary')}
                         onClick={() => handleAction(gateway, 'reload', onReload)}
                         disabled={isLoading(gateway.id, 'reload')}
                       >
@@ -202,7 +228,12 @@ export function GatewayTable({
                         Reload
                       </Button>
                     )}
-                    <Button asChild variant="ghost" size="sm" className="h-8 px-2">
+                    <Button
+                      asChild
+                      variant="outline"
+                      size="sm"
+                      className={cn(gatewayActionTone('accent'), 'h-9 px-3 hover:bg-[#17364b] hover:text-aurora-text-primary')}
+                    >
                       <Link href={gatewayDetailHref(gateway.id)}>
                         View
                       </Link>
@@ -215,152 +246,169 @@ export function GatewayTable({
         })}
       </div>
 
-      <div className="hidden md:block">
+      <div className={cn(AURORA_STRONG_PANEL, 'hidden overflow-hidden md:block')}>
         <Table className="table-fixed">
           <TableHeader>
-            <TableRow>
-              <TableHead className="w-[62%]">Gateway</TableHead>
-              <TableHead className="w-[26%]">Surfaces</TableHead>
-              <TableHead className="w-[116px] text-right">Actions</TableHead>
+            <TableRow className="border-b border-aurora-border-strong bg-[rgba(7,17,26,0.48)] hover:bg-[rgba(7,17,26,0.48)]">
+              <TableHead className={cn(AURORA_MUTED_LABEL, 'w-[62%] px-6 py-4')}>Gateway</TableHead>
+              <TableHead className={cn(AURORA_MUTED_LABEL, 'w-[26%] px-4 py-4')}>Surfaces</TableHead>
+              <TableHead className={cn(AURORA_MUTED_LABEL, 'w-[116px] px-6 py-4 text-right')}>Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {gateways.map((gateway) => {
               const supportsProbeControls = gateway.source !== 'lab_service'
               const endpointPreview = buildGatewayEndpointPreview(gateway)
+              const isDisabled = gateway.source === 'lab_service' && !(gateway.enabled ?? true)
+              const statusTone = gatewayStatusTone(gateway.status.healthy, gateway.status.connected)
 
               return (
-              <TableRow
-                key={gateway.id}
-                className={gateway.source === 'lab_service' && !(gateway.enabled ?? true) ? 'group bg-muted/20 text-muted-foreground' : 'group'}
-              >
-                <TableCell className="w-[62%] align-top whitespace-normal">
-                  <div className="min-w-0 space-y-1">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      <span
-                        className={`size-2 rounded-full ${gateway.status.healthy && gateway.status.connected ? 'bg-emerald-500' : 'bg-rose-500'}`}
-                        aria-hidden="true"
-                      />
-                      <Link 
-                        href={gatewayDetailHref(gateway.id)}
-                        className="min-w-0 max-w-full font-medium break-words hover:underline underline-offset-4"
-                      >
-                        {gateway.name}
-                      </Link>
-                      {gateway.source === 'lab_service' && !(gateway.enabled ?? true) && (
-                        <Badge variant="secondary" className="text-[10px] uppercase">
-                          Disabled
-                        </Badge>
-                      )}
-                      <TransportBadge transport={gateway.transport} />
-                      <WarningsPill warnings={gateway.warnings} />
-                    </div>
-                    <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                      <span className="truncate" title={endpointPreview}>
-                        {endpointPreview}
-                      </span>
-                      <span className="tabular-nums">
-                        {gateway.source === 'lab_service' && !(gateway.enabled ?? true) ? 'deactivated' : 'active'}
-                      </span>
-                    </div>
-                    {gateway.status.last_error && (
-                      <p className="line-clamp-2 break-words text-xs text-warning">{gateway.status.last_error}</p>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell className="align-top">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <SurfaceRatio
-                      icon={Wrench}
-                      label="Tools"
-                      exposed={gateway.status.exposed_tool_count}
-                      total={gateway.status.discovered_tool_count}
-                    />
-                    <SurfaceRatio
-                      icon={FileText}
-                      label="Resources"
-                      exposed={gateway.status.exposed_resource_count}
-                      total={gateway.status.discovered_resource_count}
-                    />
-                    <SurfaceRatio
-                      icon={MessageSquare}
-                      label="Prompts"
-                      exposed={gateway.status.exposed_prompt_count}
-                      total={gateway.status.discovered_prompt_count}
-                    />
-                  </div>
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    {supportsProbeControls && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
-                        onClick={() => handleAction(gateway, 'test', onTest)}
-                        disabled={isLoading(gateway.id, 'test')}
-                      >
-                        <Play className={`size-4 ${isLoading(gateway.id, 'test') ? 'animate-pulse' : ''}`} />
-                        <span className="sr-only">Test connection</span>
-                      </Button>
-                    )}
-                    {supportsProbeControls && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
-                        onClick={() => handleAction(gateway, 'reload', onReload)}
-                        disabled={isLoading(gateway.id, 'reload')}
-                      >
-                        <RefreshCw className={`size-4 ${isLoading(gateway.id, 'reload') ? 'animate-spin' : ''}`} />
-                        <span className="sr-only">Reload gateway</span>
-                      </Button>
-                    )}
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="size-8">
-                          <MoreHorizontal className="size-4" />
-                          <span className="sr-only">More actions</span>
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem asChild>
-                          <Link href={gatewayDetailHref(gateway.id)}>
-                            <Eye className="size-4 mr-2" />
-                            View details
-                          </Link>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => onEdit(gateway)}>
-                          <Pencil className="size-4 mr-2" />
-                          Edit gateway
-                        </DropdownMenuItem>
-                        {supportsProbeControls && (
-                          <>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem onClick={() => onTest(gateway)}>
-                              <Play className="size-4 mr-2" />
-                              Test connection
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => onReload(gateway)}>
-                              <RefreshCw className="size-4 mr-2" />
-                              Reload gateway
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem 
-                          onClick={() => onDelete(gateway)}
-                          className="text-destructive focus:text-destructive"
+                <TableRow
+                  key={gateway.id}
+                  className={cn('group', isDisabled ? AURORA_GATEWAY_DISABLED_ROW : AURORA_GATEWAY_ROW)}
+                >
+                  <TableCell className="w-[62%] px-6 py-4 align-top whitespace-normal">
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <span
+                          className={cn('size-2 rounded-full', statusTone.dot)}
+                          aria-hidden="true"
+                        />
+                        <span className={cn(AURORA_MUTED_LABEL, 'tracking-[0.14em]', statusTone.text)}>{statusTone.label}</span>
+                        <Link
+                          href={gatewayDetailHref(gateway.id)}
+                          className={cn(
+                            AURORA_DISPLAY_TITLE,
+                            'min-w-0 max-w-full break-words font-medium text-aurora-text-primary hover:text-aurora-accent-strong hover:underline underline-offset-4',
+                          )}
                         >
-                          <Trash2 className="size-4 mr-2" />
-                          {gateway.source === 'lab_service' ? 'Disable gateway' : 'Remove gateway'}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </TableCell>
-              </TableRow>
-            )})}
+                          {gateway.name}
+                        </Link>
+                        {isDisabled && (
+                          <Badge className="rounded-full border border-aurora-border-strong bg-[rgba(7,17,26,0.48)] text-[10px] uppercase tracking-[0.16em] text-aurora-text-muted">
+                            Disabled
+                          </Badge>
+                        )}
+                        <TransportBadge transport={gateway.transport} />
+                        <WarningsPill warnings={gateway.warnings} />
+                      </div>
+                      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-aurora-text-muted">
+                        <span className="truncate text-[#c8d9e3]" title={endpointPreview}>
+                          {endpointPreview}
+                        </span>
+                        <span className="tabular-nums">
+                          {isDisabled ? 'deactivated' : 'active'}
+                        </span>
+                      </div>
+                      {gateway.status.last_error && (
+                        <p className="line-clamp-2 break-words text-xs text-aurora-warn">{gateway.status.last_error}</p>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="px-4 py-4 align-top">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <SurfaceRatio
+                        icon={Wrench}
+                        label="Tools"
+                        exposed={gateway.status.exposed_tool_count}
+                        total={gateway.status.discovered_tool_count}
+                      />
+                      <SurfaceRatio
+                        icon={FileText}
+                        label="Resources"
+                        exposed={gateway.status.exposed_resource_count}
+                        total={gateway.status.discovered_resource_count}
+                      />
+                      <SurfaceRatio
+                        icon={MessageSquare}
+                        label="Prompts"
+                        exposed={gateway.status.exposed_prompt_count}
+                        total={gateway.status.discovered_prompt_count}
+                      />
+                    </div>
+                  </TableCell>
+                  <TableCell className="px-6 py-4 text-right">
+                    <div className="flex items-center justify-end gap-1">
+                      {supportsProbeControls && (
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className={cn(
+                            gatewayActionTone(),
+                            'size-9 opacity-100 transition-opacity hover:bg-[#17364b] hover:text-aurora-text-primary md:opacity-0 md:group-hover:opacity-100',
+                          )}
+                          onClick={() => handleAction(gateway, 'test', onTest)}
+                          disabled={isLoading(gateway.id, 'test')}
+                        >
+                          <Play className={`size-4 ${isLoading(gateway.id, 'test') ? 'animate-pulse' : ''}`} />
+                          <span className="sr-only">Test connection</span>
+                        </Button>
+                      )}
+                      {supportsProbeControls && (
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className={cn(
+                            gatewayActionTone(),
+                            'size-9 opacity-100 transition-opacity hover:bg-[#17364b] hover:text-aurora-text-primary md:opacity-0 md:group-hover:opacity-100',
+                          )}
+                          onClick={() => handleAction(gateway, 'reload', onReload)}
+                          disabled={isLoading(gateway.id, 'reload')}
+                        >
+                          <RefreshCw className={`size-4 ${isLoading(gateway.id, 'reload') ? 'animate-spin' : ''}`} />
+                          <span className="sr-only">Reload gateway</span>
+                        </Button>
+                      )}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="icon"
+                            className={cn(gatewayActionTone(), 'size-9 hover:bg-[#17364b] hover:text-aurora-text-primary')}
+                          >
+                            <MoreHorizontal className="size-4" />
+                            <span className="sr-only">More actions</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem asChild>
+                            <Link href={gatewayDetailHref(gateway.id)}>
+                              <Eye className="mr-2 size-4" />
+                              View details
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => onEdit(gateway)}>
+                            <Pencil className="mr-2 size-4" />
+                            Edit gateway
+                          </DropdownMenuItem>
+                          {supportsProbeControls && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem onClick={() => onTest(gateway)}>
+                                <Play className="mr-2 size-4" />
+                                Test connection
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => onReload(gateway)}>
+                                <RefreshCw className="mr-2 size-4" />
+                                Reload gateway
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => onDelete(gateway)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 size-4" />
+                            {gateway.source === 'lab_service' ? 'Disable gateway' : 'Remove gateway'}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
           </TableBody>
         </Table>
       </div>

--- a/apps/gateway-admin/components/gateway/gateway-theme.ts
+++ b/apps/gateway-admin/components/gateway/gateway-theme.ts
@@ -1,0 +1,69 @@
+import { cn } from '@/lib/utils'
+import {
+  AURORA_CONTROL_SURFACE,
+  AURORA_DISPLAY_NUMBER,
+  AURORA_DISPLAY_TITLE,
+  AURORA_MEDIUM_PANEL,
+  AURORA_MUTED_LABEL,
+  AURORA_PAGE_FRAME,
+  AURORA_PAGE_SHELL,
+  AURORA_STRONG_PANEL,
+  controlTone,
+} from '@/components/logs/log-theme'
+
+export {
+  AURORA_CONTROL_SURFACE,
+  AURORA_DISPLAY_NUMBER,
+  AURORA_DISPLAY_TITLE,
+  AURORA_MEDIUM_PANEL,
+  AURORA_MUTED_LABEL,
+  AURORA_PAGE_FRAME,
+  AURORA_PAGE_SHELL,
+  AURORA_STRONG_PANEL,
+}
+
+export const AURORA_GATEWAY_STAT =
+  'rounded-[1.05rem] border border-aurora-border-strong bg-[linear-gradient(180deg,rgba(18,40,56,0.96),rgba(12,27,38,0.98))] px-4 py-3 shadow-[0_8px_18px_rgba(0,0,0,0.18),var(--aurora-highlight-medium)]'
+
+export const AURORA_GATEWAY_CARD =
+  'rounded-[1.2rem] border border-aurora-border-strong bg-[linear-gradient(180deg,rgba(14,31,44,0.98),rgba(9,21,30,0.98))] shadow-[0_16px_30px_rgba(0,0,0,0.2),var(--aurora-highlight-medium)]'
+
+export const AURORA_GATEWAY_MUTED_CARD =
+  'rounded-[1.15rem] border border-aurora-border-strong/80 bg-[linear-gradient(180deg,rgba(9,22,31,0.92),rgba(8,18,26,0.98))] shadow-[0_12px_22px_rgba(0,0,0,0.16),var(--aurora-highlight-medium)]'
+
+export const AURORA_GATEWAY_ROW =
+  'border-t border-aurora-border-strong/80 bg-[linear-gradient(180deg,rgba(14,31,44,0.72),rgba(10,22,31,0.88))] transition-colors hover:bg-[linear-gradient(180deg,rgba(17,38,54,0.9),rgba(12,27,38,0.96))]'
+
+export const AURORA_GATEWAY_DISABLED_ROW =
+  'border-t border-aurora-border-strong/60 bg-[linear-gradient(180deg,rgba(8,19,27,0.9),rgba(7,16,24,0.96))] text-[#7f95a3]'
+
+export const AURORA_GATEWAY_SUBTLE_SURFACE =
+  'rounded-[0.95rem] border border-aurora-border-strong bg-[rgba(7,17,26,0.48)] shadow-[inset_0_1px_0_rgba(255,255,255,0.025)]'
+
+export function gatewayActionTone(variant: 'default' | 'accent' = 'default') {
+  return cn('border', AURORA_CONTROL_SURFACE, controlTone(variant))
+}
+
+export function gatewayStatusTone(healthy: boolean, connected: boolean) {
+  if (healthy && connected) {
+    return {
+      dot: 'bg-aurora-accent-strong shadow-[0_0_0_4px_rgba(103,203,250,0.08)]',
+      text: 'text-aurora-accent-strong',
+      label: 'Healthy',
+    }
+  }
+
+  if (!connected) {
+    return {
+      dot: 'bg-aurora-error shadow-[0_0_0_4px_rgba(199,132,144,0.08)]',
+      text: 'text-aurora-error',
+      label: 'Disconnected',
+    }
+  }
+
+  return {
+    dot: 'bg-aurora-warn shadow-[0_0_0_4px_rgba(198,163,107,0.08)]',
+    text: 'text-aurora-warn',
+    label: 'Needs attention',
+  }
+}

--- a/apps/gateway-admin/components/gateway/surface-ratio.tsx
+++ b/apps/gateway-admin/components/gateway/surface-ratio.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { AURORA_GATEWAY_SUBTLE_SURFACE } from './gateway-theme'
 
 interface SurfaceRatioProps {
   icon: LucideIcon
@@ -14,14 +15,16 @@ export function SurfaceRatio({ icon: Icon, label, exposed, total, className }: S
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm font-medium text-foreground',
+        AURORA_GATEWAY_SUBTLE_SURFACE,
+        'inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-aurora-text-primary',
         className,
       )}
       title={`${label}: ${exposed}/${total}`}
       aria-label={`${label}: ${exposed} of ${total}`}
     >
-      <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+      <Icon className="size-4 text-aurora-accent-strong" aria-hidden="true" />
       <span className="tabular-nums">{exposed}/{total}</span>
+      <span className="text-[11px] uppercase tracking-[0.16em] text-aurora-text-muted">{label}</span>
     </div>
   )
 }

--- a/apps/gateway-admin/components/gateway/table-skeleton.tsx
+++ b/apps/gateway-admin/components/gateway/table-skeleton.tsx
@@ -7,6 +7,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import { AURORA_STRONG_PANEL } from './gateway-theme'
 
 interface TableSkeletonProps {
   rows?: number
@@ -14,47 +16,49 @@ interface TableSkeletonProps {
 
 export function GatewayTableSkeleton({ rows = 5 }: TableSkeletonProps) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="w-[200px]">Name</TableHead>
-          <TableHead className="w-[100px]">Transport</TableHead>
-          <TableHead className="w-[100px]">Status</TableHead>
-          <TableHead className="w-[140px]">Tools</TableHead>
-          <TableHead className="w-[100px]">Warnings</TableHead>
-          <TableHead className="w-[120px]"></TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {Array.from({ length: rows }).map((_, i) => (
-          <TableRow key={i}>
-            <TableCell>
-              <Skeleton className="h-5 w-32" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-5 w-16" />
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-5 w-20" />
-            </TableCell>
-            <TableCell>
-              <div className="flex gap-2">
-                <Skeleton className="h-5 w-12" />
-                <Skeleton className="h-5 w-12" />
-              </div>
-            </TableCell>
-            <TableCell>
-              <Skeleton className="h-5 w-8" />
-            </TableCell>
-            <TableCell>
-              <div className="flex justify-end gap-1">
-                <Skeleton className="size-8 rounded-md" />
-                <Skeleton className="size-8 rounded-md" />
-              </div>
-            </TableCell>
+    <div className={cn(AURORA_STRONG_PANEL, 'overflow-hidden')}>
+      <Table>
+        <TableHeader>
+          <TableRow className="border-b border-aurora-border-strong bg-[rgba(7,17,26,0.48)] hover:bg-[rgba(7,17,26,0.48)]">
+            <TableHead className="w-[200px] text-aurora-text-muted">Name</TableHead>
+            <TableHead className="w-[100px] text-aurora-text-muted">Transport</TableHead>
+            <TableHead className="w-[100px] text-aurora-text-muted">Status</TableHead>
+            <TableHead className="w-[140px] text-aurora-text-muted">Tools</TableHead>
+            <TableHead className="w-[100px] text-aurora-text-muted">Warnings</TableHead>
+            <TableHead className="w-[120px]" />
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: rows }).map((_, i) => (
+            <TableRow key={i} className="border-t border-aurora-border-strong/70">
+              <TableCell>
+                <Skeleton className="h-5 w-32 bg-[#173245]" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-5 w-16 bg-[#173245]" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-5 w-20 bg-[#173245]" />
+              </TableCell>
+              <TableCell>
+                <div className="flex gap-2">
+                  <Skeleton className="h-5 w-12 bg-[#173245]" />
+                  <Skeleton className="h-5 w-12 bg-[#173245]" />
+                </div>
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-5 w-8 bg-[#173245]" />
+              </TableCell>
+              <TableCell>
+                <div className="flex justify-end gap-1">
+                  <Skeleton className="size-8 rounded-md bg-[#173245]" />
+                  <Skeleton className="size-8 rounded-md bg-[#173245]" />
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   )
 }

--- a/apps/gateway-admin/components/gateway/transport-badge.tsx
+++ b/apps/gateway-admin/components/gateway/transport-badge.tsx
@@ -14,21 +14,21 @@ export function TransportBadge({ transport, className }: TransportBadgeProps) {
         return {
           label: 'HTTP',
           className:
-            'bg-[#00b0ff]/20 text-[#00b0ff] border border-[#00b0ff]/50 shadow-sm shadow-[#00b0ff]/20',
+            'border-aurora-accent-primary/28 bg-[linear-gradient(180deg,rgba(16,35,48,0.96),rgba(11,25,35,0.98))] text-aurora-accent-strong shadow-[var(--aurora-active-glow)]',
           icon: Globe,
         }
       case 'stdio':
         return {
           label: 'stdio',
           className:
-            'bg-[#ea80fc]/20 text-[#ea80fc] border border-[#ea80fc]/50 shadow-sm shadow-[#ea80fc]/20',
+            'border-aurora-border-strong bg-[linear-gradient(180deg,rgba(17,32,44,0.98),rgba(11,22,30,0.98))] text-[#d2c8e8] shadow-[0_8px_16px_rgba(0,0,0,0.14),var(--aurora-highlight-medium)]',
           icon: Terminal,
         }
       case 'lab_service':
         return {
           label: 'Lab',
           className:
-            'bg-[#8bc34a]/20 text-[#8bc34a] border border-[#8bc34a]/50 shadow-sm shadow-[#8bc34a]/20',
+            'border-aurora-border-strong bg-[linear-gradient(180deg,rgba(18,40,56,0.96),rgba(14,31,44,0.98))] text-[#cae5cf] shadow-[0_8px_16px_rgba(0,0,0,0.14),var(--aurora-highlight-medium)]',
           icon: Layers,
         }
       default: {
@@ -43,7 +43,7 @@ export function TransportBadge({ transport, className }: TransportBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium',
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em]',
         config.className,
         className
       )}

--- a/apps/gateway-admin/components/gateway/warnings-pill.tsx
+++ b/apps/gateway-admin/components/gateway/warnings-pill.tsx
@@ -24,7 +24,7 @@ export function WarningsPill({ warnings, className }: WarningsPillProps) {
         <TooltipTrigger asChild>
           <span
             className={cn(
-              'inline-flex items-center gap-1 rounded-full border border-warning/20 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning',
+              'inline-flex items-center gap-1.5 rounded-full border border-aurora-warn/28 bg-[linear-gradient(180deg,rgba(51,41,22,0.42),rgba(30,24,14,0.56))] px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-aurora-warn shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]',
               className
             )}
           >
@@ -43,7 +43,7 @@ export function WarningsPill({ warnings, className }: WarningsPillProps) {
               </p>
             ))}
             {warnings.length > 3 && (
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-aurora-text-muted">
                 +{warnings.length - 3} more warnings
               </p>
             )}


### PR DESCRIPTION
## Summary
- transition the main Gateways page surface toward the Aurora control-plane theme
- restyle filters, table surfaces, pills, empty states, and skeletons to align with the logs Aurora direction
- add focused gateway render tests for the updated UI pieces

## Verification
- `git diff --check -- apps/gateway-admin/components/gateway`
- `pnpm --dir apps/gateway-admin exec tsx --test components/gateway/gateway-filters.test.tsx components/gateway/gateway-table.test.tsx` *(currently blocked in the isolated worktree because frontend dependencies are not installed there)*
- `pnpm --dir apps/gateway-admin build` *(currently blocked in the isolated worktree because frontend dependencies are not installed there)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Begin transitioning the Gateways admin to the Aurora control‑plane theme with new surfaces, tones, and compact controls. Improves readability and aligns the page with the logs Aurora direction while adding render tests for the updated UI.

- **New Features**
  - Introduced `gateway-theme.ts` with Aurora tokens and action/status tones used across Gateway cards, table rows, and subtle surfaces.
  - Restyled filters (search, state, connection, type) with a clear‑filters action and medium/strong panels; updated empty states.
  - Reworked table/card layouts, transport badges, warnings pill, surface ratios, and loading skeletons to Aurora styles and colors.
  - Added focused render tests for `GatewayFilters` and `GatewayTable` to verify control surfaces, labels, and status/warn tones.

<sup>Written for commit 443df10c2280ec4f7cecbad78a52be0f6e75e8d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

