### PR TITLE
fix: backport operational fixes from bd-work/lab-operational-fixes

### DIFF
--- a/crates/lab-apis/src/core/http.rs
+++ b/crates/lab-apis/src/core/http.rs
@@ -2,8 +2,33 @@
 
 use std::time::{Duration, Instant};
 
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::{Client, RequestBuilder, Response, Url};
 use tracing::{Level, event};
+
+/// RFC 3986 §3.3 PATH_SEGMENT encode set.
+///
+/// Encodes everything except unreserved chars (ALPHA, DIGIT, `-`, `.`, `_`, `~`)
+/// and sub-delimiters (`!`, `$`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `;`, `=`)
+/// and `:`, `@`. Crucially this encodes `/`, `?`, `#`, `[`, `]`, and `%`,
+/// preventing a caller-supplied string from escaping its intended segment.
+const PATH_SEGMENT: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
 
 use crate::core::auth::Auth;
 use crate::core::error::ApiError;
@@ -134,31 +159,23 @@ impl HttpClient {
     /// Percent-encode a single path segment so it is safe to interpolate into a
     /// URL path.
     ///
-    /// Uses the `url` crate's `path_segments_mut()` API, which applies the
-    /// RFC 3986 §3.3 PATH_SEGMENT encode set. Crucially, `/`, `?`, `#`, and
-    /// `%` are encoded, which prevents a caller-supplied string from escaping
-    /// its intended segment.
+    /// Applies the RFC 3986 §3.3 PATH_SEGMENT encode set: encodes `/`, `?`,
+    /// `#`, `%`, `[`, `]`, and control/space characters while preserving
+    /// unreserved chars and sub-delimiters. Unlike `Url::path_segments_mut()`,
+    /// this does **not** drop `.` or `..` segments.
     ///
     /// # Example
     ///
     /// ```rust
     /// # use lab_apis::core::HttpClient;
     /// let encoded = HttpClient::encode_path_segment("hello/world?foo=bar");
-    /// // '/' becomes %2F, '?' becomes %3F, '=' becomes %3D
+    /// // '/' becomes %2F, '?' becomes %3F
     /// assert!(!encoded.contains('/'));
     /// assert!(!encoded.contains('?'));
     /// ```
     #[must_use]
     pub fn encode_path_segment(s: &str) -> String {
-        // Build a scratch URL and push the segment through path_segments_mut(),
-        // which applies the correct RFC 3986 PATH_SEGMENT encode set without
-        // requiring the percent-encoding crate as a direct dependency.
-        let mut base = Url::parse("http://x").expect("static base url is valid");
-        base.path_segments_mut()
-            .expect("http scheme always has a path")
-            .push(s);
-        // The URL path is now "/<encoded-segment>". Strip the leading "/".
-        base.path().trim_start_matches('/').to_string()
+        utf8_percent_encode(s, PATH_SEGMENT).to_string()
     }
 
     fn apply_auth(&self, req: RequestBuilder) -> RequestBuilder {

--- a/crates/lab-apis/src/core/http.rs
+++ b/crates/lab-apis/src/core/http.rs
@@ -119,11 +119,46 @@ impl HttpClient {
                 "absolute URL not permitted: {path}"
             )));
         }
+        // POLICY: Callers must percent-encode any string path segments before
+        // passing to url(). Integer IDs are safe as-is. String segments that may
+        // contain '/', '?', '#', or other reserved characters must be encoded
+        // first. Use `HttpClient::encode_path_segment(s)` for that purpose, which
+        // delegates to the `url` crate's PATH_SEGMENT encode set.
         if path.starts_with('/') {
             Ok(format!("{}{path}", self.base_url.trim_end_matches('/')))
         } else {
             Ok(format!("{}/{path}", self.base_url.trim_end_matches('/')))
         }
+    }
+
+    /// Percent-encode a single path segment so it is safe to interpolate into a
+    /// URL path.
+    ///
+    /// Uses the `url` crate's `path_segments_mut()` API, which applies the
+    /// RFC 3986 §3.3 PATH_SEGMENT encode set. Crucially, `/`, `?`, `#`, and
+    /// `%` are encoded, which prevents a caller-supplied string from escaping
+    /// its intended segment.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use lab_apis::core::HttpClient;
+    /// let encoded = HttpClient::encode_path_segment("hello/world?foo=bar");
+    /// // '/' becomes %2F, '?' becomes %3F, '=' becomes %3D
+    /// assert!(!encoded.contains('/'));
+    /// assert!(!encoded.contains('?'));
+    /// ```
+    #[must_use]
+    pub fn encode_path_segment(s: &str) -> String {
+        // Build a scratch URL and push the segment through path_segments_mut(),
+        // which applies the correct RFC 3986 PATH_SEGMENT encode set without
+        // requiring the percent-encoding crate as a direct dependency.
+        let mut base = Url::parse("http://x").expect("static base url is valid");
+        base.path_segments_mut()
+            .expect("http scheme always has a path")
+            .push(s);
+        // The URL path is now "/<encoded-segment>". Strip the leading "/".
+        base.path().trim_start_matches('/').to_string()
     }
 
     fn apply_auth(&self, req: RequestBuilder) -> RequestBuilder {
@@ -745,5 +780,30 @@ mod tests {
             .url("/api/v1/status")
             .expect("should normalise trailing slash");
         assert_eq!(url, "http://localhost:8080/api/v1/status");
+    }
+
+    #[test]
+    fn encode_path_segment_encodes_slash_and_query() {
+        // A string segment containing '/' and '?' must not produce an
+        // unexpected URL when interpolated as a single path segment.
+        let raw = "foo/bar?baz=1";
+        let encoded = HttpClient::encode_path_segment(raw);
+
+        // Neither '/' nor '?' should survive encoding.
+        assert!(!encoded.contains('/'), "forward slash must be encoded: {encoded}");
+        assert!(!encoded.contains('?'), "question mark must be encoded: {encoded}");
+
+        // The encoded segment should round-trip through url() without splitting.
+        let client = make_client("http://localhost:8080");
+        let path = format!("/api/v1/items/{encoded}");
+        let url = client.url(&path).expect("encoded segment should produce valid url");
+        assert!(url.ends_with(&encoded), "encoded segment must appear verbatim in URL: {url}");
+    }
+
+    #[test]
+    fn encode_path_segment_integer_ids_unchanged() {
+        // Integer IDs (converted to strings) must not be mangled.
+        assert_eq!(HttpClient::encode_path_segment("42"), "42");
+        assert_eq!(HttpClient::encode_path_segment("1234567890"), "1234567890");
     }
 }

--- a/crates/lab/CLAUDE.md
+++ b/crates/lab/CLAUDE.md
@@ -26,16 +26,15 @@ Two files loaded in order: `~/.lab/.env` (secrets, `dotenvy`) then `config.toml`
 
 `scan_instances(prefix)` parses multi-instance env vars as `{PREFIX}_{LABEL}_{SUFFIX}`. Recognized suffixes: `URL`, `API_KEY`, `TOKEN`, `USERNAME`, `PASSWORD`. Any other suffix is silently ignored.
 
-## Catalog Registration — 4 Required Locations
+## Catalog Registration — 3 Required Locations
 
-Adding a new service requires touching all four or it silently disappears from one surface:
+Adding a new service requires touching all three or it silently disappears from one surface:
 
-1. `mcp/registry.rs` — `build_default_registry()`
+1. `mcp/registry.rs` — `register_service!(reg, "<service>", <module>)` inside `build_default_registry()`
 2. `mcp/services.rs` — module declaration (`pub mod <service>;`)
-3. `catalog.rs` — `actions_for()` hardcoded match arm
-4. `mcp/services/<service>.rs` — the dispatch file itself (must export `ACTIONS` and `dispatch`)
+3. `mcp/services/<service>.rs` — the dispatch file itself (must export `ACTIONS` and `dispatch`)
 
-`actions_for()` is a hardcoded string match. Services not listed return an empty action list with no error or warning.
+`build_catalog()` in `catalog.rs` is registry-driven: it iterates `registry.services()` and reads `svc.actions` directly. There is no `actions_for()` match arm and no separate catalog step — registering the service in `mcp/registry.rs` is sufficient for catalog coverage.
 
 ## Shared Dispatch Layer
 

--- a/crates/lab/CLAUDE.md
+++ b/crates/lab/CLAUDE.md
@@ -26,13 +26,15 @@ Two files loaded in order: `~/.lab/.env` (secrets, `dotenvy`) then `config.toml`
 
 `scan_instances(prefix)` parses multi-instance env vars as `{PREFIX}_{LABEL}_{SUFFIX}`. Recognized suffixes: `URL`, `API_KEY`, `TOKEN`, `USERNAME`, `PASSWORD`. Any other suffix is silently ignored.
 
-## Catalog Registration — 3 Required Locations
+## MCP/Catalog Registration — 3 Required Locations
 
-Adding a new service requires touching all three or it silently disappears from one surface:
+To expose a new service via MCP and the `lab://catalog` resource, touch all three or it silently disappears from the MCP surface:
 
 1. `mcp/registry.rs` — `register_service!(reg, "<service>", <module>)` inside `build_default_registry()`
 2. `mcp/services.rs` — module declaration (`pub mod <service>;`)
 3. `mcp/services/<service>.rs` — the dispatch file itself (must export `ACTIONS` and `dispatch`)
+
+Full new-service onboarding (CLI, API, TUI, dispatch layer) is covered in the root `CLAUDE.md` "Adding a New Service" checklist.
 
 `build_catalog()` in `catalog.rs` is registry-driven: it iterates `registry.services()` and reads `svc.actions` directly. There is no `actions_for()` match arm and no separate catalog step — registering the service in `mcp/registry.rs` is sufficient for catalog coverage.
 

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -391,6 +391,7 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         mount_if_enabled!(v1, state, "qdrant", "qdrant", qdrant);
         mount_if_enabled!(v1, state, "tei", "tei", tei);
         mount_if_enabled!(v1, state, "apprise", "apprise", apprise);
+        // [lab-scaffold: api-routes]
     }
 
     v1

--- a/crates/lab/src/catalog.rs
+++ b/crates/lab/src/catalog.rs
@@ -143,6 +143,8 @@ mod tests {
                     name: "tool.call".to_string(),
                     description: "Call upstream tool".to_string(),
                     destructive: false,
+                    params: vec![],
+                    returns: String::new(),
                 }],
             }],
         };

--- a/crates/lab/src/catalog.rs
+++ b/crates/lab/src/catalog.rs
@@ -43,6 +43,9 @@ pub struct ServiceCatalog {
 }
 
 /// One action inside a service's catalog.
+///
+/// Includes the full parameter list so agents can plan from a single
+/// `lab://catalog` resource read without issuing per-action `schema` calls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionEntry {
     /// Dotted action name (e.g., `movie.search`).
@@ -51,6 +54,25 @@ pub struct ActionEntry {
     pub description: String,
     /// Whether the action mutates state and requires confirmation.
     pub destructive: bool,
+    /// Declared parameters for this action. Empty when the action takes no params.
+    pub params: Vec<ParamEntry>,
+    /// Type-name hint for the return shape, e.g. `"Movie[]"`. Informational only.
+    pub returns: String,
+}
+
+/// One declared parameter in an action's catalog entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParamEntry {
+    /// Parameter name.
+    pub name: String,
+    /// Free-form type label: `"string"`, `"integer"`, `"boolean"`, `"object"`,
+    /// `"array"`, union literals like `"string|null"`, or enum literals like
+    /// `"queued|running|done"`.
+    pub ty: String,
+    /// Whether this parameter must be present for the action to succeed.
+    pub required: bool,
+    /// Human-readable description of the parameter.
+    pub description: String,
 }
 
 /// Build a [`Catalog`] from the current tool registry.
@@ -72,6 +94,17 @@ pub fn build_catalog(registry: &ToolRegistry) -> Catalog {
                     name: a.name.into(),
                     description: a.description.into(),
                     destructive: a.destructive,
+                    returns: a.returns.into(),
+                    params: a
+                        .params
+                        .iter()
+                        .map(|p| ParamEntry {
+                            name: p.name.into(),
+                            ty: p.ty.into(),
+                            required: p.required,
+                            description: p.description.into(),
+                        })
+                        .collect(),
                 })
                 .collect(),
         })

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -65,6 +65,7 @@ pub mod tei;
 pub mod unifi;
 #[cfg(feature = "unraid")]
 pub mod unraid;
+// [lab-scaffold: cli-modules]
 
 use std::process::ExitCode;
 
@@ -197,6 +198,7 @@ pub enum Command {
     /// Deploy the local lab release binary to SSH targets.
     #[cfg(feature = "deploy")]
     Deploy(deploy::DeployArgs),
+    // [lab-scaffold: cli-variants]
 }
 
 /// Dispatch a parsed [`Cli`] to the correct handler.
@@ -269,5 +271,6 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
+        // [lab-scaffold: cli-dispatch]
     }
 }

--- a/crates/lab/src/dispatch/clients.rs
+++ b/crates/lab/src/dispatch/clients.rs
@@ -61,6 +61,7 @@ pub struct ServiceClients {
     pub arcane: Option<Arc<lab_apis::arcane::ArcaneClient>>,
     #[cfg(feature = "qbittorrent")]
     pub qbittorrent: Option<Arc<lab_apis::qbittorrent::QbittorrentClient>>,
+    // [lab-scaffold: state-fields]
 }
 
 impl ServiceClients {
@@ -112,6 +113,7 @@ impl ServiceClients {
             arcane: crate::dispatch::arcane::client_from_env().map(Arc::new),
             #[cfg(feature = "qbittorrent")]
             qbittorrent: crate::dispatch::qbittorrent::client_from_env().map(Arc::new),
+            // [lab-scaffold: state-from-env]
         }
     }
 

--- a/crates/lab/src/dispatch/radarr/catalog.rs
+++ b/crates/lab/src/dispatch/radarr/catalog.rs
@@ -34,6 +34,7 @@ pub fn actions() -> &'static [ActionSpec] {
         all.extend_from_slice(config::ACTIONS);
         all.extend_from_slice(wanted::ACTIONS);
         all.extend_from_slice(customformat::ACTIONS);
+        // Vec::leak required: &'static [T] slices from sub-modules cannot be const-concatenated in stable Rust
         Vec::leak(all)
     });
     &ACTIONS

--- a/crates/lab/src/dispatch/unifi/catalog.rs
+++ b/crates/lab/src/dispatch/unifi/catalog.rs
@@ -25,6 +25,7 @@ pub fn actions() -> &'static [ActionSpec] {
         all.extend_from_slice(switching::ACTIONS);
         all.extend_from_slice(dns::ACTIONS);
         all.extend_from_slice(traffic::ACTIONS);
+        // Vec::leak required: &'static [T] slices from sub-modules cannot be const-concatenated in stable Rust
         Vec::leak(all)
     });
     &ACTIONS

--- a/crates/lab/src/mcp/services.rs
+++ b/crates/lab/src/mcp/services.rs
@@ -72,3 +72,4 @@ pub mod tei;
 
 #[cfg(feature = "apprise")]
 pub mod apprise;
+// [lab-scaffold: mcp-services]

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -155,6 +155,12 @@ impl ToolRegistry {
     /// - `status == "stub"` requires an empty action slice.
     pub fn register(&mut self, service: RegisteredService) {
         debug_assert!(
+            service.status == "available" || service.status == "stub",
+            "service '{}': unknown status '{}'; expected \"available\" or \"stub\"",
+            service.name,
+            service.status,
+        );
+        debug_assert!(
             (service.status == "available") == !service.actions.is_empty(),
             "service '{}': status '{}' is inconsistent with actions.len() == {}; \
              'available' requires non-empty ACTIONS, 'stub' requires empty ACTIONS",

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -43,6 +43,19 @@ macro_rules! dispatch_fn {
 ///   `mcp::services::foo::dispatch`.
 /// - Override: `register_service!(reg, "foo", foo, actions = $expr, dispatch = $expr)` —
 ///   for migrated services whose catalog and/or dispatch live outside `mcp::services`.
+///
+/// # Consistency invariant
+///
+/// The `actions` slice and the `dispatch` function **must be kept in sync** by the author:
+///
+/// - If `ACTIONS` is non-empty (status `"available"`), the dispatch function **must** handle
+///   at least `"help"` and every action listed in `ACTIONS`, returning `Ok(Value)`.
+/// - If `ACTIONS` is empty (status `"stub"`), the dispatch function is never called by agents
+///   that filter on `status == "available"`, but it may still be invoked directly. A stub
+///   dispatch should return an `unknown_action` envelope for all inputs.
+///
+/// A debug-build runtime check is performed in [`ToolRegistry::register`]: it asserts that
+/// `status` is consistent with `actions.len()`.
 macro_rules! register_service {
     // Full override: custom actions expr and dispatch expr (for migrated services).
     ($reg:expr, $feature:literal, $svc:ident, actions = $actions:expr, dispatch = $dispatch:expr) => {
@@ -134,7 +147,21 @@ impl ToolRegistry {
     }
 
     /// Register a service. Duplicates are ignored (first registration wins).
+    ///
+    /// # Panics (debug builds only)
+    ///
+    /// Panics if `service.status` is inconsistent with `service.actions.len()`:
+    /// - `status == "available"` requires at least one action.
+    /// - `status == "stub"` requires an empty action slice.
     pub fn register(&mut self, service: RegisteredService) {
+        debug_assert!(
+            (service.status == "available") == !service.actions.is_empty(),
+            "service '{}': status '{}' is inconsistent with actions.len() == {}; \
+             'available' requires non-empty ACTIONS, 'stub' requires empty ACTIONS",
+            service.name,
+            service.status,
+            service.actions.len(),
+        );
         if !self.services.iter().any(|s| s.name == service.name) {
             self.services.push(service);
         }

--- a/crates/lab/src/scaffold/patcher/source.rs
+++ b/crates/lab/src/scaffold/patcher/source.rs
@@ -21,47 +21,60 @@ pub fn patch_dispatch_rs(name: &str, content: &str) -> Result<String> {
 
 pub fn patch_cli_rs(name: &str, content: &str) -> Result<String> {
     // Anchor 1: module declaration — insert before the stable marker comment.
+    let module_decl = format!("pub mod {name};\n");
     let module_marker = "// [lab-scaffold: cli-modules]\n";
-    let content = insert_once(
-        content,
-        module_marker,
-        &format!("#[cfg(feature = \"{name}\")]\npub mod {name};\n{module_marker}"),
-    )?;
+    let content = if content.contains(&module_decl) {
+        content.to_string()
+    } else {
+        insert_once(
+            content,
+            module_marker,
+            &format!("#[cfg(feature = \"{name}\")]\n{module_decl}{module_marker}"),
+        )?
+    };
 
     // Anchor 2: enum variant — insert before the stable marker comment.
+    let service_pascal = pascal_case(name);
     let service_variant = format!(
-        "    #[cfg(feature = \"{name}\")]\n    {service}({snake}::{service}Args),\n",
-        service = pascal_case(name),
-        snake = name,
+        "    #[cfg(feature = \"{name}\")]\n    {service_pascal}({name}::{service_pascal}Args),\n",
     );
     let variants_marker = "    // [lab-scaffold: cli-variants]\n";
-    let content = insert_once(
-        &content,
-        variants_marker,
-        &format!("{service_variant}{variants_marker}"),
-    )?;
+    let content = if content.contains(&service_variant) {
+        content
+    } else {
+        insert_once(
+            &content,
+            variants_marker,
+            &format!("{service_variant}{variants_marker}"),
+        )?
+    };
 
     // Anchor 3: dispatch arm — insert before the stable marker comment.
     let dispatch_arm = format!(
-        "        #[cfg(feature = \"{name}\")]\n        Command::{service}(args) => {snake}::run(args, format).await,\n",
-        service = pascal_case(name),
-        snake = name,
+        "        #[cfg(feature = \"{name}\")]\n        Command::{service_pascal}(args) => {name}::run(args, format).await,\n",
     );
     let dispatch_marker = "        // [lab-scaffold: cli-dispatch]\n";
-    insert_once(
-        &content,
-        dispatch_marker,
-        &format!("{dispatch_arm}{dispatch_marker}"),
-    )
+    if content.contains(&dispatch_arm) {
+        Ok(content)
+    } else {
+        insert_once(
+            &content,
+            dispatch_marker,
+            &format!("{dispatch_arm}{dispatch_marker}"),
+        )
+    }
 }
 
 pub fn patch_mcp_services_rs(name: &str, content: &str) -> Result<String> {
-    // Anchor on the stable marker so refactoring doesn't silently fall through.
+    let module_decl = format!("pub mod {name};\n");
+    if content.contains(&module_decl) {
+        return Ok(content.to_string());
+    }
     let marker = "// [lab-scaffold: mcp-services]\n";
     insert_once(
         content,
         marker,
-        &format!("#[cfg(feature = \"{name}\")]\npub mod {name};\n{marker}"),
+        &format!("#[cfg(feature = \"{name}\")]\n{module_decl}{marker}"),
     )
 }
 
@@ -82,27 +95,37 @@ pub fn patch_api_services_rs(name: &str, content: &str) -> Result<String> {
 }
 
 pub fn patch_api_router_rs(name: &str, content: &str) -> Result<String> {
-    // Anchor on the stable marker instead of the HeaderName line.
-    let marker = "        // [lab-scaffold: api-routes]\n";
     let insert = format!("        mount_if_enabled!(v1, state, \"{name}\", \"{name}\", {name});\n");
+    if content.contains(&insert) {
+        return Ok(content.to_string());
+    }
+    let marker = "        // [lab-scaffold: api-routes]\n";
     insert_once(content, marker, &format!("{insert}{marker}"))
 }
 
 pub fn patch_dispatch_clients_rs(name: &str, content: &str) -> Result<String> {
     // Anchor 1: struct field — insert before the stable marker.
-    let fields_marker = "    // [lab-scaffold: state-fields]\n";
+    let service_type = pascal_case(name);
     let field = format!(
         "    #[cfg(feature = \"{name}\")]\n    pub {name}: Option<Arc<lab_apis::{name}::{service_type}Client>>,\n",
-        service_type = pascal_case(name)
     );
-    let content = insert_once(content, fields_marker, &format!("{field}{fields_marker}"))?;
+    let fields_marker = "    // [lab-scaffold: state-fields]\n";
+    let content = if content.contains(&field) {
+        content.to_string()
+    } else {
+        insert_once(content, fields_marker, &format!("{field}{fields_marker}"))?
+    };
 
     // Anchor 2: from_env initializer — insert before the stable marker.
-    let from_env_marker = "            // [lab-scaffold: state-from-env]\n";
     let load = format!(
         "            #[cfg(feature = \"{name}\")]\n            {name}: crate::dispatch::{name}::client_from_env().map(Arc::new),\n"
     );
-    insert_once(&content, from_env_marker, &format!("{load}{from_env_marker}"))
+    let from_env_marker = "            // [lab-scaffold: state-from-env]\n";
+    if content.contains(&load) {
+        Ok(content)
+    } else {
+        insert_once(&content, from_env_marker, &format!("{load}{from_env_marker}"))
+    }
 }
 
 fn insert_before_eof(content: &str, insert: &str) -> String {

--- a/crates/lab/src/scaffold/patcher/source.rs
+++ b/crates/lab/src/scaffold/patcher/source.rs
@@ -20,44 +20,49 @@ pub fn patch_dispatch_rs(name: &str, content: &str) -> Result<String> {
 }
 
 pub fn patch_cli_rs(name: &str, content: &str) -> Result<String> {
+    // Anchor 1: module declaration — insert before the stable marker comment.
+    let module_marker = "// [lab-scaffold: cli-modules]\n";
     let content = insert_once(
         content,
-        "pub mod serve;\n",
-        &format!("pub mod serve;\npub mod {name};\n"),
+        module_marker,
+        &format!("#[cfg(feature = \"{name}\")]\npub mod {name};\n{module_marker}"),
     )?;
+
+    // Anchor 2: enum variant — insert before the stable marker comment.
     let service_variant = format!(
         "    #[cfg(feature = \"{name}\")]\n    {service}({snake}::{service}Args),\n",
         service = pascal_case(name),
         snake = name,
     );
+    let variants_marker = "    // [lab-scaffold: cli-variants]\n";
     let content = insert_once(
         &content,
-        "    #[cfg(feature = \"apprise\")]\n    Apprise(apprise::AppriseArgs),\n",
-        &format!(
-            "{service_variant}    #[cfg(feature = \"apprise\")]\n    Apprise(apprise::AppriseArgs),\n"
-        ),
+        variants_marker,
+        &format!("{service_variant}{variants_marker}"),
     )?;
 
+    // Anchor 3: dispatch arm — insert before the stable marker comment.
     let dispatch_arm = format!(
         "        #[cfg(feature = \"{name}\")]\n        Command::{service}(args) => {snake}::run(args, format).await,\n",
         service = pascal_case(name),
         snake = name,
     );
+    let dispatch_marker = "        // [lab-scaffold: cli-dispatch]\n";
     insert_once(
         &content,
-        "        #[cfg(feature = \"apprise\")]\n        Command::Apprise(args) => apprise::run(args, format).await,\n",
-        &format!(
-            "{dispatch_arm}        #[cfg(feature = \"apprise\")]\n        Command::Apprise(args) => apprise::run(args, format).await,\n"
-        ),
+        dispatch_marker,
+        &format!("{dispatch_arm}{dispatch_marker}"),
     )
 }
 
-#[allow(clippy::unnecessary_wraps)]
 pub fn patch_mcp_services_rs(name: &str, content: &str) -> Result<String> {
-    Ok(insert_before_eof(
+    // Anchor on the stable marker so refactoring doesn't silently fall through.
+    let marker = "// [lab-scaffold: mcp-services]\n";
+    insert_once(
         content,
-        &format!("\n#[cfg(feature = \"{name}\")]\npub mod {name};\n"),
-    ))
+        marker,
+        &format!("#[cfg(feature = \"{name}\")]\npub mod {name};\n{marker}"),
+    )
 }
 
 pub fn patch_mcp_registry_rs(name: &str, content: &str) -> Result<String> {
@@ -77,39 +82,27 @@ pub fn patch_api_services_rs(name: &str, content: &str) -> Result<String> {
 }
 
 pub fn patch_api_router_rs(name: &str, content: &str) -> Result<String> {
-    let insert = format!(
-        "    #[cfg(feature = \"{name}\")]\n    if state.registry.services().iter().any(|s| s.name == \"{name}\") {{\n        v1 = v1.nest(\"/{name}\", services::{name}::routes(state.clone()));\n    }}\n"
-    );
-    insert_once(
-        content,
-        "    let x_request_id = HeaderName::from_static(\"x-request-id\");",
-        &format!("{insert}    let x_request_id = HeaderName::from_static(\"x-request-id\");"),
-    )
+    // Anchor on the stable marker instead of the HeaderName line.
+    let marker = "        // [lab-scaffold: api-routes]\n";
+    let insert = format!("        mount_if_enabled!(v1, state, \"{name}\", \"{name}\", {name});\n");
+    insert_once(content, marker, &format!("{insert}{marker}"))
 }
 
 pub fn patch_dispatch_clients_rs(name: &str, content: &str) -> Result<String> {
+    // Anchor 1: struct field — insert before the stable marker.
+    let fields_marker = "    // [lab-scaffold: state-fields]\n";
     let field = format!(
-        "    #[cfg(feature = \"{name}\")]\n    pub {name}: Option<Arc<lab_apis::{name}::{service_type}Client>>,",
+        "    #[cfg(feature = \"{name}\")]\n    pub {name}: Option<Arc<lab_apis::{name}::{service_type}Client>>,\n",
         service_type = pascal_case(name)
     );
-    let content = insert_once(
-        content,
-        "    #[cfg(feature = \"prowlarr\")]\n    pub prowlarr: Option<Arc<lab_apis::prowlarr::ProwlarrClient>>,",
-        &format!(
-            "    #[cfg(feature = \"prowlarr\")]\n    pub prowlarr: Option<Arc<lab_apis::prowlarr::ProwlarrClient>>,\n{field}"
-        ),
-    )?;
+    let content = insert_once(content, fields_marker, &format!("{field}{fields_marker}"))?;
 
+    // Anchor 2: from_env initializer — insert before the stable marker.
+    let from_env_marker = "            // [lab-scaffold: state-from-env]\n";
     let load = format!(
-        "            #[cfg(feature = \"{name}\")]\n            {name}: crate::dispatch::{name}::client_from_env().map(Arc::new),"
+        "            #[cfg(feature = \"{name}\")]\n            {name}: crate::dispatch::{name}::client_from_env().map(Arc::new),\n"
     );
-    insert_once(
-        &content,
-        "            #[cfg(feature = \"prowlarr\")]\n            prowlarr: crate::dispatch::prowlarr::client_from_env().map(Arc::new),",
-        &format!(
-            "            #[cfg(feature = \"prowlarr\")]\n            prowlarr: crate::dispatch::prowlarr::client_from_env().map(Arc::new),\n{load}"
-        ),
-    )
+    insert_once(&content, from_env_marker, &format!("{load}{from_env_marker}"))
 }
 
 fn insert_before_eof(content: &str, insert: &str) -> String {

--- a/crates/lab/src/tui/app.rs
+++ b/crates/lab/src/tui/app.rs
@@ -128,6 +128,7 @@ fn tui_main(tx: &mpsc::Sender<AppEvent>, rx: &mpsc::Receiver<AppEvent>) -> Resul
                 Ok(t) => {
                     terminal = t;
                     app.services.reload_env_cache();
+                    app.services.reload_enabled_services();
                     app.dirty = true;
                 }
                 Err(e) => {

--- a/crates/lab/src/tui/services.rs
+++ b/crates/lab/src/tui/services.rs
@@ -221,6 +221,12 @@ impl LabServicesState {
         self.env_cache = load_env_vars();
     }
 
+    /// Reload the enabled-services set from `.mcp.json`.
+    /// Call after the user returns from an editor session that may have toggled services.
+    pub fn reload_enabled_services(&mut self) {
+        self.enabled_services = seed_enabled_services(self.mcp_json_path.as_deref());
+    }
+
     /// Update health results from a completed health check pass.
     ///
     /// Replaces the map wholesale so stale entries for removed services are cleared.


### PR DESCRIPTION
## Summary

Backports 7 unreleased fixes from `bd-work/lab-operational-fixes` (50 commits ahead of main, no PR) that were not superseded by PRs #13–#22.

Commits that conflicted heavily or were already present on main were skipped (`lab-q34`, `lab-uy9`, `lab-byo.9`, `lab-1xt.11`, `lab-8ft`, `lab-bid`).

## Changes

- **fix(lab-ess)**: Add `params` field to `ActionEntry` in catalog — enables agents reading `lab://catalog` to inspect per-action parameter schemas
- **fix(lab-0kh)**: Add `debug_assert!` consistency check to `ToolRegistry::register()` — catches `status`/`actions.len()` mismatches in debug builds
- **docs(lab-s05)**: Remove stale `actions_for()` reference from `crates/lab/CLAUDE.md` service checklist (4-location count → 3)
- **fix(lab-zj1)**: Add percent-encoding policy comment and `percent_encode_path` helper to `HttpClient::url()`
- **docs(lab-az2)**: Add `Vec::leak` explanatory comments to radarr/unifi catalog builders
- **fix(lab-byo.8)**: Replace 5 fragile anchor strings in scaffold patchers with 7 stable `// [lab-scaffold: <name>]` markers; update `patch_api_router_rs` to emit `mount_if_enabled!` macro calls
- **fix(lab-1xt.12)**: Add `reload_enabled_services()` to `LabServicesState`; call it after editor exits so `.mcp.json` toggles take effect immediately

## Test plan

- [ ] `cargo check --workspace --all-features` passes (verified)
- [ ] `cargo test --workspace --all-features` passes
- [ ] `lab scaffold service <name>` generates correct files with stable markers anchoring properly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports 7 operational fixes from `bd-work/lab-operational-fixes` to improve agent planning, URL safety, scaffolding idempotency, and service toggle refresh.

- **Bug Fixes**
  - Catalog: add `params` and `returns` to `ActionEntry` so agents can plan from a single `lab://catalog` read (tests updated).
  - Registry: add `debug_assert!` checks in `ToolRegistry::register()` for unknown `status` and for `status` vs `actions.len()` mismatches; update `CLAUDE.md` to a 3-step, registry-driven flow using `register_service!`.
  - HTTP: document percent-encoding policy and add `HttpClient::encode_path_segment()` with RFC 3986 PATH_SEGMENT encoding via `percent-encoding`; avoids dropping `.`/`..`; tests included.
  - Scaffolding: replace fragile anchors with stable `// [lab-scaffold: ...]` markers; patchers are idempotent and insert at markers; API router uses `mount_if_enabled!`.
  - TUI/services: add `reload_enabled_services()` and call it after editor exit so `.mcp.json` toggles apply immediately.
  - Docs: clarify `Vec::leak` in Radarr/Unifi catalogs and scope the MCP/catalog registration checklist.

<sup>Written for commit 0e46fc48c99348733fb0b9ccd99af577920b19a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP client now includes a utility for encoding path segments.
  * Catalog entries now expose parameter definitions and return type information for actions.
* **Bug Fixes**
  * TUI service state properly refreshes when returning from external editor.
* **Documentation**
  * Updated catalog registration process documentation to reflect simplified integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->