### PR TITLE
feat(lab-auth): Google OAuth email allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,12 @@ LAB_MCP_HTTP_TOKEN=
 LAB_PUBLIC_URL=
 # Optional comma-separated redirect allowlist for non-loopback OAuth client callbacks
 LAB_AUTH_ALLOWED_REDIRECT_URIS=
-# Optional comma-separated allowlist of Google email addresses permitted to log in.
-# Case-insensitive; trailing whitespace is ignored. When unset, any Google account is allowed.
-# Example: LAB_AUTH_ALLOWED_EMAILS=alice@gmail.com,bob@example.com
-LAB_AUTH_ALLOWED_EMAILS=
+# Required (oauth mode): Google email of the bootstrap admin permitted to log in.
+# Case-insensitive; trailing whitespace is ignored. Startup fails under
+# LAB_AUTH_MODE=oauth if unset, so no Google account can authenticate unless
+# explicitly permitted. Additional users will be granted access through the
+# web UI (planned), backed by a SQLite allowlist table.
+LAB_AUTH_ADMIN_EMAIL=
 # Google OAuth app credentials (required in oauth mode)
 LAB_GOOGLE_CLIENT_ID=
 LAB_GOOGLE_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ LAB_MCP_HTTP_TOKEN=
 LAB_PUBLIC_URL=
 # Optional comma-separated redirect allowlist for non-loopback OAuth client callbacks
 LAB_AUTH_ALLOWED_REDIRECT_URIS=
+# Optional comma-separated allowlist of Google email addresses permitted to log in.
+# Case-insensitive; trailing whitespace is ignored. When unset, any Google account is allowed.
+# Example: LAB_AUTH_ALLOWED_EMAILS=alice@gmail.com,bob@example.com
+LAB_AUTH_ALLOWED_EMAILS=
 # Google OAuth app credentials (required in oauth mode)
 LAB_GOOGLE_CLIENT_ID=
 LAB_GOOGLE_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ HTTP auth modes:
 | Mode | Required config | Notes |
 | --- | --- | --- |
 | Bearer | `LAB_AUTH_MODE=bearer` or default, plus `LAB_MCP_HTTP_TOKEN` for protected deployments | Uses constant-time static bearer-token comparison |
-| OAuth | `LAB_AUTH_MODE=oauth`, `LAB_PUBLIC_URL`, `LAB_GOOGLE_CLIENT_ID`, `LAB_GOOGLE_CLIENT_SECRET` | Enables Lab's Google-backed auth server, JWT validation, metadata, browser sessions, and callback handling |
+| OAuth | `LAB_AUTH_MODE=oauth`, `LAB_PUBLIC_URL`, `LAB_GOOGLE_CLIENT_ID`, `LAB_GOOGLE_CLIENT_SECRET`, `LAB_AUTH_ADMIN_EMAIL` | Enables Lab's Google-backed auth server, JWT validation, metadata, browser sessions, and callback handling. `LAB_AUTH_ADMIN_EMAIL` is the bootstrap admin Google email; startup fails closed if unset so no Google account can authenticate without explicit permission. Additional users will be granted via a SQLite-backed allowlist managed in the Labby web UI (planned). |
 
 Protected route behavior:
 
@@ -518,6 +518,7 @@ Server and runtime env:
 | `LAB_GOOGLE_CLIENT_ID` / `LAB_GOOGLE_CLIENT_SECRET` | Google OAuth credentials for OAuth mode |
 | `LAB_GOOGLE_CALLBACK_PATH` | Optional Google callback path override |
 | `LAB_AUTH_ALLOWED_REDIRECT_URIS` | Optional non-loopback MCP OAuth callback allowlist |
+| `LAB_AUTH_ADMIN_EMAIL` | Bootstrap admin Google email; required for OAuth mode (fail-closed default) |
 | `LAB_WEB_ASSETS_DIR` | Static Labby export directory override |
 | `LAB_WEB_UI_DISABLE_AUTH` | Development-only bypass for Labby browser auth |
 | `LAB_LOG` / `LAB_LOG_FORMAT` | Tracing filter and text/json log format |

--- a/apps/gateway-admin/app/(admin)/settings/page.tsx
+++ b/apps/gateway-admin/app/(admin)/settings/page.tsx
@@ -22,9 +22,13 @@ import {
   useGatewayMutations,
   useGatewayToolSearchConfig,
 } from '@/lib/hooks/use-gateways'
+import { useBrowserSession } from '@/lib/auth/session'
 import { cn, getErrorMessage } from '@/lib/utils'
+import { AllowedUsersPanel } from '@/components/allowed-users-panel'
 
 export default function SettingsPage() {
+  const session = useBrowserSession()
+  const isAdmin = session.status === 'authenticated' && session.isAdmin === true
   const { data: gateways, isLoading, error } = useGateways()
   const {
     data: toolSearchConfig,
@@ -250,6 +254,9 @@ export default function SettingsPage() {
             )}
           </div>
         </div>
+
+        {/* Allowed users (admin only) */}
+        {isAdmin ? <AllowedUsersPanel /> : null}
       </div>
     </div>
   )

--- a/apps/gateway-admin/components/allowed-users-panel.test.tsx
+++ b/apps/gateway-admin/components/allowed-users-panel.test.tsx
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { AllowedUsersPanel } from './allowed-users-panel'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Capture initial render (loading skeleton) without triggering async effects
+function render() {
+  return renderToStaticMarkup(<AllowedUsersPanel />)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('AllowedUsersPanel renders add-email form with correct elements', () => {
+  const markup = render()
+
+  // Input for adding email
+  assert.match(markup, /id="allowed-email-input"/)
+  assert.match(markup, /type="email"/)
+  assert.match(markup, /user@example\.com/)
+  // Add button
+  assert.match(markup, /aria-label="Add email to allowlist"/)
+})
+
+test('AllowedUsersPanel renders loading skeleton initially', () => {
+  const markup = render()
+
+  assert.match(markup, /animate-pulse/)
+})
+
+test('AllowedUsersPanel renders table with aria-label for screen readers', () => {
+  const markup = render()
+
+  // The table is not rendered in loading state, but the panel container and
+  // form are always present regardless of load state
+  assert.match(markup, /Allowed users/)
+})
+
+test('AllowedUsersPanel includes accessible label for email input', () => {
+  const markup = render()
+
+  assert.match(markup, /Email address to allow/)
+  assert.match(markup, /sr-only/)
+})

--- a/apps/gateway-admin/components/allowed-users-panel.tsx
+++ b/apps/gateway-admin/components/allowed-users-panel.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, Plus, Trash2, Users } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { AURORA_STRONG_PANEL } from '@/components/aurora/tokens'
+import { cn, getErrorMessage } from '@/lib/utils'
+import {
+  authAdminApi,
+  AuthAdminApiError,
+  type AllowedEmailEntry,
+} from '@/lib/api/auth-admin-client'
+
+export function AllowedUsersPanel() {
+  const [entries, setEntries] = useState<AllowedEmailEntry[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [addEmail, setAddEmail] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+
+  const [pendingRemove, setPendingRemove] = useState<AllowedEmailEntry | null>(null)
+  const [isRemoving, setIsRemoving] = useState(false)
+
+  const loadEntries = useCallback(async () => {
+    setIsLoading(true)
+    setLoadError(null)
+    try {
+      const data = await authAdminApi.listAllowedEmails()
+      setEntries(data)
+    } catch (err) {
+      setLoadError(getErrorMessage(err, 'Failed to load allowed users'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadEntries()
+  }, [loadEntries])
+
+  async function handleAdd(event: React.FormEvent) {
+    event.preventDefault()
+    const email = addEmail.trim()
+    if (!email) return
+
+    setIsAdding(true)
+    setAddError(null)
+    try {
+      await authAdminApi.addAllowedEmail(email)
+      setAddEmail('')
+      toast.success(`${email} added to the allowlist.`)
+      await loadEntries()
+    } catch (err) {
+      if (err instanceof AuthAdminApiError && err.status === 422) {
+        setAddError(err.message || 'This email is already in the allowlist.')
+      } else {
+        setAddError(getErrorMessage(err, 'Failed to add email'))
+      }
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  async function handleRemoveConfirm() {
+    if (!pendingRemove) return
+
+    setIsRemoving(true)
+    try {
+      await authAdminApi.removeAllowedEmail(pendingRemove.email)
+      toast.success(`${pendingRemove.email} removed from the allowlist.`)
+      setPendingRemove(null)
+      await loadEntries()
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Failed to remove email'))
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <div className={cn(AURORA_STRONG_PANEL, 'px-6 py-5')}>
+      <div className="flex items-center gap-3">
+        <Users className="size-5 text-aurora-accent-primary" />
+        <div>
+          <p className="text-base font-semibold text-aurora-text-primary">Allowed users</p>
+          <p className="mt-0.5 text-sm text-aurora-text-muted">
+            Only these email addresses can sign in via OAuth.
+          </p>
+        </div>
+      </div>
+
+      {/* Add form */}
+      <form onSubmit={(e) => void handleAdd(e)} className="mt-5 flex gap-2">
+        <div className="flex-1">
+          <label htmlFor="allowed-email-input" className="sr-only">
+            Email address to allow
+          </label>
+          <input
+            id="allowed-email-input"
+            type="email"
+            value={addEmail}
+            onChange={(e) => {
+              setAddEmail(e.target.value)
+              setAddError(null)
+            }}
+            placeholder="user@example.com"
+            disabled={isAdding}
+            className={cn(
+              'w-full rounded-aurora-1 border bg-aurora-control-surface px-3 py-2 text-sm text-aurora-text-primary placeholder:text-aurora-text-muted',
+              'focus:outline-none focus:ring-2 focus:ring-aurora-accent-primary/50',
+              addError
+                ? 'border-aurora-error'
+                : 'border-aurora-border-strong',
+            )}
+          />
+          {addError ? (
+            <p className="mt-1.5 text-xs text-aurora-error" role="alert">
+              {addError}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="submit"
+          disabled={isAdding || !addEmail.trim()}
+          aria-label="Add email to allowlist"
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-aurora-1 border border-aurora-accent-primary/60 bg-aurora-accent-primary/10 px-3 py-2 text-sm font-medium text-aurora-accent-primary',
+            'hover:bg-aurora-accent-primary/20 disabled:cursor-not-allowed disabled:opacity-50',
+            'focus:outline-none focus:ring-2 focus:ring-aurora-accent-primary/50',
+          )}
+        >
+          {isAdding ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Plus className="size-4" />
+          )}
+          Add
+        </button>
+      </form>
+
+      {/* Table */}
+      <div className="mt-4">
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }, (_, index) => (
+              <div
+                key={index}
+                className="h-10 animate-pulse rounded-aurora-1 border border-aurora-border-strong bg-aurora-control-surface"
+              />
+            ))}
+          </div>
+        ) : loadError ? (
+          <div className="rounded-aurora-1 border border-aurora-error/30 bg-aurora-error/8 p-4 text-sm text-aurora-error">
+            {loadError}
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="rounded-aurora-1 border border-aurora-border-strong border-dashed p-6 text-center text-sm text-aurora-text-muted">
+            No users in the allowlist yet.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" aria-label="Allowed users">
+              <thead>
+                <tr className="border-b border-aurora-border-strong text-left text-xs text-aurora-text-muted">
+                  <th scope="col" className="pb-2 pr-4 font-medium">Email</th>
+                  <th scope="col" className="pb-2 pr-4 font-medium">Added by</th>
+                  <th scope="col" className="pb-2 pr-4 font-medium">Added</th>
+                  <th scope="col" className="pb-2 font-medium">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
+                  <tr
+                    key={entry.email}
+                    className="border-b border-aurora-border-strong/50 last:border-0"
+                  >
+                    <td className="py-2.5 pr-4 font-medium text-aurora-text-primary">
+                      {entry.email}
+                    </td>
+                    <td className="py-2.5 pr-4 text-aurora-text-muted">
+                      {entry.added_by}
+                    </td>
+                    <td className="py-2.5 pr-4 text-aurora-text-muted">
+                      {new Date(entry.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="py-2.5">
+                      <button
+                        type="button"
+                        aria-label={`Remove ${entry.email}`}
+                        onClick={() => setPendingRemove(entry)}
+                        className={cn(
+                          'inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-aurora-error',
+                          'hover:bg-aurora-error/10 focus:outline-none focus:ring-2 focus:ring-aurora-error/40',
+                        )}
+                      >
+                        <Trash2 className="size-3.5" />
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Remove confirm dialog */}
+      <AlertDialog open={!!pendingRemove} onOpenChange={(open) => { if (!open) setPendingRemove(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove allowed user</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove <strong>{pendingRemove?.email}</strong> from the allowlist? They will no longer be able to sign in via OAuth.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault()
+                void handleRemoveConfirm()
+              }}
+              disabled={isRemoving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isRemoving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/apps/gateway-admin/lib/api/auth-admin-client.test.ts
+++ b/apps/gateway-admin/lib/api/auth-admin-client.test.ts
@@ -1,0 +1,191 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { __setBrowserSessionStateForTests } from '../auth/session-store.ts'
+import {
+  AuthAdminApiError,
+  authAdminApi,
+  type AllowedEmailEntry,
+} from './auth-admin-client.ts'
+
+const CSRF = 'csrf-abc'
+
+function setAuthenticatedSession() {
+  __setBrowserSessionStateForTests({
+    status: 'authenticated',
+    user: { sub: 'admin-user', email: 'admin@example.com' },
+    expiresAt: 9999,
+    csrfToken: CSRF,
+    isAdmin: true,
+  })
+}
+
+const sampleEntry: AllowedEmailEntry = {
+  email: 'alice@example.com',
+  added_by: 'admin@example.com',
+  created_at: '2026-04-26T10:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// listAllowedEmails
+// ---------------------------------------------------------------------------
+
+test('authAdminApi.listAllowedEmails sends GET with credentials and csrf', async () => {
+  setAuthenticatedSession()
+
+  let requestUrl = ''
+  let requestInit: RequestInit | undefined
+
+  globalThis.fetch = async (input, init) => {
+    requestUrl = String(input)
+    requestInit = init
+    return new Response(
+      JSON.stringify({ entries: [sampleEntry] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const entries = await authAdminApi.listAllowedEmails()
+
+  assert.equal(requestUrl, '/v1/auth/allowed-emails')
+  assert.equal(requestInit?.credentials, 'include')
+  const headers = new Headers(requestInit?.headers)
+  assert.equal(headers.get('x-csrf-token'), CSRF)
+  assert.deepEqual(entries, [sampleEntry])
+})
+
+test('authAdminApi.listAllowedEmails returns empty array when entries is empty', async () => {
+  setAuthenticatedSession()
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ entries: [] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+
+  const entries = await authAdminApi.listAllowedEmails()
+  assert.deepEqual(entries, [])
+})
+
+test('authAdminApi.listAllowedEmails surfaces backend errors as AuthAdminApiError', async () => {
+  setAuthenticatedSession()
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ kind: 'auth_failed', message: 'admin only' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+
+  await assert.rejects(
+    authAdminApi.listAllowedEmails(),
+    (error: unknown) =>
+      error instanceof AuthAdminApiError &&
+      error.status === 403 &&
+      error.kind === 'auth_failed' &&
+      error.message === 'admin only',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// addAllowedEmail
+// ---------------------------------------------------------------------------
+
+test('authAdminApi.addAllowedEmail sends POST with email body and csrf', async () => {
+  setAuthenticatedSession()
+
+  let requestUrl = ''
+  let requestInit: RequestInit | undefined
+
+  globalThis.fetch = async (input, init) => {
+    requestUrl = String(input)
+    requestInit = init
+    return new Response(
+      JSON.stringify({ entry: sampleEntry }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const result = await authAdminApi.addAllowedEmail('alice@example.com')
+
+  assert.equal(requestUrl, '/v1/auth/allowed-emails')
+  assert.equal(requestInit?.method, 'POST')
+  assert.equal(requestInit?.credentials, 'include')
+  assert.deepEqual(JSON.parse(String(requestInit?.body)), { email: 'alice@example.com' })
+  const headers = new Headers(requestInit?.headers)
+  assert.equal(headers.get('x-csrf-token'), CSRF)
+  assert.deepEqual(result, sampleEntry)
+})
+
+test('authAdminApi.addAllowedEmail surfaces 422 duplicate as AuthAdminApiError', async () => {
+  setAuthenticatedSession()
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ kind: 'already_exists', message: 'email already in allowlist' }),
+      { status: 422, headers: { 'Content-Type': 'application/json' } },
+    )
+
+  await assert.rejects(
+    authAdminApi.addAllowedEmail('alice@example.com'),
+    (error: unknown) =>
+      error instanceof AuthAdminApiError &&
+      error.status === 422 &&
+      error.kind === 'already_exists',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// removeAllowedEmail
+// ---------------------------------------------------------------------------
+
+test('authAdminApi.removeAllowedEmail sends DELETE to url-encoded path', async () => {
+  setAuthenticatedSession()
+
+  let requestUrl = ''
+  let requestInit: RequestInit | undefined
+
+  globalThis.fetch = async (input, init) => {
+    requestUrl = String(input)
+    requestInit = init
+    return new Response(null, { status: 204 })
+  }
+
+  await authAdminApi.removeAllowedEmail('alice+alias@example.com')
+
+  assert.equal(requestUrl, '/v1/auth/allowed-emails/alice%2Balias%40example.com')
+  assert.equal(requestInit?.method, 'DELETE')
+  assert.equal(requestInit?.credentials, 'include')
+  const headers = new Headers(requestInit?.headers)
+  assert.equal(headers.get('x-csrf-token'), CSRF)
+})
+
+test('authAdminApi.removeAllowedEmail surfaces non-204 errors as AuthAdminApiError', async () => {
+  setAuthenticatedSession()
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ kind: 'not_found', message: 'email not in allowlist' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    )
+
+  await assert.rejects(
+    authAdminApi.removeAllowedEmail('alice@example.com'),
+    (error: unknown) =>
+      error instanceof AuthAdminApiError &&
+      error.status === 404 &&
+      error.kind === 'not_found',
+  )
+})
+
+test('authAdminApi.removeAllowedEmail rethrows AbortError unchanged', async () => {
+  setAuthenticatedSession()
+
+  globalThis.fetch = async () => {
+    throw new DOMException('request aborted', 'AbortError')
+  }
+
+  await assert.rejects(
+    authAdminApi.removeAllowedEmail('alice@example.com'),
+    (error: unknown) => error instanceof DOMException && error.name === 'AbortError',
+  )
+})

--- a/apps/gateway-admin/lib/api/auth-admin-client.ts
+++ b/apps/gateway-admin/lib/api/auth-admin-client.ts
@@ -1,0 +1,81 @@
+import { normalizeGatewayApiBase } from './gateway-config.ts'
+import { gatewayHeaders } from './gateway-request.ts'
+
+export interface AllowedEmailEntry {
+  email: string
+  added_by: string
+  created_at: string
+}
+
+export class AuthAdminApiError extends Error {
+  status: number
+  kind?: string
+
+  constructor(message: string, status: number, kind?: string) {
+    super(message)
+    this.name = 'AuthAdminApiError'
+    this.status = status
+    this.kind = kind
+  }
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const base = normalizeGatewayApiBase()
+  const res = await fetch(`${base}${path}`, {
+    credentials: 'include',
+    ...init,
+    headers: { ...gatewayHeaders(), ...init?.headers },
+  })
+
+  if (res.status === 204) {
+    return undefined as T
+  }
+
+  if (!res.ok) {
+    let body: { kind?: string; message?: string } = {}
+    try {
+      body = (await res.json()) as { kind?: string; message?: string }
+    } catch {
+      /* ignore parse errors */
+    }
+    throw new AuthAdminApiError(
+      body.message ?? `HTTP ${res.status}`,
+      res.status,
+      body.kind,
+    )
+  }
+
+  return res.json() as Promise<T>
+}
+
+export const authAdminApi = {
+  async listAllowedEmails(signal?: AbortSignal): Promise<AllowedEmailEntry[]> {
+    const data = await apiFetch<{ entries: AllowedEmailEntry[] }>(
+      '/auth/allowed-emails',
+      { signal },
+    )
+    return data.entries
+  },
+
+  async addAllowedEmail(
+    email: string,
+    signal?: AbortSignal,
+  ): Promise<AllowedEmailEntry> {
+    const data = await apiFetch<{ entry: AllowedEmailEntry }>(
+      '/auth/allowed-emails',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email }),
+        signal,
+      },
+    )
+    return data.entry
+  },
+
+  async removeAllowedEmail(email: string, signal?: AbortSignal): Promise<void> {
+    await apiFetch<undefined>(
+      `/auth/allowed-emails/${encodeURIComponent(email)}`,
+      { method: 'DELETE', signal },
+    )
+  },
+}

--- a/apps/gateway-admin/lib/auth/session-store.ts
+++ b/apps/gateway-admin/lib/auth/session-store.ts
@@ -8,6 +8,7 @@ export type BrowserSessionState =
       }
       expiresAt: number
       csrfToken: string
+      isAdmin?: boolean
     }
   | { status: 'unauthenticated' }
   | {
@@ -26,6 +27,7 @@ type SessionPayload =
       }
       expires_at: number
       csrf_token: string
+      is_admin: boolean
     }
   | {
       authenticated: false
@@ -59,6 +61,7 @@ function normalizePayload(payload: SessionPayload): BrowserSessionState {
     user: payload.user,
     expiresAt: payload.expires_at,
     csrfToken: payload.csrf_token,
+    isAdmin: payload.is_admin ?? false,
   }
 }
 

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -326,10 +326,9 @@ pub async fn callback(
     )
     .is_err()
     {
-        let mut redirect_target =
-            reqwest::Url::parse(&request.redirect_uri).map_err(|error| {
-                AuthError::Server(format!("failed to parse registered redirect_uri: {error}"))
-            })?;
+        let mut redirect_target = reqwest::Url::parse(&request.redirect_uri).map_err(|error| {
+            AuthError::Server(format!("failed to parse registered redirect_uri: {error}"))
+        })?;
         redirect_target
             .query_pairs_mut()
             .append_pair("error", "access_denied")
@@ -1058,10 +1057,7 @@ pub mod tests {
             params.get("error").map(|v| v.as_ref()),
             Some("access_denied")
         );
-        assert_eq!(
-            params.get("state").map(|v| v.as_ref()),
-            Some("client-abc")
-        );
+        assert_eq!(params.get("state").map(|v| v.as_ref()), Some("client-abc"));
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -5,7 +5,7 @@ use axum::{Json, response::Response};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use sha2::{Digest, Sha256};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::error::AuthError;
 use crate::google::AuthorizeUrlRequest;
@@ -20,6 +20,49 @@ use crate::util::{expires_at, fingerprint, now_unix, random_token};
 
 const AUTH_REQUEST_TTL_SECS: i64 = 300;
 const LAB_SCOPE: &str = "lab";
+
+/// Enforces the configured email allowlist for browser-login callbacks.
+///
+/// Returns `Ok(())` when the allowlist is empty (no restriction), or when the
+/// supplied email is verified by Google and matches an entry case-insensitively.
+/// All other cases return `AuthError::AuthFailed`.
+///
+/// `email_verified` is enforced before the email comparison: an attacker who
+/// creates a Google account with someone else's address (without verifying it)
+/// must not be able to bypass the allowlist.
+fn check_email_allowlist(
+    email: Option<&str>,
+    email_verified: Option<bool>,
+    allowed_emails: &[String],
+) -> Result<(), AuthError> {
+    if allowed_emails.is_empty() {
+        return Ok(());
+    }
+    if email_verified != Some(true) {
+        error!("browser login rejected: google did not return a verified email address");
+        return Err(AuthError::AuthFailed(
+            "google did not return a verified email address".to_string(),
+        ));
+    }
+    match email {
+        Some(e) if allowed_emails.iter().any(|a| a.eq_ignore_ascii_case(e)) => Ok(()),
+        Some(e) => {
+            warn!(
+                email_id = %fingerprint(e),
+                "browser login rejected: email not in allowed list"
+            );
+            Err(AuthError::AuthFailed(
+                "google account is not permitted to access this gateway".to_string(),
+            ))
+        }
+        None => {
+            error!("browser login rejected: google did not return an email address");
+            Err(AuthError::AuthFailed(
+                "google did not return an email address".to_string(),
+            ))
+        }
+    }
+}
 
 pub async fn browser_login(
     State(state): State<AuthState>,
@@ -1143,4 +1186,57 @@ LEH/fA5CRiOs7Plrt2Sv54wAup4Y6+HQ8i/KFOXIejEN9vfY1YRfyD5Ajc05zg90
 uE8aLb5YtFvoaLAnc/A2ceW8sNxGgT5aPyLPUdmfSryAO4ayFDHmRlGFRsZtTUbn
 Iy60nwnOxK6B5mZV2Cs+kv8=
 -----END PRIVATE KEY-----";
+
+    mod allowlist_tests {
+        use super::super::check_email_allowlist;
+
+        #[test]
+        fn empty_allowlist_permits_any_email() {
+            assert!(check_email_allowlist(Some("anyone@example.com"), Some(true), &[]).is_ok());
+        }
+
+        #[test]
+        fn empty_allowlist_permits_even_unverified_email() {
+            // When no allowlist is configured, email_verified is not enforced.
+            assert!(check_email_allowlist(Some("anyone@example.com"), Some(false), &[]).is_ok());
+        }
+
+        #[test]
+        fn matching_verified_email_is_permitted() {
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(Some("alice@example.com"), Some(true), &list).is_ok());
+        }
+
+        #[test]
+        fn matching_email_is_case_insensitive() {
+            // Allowlist is pre-normalized to lowercase at config load.
+            // Incoming email from Google may have any case.
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(Some("Alice@Example.com"), Some(true), &list).is_ok());
+        }
+
+        #[test]
+        fn non_matching_email_is_rejected() {
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(Some("eve@example.com"), Some(true), &list).is_err());
+        }
+
+        #[test]
+        fn unverified_email_is_rejected_even_when_in_allowlist() {
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(Some("alice@example.com"), Some(false), &list).is_err());
+        }
+
+        #[test]
+        fn missing_email_verified_claim_is_rejected_when_allowlist_is_set() {
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(Some("alice@example.com"), None, &list).is_err());
+        }
+
+        #[test]
+        fn none_email_is_rejected_when_allowlist_is_set() {
+            let list = vec!["alice@example.com".to_string()];
+            assert!(check_email_allowlist(None, Some(true), &list).is_err());
+        }
+    }
 }

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -21,15 +21,11 @@ use crate::util::{expires_at, fingerprint, now_unix, random_token};
 const AUTH_REQUEST_TTL_SECS: i64 = 300;
 const LAB_SCOPE: &str = "lab";
 
-/// Enforces the configured email allowlist for browser-login callbacks.
+/// Enforces the configured email allowlist.
 ///
-/// Returns `Ok(())` when the allowlist is empty (no restriction), or when the
-/// supplied email is verified by Google and matches an entry case-insensitively.
-/// All other cases return `AuthError::AuthFailed`.
-///
-/// `email_verified` is enforced before the email comparison: an attacker who
-/// creates a Google account with someone else's address (without verifying it)
-/// must not be able to bypass the allowlist.
+/// `email_verified` is enforced before the email comparison: without this guard,
+/// an attacker who creates a Google account with someone else's address (without
+/// verifying it) could bypass the allowlist.
 fn check_email_allowlist(
     email: Option<&str>,
     email_verified: Option<bool>,
@@ -314,11 +310,8 @@ pub async fn callback(
         .exchange_code(&query.code, &request.provider_code_verifier)
         .await?;
 
-    // Allowlist check for the OAuth-client branch.
-    // Per RFC 6749 §4.1.2.1, errors must be sent via redirect to the client's
-    // registered redirect_uri, not returned as a direct HTTP error response.
-    // Do NOT use `?` here — propagating AuthError::AuthFailed would emit a JSON 401
-    // and break registered MCP clients that expect `error=access_denied` via redirect.
+    // RFC 6749 §4.1.2.1: errors must redirect to the client's redirect_uri,
+    // not surface as a JSON HTTP error.
     if check_email_allowlist(
         google.email.as_deref(),
         google.email_verified,
@@ -1336,22 +1329,6 @@ pub mod tests {
             "sub": "google-subject-123",
             "email": "user@example.com",
             "email_verified": true,
-            "iat": now_unix() as usize,
-            "exp": (now_unix() + 3600) as usize,
-        });
-        let mut header = Header::new(Algorithm::RS256);
-        header.kid = Some("test-kid".to_string());
-        encode(&header, &claims, &test_encoding_key()).unwrap()
-    }
-
-    #[allow(dead_code)]
-    fn signed_test_id_token_unverified() -> String {
-        let claims = json!({
-            "iss": "https://accounts.google.com",
-            "aud": "client-id",
-            "sub": "google-subject-123",
-            "email": "user@example.com",
-            "email_verified": false,
             "iat": now_unix() as usize,
             "exp": (now_unix() + 3600) as usize,
         });

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -272,7 +272,7 @@ pub async fn callback(
         check_email_allowlist(
             google.email.as_deref(),
             google.email_verified,
-            &state.config.allowed_emails,
+            std::slice::from_ref(&state.config.admin_email),
         )?;
         let session = create_browser_session(&state, google.subject, google.email).await?;
         let mut response = Redirect::to(&login.return_to).into_response();
@@ -318,7 +318,7 @@ pub async fn callback(
     if let Err(denial) = check_email_allowlist(
         google.email.as_deref(),
         google.email_verified,
-        &state.config.allowed_emails,
+        std::slice::from_ref(&state.config.admin_email),
     ) {
         let mut redirect_target = url::Url::parse(&request.redirect_uri).map_err(|error| {
             // Unreachable in practice: redirect_uri was validated against the
@@ -955,7 +955,7 @@ pub mod tests {
     #[tokio::test]
     async fn oauth_client_callback_redirects_with_access_denied_when_email_not_in_allowlist() {
         let mut config = test_auth_config();
-        config.allowed_emails = vec!["allowed@example.com".to_string()];
+        config.admin_email = "allowed@example.com".to_string();
         let base_state = test_auth_state_with_config(config).await;
         base_state
             .store
@@ -1053,7 +1053,7 @@ pub mod tests {
         let mut config = test_auth_config();
         // "allowed@example.com" is permitted; the mock id_token returns
         // "user@example.com" → callback must be denied with 401.
-        config.allowed_emails = vec!["allowed@example.com".to_string()];
+        config.admin_email = "allowed@example.com".to_string();
         let base_state = test_auth_state_with_config(config).await;
         base_state
             .store
@@ -1236,6 +1236,9 @@ pub mod tests {
             key_path: dir.path().join("auth-jwt.pem"),
             bootstrap_secret: Some("bootstrap-secret".to_string()),
             allowed_client_redirect_uris: Vec::new(),
+            // Matches the mock id_token email returned by signed_test_id_token,
+            // so happy-path callback tests pass the allowlist check.
+            admin_email: "user@example.com".to_string(),
             google: GoogleConfig {
                 client_id: "client-id".to_string(),
                 client_secret: "client-secret".to_string(),

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -313,6 +313,39 @@ pub async fn callback(
         .google
         .exchange_code(&query.code, &request.provider_code_verifier)
         .await?;
+
+    // Allowlist check for the OAuth-client branch.
+    // Per RFC 6749 §4.1.2.1, errors must be sent via redirect to the client's
+    // registered redirect_uri, not returned as a direct HTTP error response.
+    // Do NOT use `?` here — propagating AuthError::AuthFailed would emit a JSON 401
+    // and break registered MCP clients that expect `error=access_denied` via redirect.
+    if check_email_allowlist(
+        google.email.as_deref(),
+        google.email_verified,
+        &state.config.allowed_emails,
+    )
+    .is_err()
+    {
+        let mut redirect_target =
+            reqwest::Url::parse(&request.redirect_uri).map_err(|error| {
+                AuthError::Server(format!("failed to parse registered redirect_uri: {error}"))
+            })?;
+        redirect_target
+            .query_pairs_mut()
+            .append_pair("error", "access_denied")
+            .append_pair(
+                "error_description",
+                "google account is not permitted to access this gateway",
+            )
+            .append_pair("state", &request.client_state);
+        warn!(
+            client_id = %request.client_id,
+            oauth_state_id = %oauth_state_id,
+            "oauth callback: email not in allowlist, redirecting client with access_denied"
+        );
+        return Ok(Redirect::to(redirect_target.as_str()).into_response());
+    }
+
     let subject_id = fingerprint(&google.subject);
     info!(
         client_id = %request.client_id,
@@ -930,6 +963,105 @@ pub mod tests {
             .find_map(|value| value.to_str().ok())
             .unwrap();
         assert!(cookie.contains("lab_session="));
+    }
+
+    #[tokio::test]
+    async fn oauth_client_callback_redirects_with_access_denied_when_email_not_in_allowlist() {
+        let mut config = test_auth_config();
+        config.allowed_emails = vec!["allowed@example.com".to_string()];
+        let base_state = test_auth_state_with_config(config).await;
+        base_state
+            .store
+            .register_client(RegisteredClient {
+                client_id: "client".to_string(),
+                redirect_uris: vec!["http://127.0.0.1:7777/callback".to_string()],
+                created_at: now_unix(),
+            })
+            .await
+            .unwrap();
+        // Pre-insert an authorization request (OAuth-client flow, not browser-login).
+        base_state
+            .store
+            .insert_authorization_request(AuthorizationRequestRow {
+                state: "good-state".to_string(),
+                client_id: "client".to_string(),
+                redirect_uri: "http://127.0.0.1:7777/callback".to_string(),
+                client_state: "client-abc".to_string(),
+                scope: "lab".to_string(),
+                provider_code_verifier: "provider-verifier".to_string(),
+                code_challenge: "challenge".to_string(),
+                code_challenge_method: "S256".to_string(),
+                created_at: now_unix(),
+                expires_at: now_unix() + 300,
+            })
+            .await
+            .unwrap();
+
+        let server = Box::leak(Box::new(MockServer::start().await));
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "google-access-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "id_token": signed_test_id_token(), // email=user@example.com, not in allowlist
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/certs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_jwks()))
+            .mount(server)
+            .await;
+
+        let google = GoogleProvider::new(
+            "client-id".to_string(),
+            "client-secret".to_string(),
+            Url::parse("https://lab.example.com/auth/google/callback").unwrap(),
+        )
+        .unwrap()
+        .with_endpoints(
+            server.uri().parse::<Url>().unwrap(),
+            server.uri().parse::<Url>().unwrap().join("/token").unwrap(),
+        )
+        .with_jwks_endpoint(server.uri().parse::<Url>().unwrap().join("/certs").unwrap());
+
+        let state = AuthState::for_tests(
+            (*base_state.config).clone(),
+            base_state.store.clone(),
+            (*base_state.signing_keys).clone(),
+            google,
+        );
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/auth/google/callback?state=good-state&code=upstream-code")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Must redirect (not 401) with error=access_denied and the original client state.
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let redirect = Url::parse(location).unwrap();
+        let params: std::collections::HashMap<_, _> = redirect.query_pairs().collect();
+        assert_eq!(
+            params.get("error").map(|v| v.as_ref()),
+            Some("access_denied")
+        );
+        assert_eq!(
+            params.get("state").map(|v| v.as_ref()),
+            Some("client-abc")
+        );
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -1066,6 +1066,23 @@ pub mod tests {
             "aud": "client-id",
             "sub": "google-subject-123",
             "email": "user@example.com",
+            "email_verified": true,
+            "iat": now_unix() as usize,
+            "exp": (now_unix() + 3600) as usize,
+        });
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+        encode(&header, &claims, &test_encoding_key()).unwrap()
+    }
+
+    #[allow(dead_code)]
+    fn signed_test_id_token_unverified() -> String {
+        let claims = json!({
+            "iss": "https://accounts.google.com",
+            "aud": "client-id",
+            "sub": "google-subject-123",
+            "email": "user@example.com",
+            "email_verified": false,
             "iat": now_unix() as usize,
             "exp": (now_unix() + 3600) as usize,
         });

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -313,11 +313,9 @@ pub async fn callback(
     // not surface as a JSON HTTP error. The denial reason is sourced from the
     // AuthError so we only log once (inside check_email_allowlist).
     let allowed = state.resolve_allowed_emails().await?;
-    if let Err(denial) = check_email_allowlist(
-        google.email.as_deref(),
-        google.email_verified,
-        &allowed,
-    ) {
+    if let Err(denial) =
+        check_email_allowlist(google.email.as_deref(), google.email_verified, &allowed)
+    {
         let mut redirect_target = url::Url::parse(&request.redirect_uri).map_err(|error| {
             // Unreachable in practice: redirect_uri was validated against the
             // client's registered URIs before being stored.
@@ -1438,9 +1436,7 @@ Iy60nwnOxK6B5mZV2Cs+kv8=
                 server.uri().parse::<Url>().unwrap(),
                 server.uri().parse::<Url>().unwrap().join("/token").unwrap(),
             )
-            .with_jwks_endpoint(
-                server.uri().parse::<Url>().unwrap().join("/certs").unwrap(),
-            );
+            .with_jwks_endpoint(server.uri().parse::<Url>().unwrap().join("/certs").unwrap());
             AuthState::for_tests(
                 (*base_state.config).clone(),
                 base_state.store.clone(),
@@ -1610,8 +1606,14 @@ Iy60nwnOxK6B5mZV2Cs+kv8=
                 .unwrap();
             let redirect = Url::parse(location).unwrap();
             let params: std::collections::HashMap<_, _> = redirect.query_pairs().collect();
-            assert!(params.contains_key("code"), "expected code in redirect: {location}");
-            assert!(!params.contains_key("error"), "unexpected error in redirect: {location}");
+            assert!(
+                params.contains_key("code"),
+                "expected code in redirect: {location}"
+            );
+            assert!(
+                !params.contains_key("error"),
+                "unexpected error in redirect: {location}"
+            );
         }
 
         /// Email not in admin or allowed_users must be rejected in the browser-login

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -5,7 +5,7 @@ use axum::{Json, response::Response};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use sha2::{Digest, Sha256};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::AuthError;
 use crate::google::AuthorizeUrlRequest;
@@ -35,29 +35,31 @@ fn check_email_allowlist(
         return Ok(());
     }
     if email_verified != Some(true) {
-        error!("browser login rejected: google did not return a verified email address");
+        warn!("oauth callback rejected: google did not return a verified email address");
         return Err(AuthError::AuthFailed(
             "google did not return a verified email address".to_string(),
         ));
     }
-    match email {
-        Some(e) if allowed_emails.iter().any(|a| a.eq_ignore_ascii_case(e)) => Ok(()),
-        Some(e) => {
-            warn!(
-                email_id = %fingerprint(e),
-                "browser login rejected: email not in allowed list"
-            );
-            Err(AuthError::AuthFailed(
-                "google account is not permitted to access this gateway".to_string(),
-            ))
-        }
-        None => {
-            error!("browser login rejected: google did not return an email address");
-            Err(AuthError::AuthFailed(
-                "google did not return an email address".to_string(),
-            ))
-        }
+    let Some(e) = email else {
+        warn!("oauth callback rejected: google did not return an email address");
+        return Err(AuthError::AuthFailed(
+            "google did not return an email address".to_string(),
+        ));
+    };
+    let trimmed = e.trim();
+    if allowed_emails
+        .iter()
+        .any(|a| a.eq_ignore_ascii_case(trimmed))
+    {
+        return Ok(());
     }
+    warn!(
+        email_id = %fingerprint(trimmed),
+        "oauth callback rejected: email not in allowed list"
+    );
+    Err(AuthError::AuthFailed(
+        "google account is not permitted to access this gateway".to_string(),
+    ))
 }
 
 pub async fn browser_login(
@@ -319,8 +321,10 @@ pub async fn callback(
     )
     .is_err()
     {
-        let mut redirect_target = reqwest::Url::parse(&request.redirect_uri).map_err(|error| {
-            AuthError::Server(format!("failed to parse registered redirect_uri: {error}"))
+        let mut redirect_target = url::Url::parse(&request.redirect_uri).map_err(|error| {
+            // Unreachable in practice: redirect_uri was validated against the
+            // client's registered URIs before being stored.
+            AuthError::Config(format!("failed to parse registered redirect_uri: {error}"))
         })?;
         redirect_target
             .query_pairs_mut()
@@ -333,6 +337,7 @@ pub async fn callback(
         warn!(
             client_id = %request.client_id,
             oauth_state_id = %oauth_state_id,
+            email_id = google.email.as_deref().map(fingerprint),
             "oauth callback: email not in allowlist, redirecting client with access_denied"
         );
         return Ok(Redirect::to(redirect_target.as_str()).into_response());

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -313,14 +313,13 @@ pub async fn callback(
         .await?;
 
     // RFC 6749 §4.1.2.1: errors must redirect to the client's redirect_uri,
-    // not surface as a JSON HTTP error.
-    if check_email_allowlist(
+    // not surface as a JSON HTTP error. The denial reason is sourced from the
+    // AuthError so we only log once (inside check_email_allowlist).
+    if let Err(denial) = check_email_allowlist(
         google.email.as_deref(),
         google.email_verified,
         &state.config.allowed_emails,
-    )
-    .is_err()
-    {
+    ) {
         let mut redirect_target = url::Url::parse(&request.redirect_uri).map_err(|error| {
             // Unreachable in practice: redirect_uri was validated against the
             // client's registered URIs before being stored.
@@ -329,17 +328,8 @@ pub async fn callback(
         redirect_target
             .query_pairs_mut()
             .append_pair("error", "access_denied")
-            .append_pair(
-                "error_description",
-                "google account is not permitted to access this gateway",
-            )
+            .append_pair("error_description", &denial.to_string())
             .append_pair("state", &request.client_state);
-        warn!(
-            client_id = %request.client_id,
-            oauth_state_id = %oauth_state_id,
-            email_id = google.email.as_deref().map(fingerprint),
-            "oauth callback: email not in allowlist, redirecting client with access_denied"
-        );
         return Ok(Redirect::to(redirect_target.as_str()).into_response());
     }
 

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -269,11 +269,8 @@ pub async fn callback(
             .google
             .exchange_code(&query.code, &login.provider_code_verifier)
             .await?;
-        check_email_allowlist(
-            google.email.as_deref(),
-            google.email_verified,
-            std::slice::from_ref(&state.config.admin_email),
-        )?;
+        let allowed = state.resolve_allowed_emails().await?;
+        check_email_allowlist(google.email.as_deref(), google.email_verified, &allowed)?;
         let session = create_browser_session(&state, google.subject, google.email).await?;
         let mut response = Redirect::to(&login.return_to).into_response();
         append_set_cookie(
@@ -315,10 +312,11 @@ pub async fn callback(
     // RFC 6749 §4.1.2.1: errors must redirect to the client's redirect_uri,
     // not surface as a JSON HTTP error. The denial reason is sourced from the
     // AuthError so we only log once (inside check_email_allowlist).
+    let allowed = state.resolve_allowed_emails().await?;
     if let Err(denial) = check_email_allowlist(
         google.email.as_deref(),
         google.email_verified,
-        std::slice::from_ref(&state.config.admin_email),
+        &allowed,
     ) {
         let mut redirect_target = url::Url::parse(&request.redirect_uri).map_err(|error| {
             // Unreachable in practice: redirect_uri was validated against the
@@ -1387,6 +1385,316 @@ LEH/fA5CRiOs7Plrt2Sv54wAup4Y6+HQ8i/KFOXIejEN9vfY1YRfyD5Ajc05zg90
 uE8aLb5YtFvoaLAnc/A2ceW8sNxGgT5aPyLPUdmfSryAO4ayFDHmRlGFRsZtTUbn
 Iy60nwnOxK6B5mZV2Cs+kv8=
 -----END PRIVATE KEY-----";
+
+    /// Tests that exercise the merged allowlist path through real callback handlers.
+    /// These verify that `resolve_allowed_emails` is correctly wired at both call
+    /// sites (browser-login branch and oauth-client branch).
+    mod merged_allowlist_callback_tests {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode, header};
+        use serde_json::json;
+        use tower::util::ServiceExt;
+        use url::Url;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use super::{
+            signed_test_id_token, test_auth_config, test_auth_state_with_config,
+            test_auth_state_with_mock_google, test_jwks,
+        };
+        use crate::google::GoogleProvider;
+        use crate::routes::router;
+        use crate::state::AuthState;
+        use crate::types::{AuthorizationRequestRow, BrowserLoginStateRow, RegisteredClient};
+        use crate::util::now_unix;
+
+        /// Helper that mounts Google mock endpoints on a fresh server and builds
+        /// an `AuthState` with that mock, reusing an existing base state's store
+        /// and signing keys (so DB writes made to `base_state.store` are visible).
+        async fn state_with_mock_google_from(base_state: &AuthState) -> AuthState {
+            let server = Box::leak(Box::new(MockServer::start().await));
+            Mock::given(method("POST"))
+                .and(path("/token"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "access_token": "google-access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_in": 3600,
+                    "id_token": signed_test_id_token(),
+                })))
+                .mount(server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/certs"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(test_jwks()))
+                .mount(server)
+                .await;
+            let google = GoogleProvider::new(
+                "client-id".to_string(),
+                "client-secret".to_string(),
+                Url::parse("https://lab.example.com/auth/google/callback").unwrap(),
+            )
+            .unwrap()
+            .with_endpoints(
+                server.uri().parse::<Url>().unwrap(),
+                server.uri().parse::<Url>().unwrap().join("/token").unwrap(),
+            )
+            .with_jwks_endpoint(
+                server.uri().parse::<Url>().unwrap().join("/certs").unwrap(),
+            );
+            AuthState::for_tests(
+                (*base_state.config).clone(),
+                base_state.store.clone(),
+                (*base_state.signing_keys).clone(),
+                google,
+            )
+        }
+
+        /// The mock id_token always returns `user@example.com`. When admin is set
+        /// to a *different* email and that address is added to `allowed_users`, the
+        /// browser-login callback must succeed (DB row authorises the login).
+        #[tokio::test]
+        async fn browser_login_succeeds_for_allowlisted_non_admin_email() {
+            let mut config = test_auth_config();
+            // Set admin to something other than the id_token email.
+            config.admin_email = "admin@example.com".to_string();
+            let base_state = test_auth_state_with_config(config).await;
+
+            // Insert id_token email into allowed_users.
+            base_state
+                .store
+                .add_allowed_user("user@example.com", "admin", now_unix())
+                .await
+                .unwrap();
+
+            let state = state_with_mock_google_from(&base_state).await;
+
+            // Seed the browser-login state row so the callback recognises the flow.
+            state
+                .store
+                .insert_browser_login_state(BrowserLoginStateRow {
+                    state: "browser-state".to_string(),
+                    return_to: "/".to_string(),
+                    provider_code_verifier: "provider-verifier".to_string(),
+                    created_at: now_unix(),
+                    expires_at: now_unix() + 300,
+                })
+                .await
+                .unwrap();
+
+            let app = router(state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/auth/google/callback?state=browser-state&code=upstream-code")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Successful browser login → redirect with a Set-Cookie header (session).
+            assert_eq!(response.status(), StatusCode::SEE_OTHER);
+            assert!(response.headers().contains_key(header::SET_COOKIE));
+        }
+
+        /// Admin email is always authorised even when the `allowed_users` table is
+        /// empty (browser-login branch).
+        #[tokio::test]
+        async fn browser_login_succeeds_for_admin_when_allowed_users_is_empty() {
+            // Default test config sets admin_email = "user@example.com", which
+            // matches the id_token returned by signed_test_id_token.
+            let base_state = test_auth_state_with_mock_google().await;
+
+            // Confirm no extra rows exist.
+            assert!(
+                base_state
+                    .store
+                    .list_allowed_users()
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            // Seed browser-login state.
+            base_state
+                .store
+                .insert_browser_login_state(BrowserLoginStateRow {
+                    state: "browser-state-2".to_string(),
+                    return_to: "/".to_string(),
+                    provider_code_verifier: "provider-verifier".to_string(),
+                    created_at: now_unix(),
+                    expires_at: now_unix() + 300,
+                })
+                .await
+                .unwrap();
+
+            let app = router(base_state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/auth/google/callback?state=browser-state-2&code=upstream-code")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::SEE_OTHER);
+            assert!(response.headers().contains_key(header::SET_COOKIE));
+        }
+
+        /// The oauth-client callback must also succeed for a non-admin email that
+        /// exists in `allowed_users`.
+        #[tokio::test]
+        async fn oauth_client_callback_succeeds_for_allowlisted_non_admin_email() {
+            let mut config = test_auth_config();
+            config.admin_email = "admin@example.com".to_string();
+            let base_state = test_auth_state_with_config(config).await;
+
+            // Register a client.
+            base_state
+                .store
+                .register_client(RegisteredClient {
+                    client_id: "client".to_string(),
+                    redirect_uris: vec!["http://127.0.0.1:7777/callback".to_string()],
+                    created_at: now_unix(),
+                })
+                .await
+                .unwrap();
+
+            // Add id_token email to allowed_users.
+            base_state
+                .store
+                .add_allowed_user("user@example.com", "admin", now_unix())
+                .await
+                .unwrap();
+
+            let state = state_with_mock_google_from(&base_state).await;
+
+            // Seed an authorization request row.
+            state
+                .store
+                .insert_authorization_request(AuthorizationRequestRow {
+                    state: "oauth-state".to_string(),
+                    client_id: "client".to_string(),
+                    redirect_uri: "http://127.0.0.1:7777/callback".to_string(),
+                    client_state: "client-xyz".to_string(),
+                    scope: "lab".to_string(),
+                    provider_code_verifier: "provider-verifier".to_string(),
+                    code_challenge: "challenge".to_string(),
+                    code_challenge_method: "S256".to_string(),
+                    created_at: now_unix(),
+                    expires_at: now_unix() + 300,
+                })
+                .await
+                .unwrap();
+
+            let app = router(state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/auth/google/callback?state=oauth-state&code=upstream-code")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Success: redirect to client callback with `code` param (no `error`).
+            assert_eq!(response.status(), StatusCode::SEE_OTHER);
+            let location = response
+                .headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap();
+            let redirect = Url::parse(location).unwrap();
+            let params: std::collections::HashMap<_, _> = redirect.query_pairs().collect();
+            assert!(params.contains_key("code"), "expected code in redirect: {location}");
+            assert!(!params.contains_key("error"), "unexpected error in redirect: {location}");
+        }
+
+        /// Email not in admin or allowed_users must be rejected in the browser-login
+        /// branch (401 Unauthorized).
+        #[tokio::test]
+        async fn browser_login_rejects_email_absent_from_both_admin_and_db() {
+            let mut config = test_auth_config();
+            // Neither admin nor allowed_users contains "user@example.com" (the id_token email).
+            config.admin_email = "admin@example.com".to_string();
+            let base_state = test_auth_state_with_config(config).await;
+
+            let state = state_with_mock_google_from(&base_state).await;
+
+            state
+                .store
+                .insert_browser_login_state(BrowserLoginStateRow {
+                    state: "browser-state-3".to_string(),
+                    return_to: "/".to_string(),
+                    provider_code_verifier: "provider-verifier".to_string(),
+                    created_at: now_unix(),
+                    expires_at: now_unix() + 300,
+                })
+                .await
+                .unwrap();
+
+            let app = router(state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/auth/google/callback?state=browser-state-3&code=upstream-code")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        }
+
+        /// Admin also in the DB table must not appear twice (dedup check via
+        /// resolve_allowed_emails, verified indirectly: the callback still succeeds
+        /// and there is no panic from duplicate iteration).
+        #[tokio::test]
+        async fn admin_in_db_table_is_deduped_and_still_authorised() {
+            // Default config: admin_email = "user@example.com".
+            let base_state = test_auth_state_with_mock_google().await;
+
+            // Also add the admin email to allowed_users — this is the duplicate.
+            base_state
+                .store
+                .add_allowed_user("user@example.com", "self", now_unix())
+                .await
+                .unwrap();
+
+            // Seed browser-login state.
+            base_state
+                .store
+                .insert_browser_login_state(BrowserLoginStateRow {
+                    state: "browser-state-4".to_string(),
+                    return_to: "/".to_string(),
+                    provider_code_verifier: "provider-verifier".to_string(),
+                    created_at: now_unix(),
+                    expires_at: now_unix() + 300,
+                })
+                .await
+                .unwrap();
+
+            let app = router(base_state);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/auth/google/callback?state=browser-state-4&code=upstream-code")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Must still succeed — dedup should not break the check.
+            assert_eq!(response.status(), StatusCode::SEE_OTHER);
+            assert!(response.headers().contains_key(header::SET_COOKIE));
+        }
+    }
 
     mod allowlist_tests {
         use super::super::check_email_allowlist;

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -271,6 +271,11 @@ pub async fn callback(
             .google
             .exchange_code(&query.code, &login.provider_code_verifier)
             .await?;
+        check_email_allowlist(
+            google.email.as_deref(),
+            google.email_verified,
+            &state.config.allowed_emails,
+        )?;
         let session = create_browser_session(&state, google.subject, google.email).await?;
         let mut response = Redirect::to(&login.return_to).into_response();
         append_set_cookie(
@@ -925,6 +930,99 @@ pub mod tests {
             .find_map(|value| value.to_str().ok())
             .unwrap();
         assert!(cookie.contains("lab_session="));
+    }
+
+    #[tokio::test]
+    async fn browser_login_callback_rejects_email_not_in_allowlist() {
+        let mut config = test_auth_config();
+        // "allowed@example.com" is permitted; the mock id_token returns
+        // "user@example.com" → callback must be denied with 401.
+        config.allowed_emails = vec!["allowed@example.com".to_string()];
+        let base_state = test_auth_state_with_config(config).await;
+        base_state
+            .store
+            .register_client(RegisteredClient {
+                client_id: "client".to_string(),
+                redirect_uris: vec!["http://127.0.0.1:7777/callback".to_string()],
+                created_at: now_unix(),
+            })
+            .await
+            .unwrap();
+
+        let server = Box::leak(Box::new(MockServer::start().await));
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "google-access-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "id_token": signed_test_id_token(),
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/certs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_jwks()))
+            .mount(server)
+            .await;
+
+        let google = GoogleProvider::new(
+            "client-id".to_string(),
+            "client-secret".to_string(),
+            Url::parse("https://lab.example.com/auth/google/callback").unwrap(),
+        )
+        .unwrap()
+        .with_endpoints(
+            server.uri().parse::<Url>().unwrap(),
+            server.uri().parse::<Url>().unwrap().join("/token").unwrap(),
+        )
+        .with_jwks_endpoint(server.uri().parse::<Url>().unwrap().join("/certs").unwrap());
+
+        let state = AuthState::for_tests(
+            (*base_state.config).clone(),
+            base_state.store.clone(),
+            (*base_state.signing_keys).clone(),
+            google,
+        );
+        let app = router(state.clone());
+
+        let login = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/auth/login?return_to=%2F")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let location = Url::parse(
+            login
+                .headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+        )
+        .unwrap();
+        let upstream_state = location
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.into_owned())
+            .unwrap();
+
+        let callback = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/auth/google/callback?state={upstream_state}&code=upstream-code"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -78,6 +78,7 @@ pub struct AuthConfig {
     pub key_path: PathBuf,
     pub bootstrap_secret: Option<String>,
     pub allowed_client_redirect_uris: Vec<String>,
+    pub allowed_emails: Vec<String>,
     pub google: GoogleConfig,
     pub access_token_ttl: Duration,
     pub refresh_token_ttl: Duration,
@@ -97,6 +98,7 @@ impl Default for AuthConfig {
             key_path: base_dir.join(DEFAULT_KEY_NAME),
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
+            allowed_emails: Vec::new(),
             google: GoogleConfig::default(),
             access_token_ttl: Duration::from_secs(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             refresh_token_ttl: Duration::from_secs(DEFAULT_REFRESH_TOKEN_TTL_SECS),
@@ -124,6 +126,11 @@ impl AuthConfig {
             bootstrap_secret: read_string(&vars, "LAB_AUTH_BOOTSTRAP_SECRET"),
             allowed_client_redirect_uris: read_csv(&vars, "LAB_AUTH_ALLOWED_REDIRECT_URIS")
                 .unwrap_or_default(),
+            allowed_emails: read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
+                .unwrap_or_default()
+                .into_iter()
+                .map(|e| e.to_ascii_lowercase())
+                .collect(),
             google: GoogleConfig {
                 client_id: read_string(&vars, "LAB_GOOGLE_CLIENT_ID").unwrap_or_default(),
                 client_secret: read_string(&vars, "LAB_GOOGLE_CLIENT_SECRET").unwrap_or_default(),
@@ -319,6 +326,40 @@ mod tests {
         assert_eq!(cfg.sqlite_path.file_name().unwrap(), "auth.db");
         assert_eq!(cfg.key_path.file_name().unwrap(), "auth-jwt.pem");
         assert_eq!(cfg.google.callback_path, "/auth/google/callback");
+    }
+
+    #[test]
+    fn allowed_emails_defaults_to_empty_vec() {
+        let cfg = AuthConfig::from_sources(fake_env_with_many([
+            ("LAB_AUTH_MODE", "oauth"),
+            ("LAB_PUBLIC_URL", "https://lab.example.com"),
+            ("LAB_GOOGLE_CLIENT_ID", "id"),
+            ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
+        ]))
+        .unwrap();
+        assert!(cfg.allowed_emails.is_empty());
+    }
+
+    #[test]
+    fn allowed_emails_normalizes_case_and_trims_whitespace() {
+        let cfg = AuthConfig::from_sources(fake_env_with_many([
+            ("LAB_AUTH_MODE", "oauth"),
+            ("LAB_PUBLIC_URL", "https://lab.example.com"),
+            ("LAB_GOOGLE_CLIENT_ID", "id"),
+            ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
+            (
+                "LAB_AUTH_ALLOWED_EMAILS",
+                "Alice@Example.com , BOB@EXAMPLE.COM ",
+            ),
+        ]))
+        .unwrap();
+        assert_eq!(
+            cfg.allowed_emails,
+            vec![
+                "alice@example.com".to_string(),
+                "bob@example.com".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 use url::Url;
 
 use crate::error::AuthError;
@@ -79,7 +78,11 @@ pub struct AuthConfig {
     pub key_path: PathBuf,
     pub bootstrap_secret: Option<String>,
     pub allowed_client_redirect_uris: Vec<String>,
-    pub allowed_emails: Vec<String>,
+    /// Single bootstrap admin email permitted to log in via Google OAuth.
+    /// Required when `mode == AuthMode::OAuth`. Additional users will be
+    /// granted access through a future SQLite-backed allowlist managed via
+    /// the web UI.
+    pub admin_email: String,
     pub google: GoogleConfig,
     pub access_token_ttl: Duration,
     pub refresh_token_ttl: Duration,
@@ -99,7 +102,7 @@ impl Default for AuthConfig {
             key_path: base_dir.join(DEFAULT_KEY_NAME),
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
-            allowed_emails: Vec::new(),
+            admin_email: String::new(),
             google: GoogleConfig::default(),
             access_token_ttl: Duration::from_secs(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             refresh_token_ttl: Duration::from_secs(DEFAULT_REFRESH_TOKEN_TTL_SECS),
@@ -117,19 +120,9 @@ impl AuthConfig {
     ) -> Result<Self, AuthError> {
         let vars = normalize(vars);
         let mode = AuthMode::parse(vars.get("LAB_AUTH_MODE").map(String::as_str))?;
-        let raw_allowed_emails = vars.get("LAB_AUTH_ALLOWED_EMAILS").cloned();
-        let allowed_emails: Vec<String> = read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
-            .unwrap_or_default()
-            .into_iter()
-            .map(|e| e.to_ascii_lowercase())
-            .collect();
-        if raw_allowed_emails.is_some() && allowed_emails.is_empty() {
-            warn!(
-                env_var = "LAB_AUTH_ALLOWED_EMAILS",
-                "allowed_emails env var is set but resolved to an empty list — \
-                 all Google accounts are permitted. Check for typos or whitespace-only values."
-            );
-        }
+        let admin_email = read_string(&vars, "LAB_AUTH_ADMIN_EMAIL")
+            .map(|raw| raw.trim().to_ascii_lowercase())
+            .unwrap_or_default();
         let config = Self {
             mode,
             public_url: read_url(&vars, "LAB_PUBLIC_URL")?,
@@ -140,7 +133,7 @@ impl AuthConfig {
             bootstrap_secret: read_string(&vars, "LAB_AUTH_BOOTSTRAP_SECRET"),
             allowed_client_redirect_uris: read_csv(&vars, "LAB_AUTH_ALLOWED_REDIRECT_URIS")
                 .unwrap_or_default(),
-            allowed_emails,
+            admin_email,
             google: GoogleConfig {
                 client_id: read_string(&vars, "LAB_GOOGLE_CLIENT_ID").unwrap_or_default(),
                 client_secret: read_string(&vars, "LAB_GOOGLE_CLIENT_SECRET").unwrap_or_default(),
@@ -196,6 +189,14 @@ impl AuthConfig {
             if self.google.client_secret.is_empty() {
                 return Err(AuthError::Config(
                     "LAB_GOOGLE_CLIENT_SECRET is required when LAB_AUTH_MODE=oauth".to_string(),
+                ));
+            }
+            if self.admin_email.is_empty() {
+                return Err(AuthError::Config(
+                    "LAB_AUTH_ADMIN_EMAIL is required when LAB_AUTH_MODE=oauth — \
+                     set the Google email of the bootstrap admin so no account \
+                     can log in unless explicitly permitted"
+                        .to_string(),
                 ));
             }
         }
@@ -331,6 +332,7 @@ mod tests {
             ("LAB_PUBLIC_URL", "https://lab.example.com"),
             ("LAB_GOOGLE_CLIENT_ID", "id"),
             ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
+            ("LAB_AUTH_ADMIN_EMAIL", "admin@example.com"),
         ]))
         .unwrap();
         assert_eq!(cfg.sqlite_path.file_name().unwrap(), "auth.db");
@@ -339,37 +341,28 @@ mod tests {
     }
 
     #[test]
-    fn allowed_emails_defaults_to_empty_vec() {
-        let cfg = AuthConfig::from_sources(fake_env_with_many([
+    fn oauth_mode_requires_admin_email() {
+        let err = AuthConfig::from_sources(fake_env_with_many([
             ("LAB_AUTH_MODE", "oauth"),
             ("LAB_PUBLIC_URL", "https://lab.example.com"),
             ("LAB_GOOGLE_CLIENT_ID", "id"),
             ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
         ]))
-        .unwrap();
-        assert!(cfg.allowed_emails.is_empty());
+        .unwrap_err();
+        assert!(err.to_string().contains("LAB_AUTH_ADMIN_EMAIL"));
     }
 
     #[test]
-    fn allowed_emails_normalizes_case_and_trims_whitespace() {
+    fn admin_email_normalizes_case_and_trims_whitespace() {
         let cfg = AuthConfig::from_sources(fake_env_with_many([
             ("LAB_AUTH_MODE", "oauth"),
             ("LAB_PUBLIC_URL", "https://lab.example.com"),
             ("LAB_GOOGLE_CLIENT_ID", "id"),
             ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
-            (
-                "LAB_AUTH_ALLOWED_EMAILS",
-                "Alice@Example.com , BOB@EXAMPLE.COM ",
-            ),
+            ("LAB_AUTH_ADMIN_EMAIL", "  Admin@Example.COM  "),
         ]))
         .unwrap();
-        assert_eq!(
-            cfg.allowed_emails,
-            vec![
-                "alice@example.com".to_string(),
-                "bob@example.com".to_string()
-            ]
-        );
+        assert_eq!(cfg.admin_email, "admin@example.com");
     }
 
     #[test]
@@ -379,6 +372,7 @@ mod tests {
             ("LAB_PUBLIC_URL", "https://lab.example.com"),
             ("LAB_GOOGLE_CLIENT_ID", "id"),
             ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
+            ("LAB_AUTH_ADMIN_EMAIL", "admin@example.com"),
             (
                 "LAB_AUTH_ALLOWED_REDIRECT_URIS",
                 "https://callback.tootie.tv/callback/*,https://claude.ai/api/mcp/auth_callback",

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use url::Url;
 
 use crate::error::AuthError;
@@ -79,10 +80,6 @@ pub struct AuthConfig {
     pub bootstrap_secret: Option<String>,
     pub allowed_client_redirect_uris: Vec<String>,
     pub allowed_emails: Vec<String>,
-    /// True when `LAB_AUTH_ALLOWED_EMAILS` was provided but parsed to an empty
-    /// list (whitespace/comma-only). Used to surface a startup warning since an
-    /// empty allowlist means "no restriction".
-    pub allowed_emails_was_empty: bool,
     pub google: GoogleConfig,
     pub access_token_ttl: Duration,
     pub refresh_token_ttl: Duration,
@@ -103,7 +100,6 @@ impl Default for AuthConfig {
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
             allowed_emails: Vec::new(),
-            allowed_emails_was_empty: false,
             google: GoogleConfig::default(),
             access_token_ttl: Duration::from_secs(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             refresh_token_ttl: Duration::from_secs(DEFAULT_REFRESH_TOKEN_TTL_SECS),
@@ -121,6 +117,19 @@ impl AuthConfig {
     ) -> Result<Self, AuthError> {
         let vars = normalize(vars);
         let mode = AuthMode::parse(vars.get("LAB_AUTH_MODE").map(String::as_str))?;
+        let raw_allowed_emails = vars.get("LAB_AUTH_ALLOWED_EMAILS").cloned();
+        let allowed_emails: Vec<String> = read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| e.to_ascii_lowercase())
+            .collect();
+        if raw_allowed_emails.is_some() && allowed_emails.is_empty() {
+            warn!(
+                env_var = "LAB_AUTH_ALLOWED_EMAILS",
+                "allowed_emails env var is set but resolved to an empty list — \
+                 all Google accounts are permitted. Check for typos or whitespace-only values."
+            );
+        }
         let config = Self {
             mode,
             public_url: read_url(&vars, "LAB_PUBLIC_URL")?,
@@ -131,17 +140,7 @@ impl AuthConfig {
             bootstrap_secret: read_string(&vars, "LAB_AUTH_BOOTSTRAP_SECRET"),
             allowed_client_redirect_uris: read_csv(&vars, "LAB_AUTH_ALLOWED_REDIRECT_URIS")
                 .unwrap_or_default(),
-            allowed_emails: read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
-                .unwrap_or_default()
-                .into_iter()
-                .map(|e| e.to_ascii_lowercase())
-                .collect(),
-            allowed_emails_was_empty: matches!(
-                vars.get("LAB_AUTH_ALLOWED_EMAILS"),
-                Some(raw) if !raw.is_empty()
-            ) && read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
-                .unwrap_or_default()
-                .is_empty(),
+            allowed_emails,
             google: GoogleConfig {
                 client_id: read_string(&vars, "LAB_GOOGLE_CLIENT_ID").unwrap_or_default(),
                 client_secret: read_string(&vars, "LAB_GOOGLE_CLIENT_SECRET").unwrap_or_default(),

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -79,6 +79,10 @@ pub struct AuthConfig {
     pub bootstrap_secret: Option<String>,
     pub allowed_client_redirect_uris: Vec<String>,
     pub allowed_emails: Vec<String>,
+    /// True when `LAB_AUTH_ALLOWED_EMAILS` was provided but parsed to an empty
+    /// list (whitespace/comma-only). Used to surface a startup warning since an
+    /// empty allowlist means "no restriction".
+    pub allowed_emails_was_empty: bool,
     pub google: GoogleConfig,
     pub access_token_ttl: Duration,
     pub refresh_token_ttl: Duration,
@@ -99,6 +103,7 @@ impl Default for AuthConfig {
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
             allowed_emails: Vec::new(),
+            allowed_emails_was_empty: false,
             google: GoogleConfig::default(),
             access_token_ttl: Duration::from_secs(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             refresh_token_ttl: Duration::from_secs(DEFAULT_REFRESH_TOKEN_TTL_SECS),
@@ -131,6 +136,12 @@ impl AuthConfig {
                 .into_iter()
                 .map(|e| e.to_ascii_lowercase())
                 .collect(),
+            allowed_emails_was_empty: matches!(
+                vars.get("LAB_AUTH_ALLOWED_EMAILS"),
+                Some(raw) if !raw.is_empty()
+            ) && read_csv(&vars, "LAB_AUTH_ALLOWED_EMAILS")
+                .unwrap_or_default()
+                .is_empty(),
             google: GoogleConfig {
                 client_id: read_string(&vars, "LAB_GOOGLE_CLIENT_ID").unwrap_or_default(),
                 client_secret: read_string(&vars, "LAB_GOOGLE_CLIENT_SECRET").unwrap_or_default(),

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -589,25 +589,8 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        AuthorizeUrlRequest, CachedGoogleJwks, GoogleExchange, GoogleJwk, GoogleJwks,
-        GoogleProvider,
+        AuthorizeUrlRequest, CachedGoogleJwks, GoogleJwk, GoogleJwks, GoogleProvider,
     };
-
-    #[tokio::test]
-    async fn google_exchange_exposes_email_verified_claim() {
-        // GoogleExchange must carry the `email_verified` claim through from the id_token
-        // so the email allowlist can refuse unverified emails.
-        let exchange = GoogleExchange {
-            subject: "sub".to_string(),
-            email: Some("user@example.com".to_string()),
-            email_verified: Some(false),
-            access_token: "tok".to_string(),
-            refresh_token: None,
-            expires_in: None,
-            id_token: "id".to_string(),
-        };
-        assert_eq!(exchange.email_verified, Some(false));
-    }
 
     #[test]
     fn google_authorize_url_includes_offline_access_prompt_and_pkce() {

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -54,6 +54,7 @@ impl std::fmt::Debug for GoogleProvider {
 pub struct GoogleExchange {
     pub subject: String,
     pub email: Option<String>,
+    pub email_verified: Option<bool>,
     pub access_token: String,
     pub refresh_token: Option<String>,
     pub expires_in: Option<u64>,
@@ -76,6 +77,8 @@ struct GoogleIdTokenClaims {
     sub: String,
     #[serde(default)]
     email: Option<String>,
+    #[serde(default)]
+    email_verified: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -351,6 +354,7 @@ impl GoogleProvider {
         Ok(GoogleExchange {
             subject: claims.sub,
             email: claims.email,
+            email_verified: claims.email_verified,
             access_token: payload.access_token,
             refresh_token: payload.refresh_token,
             expires_in: payload.expires_in,
@@ -394,6 +398,7 @@ impl GoogleProvider {
         Ok(GoogleExchange {
             subject: claims.sub,
             email: claims.email,
+            email_verified: claims.email_verified,
             access_token: payload.access_token,
             refresh_token: payload.refresh_token,
             expires_in: payload.expires_in,
@@ -583,7 +588,26 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::{AuthorizeUrlRequest, CachedGoogleJwks, GoogleJwk, GoogleJwks, GoogleProvider};
+    use super::{
+        AuthorizeUrlRequest, CachedGoogleJwks, GoogleExchange, GoogleJwk, GoogleJwks,
+        GoogleProvider,
+    };
+
+    #[tokio::test]
+    async fn google_exchange_exposes_email_verified_claim() {
+        // GoogleExchange must carry the `email_verified` claim through from the id_token
+        // so the email allowlist can refuse unverified emails.
+        let exchange = GoogleExchange {
+            subject: "sub".to_string(),
+            email: Some("user@example.com".to_string()),
+            email_verified: Some(false),
+            access_token: "tok".to_string(),
+            refresh_token: None,
+            expires_in: None,
+            id_token: "id".to_string(),
+        };
+        assert_eq!(exchange.email_verified, Some(false));
+    }
 
     #[test]
     fn google_authorize_url_includes_offline_access_prompt_and_pkce() {

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -588,9 +588,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::{
-        AuthorizeUrlRequest, CachedGoogleJwks, GoogleJwk, GoogleJwks, GoogleProvider,
-    };
+    use super::{AuthorizeUrlRequest, CachedGoogleJwks, GoogleJwk, GoogleJwks, GoogleProvider};
 
     #[test]
     fn google_authorize_url_includes_offline_access_prompt_and_pkce() {

--- a/crates/lab-auth/src/lib.rs
+++ b/crates/lab-auth/src/lib.rs
@@ -10,4 +10,4 @@ pub mod sqlite;
 pub mod state;
 pub mod token;
 pub mod types;
-pub(crate) mod util;
+pub mod util;

--- a/crates/lab-auth/src/sqlite.rs
+++ b/crates/lab-auth/src/sqlite.rs
@@ -8,12 +8,15 @@ use tracing::warn;
 
 use crate::error::AuthError;
 use crate::types::{
-    AuthorizationCodeRow, AuthorizationRequestRow, BrowserLoginStateRow, BrowserSessionRow,
-    RefreshTokenRow, RegisteredClient, UpstreamOauthCredentialRow, UpstreamOauthStateRow,
+    AllowedUserRow, AuthorizationCodeRow, AuthorizationRequestRow, BrowserLoginStateRow,
+    BrowserSessionRow, RefreshTokenRow, RegisteredClient, UpstreamOauthCredentialRow,
+    UpstreamOauthStateRow,
 };
 
 const UPSTREAM_OAUTH_STATE_MAX_TTL_SECS: i64 = 600;
-use crate::util::{ensure_restrictive_permissions, now_unix, set_restrictive_permissions};
+use crate::util::{
+    ensure_restrictive_permissions, fingerprint, now_unix, set_restrictive_permissions,
+};
 
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_POOL_SIZE: usize = 4;
@@ -731,6 +734,75 @@ impl SqliteStore {
         .await
     }
 
+    /// Add an email address to the allowlist.
+    ///
+    /// `email` is normalised to lowercase before storage. Returns
+    /// `AuthError::Validation` if the email is already present.
+    pub async fn add_allowed_user(
+        &self,
+        email: &str,
+        added_by: &str,
+        created_at: i64,
+    ) -> Result<(), AuthError> {
+        let email = email.to_lowercase();
+        let fp = fingerprint(&email);
+        let added_by = added_by.to_string();
+        self.with_conn(move |conn| {
+            let changed = conn
+                .execute(
+                    "INSERT INTO allowed_users (email, added_by, created_at)
+                     VALUES (?1, ?2, ?3)",
+                    params![email, added_by, created_at],
+                )
+                .map_err(|error| match error {
+                    rusqlite::Error::SqliteFailure(ref e, _)
+                        if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+                    {
+                        AuthError::Validation(format!(
+                            "email fingerprint {fp} is already in the allowlist"
+                        ))
+                    }
+                    other => sqlite_error(other),
+                })?;
+            debug_assert_eq!(changed, 1);
+            Ok(())
+        })
+        .await
+    }
+
+    /// Remove an email address from the allowlist.
+    ///
+    /// Idempotent: returns `Ok(())` even if the email was not present.
+    pub async fn remove_allowed_user(&self, email: &str) -> Result<(), AuthError> {
+        let email = email.to_lowercase();
+        self.with_conn(move |conn| {
+            conn.execute("DELETE FROM allowed_users WHERE email = ?1", params![email])
+                .map_err(sqlite_error)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Return all allowlist rows ordered by `created_at ASC`.
+    pub async fn list_allowed_users(&self) -> Result<Vec<AllowedUserRow>, AuthError> {
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT email, added_by, created_at
+                     FROM allowed_users
+                     ORDER BY created_at ASC",
+                )
+                .map_err(sqlite_error)?;
+            let rows = stmt
+                .query_map([], row_to_allowed_user)
+                .map_err(sqlite_error)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(sqlite_error)?;
+            Ok(rows)
+        })
+        .await
+    }
+
     async fn with_conn<T, F>(&self, op: F) -> Result<T, AuthError>
     where
         T: Send + 'static,
@@ -865,7 +937,12 @@ fn open_connection(path: &Path) -> Result<Connection, AuthError> {
             client_id       TEXT NOT NULL,
             created_at      INTEGER NOT NULL,
             PRIMARY KEY (upstream_name, subject)
-        ) WITHOUT ROWID;",
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS allowed_users (
+            email       TEXT PRIMARY KEY NOT NULL,
+            added_by    TEXT NOT NULL,
+            created_at  INTEGER NOT NULL
+        );",
     )
     .map_err(sqlite_error)?;
 
@@ -896,6 +973,14 @@ fn validate_or_reopen_connection(conn: &mut Connection, path: &Path) -> Result<(
 #[allow(clippy::needless_pass_by_value)]
 fn sqlite_error(error: rusqlite::Error) -> AuthError {
     AuthError::Storage(format!("sqlite error: {error}"))
+}
+
+fn row_to_allowed_user(row: &rusqlite::Row<'_>) -> rusqlite::Result<AllowedUserRow> {
+    Ok(AllowedUserRow {
+        email: row.get(0)?,
+        added_by: row.get(1)?,
+        created_at: row.get(2)?,
+    })
 }
 
 fn row_to_authorization_request(
@@ -996,8 +1081,8 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::types::{
-        AuthorizationCodeRow, BrowserSessionRow, RefreshTokenRow, UpstreamOauthCredentialRow,
-        UpstreamOauthStateRow,
+        AllowedUserRow, AuthorizationCodeRow, BrowserSessionRow, RefreshTokenRow,
+        UpstreamOauthCredentialRow, UpstreamOauthStateRow,
     };
 
     use crate::util::now_unix;
@@ -1440,5 +1525,106 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    // ── allowed_users tests ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn allowed_users_add_and_list() {
+        let store = temp_store().await;
+        store
+            .add_allowed_user("alice@example.com", "admin", now_unix())
+            .await
+            .unwrap();
+        let rows = store.list_allowed_users().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].email, "alice@example.com");
+        assert_eq!(rows[0].added_by, "admin");
+    }
+
+    #[tokio::test]
+    async fn allowed_users_duplicate_returns_validation_error() {
+        let store = temp_store().await;
+        let now = now_unix();
+        store
+            .add_allowed_user("bob@example.com", "admin", now)
+            .await
+            .unwrap();
+        let err = store
+            .add_allowed_user("bob@example.com", "admin2", now)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::AuthError::Validation(_)),
+            "expected Validation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_users_input_is_lowercased() {
+        let store = temp_store().await;
+        store
+            .add_allowed_user("Alice@Example.COM", "admin", now_unix())
+            .await
+            .unwrap();
+        let rows = store.list_allowed_users().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].email, "alice@example.com");
+    }
+
+    #[tokio::test]
+    async fn allowed_users_remove_nonexistent_is_idempotent() {
+        let store = temp_store().await;
+        // Must not error even when no row exists.
+        store
+            .remove_allowed_user("nobody@example.com")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn allowed_users_list_ordered_by_created_at_asc() {
+        let store = temp_store().await;
+        let base = now_unix();
+        store
+            .add_allowed_user("third@example.com", "admin", base + 2)
+            .await
+            .unwrap();
+        store
+            .add_allowed_user("first@example.com", "admin", base)
+            .await
+            .unwrap();
+        store
+            .add_allowed_user("second@example.com", "admin", base + 1)
+            .await
+            .unwrap();
+        let rows = store.list_allowed_users().await.unwrap();
+        let emails: Vec<&str> = rows.iter().map(|r| r.email.as_str()).collect();
+        assert_eq!(
+            emails,
+            vec![
+                "first@example.com",
+                "second@example.com",
+                "third@example.com"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_users_schema_bootstrap_is_idempotent() {
+        // Open the same file twice; second open must not error.
+        let path = temp_db_path();
+        let _store1 = SqliteStore::open(path.clone()).await.unwrap();
+        let _store2 = SqliteStore::open(path).await.unwrap();
+    }
+
+    // Ensure AllowedUserRow is importable as the right type in tests.
+    #[allow(dead_code)]
+    fn _assert_allowed_user_row_type() -> AllowedUserRow {
+        AllowedUserRow {
+            email: String::new(),
+            added_by: String::new(),
+            created_at: 0,
+        }
     }
 }

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -269,11 +269,7 @@ mod tests {
         // Admin is always first; DB rows follow in created_at ASC order.
         assert_eq!(
             emails,
-            vec![
-                "admin@example.com",
-                "alice@example.com",
-                "bob@example.com"
-            ]
+            vec!["admin@example.com", "alice@example.com", "bob@example.com"]
         );
     }
 
@@ -293,10 +289,7 @@ mod tests {
             .unwrap();
         let emails = state.resolve_allowed_emails().await.unwrap();
         // "admin@example.com" from DB is deduped; "other@example.com" remains.
-        assert_eq!(
-            emails,
-            vec!["admin@example.com", "other@example.com"]
-        );
+        assert_eq!(emails, vec!["admin@example.com", "other@example.com"]);
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -100,15 +100,7 @@ impl AuthState {
             "lab-auth state initialized"
         );
 
-        // Warn if LAB_AUTH_ALLOWED_EMAILS is set in env but resolved empty.
-        // This happens when the value is whitespace-only or comma-only.
-        // An empty list means ALL Google accounts are permitted — which may surprise
-        // an operator who thought they enabled the allowlist.
-        if config.allowed_emails.is_empty()
-            && std::env::var("LAB_AUTH_ALLOWED_EMAILS")
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false)
-        {
+        if config.allowed_emails_was_empty {
             warn!(
                 env_var = "LAB_AUTH_ALLOWED_EMAILS",
                 "allowed_emails env var is set but resolved to an empty list — \
@@ -220,6 +212,7 @@ mod tests {
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
             allowed_emails: Vec::new(),
+            allowed_emails_was_empty: false,
             google: GoogleConfig {
                 client_id: "client-id".to_string(),
                 client_secret: "client-secret".to_string(),

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -136,6 +136,25 @@ impl AuthState {
         }
     }
 
+    /// Returns the merged email allowlist: admin first, then all `allowed_users` rows,
+    /// deduplicating case-insensitively so admin is never counted twice.
+    ///
+    /// This is the single source of truth used in both OAuth callback branches. A DB
+    /// error is surfaced as [`AuthError::Storage`] (fail-closed — server fault, not
+    /// user fault).
+    ///
+    /// Never log the returned emails directly — pass them only to
+    /// `check_email_allowlist`, which uses `fingerprint()` for safe diagnostics.
+    pub async fn resolve_allowed_emails(&self) -> Result<Vec<String>, AuthError> {
+        let mut emails = vec![self.config.admin_email.clone()];
+        for row in self.store.list_allowed_users().await? {
+            if !row.email.eq_ignore_ascii_case(&self.config.admin_email) {
+                emails.push(row.email);
+            }
+        }
+        Ok(emails)
+    }
+
     /// Rejects new OAuth state rows when the pending count exceeds `max_pending_oauth_states`.
     pub async fn ensure_pending_oauth_state_capacity(&self) -> Result<(), AuthError> {
         let count = self.store.count_pending_oauth_states().await?;
@@ -192,6 +211,93 @@ mod tests {
 
     use super::*;
     use crate::config::GoogleConfig;
+    use crate::util::now_unix;
+
+    /// Builds a minimal `AuthState` for unit-testing `resolve_allowed_emails`.
+    async fn resolve_state(admin_email: &str) -> AuthState {
+        let dir = tempdir().expect("tempdir");
+        AuthState::new(AuthConfig {
+            mode: AuthMode::OAuth,
+            public_url: Some(Url::parse("https://lab.example.com").expect("url")),
+            sqlite_path: dir.path().join("auth.db"),
+            key_path: dir.path().join("auth.pem"),
+            bootstrap_secret: None,
+            allowed_client_redirect_uris: Vec::new(),
+            admin_email: admin_email.to_string(),
+            google: GoogleConfig {
+                client_id: "client-id".to_string(),
+                client_secret: "client-secret".to_string(),
+                callback_path: "/auth/google/callback".to_string(),
+                scopes: vec![
+                    "openid".to_string(),
+                    "email".to_string(),
+                    "profile".to_string(),
+                ],
+            },
+            access_token_ttl: Duration::from_secs(3600),
+            refresh_token_ttl: Duration::from_secs(3600),
+            auth_code_ttl: Duration::from_secs(300),
+            register_requests_per_minute: 10,
+            authorize_requests_per_minute: 20,
+            max_pending_oauth_states: 1024,
+        })
+        .await
+        .expect("auth state")
+    }
+
+    #[tokio::test]
+    async fn resolve_allowed_emails_returns_admin_when_table_is_empty() {
+        let state = resolve_state("admin@example.com").await;
+        let emails = state.resolve_allowed_emails().await.unwrap();
+        assert_eq!(emails, vec!["admin@example.com"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_allowed_emails_includes_db_rows_after_admin() {
+        let state = resolve_state("admin@example.com").await;
+        state
+            .store
+            .add_allowed_user("alice@example.com", "admin", now_unix())
+            .await
+            .unwrap();
+        state
+            .store
+            .add_allowed_user("bob@example.com", "admin", now_unix() + 1)
+            .await
+            .unwrap();
+        let emails = state.resolve_allowed_emails().await.unwrap();
+        // Admin is always first; DB rows follow in created_at ASC order.
+        assert_eq!(
+            emails,
+            vec![
+                "admin@example.com",
+                "alice@example.com",
+                "bob@example.com"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_allowed_emails_deduplicates_admin_present_in_db() {
+        let state = resolve_state("admin@example.com").await;
+        // add_allowed_user lowercases; admin_email may differ in case → still deduped.
+        state
+            .store
+            .add_allowed_user("Admin@Example.COM", "self", now_unix())
+            .await
+            .unwrap();
+        state
+            .store
+            .add_allowed_user("other@example.com", "admin", now_unix() + 1)
+            .await
+            .unwrap();
+        let emails = state.resolve_allowed_emails().await.unwrap();
+        // "admin@example.com" from DB is deduped; "other@example.com" remains.
+        assert_eq!(
+            emails,
+            vec!["admin@example.com", "other@example.com"]
+        );
+    }
 
     #[tokio::test]
     async fn auth_state_preserves_public_url_path_prefix_in_google_redirect_uri() {

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Instant;
 
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 use crate::config::{AuthConfig, AuthMode};
@@ -99,6 +99,22 @@ impl AuthState {
             google_scopes = ?config.google.scopes,
             "lab-auth state initialized"
         );
+
+        // Warn if LAB_AUTH_ALLOWED_EMAILS is set in env but resolved empty.
+        // This happens when the value is whitespace-only or comma-only.
+        // An empty list means ALL Google accounts are permitted — which may surprise
+        // an operator who thought they enabled the allowlist.
+        if config.allowed_emails.is_empty()
+            && std::env::var("LAB_AUTH_ALLOWED_EMAILS")
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false)
+        {
+            warn!(
+                env_var = "LAB_AUTH_ALLOWED_EMAILS",
+                "allowed_emails env var is set but resolved to an empty list — \
+                 all Google accounts are permitted. Check for typos or whitespace-only values."
+            );
+        }
 
         let authorize_limiter = RateLimiter::new(config.authorize_requests_per_minute);
         let register_limiter = RateLimiter::new(config.register_requests_per_minute);
@@ -203,6 +219,7 @@ mod tests {
             key_path: temp.path().join("auth.pem"),
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
+            allowed_emails: Vec::new(),
             google: GoogleConfig {
                 client_id: "client-id".to_string(),
                 client_secret: "client-secret".to_string(),

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Instant;
 
-use tracing::{info, warn};
+use tracing::info;
 use url::Url;
 
 use crate::config::{AuthConfig, AuthMode};
@@ -99,14 +99,6 @@ impl AuthState {
             google_scopes = ?config.google.scopes,
             "lab-auth state initialized"
         );
-
-        if config.allowed_emails_was_empty {
-            warn!(
-                env_var = "LAB_AUTH_ALLOWED_EMAILS",
-                "allowed_emails env var is set but resolved to an empty list — \
-                 all Google accounts are permitted. Check for typos or whitespace-only values."
-            );
-        }
 
         let authorize_limiter = RateLimiter::new(config.authorize_requests_per_minute);
         let register_limiter = RateLimiter::new(config.register_requests_per_minute);
@@ -212,7 +204,6 @@ mod tests {
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
             allowed_emails: Vec::new(),
-            allowed_emails_was_empty: false,
             google: GoogleConfig {
                 client_id: "client-id".to_string(),
                 client_secret: "client-secret".to_string(),

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -203,7 +203,7 @@ mod tests {
             key_path: temp.path().join("auth.pem"),
             bootstrap_secret: None,
             allowed_client_redirect_uris: Vec::new(),
-            allowed_emails: Vec::new(),
+            admin_email: "admin@example.com".to_string(),
             google: GoogleConfig {
                 client_id: "client-id".to_string(),
                 client_secret: "client-secret".to_string(),

--- a/crates/lab-auth/src/types.rs
+++ b/crates/lab-auth/src/types.rs
@@ -207,6 +207,18 @@ pub struct UpstreamOauthStateRow {
     pub expires_at: i64,
 }
 
+/// A row from the `allowed_users` table.
+///
+/// Email is always stored and returned in lowercase. `added_by` is the subject
+/// of the admin who added the entry. Never log `email` directly — use
+/// `util::fingerprint(email)` for safe diagnostic output.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AllowedUserRow {
+    pub email: String,
+    pub added_by: String,
+    pub created_at: i64,
+}
+
 impl std::fmt::Debug for UpstreamOauthStateRow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UpstreamOauthStateRow")

--- a/crates/lab-auth/src/util.rs
+++ b/crates/lab-auth/src/util.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::AuthError;
 
-pub(crate) fn now_unix() -> i64 {
+pub fn now_unix() -> i64 {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -25,7 +25,7 @@ pub(crate) fn random_token(bytes: usize) -> Result<String, AuthError> {
     Ok(URL_SAFE_NO_PAD.encode(buf))
 }
 
-pub(crate) fn fingerprint(value: &str) -> String {
+pub fn fingerprint(value: &str) -> String {
     let digest = Sha256::digest(value.as_bytes());
     let mut output = String::with_capacity(12);
     for byte in &digest[..6] {

--- a/crates/lab/src/api/browser_session.rs
+++ b/crates/lab/src/api/browser_session.rs
@@ -105,9 +105,12 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
     log_auth_dispatch_start("session.get", request_id.as_deref());
 
     if state.web_ui_auth_disabled {
+        // Dev mode bypasses auth entirely — treat the synthetic dev user as admin
+        // so admin UI is reachable in local development without real credentials.
         let response = no_store_json(serde_json::json!({
             "authenticated": true,
             "login_available": false,
+            "is_admin": true,
             "user": {
                 "sub": "labby-dev",
                 "email": serde_json::Value::Null,
@@ -126,17 +129,30 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
         return response;
     };
 
+    let admin_email = state
+        .auth_config
+        .as_ref()
+        .map(|cfg| cfg.admin_email.as_str())
+        .unwrap_or("");
+
     let body = match load_browser_session(&auth_state, &headers).await {
-        Ok(Some(session)) => serde_json::json!({
-            "authenticated": true,
-            "login_available": login_available,
-            "user": {
-                "sub": session.subject,
-                "email": session.email,
-            },
-            "expires_at": session.expires_at,
-            "csrf_token": session.csrf_token,
-        }),
+        Ok(Some(session)) => {
+            let is_admin = session
+                .email
+                .as_deref()
+                .is_some_and(|e| e.eq_ignore_ascii_case(admin_email) && !admin_email.is_empty());
+            serde_json::json!({
+                "authenticated": true,
+                "login_available": login_available,
+                "is_admin": is_admin,
+                "user": {
+                    "sub": session.subject,
+                    "email": session.email,
+                },
+                "expires_at": session.expires_at,
+                "csrf_token": session.csrf_token,
+            })
+        }
         Ok(None) => {
             let response = unauthenticated_session_response(login_available);
             log_auth_dispatch("session.get", request_id.as_deref(), start, None);

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -375,7 +375,11 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
             )
             .nest("/extract", services::extract::routes(state.clone()))
             .nest("/marketplace", services::marketplace::routes(state.clone()))
-            .nest("/doctor", services::doctor::routes(state.clone()));
+            .nest("/doctor", services::doctor::routes(state.clone()))
+            .nest(
+                "/auth/allowed-emails",
+                services::auth_admin::routes(state.clone()),
+            );
 
         if state
             .registry

--- a/crates/lab/src/api/services.rs
+++ b/crates/lab/src/api/services.rs
@@ -10,6 +10,9 @@
 /// Shared dispatch wrapper: confirmation gate, timing, logging.
 pub mod helpers;
 
+/// Admin-only allowlist management (`/v1/auth/allowed-emails`).
+pub mod auth_admin;
+
 pub mod acp;
 pub mod doctor;
 pub mod extract;

--- a/crates/lab/src/api/services/auth_admin.rs
+++ b/crates/lab/src/api/services/auth_admin.rs
@@ -1,0 +1,408 @@
+//! HTTP route group for admin-only allowlist management.
+//!
+//! All endpoints require a browser session with an email matching the
+//! configured `admin_email`. JWT bearer callers receive 403 even if they
+//! hold a valid token — these endpoints are intentionally browser-session-only.
+//!
+//! Routes:
+//! - `GET  /v1/auth/allowed-emails`          → list entries (200)
+//! - `POST /v1/auth/allowed-emails`           → add entry (201)
+//! - `DELETE /v1/auth/allowed-emails/:email`  → remove entry (204, idempotent)
+//!
+//! CSRF for mutations is enforced by the /v1 auth middleware before these
+//! handlers are reached — no manual CSRF check is needed here.
+
+use std::time::Instant;
+
+use axum::Extension;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router, routing};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::api::auth_helpers::{log_auth_dispatch, log_auth_dispatch_start, request_id};
+use crate::api::oauth::AuthContext;
+use crate::api::state::AppState;
+use crate::dispatch::error::ToolError;
+use lab_auth::util::{fingerprint, now_unix};
+
+// ── email validation ─────────────────────────────────────────────────────────
+
+const MAX_EMAIL_LENGTH: usize = 320;
+
+/// Validate and normalize an email for storage.
+///
+/// Order: trim → empty check → length check → whitespace check → `@` check → lowercase.
+fn validate_email(raw: &str) -> Result<String, ToolError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "validation_failed".to_string(),
+            message: "email must not be empty".to_string(),
+        });
+    }
+    if trimmed.len() > MAX_EMAIL_LENGTH {
+        return Err(ToolError::Sdk {
+            sdk_kind: "validation_failed".to_string(),
+            message: format!(
+                "email must be at most {MAX_EMAIL_LENGTH} characters (got {})",
+                trimmed.len()
+            ),
+        });
+    }
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "validation_failed".to_string(),
+            message: "email must not contain whitespace".to_string(),
+        });
+    }
+    if !trimmed.contains('@') {
+        return Err(ToolError::Sdk {
+            sdk_kind: "validation_failed".to_string(),
+            message: "email must contain '@'".to_string(),
+        });
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
+// ── admin guard ───────────────────────────────────────────────────────────────
+
+/// Verify the caller is a browser-session user whose email matches `admin_email`.
+///
+/// Returns `Err(forbidden)` for:
+/// - JWT bearer callers (`via_session == false`)
+/// - Browser-session callers with no email claim
+/// - Email that does not match `admin_email` (case-insensitive)
+fn require_admin(ctx: &AuthContext, admin_email: &str) -> Result<(), ToolError> {
+    if !ctx.via_session {
+        return Err(ToolError::Sdk {
+            sdk_kind: "forbidden".to_string(),
+            message: "this endpoint requires a browser session, not a bearer token".to_string(),
+        });
+    }
+    let Some(ref email) = ctx.email else {
+        return Err(ToolError::Sdk {
+            sdk_kind: "forbidden".to_string(),
+            message: "session has no email — cannot verify admin access".to_string(),
+        });
+    };
+    if !email.eq_ignore_ascii_case(admin_email) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "forbidden".to_string(),
+            message: "caller is not the configured admin".to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Extract `oauth_state` or return a 404 `ToolError`.
+///
+/// 404 (not 503) is used when OAuth is not configured — the endpoint simply
+/// does not exist in bearer-only mode.
+fn require_oauth_state(
+    state: &AppState,
+) -> Result<&lab_auth::state::AuthState, ToolError> {
+    state
+        .oauth_state
+        .as_deref()
+        .ok_or_else(|| ToolError::Sdk {
+            sdk_kind: "not_found".to_string(),
+            message: "allowlist management is only available in OAuth mode".to_string(),
+        })
+}
+
+/// Extract `admin_email` from `auth_config`.
+///
+/// Returns an `internal_error` ToolError if auth config is not mounted.
+fn require_admin_email(state: &AppState) -> Result<&str, ToolError> {
+    state
+        .auth_config
+        .as_ref()
+        .map(|cfg| cfg.admin_email.as_str())
+        .ok_or_else(|| ToolError::internal_message("auth config not mounted"))
+}
+
+/// Map `AuthError` to a `ToolError` preserving its stable kind.
+fn auth_err(e: lab_auth::error::AuthError) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: e.kind().to_string(),
+        message: e.to_string(),
+    }
+}
+
+fn no_store(response: Response) -> Response {
+    let mut response = response;
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("private, no-store"),
+    );
+    response
+}
+
+// ── route registration ────────────────────────────────────────────────────────
+
+pub fn routes(_state: AppState) -> Router<AppState> {
+    Router::new()
+        .route(
+            "/",
+            routing::get(list_allowed_emails).post(add_allowed_email),
+        )
+        .route("/{email}", routing::delete(delete_allowed_email))
+}
+
+// ── handlers ──────────────────────────────────────────────────────────────────
+
+/// `GET /v1/auth/allowed-emails`
+///
+/// Returns `{ "entries": [{email, added_by, created_at}] }` (200).
+async fn list_allowed_emails(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Extension(auth): Extension<AuthContext>,
+) -> Response {
+    let start = Instant::now();
+    let req_id = request_id(&headers).map(ToOwned::to_owned);
+    let action = "auth.allowed_user.list";
+    log_auth_dispatch_start(action, req_id.as_deref());
+
+    // Require admin.
+    let admin_email = match require_admin_email(&state) {
+        Ok(e) => e,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+    if let Err(err) = require_admin(&auth, admin_email) {
+        log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+        return no_store(err.into_response());
+    }
+
+    // Require oauth_state.
+    let auth_state = match require_oauth_state(&state) {
+        Ok(s) => s,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+
+    let entries = match auth_state.store.list_allowed_users().await {
+        Ok(rows) => rows,
+        Err(err) => {
+            let kind = err.kind();
+            tracing::error!(
+                surface = "api",
+                service = "auth",
+                action,
+                kind,
+                elapsed_ms = start.elapsed().as_millis(),
+                "auth.allowed_user.list failed"
+            );
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(kind));
+            return no_store(auth_err(err).into_response());
+        }
+    };
+
+    log_auth_dispatch(action, req_id.as_deref(), start, None);
+    no_store(
+        (
+            StatusCode::OK,
+            Json(json!({ "entries": entries })),
+        )
+            .into_response(),
+    )
+}
+
+#[derive(Deserialize)]
+struct AddEmailBody {
+    email: String,
+}
+
+/// `POST /v1/auth/allowed-emails`
+///
+/// Body: `{ "email": "alice@example.com" }`
+/// Returns `{ "entry": {email, added_by, created_at} }` (201).
+async fn add_allowed_email(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Extension(auth): Extension<AuthContext>,
+    Json(body): Json<AddEmailBody>,
+) -> Response {
+    let start = Instant::now();
+    let req_id = request_id(&headers).map(ToOwned::to_owned);
+    let action = "auth.allowed_user.add";
+    log_auth_dispatch_start(action, req_id.as_deref());
+
+    // Require admin.
+    let admin_email = match require_admin_email(&state) {
+        Ok(e) => e,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+    if let Err(err) = require_admin(&auth, admin_email) {
+        log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+        return no_store(err.into_response());
+    }
+
+    // Require oauth_state.
+    let auth_state = match require_oauth_state(&state) {
+        Ok(s) => s,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+
+    // Validate email before any side effects.
+    let email = match validate_email(&body.email) {
+        Ok(e) => e,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+
+    let email_fp = fingerprint(&email);
+    let added_by = auth.sub.clone();
+    let created_at = now_unix();
+
+    // Log intent before the destructive/mutating operation.
+    tracing::info!(
+        surface = "api",
+        service = "auth",
+        action,
+        email_fp,
+        "auth.allowed_user.add intent"
+    );
+
+    match auth_state
+        .store
+        .add_allowed_user(&email, &added_by, created_at)
+        .await
+    {
+        Ok(()) => {}
+        Err(err) => {
+            let kind = err.kind();
+            tracing::warn!(
+                surface = "api",
+                service = "auth",
+                action,
+                email_fp,
+                kind,
+                elapsed_ms = start.elapsed().as_millis(),
+                "auth.allowed_user.add failed"
+            );
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(kind));
+            return no_store(auth_err(err).into_response());
+        }
+    }
+
+    let entry = lab_auth::types::AllowedUserRow {
+        email: email.clone(),
+        added_by,
+        created_at,
+    };
+
+    tracing::info!(
+        surface = "api",
+        service = "auth",
+        action,
+        email_fp,
+        elapsed_ms = start.elapsed().as_millis(),
+        "auth.allowed_user.add complete"
+    );
+    log_auth_dispatch(action, req_id.as_deref(), start, None);
+    no_store(
+        (
+            StatusCode::CREATED,
+            Json(json!({ "entry": entry })),
+        )
+            .into_response(),
+    )
+}
+
+/// `DELETE /v1/auth/allowed-emails/:email`
+///
+/// Returns 204 (idempotent — returns 204 even if the email was not present).
+async fn delete_allowed_email(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Extension(auth): Extension<AuthContext>,
+    Path(raw_email): Path<String>,
+) -> Response {
+    let start = Instant::now();
+    let req_id = request_id(&headers).map(ToOwned::to_owned);
+    let action = "auth.allowed_user.remove";
+    log_auth_dispatch_start(action, req_id.as_deref());
+
+    // Require admin.
+    let admin_email = match require_admin_email(&state) {
+        Ok(e) => e,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+    if let Err(err) = require_admin(&auth, admin_email) {
+        log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+        return no_store(err.into_response());
+    }
+
+    // Require oauth_state.
+    let auth_state = match require_oauth_state(&state) {
+        Ok(s) => s,
+        Err(err) => {
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(err.kind()));
+            return no_store(err.into_response());
+        }
+    };
+
+    // Normalize email from URL path.
+    let email = raw_email.trim().to_ascii_lowercase();
+    let email_fp = fingerprint(&email);
+
+    // Log intent before the mutating operation.
+    tracing::info!(
+        surface = "api",
+        service = "auth",
+        action,
+        email_fp,
+        "auth.allowed_user.remove intent"
+    );
+
+    match auth_state.store.remove_allowed_user(&email).await {
+        Ok(()) => {}
+        Err(err) => {
+            let kind = err.kind();
+            tracing::warn!(
+                surface = "api",
+                service = "auth",
+                action,
+                email_fp,
+                kind,
+                elapsed_ms = start.elapsed().as_millis(),
+                "auth.allowed_user.remove failed"
+            );
+            log_auth_dispatch(action, req_id.as_deref(), start, Some(kind));
+            return no_store(auth_err(err).into_response());
+        }
+    }
+
+    tracing::info!(
+        surface = "api",
+        service = "auth",
+        action,
+        email_fp,
+        elapsed_ms = start.elapsed().as_millis(),
+        "auth.allowed_user.remove complete"
+    );
+    log_auth_dispatch(action, req_id.as_deref(), start, None);
+    no_store(StatusCode::NO_CONTENT.into_response())
+}

--- a/crates/lab/src/api/services/auth_admin.rs
+++ b/crates/lab/src/api/services/auth_admin.rs
@@ -103,16 +103,11 @@ fn require_admin(ctx: &AuthContext, admin_email: &str) -> Result<(), ToolError> 
 ///
 /// 404 (not 503) is used when OAuth is not configured — the endpoint simply
 /// does not exist in bearer-only mode.
-fn require_oauth_state(
-    state: &AppState,
-) -> Result<&lab_auth::state::AuthState, ToolError> {
-    state
-        .oauth_state
-        .as_deref()
-        .ok_or_else(|| ToolError::Sdk {
-            sdk_kind: "not_found".to_string(),
-            message: "allowlist management is only available in OAuth mode".to_string(),
-        })
+fn require_oauth_state(state: &AppState) -> Result<&lab_auth::state::AuthState, ToolError> {
+    state.oauth_state.as_deref().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "not_found".to_string(),
+        message: "allowlist management is only available in OAuth mode".to_string(),
+    })
 }
 
 /// Extract `admin_email` from `auth_config`.
@@ -209,13 +204,7 @@ async fn list_allowed_emails(
     };
 
     log_auth_dispatch(action, req_id.as_deref(), start, None);
-    no_store(
-        (
-            StatusCode::OK,
-            Json(json!({ "entries": entries })),
-        )
-            .into_response(),
-    )
+    no_store((StatusCode::OK, Json(json!({ "entries": entries }))).into_response())
 }
 
 #[derive(Deserialize)]
@@ -319,13 +308,7 @@ async fn add_allowed_email(
         "auth.allowed_user.add complete"
     );
     log_auth_dispatch(action, req_id.as_deref(), start, None);
-    no_store(
-        (
-            StatusCode::CREATED,
-            Json(json!({ "entry": entry })),
-        )
-            .into_response(),
-    )
+    no_store((StatusCode::CREATED, Json(json!({ "entry": entry }))).into_response())
 }
 
 /// `DELETE /v1/auth/allowed-emails/:email`

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -545,6 +545,9 @@ pub struct AuthFileConfig {
     /// Optional authorization-code lifetime override in seconds.
     #[serde(default)]
     pub auth_code_ttl_secs: Option<u64>,
+    /// Bootstrap admin Google email — required in oauth mode.
+    #[serde(default)]
+    pub admin_email: Option<String>,
 }
 
 /// Resolve auth configuration from config file + environment variables.
@@ -616,6 +619,11 @@ pub fn resolve_auth(config: Option<&AuthFileConfig>) -> Result<auth_config::Auth
             &mut merged,
             "LAB_AUTH_CODE_TTL_SECS",
             config.auth_code_ttl_secs.map(|value| value.to_string()),
+        );
+        insert_if_some(
+            &mut merged,
+            "LAB_AUTH_ADMIN_EMAIL",
+            config.admin_email.clone(),
         );
     }
 
@@ -1378,6 +1386,7 @@ mod tests {
             access_token_ttl_secs: Some(120),
             refresh_token_ttl_secs: Some(3600),
             auth_code_ttl_secs: Some(45),
+            admin_email: Some("admin@example.com".to_string()),
         };
 
         let resolved = resolve_auth(Some(&cfg)).expect("auth config should resolve");

--- a/crates/lab/tests/auth_admin_api.rs
+++ b/crates/lab/tests/auth_admin_api.rs
@@ -1,0 +1,623 @@
+//! Integration tests for the admin-only allowlist API.
+//!
+//! Coverage:
+//! - Unauthenticated requests (no cookie, no bearer) → 401
+//! - JWT bearer (valid OAuth token) → 403 (authenticated but not via session)
+//! - Browser session, email != admin_email → 403
+//! - Browser session, email == admin_email → 200 / 201 / 204
+//! - POST missing email field → 422 (JSON parse fails → 422)
+//! - POST empty email → 422
+//! - POST bad format (no @) → 422
+//! - POST email > 320 chars → 422
+//! - POST duplicate email → 422
+//! - DELETE nonexistent email → 204 (idempotent)
+//! - No oauth_state (bearer-only mode) → 404
+//! - CSRF missing on mutations → 422 (enforced by /v1 middleware)
+
+use axum::{body::Body, http::{Request, StatusCode, header}};
+use lab::api::{router::build_router, state::AppState};
+use lab_auth::{
+    config::{AuthConfig, AuthMode, GoogleConfig},
+    state::AuthState,
+    types::BrowserSessionRow,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// ── test harness ─────────────────────────────────────────────────────────────
+
+struct Harness {
+    /// Keep alive so the temp dir isn't deleted.
+    _tmp: TempDir,
+    auth_state: AuthState,
+    /// Admin email configured in the harness.
+    admin_email: String,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let admin_email = "admin@example.com".to_string();
+        let config = AuthConfig {
+            mode: AuthMode::OAuth,
+            public_url: Some(url::Url::parse("https://lab.example.com").unwrap()),
+            sqlite_path: tmp.path().join("auth.db"),
+            key_path: tmp.path().join("auth-jwt.pem"),
+            bootstrap_secret: Some("secret".to_string()),
+            admin_email: admin_email.clone(),
+            google: GoogleConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                callback_path: "/auth/google/callback".to_string(),
+                scopes: vec!["openid".to_string(), "email".to_string()],
+            },
+            ..AuthConfig::default()
+        };
+        let auth_state = AuthState::new(config).await.expect("auth state");
+        Self {
+            _tmp: tmp,
+            auth_state,
+            admin_email,
+        }
+    }
+
+    /// Build a router with OAuth auth state and auth_config attached.
+    fn router(&self) -> axum::Router {
+        let auth_config = AuthConfig {
+            mode: AuthMode::OAuth,
+            public_url: Some(url::Url::parse("https://lab.example.com").unwrap()),
+            sqlite_path: self._tmp.path().join("auth.db"),
+            key_path: self._tmp.path().join("auth-jwt.pem"),
+            bootstrap_secret: Some("secret".to_string()),
+            admin_email: self.admin_email.clone(),
+            google: GoogleConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                callback_path: "/auth/google/callback".to_string(),
+                scopes: vec!["openid".to_string(), "email".to_string()],
+            },
+            ..AuthConfig::default()
+        };
+        let state = AppState::new()
+            .with_oauth_state(self.auth_state.clone())
+            .with_auth_config(auth_config);
+        build_router(state, None, Some(self.auth_state.clone()), None, &[])
+    }
+
+    /// Seed a browser session in the store. Returns the session row.
+    async fn seed_session(&self, email: Option<&str>, csrf: &str) -> BrowserSessionRow {
+        let session = BrowserSessionRow {
+            session_id: format!("sess-{csrf}"),
+            subject: "user-sub".to_string(),
+            email: email.map(ToOwned::to_owned),
+            csrf_token: csrf.to_string(),
+            created_at: 1,
+            expires_at: i64::MAX,
+        };
+        self.auth_state
+            .store
+            .upsert_browser_session(session.clone())
+            .await
+            .expect("upsert session");
+        session
+    }
+
+    /// Seed an admin session (email == admin_email).
+    async fn seed_admin_session(&self) -> BrowserSessionRow {
+        self.seed_session(Some(&self.admin_email), "csrf-admin").await
+    }
+
+    /// Issue a JWT access token for the test issuer.
+    fn issue_jwt(&self) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as usize;
+        self.auth_state
+            .signing_keys
+            .issue_access_token(&lab_auth::jwt::AccessClaims {
+                iss: "https://lab.example.com".to_string(),
+                sub: "jwt-user".to_string(),
+                aud: "https://lab.example.com/mcp".to_string(),
+                exp: now + 3600,
+                iat: now,
+                jti: "test-jti".to_string(),
+                scope: "lab".to_string(),
+                azp: "client".to_string(),
+            })
+            .unwrap()
+    }
+
+    /// Build a GET request with a session cookie and optional CSRF header.
+    fn get_with_session(uri: &str, session: &BrowserSessionRow) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header(
+                header::COOKIE,
+                format!(
+                    "{}={}",
+                    lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
+                    session.session_id
+                ),
+            )
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    /// Build a POST request with a session cookie + CSRF header + JSON body.
+    fn post_with_session(uri: &str, session: &BrowserSessionRow, body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(
+                header::COOKIE,
+                format!(
+                    "{}={}",
+                    lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
+                    session.session_id
+                ),
+            )
+            .header(lab_auth::session::BROWSER_CSRF_HEADER_NAME, &session.csrf_token)
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// Build a DELETE request with a session cookie + CSRF header.
+    fn delete_with_session(uri: &str, session: &BrowserSessionRow) -> Request<Body> {
+        Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .header(
+                header::COOKIE,
+                format!(
+                    "{}={}",
+                    lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
+                    session.session_id
+                ),
+            )
+            .header(lab_auth::session::BROWSER_CSRF_HEADER_NAME, &session.csrf_token)
+            .body(Body::empty())
+            .unwrap()
+    }
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+}
+
+// ── authentication tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_unauthenticated_returns_401() {
+    let h = Harness::new().await;
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/allowed-emails")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn post_unauthenticated_returns_401() {
+    let h = Harness::new().await;
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/allowed-emails")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"email":"x@x.com"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn delete_unauthenticated_returns_401() {
+    let h = Harness::new().await;
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/auth/allowed-emails/x@x.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn get_jwt_bearer_returns_403() {
+    let h = Harness::new().await;
+    let token = h.issue_jwt();
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/allowed-emails")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "forbidden");
+}
+
+#[tokio::test]
+async fn post_jwt_bearer_returns_403() {
+    let h = Harness::new().await;
+    let token = h.issue_jwt();
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/allowed-emails")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(r#"{"email":"x@x.com"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn get_non_admin_session_returns_403() {
+    let h = Harness::new().await;
+    let session = h.seed_session(Some("notadmin@example.com"), "csrf-na").await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "forbidden");
+}
+
+// ── success path tests ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_admin_session_returns_200_with_entries() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert!(json["entries"].is_array());
+}
+
+#[tokio::test]
+async fn post_admin_session_adds_email_returns_201() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":"alice@example.com"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(json["entry"]["email"], "alice@example.com");
+}
+
+#[tokio::test]
+async fn delete_admin_session_removes_email_returns_204() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    // First add an entry.
+    h.auth_state
+        .store
+        .add_allowed_user("bob@example.com", "admin", 1)
+        .await
+        .unwrap();
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::delete_with_session(
+            "/v1/auth/allowed-emails/bob@example.com",
+            &session,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn delete_nonexistent_email_returns_204() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::delete_with_session(
+            "/v1/auth/allowed-emails/nobody@example.com",
+            &session,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+// ── validation tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn post_missing_email_field_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    // JSON body without "email" field — deserialization fails → 422.
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"not_email":"x"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn post_empty_email_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":""}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "validation_failed");
+}
+
+#[tokio::test]
+async fn post_whitespace_only_email_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":"   "}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "validation_failed");
+}
+
+#[tokio::test]
+async fn post_email_without_at_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":"notanemail"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "validation_failed");
+}
+
+#[tokio::test]
+async fn post_email_too_long_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    // 321 characters: "a...a@example.com"
+    let local = "a".repeat(321 - "@example.com".len());
+    let long_email = format!("{local}@example.com");
+    assert!(long_email.len() > 320);
+    let body = serde_json::json!({ "email": long_email }).to_string();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            &body,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "validation_failed");
+}
+
+#[tokio::test]
+async fn post_duplicate_email_returns_422() {
+    let h = Harness::new().await;
+    // Pre-seed the email so the second add is a duplicate.
+    h.auth_state
+        .store
+        .add_allowed_user("dup@example.com", "admin", 1)
+        .await
+        .unwrap();
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":"dup@example.com"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let json = body_json(response).await;
+    assert_eq!(json["kind"], "validation_failed");
+}
+
+// ── CSRF enforcement ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn post_missing_csrf_header_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    // POST without the CSRF header — middleware rejects before handler runs.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/allowed-emails")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(
+                    header::COOKIE,
+                    format!(
+                        "{}={}",
+                        lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
+                        session.session_id
+                    ),
+                )
+                // Intentionally omit BROWSER_CSRF_HEADER_NAME
+                .body(Body::from(r#"{"email":"x@x.com"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn delete_missing_csrf_header_returns_422() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/auth/allowed-emails/x@x.com")
+                .header(
+                    header::COOKIE,
+                    format!(
+                        "{}={}",
+                        lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
+                        session.session_id
+                    ),
+                )
+                // Intentionally omit BROWSER_CSRF_HEADER_NAME
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// ── bearer-only mode (no oauth_state) ────────────────────────────────────────
+
+#[tokio::test]
+async fn get_no_oauth_state_with_bearer_returns_403() {
+    // Bearer-only mode: static bearer token configured, no oauth_state.
+    // AuthContext is inserted with via_session=false by the static-bearer path,
+    // so require_admin() → 403 (not via_session).
+    // The handler never reaches require_oauth_state() because require_admin fails first.
+    let state = AppState::new(); // no oauth_state, no auth_config
+    let app = build_router(state, Some("static-token".into()), None, None, &[]);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/allowed-emails")
+                .header(header::AUTHORIZATION, "Bearer static-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Static bearer inserts AuthContext with via_session=false → require_admin() → 403.
+    // (require_admin_email returns internal_error when auth_config is None, but
+    //  we just check it's not 200.)
+    assert!(
+        response.status() == StatusCode::FORBIDDEN
+            || response.status() == StatusCode::INTERNAL_SERVER_ERROR,
+        "expected 403 or 500, got {}",
+        response.status()
+    );
+}
+
+// ── list reflects additions ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_shows_added_emails() {
+    let h = Harness::new().await;
+    h.auth_state
+        .store
+        .add_allowed_user("carol@example.com", "admin", 1)
+        .await
+        .unwrap();
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let entries = json["entries"].as_array().unwrap();
+    assert!(entries.iter().any(|e| e["email"] == "carol@example.com"));
+}
+
+// ── email normalization ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn post_normalizes_email_to_lowercase() {
+    let h = Harness::new().await;
+    let session = h.seed_admin_session().await;
+    let app = h.router();
+    let response = app
+        .oneshot(Harness::post_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+            r#"{"email":"  Alice@Example.COM  "}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(json["entry"]["email"], "alice@example.com");
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ changes rather than internal refactors.
 ## [Unreleased]
 
 ### Added
+- Added `LAB_AUTH_ADMIN_EMAIL` env var (required in oauth mode). The Google
+  email of the bootstrap admin permitted to log in. The id_token's
+  `email_verified` claim is enforced — unverified accounts are rejected even
+  when the address matches. A SQLite-backed multi-user allowlist managed
+  through the Labby web UI is planned as a follow-up.
 - Added `lab-auth`, a dedicated auth crate for hosted HTTP OAuth flows.
 - Added Google-backed OAuth support for the HTTP MCP server, including dynamic
   client registration, PKCE, local JWT issuance, and JWKS publishing.
@@ -22,6 +27,12 @@ changes rather than internal refactors.
   patterns for callback-relay style clients such as Codex.
 
 ### Changed
+- **Breaking (auth):** OAuth mode now requires `LAB_AUTH_ADMIN_EMAIL` to be set.
+  Startup fails closed if it is missing. The previous behavior of allowing every
+  Google account when no allowlist was configured was a fail-open
+  misconfiguration risk. Operators upgrading to this release must add
+  `LAB_AUTH_ADMIN_EMAIL` to their environment before `lab serve --transport http`
+  will start in oauth mode.
 - **Breaking (HTTP API):** `gateway.add`, `gateway.update`, `gateway.remove`, and
   `gateway.reload` are now marked destructive. HTTP and MCP callers must include
   `"confirm": true` in `params` or the request is rejected with

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -322,6 +322,7 @@ Full details in [OAUTH.md](./OAUTH.md).
 | `LAB_GOOGLE_CALLBACK_PATH` | no | Callback path appended to `LAB_PUBLIC_URL`. Defaults to `/auth/google/callback`. |
 | `LAB_GOOGLE_SCOPES` | no | Comma-separated Google scopes. Defaults to `openid,email,profile`. |
 | `LAB_AUTH_ALLOWED_REDIRECT_URIS` | no | Comma-separated non-loopback redirect URI patterns. Host wildcards must be full labels, not raw suffix globs. |
+| `LAB_AUTH_ADMIN_EMAIL` | oauth mode | Google email of the bootstrap admin permitted to log in. Normalized to lowercase. **Required** in oauth mode — startup fails if unset so no Google account can authenticate unless explicitly permitted. The id_token's `email_verified` claim is enforced (unverified accounts are rejected even when the address matches). Additional users will be granted via a SQLite-backed allowlist managed in the web UI (planned). |
 | `LAB_AUTH_ACCESS_TOKEN_TTL_SECS` | no | Override lab-issued JWT access token lifetime. Defaults to `3600`. |
 | `LAB_AUTH_REFRESH_TOKEN_TTL_SECS` | no | Override refresh token lifetime. Defaults to `2592000` (30 days). |
 | `LAB_AUTH_CODE_TTL_SECS` | no | Override authorization code lifetime. Defaults to `300`. |

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -18,6 +18,7 @@ LAB_AUTH_MODE=oauth
 LAB_PUBLIC_URL=https://lab.example.com
 LAB_GOOGLE_CLIENT_ID=google-client-id
 LAB_GOOGLE_CLIENT_SECRET=google-client-secret
+LAB_AUTH_ADMIN_EMAIL=admin@example.com
 ```
 
 Optional auth overrides:
@@ -39,6 +40,7 @@ Rules:
 
 - `LAB_AUTH_MODE` defaults to `bearer`
 - bearer mode keeps using `LAB_MCP_HTTP_TOKEN`
-- oauth mode requires `LAB_PUBLIC_URL`, `LAB_GOOGLE_CLIENT_ID`, and `LAB_GOOGLE_CLIENT_SECRET`
+- oauth mode requires `LAB_PUBLIC_URL`, `LAB_GOOGLE_CLIENT_ID`, `LAB_GOOGLE_CLIENT_SECRET`, and `LAB_AUTH_ADMIN_EMAIL`
+- `LAB_AUTH_ADMIN_EMAIL` is the bootstrap admin Google email; startup fails closed if unset under oauth mode so no Google account can authenticate without explicit permission. Future SQLite-backed allowlist (web-UI managed) will grant access to additional users.
 - the old external issuer variables (`LAB_OAUTH_ISSUER`, `LAB_OAUTH_AUDIENCE`, `LAB_OAUTH_CLIENT_ID`) are no longer used
 - `LAB_PUBLIC_URL` also feeds RFC 9728 metadata, JWT issuer/audience, and HTTP allowed-host derivation

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -25,6 +25,7 @@ OAuth mode is configured through env vars and/or `config.toml`. Env vars take pr
 | `LAB_AUTH_SQLITE_PATH` | no | Override path for the SQLite auth database. |
 | `LAB_AUTH_KEY_PATH` | no | Override path for the persisted JWT signing key. |
 | `LAB_AUTH_ALLOWED_REDIRECT_URIS` | no | Comma-separated redirect URI patterns allowed for dynamic client registration in addition to loopback callbacks. |
+| `LAB_AUTH_ALLOWED_EMAILS` | no | Comma-separated list of Google email addresses permitted to log in. Entries are normalized to lowercase at startup. When empty (the default), any Google account that completes the OAuth flow is allowed. When set, the `email_verified` claim in Google's id_token is also enforced — accounts with unverified email addresses are rejected even if their address is in the list. |
 | `LAB_GOOGLE_CALLBACK_PATH` | no | Callback path appended to `LAB_PUBLIC_URL`. Defaults to `/auth/google/callback`. |
 | `LAB_GOOGLE_SCOPES` | no | Comma-separated Google scopes. Defaults to `openid,email,profile`. |
 | `LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `POST /register`. Defaults to `20`. |

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -25,7 +25,7 @@ OAuth mode is configured through env vars and/or `config.toml`. Env vars take pr
 | `LAB_AUTH_SQLITE_PATH` | no | Override path for the SQLite auth database. |
 | `LAB_AUTH_KEY_PATH` | no | Override path for the persisted JWT signing key. |
 | `LAB_AUTH_ALLOWED_REDIRECT_URIS` | no | Comma-separated redirect URI patterns allowed for dynamic client registration in addition to loopback callbacks. |
-| `LAB_AUTH_ALLOWED_EMAILS` | no | Comma-separated list of Google email addresses permitted to log in. Entries are normalized to lowercase at startup. When empty (the default), any Google account that completes the OAuth flow is allowed. When set, the `email_verified` claim in Google's id_token is also enforced — accounts with unverified email addresses are rejected even if their address is in the list. |
+| `LAB_AUTH_ADMIN_EMAIL` | oauth mode | Google email address of the bootstrap admin permitted to log in. Normalized to lowercase at startup. **Required** when `LAB_AUTH_MODE=oauth`: startup fails if unset so no Google account can authenticate unless explicitly permitted. The `email_verified` claim in Google's id_token is enforced — accounts with unverified email addresses are rejected even if the address matches. Additional users will be granted access through a SQLite-backed allowlist managed via the web UI (planned). |
 | `LAB_GOOGLE_CALLBACK_PATH` | no | Callback path appended to `LAB_PUBLIC_URL`. Defaults to `/auth/google/callback`. |
 | `LAB_GOOGLE_SCOPES` | no | Comma-separated Google scopes. Defaults to `openid,email,profile`. |
 | `LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE` | no | Process-local rate limit for `POST /register`. Defaults to `20`. |

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -36,7 +36,7 @@ OAuth mode is configured through env vars and/or `config.toml`. Env vars take pr
 
 When OAuth mode is configured, `lab serve --transport http` performs these steps at startup:
 
-1. Validate that `LAB_PUBLIC_URL` and Google credentials are present.
+1. Validate that `LAB_PUBLIC_URL`, Google credentials, and `LAB_AUTH_ADMIN_EMAIL` are present.
 2. Open the SQLite auth store in WAL mode with a non-zero busy timeout.
 3. Load or generate the persisted RSA signing key.
 4. Build the concrete Google provider callback URL from `LAB_PUBLIC_URL` and `LAB_GOOGLE_CALLBACK_PATH`.
@@ -47,6 +47,7 @@ Startup also fails if:
 
 - `LAB_AUTH_MODE=oauth` is set without `LAB_PUBLIC_URL`
 - Google client credentials are missing
+- `LAB_AUTH_ADMIN_EMAIL` is missing — fail-closed default so no Google account can authenticate without explicit permission
 - the auth database or signing key has insecure file permissions
 
 ## Registration and Authorize Flow
@@ -72,8 +73,9 @@ Flow summary:
 2. The client sends the user to `/authorize` with `response_type=code`.
 3. `lab` stores the request state, generates PKCE data, and redirects to Google.
 4. Google redirects back to `/auth/google/callback`.
-5. `lab` exchanges the Google code server-side, stores a local authorization code, and redirects the client back to its registered redirect URI with the local code.
-6. The client exchanges that local code at `/token` for a `lab` access token and, when Google granted offline access, a `lab` refresh token.
+5. `lab` enforces the email allowlist (currently `LAB_AUTH_ADMIN_EMAIL`; expanding to a SQLite-backed user list managed via the web UI). The id_token's `email_verified` claim is required — unverified accounts are rejected even when the address matches. Browser-login callers receive a 401; OAuth-client callers receive an RFC 6749 §4.1.2.1 redirect with `error=access_denied`.
+6. `lab` exchanges the Google code server-side, stores a local authorization code, and redirects the client back to its registered redirect URI with the local code.
+7. The client exchanges that local code at `/token` for a `lab` access token and, when Google granted offline access, a `lab` refresh token.
 
 Google access and refresh tokens remain server-side only.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -55,6 +55,7 @@ When `LAB_AUTH_MODE=oauth`, `lab` persists local auth state on disk:
 
 Rules:
 
+- `LAB_AUTH_ADMIN_EMAIL` must be set to the bootstrap admin's Google email; startup fails closed if it is missing so no Google account can authenticate without explicit permission
 - both files must use restrictive permissions; on Unix, `lab` requires they are not group- or world-readable
 - new files are created with `0600` permissions on Unix
 - the SQLite store is opened in WAL mode with a non-zero busy timeout


### PR DESCRIPTION
## Summary

Adds Google OAuth email allowlist to `lab-auth`, shipping in two parts:

### Part 1: Bootstrap admin (fail-closed default)
- `LAB_AUTH_ADMIN_EMAIL` — required in oauth mode; startup fails if unset so no Google account can log in without explicit permission
- `email_verified` claim enforced before comparison — unverified accounts rejected even if address matches
- Browser-login branch returns 401; OAuth-client branch sends RFC 6749 `error=access_denied` redirect
- Implements bead `lab-dzhw`

### Part 2: Runtime multi-user allowlist (web UI managed)
- `allowed_users` SQLite table in lab-auth store (`email`, `added_by`, `created_at`)
- `AuthState::resolve_allowed_emails()` — merges admin + db rows; both OAuth callback branches use it
- REST API: `GET/POST/DELETE /v1/auth/allowed-emails` (browser-session + admin gate)
- `/auth/session` extended with `is_admin: boolean`
- Gateway-admin settings page: "Allowed Users" panel (list, add with inline validation, remove with confirm dialog)
- Implements epic `lab-1bri`

## Breaking Change

`LAB_AUTH_ALLOWED_EMAILS` removed. Operators running `LAB_AUTH_MODE=oauth` must set `LAB_AUTH_ADMIN_EMAIL` before `lab serve --transport http` will start.

## Test plan

- [x] `cargo test -p lab-auth --all-features` — 89 tests (75 original + 14 new)
- [x] `cargo test -p lab --all-features` — 21 new integration tests for admin API
- [x] `cd apps/gateway-admin && pnpm test` — 192 tests, 0 fail
- [x] Clippy clean on all changed files
- [x] All PR review threads resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)