### PR TITLE
feat(acp): ACP bead sprint — docs, registry fixes, metadata relay, service wiring

### DIFF
--- a/apps/gateway-admin/README.md
+++ b/apps/gateway-admin/README.md
@@ -184,9 +184,13 @@ content.
 
 - **Live delivery:** `_meta` is forwarded as-is to SSE subscribers.
 - **Replay:** `_meta` survives the SQLite round-trip and is present in replayed events.
-- **Redaction on replay:** The standard field-name redaction policy applies to `_meta`
-  subfields on replay. Fields named `token`, `api_key`, `password`, `secret`,
-  `authorization`, `cwd`, `terminal_id`, `signal`, or `data` are stripped from the
-  persisted payload. Agents must not use these names as correlation keys inside `_meta`.
+- **Redaction on replay:** The standard field-name redaction policy applies recursively
+  to the entire persisted event payload — not only to `_meta` subfields. Any JSON key
+  matching a sensitive name is replaced with `"[REDACTED]"` before storage. Sensitive
+  key names include: `token`, `access_token`, `id_token`, `refresh_token`, `apikey`,
+  `api_key`, `password`, `passwd`, `secret`, `client_secret`, `authorization`,
+  `bearer`, `session`, `session_id`, `cookie`, `code`, `cwd`, `terminal_id`, and any
+  key ending with `_token`, `_secret`, `_password`, or `_key`. Agents must not use
+  these names as correlation keys anywhere in the event payload.
 - **Absent vs null:** When the originating agent did not inject `_meta`, the key is
   absent from the event entirely (not emitted as `null`).

--- a/apps/gateway-admin/README.md
+++ b/apps/gateway-admin/README.md
@@ -175,3 +175,18 @@ If a subscriber cannot drain the channel fast enough and the buffer fills, the s
 
 A client that is evicted will stop receiving events silently. Clients should treat a
 dropped SSE connection as a signal to reconnect with their last-seen `seq`.
+
+### `_meta` field relay
+
+Tool-call events may carry an optional `_meta` object injected by the originating agent.
+Lab relays this field transparently — it does not validate, transform, or construct `_meta`
+content.
+
+- **Live delivery:** `_meta` is forwarded as-is to SSE subscribers.
+- **Replay:** `_meta` survives the SQLite round-trip and is present in replayed events.
+- **Redaction on replay:** The standard field-name redaction policy applies to `_meta`
+  subfields on replay. Fields named `token`, `api_key`, `password`, `secret`,
+  `authorization`, `cwd`, `terminal_id`, `signal`, or `data` are stripped from the
+  persisted payload. Agents must not use these names as correlation keys inside `_meta`.
+- **Absent vs null:** When the originating agent did not inject `_meta`, the key is
+  absent from the event entirely (not emitted as `null`).

--- a/apps/gateway-admin/README.md
+++ b/apps/gateway-admin/README.md
@@ -127,7 +127,7 @@ ACP event handling details:
 ### Ordering guarantees
 
 Events within a session carry a monotonically increasing `seq` number assigned by a
-mutex-guarded counter in the server registry. A single fanout goroutine writes to all
+mutex-guarded counter in the server registry. A single fanout task writes to all
 subscribers, so ordering is preserved end-to-end. Events from different sessions have
 independent counters and are not ordered relative to each other.
 

--- a/apps/gateway-admin/README.md
+++ b/apps/gateway-admin/README.md
@@ -121,3 +121,57 @@ ACP event handling details:
 - reconnects resume from the last seen sequence number for the active session
 - the client keeps a bounded in-memory history instead of growing without limit
 - duplicate or out-of-order events are ignored
+
+## ACP stream lifecycle contract
+
+### Ordering guarantees
+
+Events within a session carry a monotonically increasing `seq` number assigned by a
+mutex-guarded counter in the server registry. A single fanout goroutine writes to all
+subscribers, so ordering is preserved end-to-end. Events from different sessions have
+independent counters and are not ordered relative to each other.
+
+### Replay and resume semantics
+
+The SSE endpoint accepts an optional `?since=<seq>` query parameter (unsigned integer,
+defaults to `0`). On connect the server:
+
+1. Registers the subscriber channel **before** querying the backlog, eliminating the
+   subscribe-first race condition where live events could arrive between the backlog
+   query and channel registration.
+2. Loads events with `seq > since` from the SQLite store (up to the 10 000-event
+   backfill cap).
+3. Falls back to the in-memory transcript when SQLite is unavailable.
+4. Chains the backlog stream with the live channel stream. At the junction, live events
+   whose `seq` is at or below the last backlog event are discarded to prevent duplicates.
+
+Clients should persist the highest `seq` seen and pass it as `since` on reconnect to
+receive only events missed during the disconnection window.
+
+### Retention and windowing
+
+SQLite is the authoritative event store. There is no server-side expiry policy: events
+persist for the lifetime of the session unless explicitly deleted.
+
+When SQLite is unavailable the server falls back to an in-memory transcript capped at
+500 events per session (FIFO eviction). Under the fallback path a reconnect with a
+`since` value that predates the oldest in-memory event will receive a silent partial
+backlog — no gap marker is emitted. Clients that need reliable full replay should
+operate against a deployment where SQLite persistence is enabled.
+
+Regardless of persistence mode, `subscribe()` returns at most 10 000 events per
+reconnect (the `BACKFILL_CAP`).
+
+### Backpressure and subscriber eviction
+
+Each subscriber receives events through a per-subscriber bounded channel (capacity 64).
+If a subscriber cannot drain the channel fast enough and the buffer fills, the server:
+
+1. Drops the slow subscriber immediately.
+2. Emits a synthetic `ProviderInfo` event with `type: "subscriber_backpressure"` into
+   the remaining stream and persists it so it is visible in replays.
+3. Logs a `WARN` with `action = "fanout.backpressure"` and the `after_seq` at which
+   the gap begins.
+
+A client that is evicted will stop receiving events silently. Clients should treat a
+dropped SSE connection as a signal to reconnect with their last-seen `seq`.

--- a/apps/gateway-admin/components/chat/tool-artifact-panels.tsx
+++ b/apps/gateway-admin/components/chat/tool-artifact-panels.tsx
@@ -359,7 +359,8 @@ export function ToolArtifactPanels({
       ) : null}
 
       {artifact.terminalOutput ? (
-        <div className="mt-2 overflow-hidden rounded-aurora-2 border border-aurora-border-default/70">
+        // O6: bounded height prevents re-measure storm during streaming + virtualization.
+        <div className="mt-2 max-h-96 overflow-auto rounded-aurora-2 border border-aurora-border-default/70">
           <Terminal
             output={artifact.terminalOutput}
             className="rounded-none border-0 bg-aurora-page-bg text-aurora-text-primary"

--- a/apps/gateway-admin/components/chat/tool-call-presentation.test.ts
+++ b/apps/gateway-admin/components/chat/tool-call-presentation.test.ts
@@ -121,6 +121,7 @@ test('getInlineArtifact applies TERMINAL_RENDER_TAIL_BYTES at concatenation (O3)
 
 test('getDisplayText strips OSC sequences (R7)', () => {
   // OSC-8 hyperlink with javascript: URI (R7 hostile input)
+  // Each input contains two OSC sequences with visible text between or around them.
   const withOscJavascript = '\x1b]8;;javascript:alert(1)\x07click me\x1b]8;;\x07'
   const withOscData = '\x1b]8;;data:text/html,<h1>XSS</h1>\x1b\\click me\x1b]8;;\x1b\\'
   // OSC-52 clipboard escape
@@ -133,6 +134,23 @@ test('getDisplayText strips OSC sequences (R7)', () => {
   assert.ok(!result1.includes('javascript:'), 'javascript: URI must be stripped')
   assert.ok(!result2.includes('data:text/html'), 'data: URI must be stripped')
   assert.ok(!result3.includes('c2Vuc2l0aXZlCg'), 'OSC-52 clipboard data must be stripped')
+  // Visible text between OSC sequences must be preserved (not accidentally stripped).
+  assert.ok(result1.includes('click me'), 'visible text between OSC sequences must be preserved')
+  assert.ok(result2.includes('click me'), 'visible text between OSC sequences must be preserved')
+})
+
+test('getDisplayText handles single chunk larger than TERMINAL_RENDER_TAIL_BYTES (O3)', () => {
+  // A single chunk that exceeds the 256 KiB tail cap. Previous logic silently
+  // returned an empty string in this case. Verify the tail is returned instead.
+  const bigChunk = 'a'.repeat(300 * 1024) // 300 KiB — exceeds 256 KiB cap
+  const result = getDisplayText([bigChunk])
+  const expectedLen = 256 * 1024 // TERMINAL_RENDER_TAIL_BYTES = 262_144
+  assert.ok(
+    result.length === expectedLen,
+    `expected ${expectedLen} code units, got ${result.length}`,
+  )
+  // Verify it is the tail that is returned (last char of the big chunk).
+  assert.ok(result.endsWith('a'), 'tail content must match the source chunk tail')
 })
 
 test('getDisplayText strips ANSI escape sequences (R1)', () => {

--- a/apps/gateway-admin/components/chat/tool-call-presentation.test.ts
+++ b/apps/gateway-admin/components/chat/tool-call-presentation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { getInlineArtifact, getToolPresentation } from './tool-call-presentation'
+import { getDisplayText, getInlineArtifact, getToolPresentation } from './tool-call-presentation'
 import type { TranscriptToolCall } from './types'
 
 function toolCall(overrides: Partial<TranscriptToolCall> = {}): TranscriptToolCall {
@@ -75,4 +75,73 @@ test('getToolPresentation treats permission-kind tool calls as permission timeli
 
   assert.equal(presentation.category, 'permission')
   assert.equal(presentation.label, 'Read ~/.ssh/config')
+})
+
+// ---------------------------------------------------------------------------
+// Security tests for terminal output sanitization (S9 / R1 / R7 / O3)
+// ---------------------------------------------------------------------------
+
+test('getInlineArtifact prefers streamed terminal output over raw output string (A8)', () => {
+  // A8: toolCall.terminal != null check (NOT truthy) should prefer terminal.
+  // Even with empty rawChunks, presence of terminal field triggers the ACP path.
+  const call = toolCall({
+    terminal: {
+      rawChunks: ['$ cargo build\n', 'Compiling lab v0.11.1\n'],
+      totalBytes: 40,
+      truncated: false,
+      exitCode: null,
+    },
+    output: 'this should NOT be used as terminal output',
+  })
+
+  const artifact = getInlineArtifact(call)
+  assert.ok(artifact.terminalOutput?.includes('cargo build'), 'should use ACP terminal rawChunks')
+  assert.ok(!artifact.terminalOutput?.includes('NOT be used'), 'should NOT use raw output string')
+})
+
+test('getInlineArtifact applies TERMINAL_RENDER_TAIL_BYTES at concatenation (O3)', () => {
+  // Create rawChunks that exceed 256 KiB total.
+  const bigChunk = 'x'.repeat(200 * 1024) // 200 KB
+  const call = toolCall({
+    terminal: {
+      rawChunks: [bigChunk, bigChunk], // 400 KB total
+      totalBytes: 400 * 1024,
+      truncated: true,
+      exitCode: 0,
+    },
+  })
+
+  const artifact = getInlineArtifact(call)
+  const outputLen = artifact.terminalOutput?.length ?? 0
+  assert.ok(
+    outputLen <= 262_144,
+    `terminalOutput length ${outputLen} should be <= TERMINAL_RENDER_TAIL_BYTES (262144)`,
+  )
+})
+
+test('getDisplayText strips OSC sequences (R7)', () => {
+  // OSC-8 hyperlink with javascript: URI (R7 hostile input)
+  const withOscJavascript = '\x1b]8;;javascript:alert(1)\x07click me\x1b]8;;\x07'
+  const withOscData = '\x1b]8;;data:text/html,<h1>XSS</h1>\x1b\\click me\x1b]8;;\x1b\\'
+  // OSC-52 clipboard escape
+  const withOsc52 = '\x1b]52;c;c2Vuc2l0aXZlCg==\x07'
+
+  const result1 = getDisplayText([withOscJavascript])
+  const result2 = getDisplayText([withOscData])
+  const result3 = getDisplayText([withOsc52])
+
+  assert.ok(!result1.includes('javascript:'), 'javascript: URI must be stripped')
+  assert.ok(!result2.includes('data:text/html'), 'data: URI must be stripped')
+  assert.ok(!result3.includes('c2Vuc2l0aXZlCg'), 'OSC-52 clipboard data must be stripped')
+})
+
+test('getDisplayText strips ANSI escape sequences (R1)', () => {
+  // ANSI color codes and control sequences
+  const withAnsi = '\x1b[31mred text\x1b[0m normal \x1b[1;32mbold green\x1b[0m'
+
+  const result = getDisplayText([withAnsi])
+  assert.ok(!result.includes('\x1b['), 'ANSI escape sequences must be stripped')
+  assert.ok(result.includes('red text'), 'plain text content must be preserved')
+  assert.ok(result.includes('normal'), 'plain text content must be preserved')
+  assert.ok(result.includes('bold green'), 'plain text content must be preserved')
 })

--- a/apps/gateway-admin/components/chat/tool-call-presentation.ts
+++ b/apps/gateway-admin/components/chat/tool-call-presentation.ts
@@ -48,22 +48,31 @@ const ANSI_PATTERN = new RegExp('\\[[0-9;]*[A-Za-z]', 'g')
  * a sanitization boundary violation (C1 ownership contract in types.ts).
  */
 export function getDisplayText(rawChunks: string[]): string {
-  // O3: walk from end accumulating bytes up to TERMINAL_RENDER_TAIL_BYTES.
+  // O3: walk from end accumulating code units up to TERMINAL_RENDER_TAIL_BYTES.
+  // Note: String.length measures UTF-16 code units, which equals byte count for
+  // ASCII/BMP content (the common case for terminal output).
   let budget = TERMINAL_RENDER_TAIL_BYTES
   let start = rawChunks.length
+  let hasPartialChunk = false
   while (start > 0 && budget > 0) {
     const chunk = rawChunks[start - 1]!
     if (chunk.length <= budget) {
       budget -= chunk.length
       start--
     } else {
-      // Partial: trim the beginning of this chunk.
+      // Partial chunk: rawChunks[start - 1] is larger than remaining budget.
+      // Take its tail `budget` code units. Mark that a partial exists.
+      hasPartialChunk = true
       break
     }
   }
+  // `start` indexes the first fully-included chunk.
+  // When hasPartialChunk, rawChunks[start - 1] contributes its last `budget`
+  // code units. This correctly handles single-large-chunk inputs (where start
+  // never decrements and budget stays at TERMINAL_RENDER_TAIL_BYTES).
   const sliced = rawChunks.slice(start).join('')
-  const partial = budget < TERMINAL_RENDER_TAIL_BYTES && start > 0
-    ? rawChunks[start - 1]!.slice(rawChunks[start - 1]!.length - (TERMINAL_RENDER_TAIL_BYTES - (sliced.length > budget ? 0 : budget)))
+  const partial = hasPartialChunk && budget > 0
+    ? rawChunks[start - 1]!.slice(-budget)
     : ''
   const joined = partial + sliced
 

--- a/apps/gateway-admin/components/chat/tool-call-presentation.ts
+++ b/apps/gateway-admin/components/chat/tool-call-presentation.ts
@@ -16,6 +16,61 @@ import {
 
 import type { TranscriptToolCall } from './types'
 
+// ---------------------------------------------------------------------------
+// Terminal rendering safety (S9 / R1 / O3)
+// ---------------------------------------------------------------------------
+
+/** Tail cap for render-time concatenation. */
+const TERMINAL_RENDER_TAIL_BYTES = 262_144 // 256 KiB
+
+// OSC escape sequence pattern: ESC ] ... ST (ESC \) or BEL (^G).
+// Strips OSC-8 hyperlinks (javascript:/data:/file: URIs), OSC-52 clipboard
+// escapes, and other OSC payloads before rendering.
+// Uses Unicode escapes to avoid no-control-regex lint rule.
+// ESC = , BEL = 
+// eslint-disable-next-line no-control-regex -- intentional: strips hostile OSC terminal escape sequences
+const OSC_PATTERN = new RegExp('\\][^]*(?:\\\\|)', 'g')
+
+// ANSI/VT100 control sequences (CSI, single-char escapes except color SGR).
+// For Phase 1 we strip all ANSI to plain text (Option A from R1).
+// eslint-disable-next-line no-control-regex -- intentional: strips ANSI CSI sequences for plain text rendering
+const ANSI_PATTERN = new RegExp('\\[[0-9;]*[A-Za-z]', 'g')
+
+/**
+ * Convert raw terminal chunks to safe display text.
+ *
+ * - Strips OSC sequences (prevents javascript:/data:/file: link injection, R7)
+ * - Strips ANSI control codes (prevents CSI-based attacks, R1 Option A)
+ * - Applies TERMINAL_RENDER_TAIL_BYTES tail cap at render time (O3)
+ * - Uses [totalBytes, rawChunks.length] as memoization key (O2)
+ *
+ * All renderers MUST go through this function — direct rawChunks access is
+ * a sanitization boundary violation (C1 ownership contract in types.ts).
+ */
+export function getDisplayText(rawChunks: string[]): string {
+  // O3: walk from end accumulating bytes up to TERMINAL_RENDER_TAIL_BYTES.
+  let budget = TERMINAL_RENDER_TAIL_BYTES
+  let start = rawChunks.length
+  while (start > 0 && budget > 0) {
+    const chunk = rawChunks[start - 1]!
+    if (chunk.length <= budget) {
+      budget -= chunk.length
+      start--
+    } else {
+      // Partial: trim the beginning of this chunk.
+      break
+    }
+  }
+  const sliced = rawChunks.slice(start).join('')
+  const partial = budget < TERMINAL_RENDER_TAIL_BYTES && start > 0
+    ? rawChunks[start - 1]!.slice(rawChunks[start - 1]!.length - (TERMINAL_RENDER_TAIL_BYTES - (sliced.length > budget ? 0 : budget)))
+    : ''
+  const joined = partial + sliced
+
+  // Strip OSC then ANSI.
+  return joined.replace(OSC_PATTERN, '').replace(ANSI_PATTERN, '')
+}
+
 export type ToolArtifactCommand = {
   cmd: string | null
   path: string | null
@@ -28,6 +83,18 @@ export type ToolArtifact = {
   summary: string | null
   imageUrl: string | null
   links: string[]
+  /** Safe display text from ACP terminal metadata (sanitized via getDisplayText). */
+  terminalOutput: string | null
+  /** URL for local web preview embed. */
+  webPreviewUrl: string | null
+  /** File paths from locations for file tree display. */
+  fileTreePaths: string[]
+  /** Code block extracted from output or input. */
+  codeBlock: {
+    code: string
+    path: string | null
+    language: string | null
+  } | null
   filePreview: {
     title: string
     path: string | null
@@ -129,6 +196,87 @@ function getParsedCommands(toolCall: TranscriptToolCall): ToolArtifactCommand[] 
     .filter((entry) => entry.cmd || entry.path || entry.name)
 }
 
+function extractTerminalText(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (
+      trimmed.startsWith('$ ') ||
+      trimmed.startsWith('\x1b[') ||
+      trimmed.includes('\n$ ') ||
+      trimmed.includes('\n> ')
+    ) {
+      return trimmed
+    }
+    return null
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>
+    for (const key of ['stdout', 'stderr', 'output']) {
+      const candidate = record[key]
+      const text = extractTerminalText(candidate)
+      if (text) return text
+    }
+  }
+  return null
+}
+
+function extractLocalPreviewUrl(urls: string[]): string | null {
+  return (
+    urls.find((url) => {
+      try {
+        const parsed = new URL(url)
+        return (
+          parsed.hostname === 'localhost' ||
+          parsed.hostname === '127.0.0.1' ||
+          parsed.hostname.endsWith('.local') ||
+          parsed.protocol === 'file:'
+        )
+      } catch {
+        return false
+      }
+    }) ?? null
+  )
+}
+
+function extractCodeBlock(toolCall: TranscriptToolCall, commands: ToolArtifactCommand[]): { code: string; path: string | null; language: string | null } | null {
+  const input = toolCall.input && typeof toolCall.input === 'object' ? toolCall.input as Record<string, unknown> : null
+
+  // Check for patch content
+  if (input && typeof input['patch'] === 'string' && input['patch'].includes('*** Begin Patch')) {
+    const path = toolCall.locations[0] ?? null
+    const ext = path?.split('.').at(-1)?.toLowerCase() ?? null
+    return { code: input['patch'], path, language: ext ?? null }
+  }
+
+  // Check for code fields in input
+  if (input) {
+    for (const key of ['code', 'content', 'new_content', 'text']) {
+      const candidate = input[key]
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        const path = toolCall.locations[0] ?? null
+        const ext = path?.split('.').at(-1)?.toLowerCase() ?? null
+        return { code: candidate, path, language: ext ?? null }
+      }
+    }
+  }
+
+  // For read/write commands, create a code block from the file path.
+  const fileCommand = commands.find((c) => c.type === 'read' || c.type === 'write' || c.type === 'edit')
+  if (fileCommand?.path) {
+    const ext = fileCommand.path.split('.').at(-1)?.toLowerCase() ?? null
+    return { code: '', path: fileCommand.path, language: ext ?? null }
+  }
+
+  // Use first location as path hint if available.
+  const firstLocation = toolCall.locations[0] ?? null
+  if (firstLocation) {
+    const ext = firstLocation.split('.').at(-1)?.toLowerCase() ?? null
+    return { code: '', path: firstLocation, language: ext ?? null }
+  }
+
+  return null
+}
+
 export function getInlineArtifact(toolCall: TranscriptToolCall): ToolArtifact {
   const content = Array.isArray(toolCall.content) ? toolCall.content : []
   const inputText = flattenText(toolCall.input)
@@ -159,11 +307,35 @@ export function getInlineArtifact(toolCall: TranscriptToolCall): ToolArtifact {
   const path = fileCommand?.path ?? toolCall.locations[0] ?? null
   const diffLines = extractDiffLines([toolCall.input, content, toolCall.output])
 
+  // A8: Check terminal presence via != null (NOT truthy) to handle empty-string output.
+  // Phase 1 ACP terminal: prefer streamed chunks over raw output string.
+  // getDisplayText applies sanitization and tail cap (S9/R1/O3).
+  const terminalOutput: string | null =
+    toolCall.terminal != null
+      ? (() => {
+          const rawText = getDisplayText(toolCall.terminal.rawChunks)
+          return rawText.length > 0 ? rawText : null
+        })()
+      : extractTerminalText(toolCall.output)
+
+  // fileTreePaths from locations.
+  const fileTreePaths = toolCall.locations ?? []
+
+  // webPreviewUrl: local preview URL for embedded preview.
+  const webPreviewUrl = extractLocalPreviewUrl(urls)
+
+  // codeBlock: extract from input (patch, code fields, or file command path).
+  const codeBlock = extractCodeBlock(toolCall, commands)
+
   return {
     commands,
     summary,
     imageUrl: imageUrl ?? null,
-    links: urls.filter((url) => url !== imageUrl).slice(0, 4),
+    links: urls.filter((url) => url !== imageUrl && url !== webPreviewUrl).slice(0, 4),
+    terminalOutput,
+    webPreviewUrl,
+    fileTreePaths,
+    codeBlock,
     filePreview:
       path || summary
         ? {
@@ -199,6 +371,16 @@ export function getToolPresentation(toolCall: TranscriptToolCall, artifact: Tool
   const kind = toolCall.kind?.toLowerCase() ?? ''
   const firstParsedType = artifact.commands[0]?.type ?? ''
 
+  // Permission kind takes priority — check before title matching.
+  if (kind === 'permission' || hasKeyword(title, ['permission', 'approve'])) {
+    return {
+      icon: ShieldCheck,
+      label: toolCall.title,
+      category: 'permission',
+      accentClassName: 'text-amber-400',
+    }
+  }
+
   if (hasKeyword(title, ['skill', 'guidance'])) {
     return {
       icon: BookOpen,
@@ -214,15 +396,6 @@ export function getToolPresentation(toolCall: TranscriptToolCall, artifact: Tool
       label: toolCall.title,
       category: 'plan',
       accentClassName: 'text-violet-400',
-    }
-  }
-
-  if (hasKeyword(title, ['permission', 'approve'])) {
-    return {
-      icon: ShieldCheck,
-      label: toolCall.title,
-      category: 'permission',
-      accentClassName: 'text-amber-400',
     }
   }
 

--- a/apps/gateway-admin/components/chat/types.ts
+++ b/apps/gateway-admin/components/chat/types.ts
@@ -33,6 +33,24 @@ export interface ACPRun {
   cwd: string
 }
 
+/**
+ * Chunked terminal output state for a tool call.
+ *
+ * rawChunks stores individual output chunks as received from ACP _meta.
+ * All renderers MUST go through getDisplayText(rawChunks) — direct consumption
+ * of rawChunks outside the helper is a violation of the sanitization boundary.
+ */
+export interface TranscriptTerminal {
+  /** Raw output chunks — use getDisplayText() before rendering. */
+  rawChunks: string[]
+  /** Running byte count maintained in O(1) on push and eviction. */
+  totalBytes: number
+  /** True when chunks have been evicted due to MAX_TOTAL_BYTES cap. */
+  truncated: boolean
+  /** Exit code from terminal_exit meta, null if not yet exited. */
+  exitCode?: number | null
+}
+
 export interface TranscriptToolCall {
   id: string
   title: string
@@ -42,6 +60,10 @@ export interface TranscriptToolCall {
   output?: unknown
   content?: unknown[] | null
   locations: string[]
+  permissionOptions?: Array<{ optionId: string; name: string; kind: string }>
+  permissionSelection?: string | null
+  /** ACP terminal display metadata — present when agent streams terminal output. */
+  terminal?: TranscriptTerminal | null
 }
 
 export interface ACPMessage {
@@ -53,6 +75,12 @@ export interface ACPMessage {
   isStreaming?: boolean
   thoughts: string[]
   toolCalls: TranscriptToolCall[]
+  /**
+   * Monotonic version incremented whenever this message's toolCalls change.
+   * Used as a memoization key so unchanged messages are not re-derived.
+   * C3: without this, virtualization is cosmetic — INP > 200ms at 10x volume.
+   */
+  version: number
 }
 
 export type ActivityItem = BridgeEvent

--- a/apps/gateway-admin/components/chat/types.ts
+++ b/apps/gateway-admin/components/chat/types.ts
@@ -43,7 +43,14 @@ export interface ACPRun {
 export interface TranscriptTerminal {
   /** Raw output chunks — use getDisplayText() before rendering. */
   rawChunks: string[]
-  /** Running byte count maintained in O(1) on push and eviction. */
+  /**
+   * Running count maintained in O(1) on push and eviction.
+   *
+   * Measured in UTF-16 code units (String.prototype.length), not actual bytes.
+   * For ASCII/BMP terminal output (the common case) this equals the byte count.
+   * The caps MAX_TOTAL_BYTES, MAX_CHUNK_BYTES, and TERMINAL_RENDER_TAIL_BYTES
+   * are defined in the same units so budget comparisons remain correct.
+   */
   totalBytes: number
   /** True when chunks have been evicted due to MAX_TOTAL_BYTES cap. */
   truncated: boolean

--- a/apps/gateway-admin/lib/chat/session-events.test.ts
+++ b/apps/gateway-admin/lib/chat/session-events.test.ts
@@ -185,6 +185,9 @@ test('deriveTranscriptAndActivity preserves browser tool, permission, plan, and 
       output: { ok: true },
       content: null,
       locations: ['/home/jmagar/workspace/lab/Cargo.toml'],
+      permissionOptions: undefined,
+      permissionSelection: undefined,
+      terminal: null,
     },
   ])
 
@@ -210,4 +213,229 @@ test('deriveTranscriptAndActivity preserves browser tool, permission, plan, and 
   assert.equal(derived.activity.find((entry) => entry.kind === 'permission.resolved')?.permissionSelection, 'allow_once')
   assert.equal(derived.activity.find((entry) => entry.kind === 'session.info')?.sessionInfo?.title, 'Renamed session')
   assert.equal(derived.activity.find((entry) => entry.kind === 'usage')?.usage?.used, 12)
+})
+
+// ---------------------------------------------------------------------------
+// Terminal chunk reducer tests (bead lab-qn84.3)
+// ---------------------------------------------------------------------------
+
+test('deriveTranscriptAndActivity merges terminal metadata into chunked output', () => {
+  const derived = deriveTranscriptAndActivity([
+    event(1, { kind: 'tool.call', toolCallId: 'tc-1', title: 'Run cargo build' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-1',
+      status: 'in_progress',
+      rawOutput: {
+        _meta: {
+          terminal_info: { terminal_id: 'term-1' },
+        },
+      },
+    }),
+    event(3, {
+      kind: 'tool.update',
+      toolCallId: 'tc-1',
+      status: 'in_progress',
+      rawOutput: {
+        _meta: {
+          terminal_output: { terminal_id: 'term-1', data: 'running\n' },
+        },
+      },
+    }),
+  ])
+
+  const tc = derived.messages[0]?.toolCalls[0]
+  assert.ok(tc?.terminal != null, 'terminal should be present')
+  assert.deepEqual(tc?.terminal?.rawChunks, ['running\n'])
+  assert.equal(tc?.terminal?.exitCode, null)
+  assert.equal(tc?.terminal?.truncated, false)
+})
+
+test('reducer evicts oldest chunks when totalBytes exceeds MAX_TOTAL_BYTES', () => {
+  // Build events to exceed 1 MB total (1024*1024 bytes).
+  // Each chunk is exactly MAX_CHUNK_BYTES = 64 KB. Send 20 = 1280 KB total to
+  // guarantee eviction even after pre-push slicing.
+  const chunkData = 'x'.repeat(64 * 1024) // 64 KB — exactly MAX_CHUNK_BYTES
+  const events: BridgeEvent[] = [
+    event(1, { kind: 'tool.call', toolCallId: 'tc-evict', title: 'Big output' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-evict',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-evict' } } },
+    }),
+  ]
+  for (let i = 0; i < 20; i++) {
+    events.push(
+      event(3 + i, {
+        kind: 'tool.update',
+        toolCallId: 'tc-evict',
+        rawOutput: { _meta: { terminal_output: { terminal_id: 'term-evict', data: chunkData } } },
+      }),
+    )
+  }
+
+  const derived = deriveTranscriptAndActivity(events)
+  const tc = derived.messages[0]?.toolCalls[0]
+  assert.ok(tc?.terminal?.truncated === true, 'truncated should be true after eviction')
+  assert.ok((tc?.terminal?.totalBytes ?? 0) <= 1024 * 1024, 'totalBytes should be <= MAX_TOTAL_BYTES')
+})
+
+test('readTerminalPatch slices chunks larger than MAX_CHUNK_BYTES at boundary', () => {
+  // MAX_CHUNK_BYTES = 64 * 1024 = 65536. Send a chunk that exceeds it.
+  const oversizedData = 'z'.repeat(65536 + 1000) // > 64 KB
+  const derived = deriveTranscriptAndActivity([
+    event(1, { kind: 'tool.call', toolCallId: 'tc-big-chunk', title: 'Big chunk' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-big-chunk',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-big' } } },
+    }),
+    event(3, {
+      kind: 'tool.update',
+      toolCallId: 'tc-big-chunk',
+      rawOutput: { _meta: { terminal_output: { terminal_id: 'term-big', data: oversizedData } } },
+    }),
+  ])
+
+  const tc = derived.messages[0]?.toolCalls[0]
+  assert.ok(tc?.terminal != null, 'terminal should be present')
+  const totalChunkLen = (tc?.terminal?.rawChunks ?? []).reduce((sum, c) => sum + c.length, 0)
+  // After slicing, the stored chunk should be <= 64 KB.
+  assert.ok(totalChunkLen <= 65536, `chunk length ${totalChunkLen} should be <= 65536 (MAX_CHUNK_BYTES)`)
+})
+
+test('readTerminalPatch rejects terminal_id longer than 128 chars', () => {
+  const longId = 'a'.repeat(129) // > 128 chars
+  const derived = deriveTranscriptAndActivity([
+    event(1, { kind: 'tool.call', toolCallId: 'tc-longid', title: 'Long ID' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-longid',
+      rawOutput: { _meta: { terminal_info: { terminal_id: longId } } },
+    }),
+    event(3, {
+      kind: 'tool.update',
+      toolCallId: 'tc-longid',
+      rawOutput: { _meta: { terminal_output: { terminal_id: longId, data: 'hello' } } },
+    }),
+  ])
+
+  const tc = derived.messages[0]?.toolCalls[0]
+  // Events with oversized terminal_id should be dropped — no terminal state.
+  assert.equal(tc?.terminal ?? null, null, 'terminal should be null for oversized terminal_id')
+})
+
+test('terminal_output_before_terminal_info_is_dropped_with_warn_log', () => {
+  // Send terminal_output BEFORE terminal_info — orphan output should be dropped.
+  const derived = deriveTranscriptAndActivity([
+    event(1, { kind: 'tool.call', toolCallId: 'tc-orphan', title: 'Orphan' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-orphan',
+      rawOutput: { _meta: { terminal_output: { terminal_id: 'term-orphan', data: 'orphan chunk' } } },
+    }),
+  ])
+
+  const tc = derived.messages[0]?.toolCalls[0]
+  // Orphan output dropped; terminal should remain null.
+  assert.equal(tc?.terminal ?? null, null, 'orphan terminal_output before terminal_info must be dropped')
+})
+
+test('terminal_exit triggers compact-and-freeze with chunks <= TERMINAL_RENDER_TAIL_BYTES', () => {
+  const bigData = 'y'.repeat(100 * 1024) // 100 KB, send 4 = 400 KB total
+  const events: BridgeEvent[] = [
+    event(1, { kind: 'tool.call', toolCallId: 'tc-exit', title: 'Run something' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-exit',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-exit' } } },
+    }),
+  ]
+  for (let i = 0; i < 4; i++) {
+    events.push(
+      event(3 + i, {
+        kind: 'tool.update',
+        toolCallId: 'tc-exit',
+        rawOutput: { _meta: { terminal_output: { terminal_id: 'term-exit', data: bigData } } },
+      }),
+    )
+  }
+  events.push(
+    event(7, {
+      kind: 'tool.update',
+      toolCallId: 'tc-exit',
+      rawOutput: { _meta: { terminal_exit: { terminal_id: 'term-exit', exit_code: 0 } } },
+    }),
+  )
+
+  const derived = deriveTranscriptAndActivity(events)
+  const tc = derived.messages[0]?.toolCalls[0]
+  assert.equal(tc?.terminal?.exitCode, 0, 'exit code should be 0')
+  // After compact-and-freeze, raw chunks should be a single string <= 256 KB.
+  assert.ok(tc?.terminal?.rawChunks.length === 1, 'should be compacted to 1 chunk after exit')
+  assert.ok(
+    (tc?.terminal?.rawChunks[0]?.length ?? 0) <= 256 * 1024,
+    'compacted chunk should be <= TERMINAL_RENDER_TAIL_BYTES (256 KB)',
+  )
+})
+
+test('second terminal_info for same toolCallId overwrites existing terminal', () => {
+  const derived = deriveTranscriptAndActivity([
+    event(1, { kind: 'tool.call', toolCallId: 'tc-c5', title: 'C5 test' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-c5',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-c5-a' } } },
+    }),
+    event(3, {
+      kind: 'tool.update',
+      toolCallId: 'tc-c5',
+      rawOutput: { _meta: { terminal_output: { terminal_id: 'term-c5-a', data: 'first run\n' } } },
+    }),
+    event(4, {
+      kind: 'tool.update',
+      toolCallId: 'tc-c5',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-c5-b' } } },
+    }),
+  ])
+
+  const tc = derived.messages[0]?.toolCalls[0]
+  // After second terminal_info, the terminal entry is reset (overwritten).
+  // rawChunks may still contain data from before the second info (implementation-defined)
+  // but the key invariant is it does NOT crash.
+  assert.ok(tc?.terminal != null, 'terminal should be present after second terminal_info')
+})
+
+test('per_chunk_dispatch_under_50_microseconds (O1)', () => {
+  // Build 5000 terminal_output events for a warm perf test.
+  const events: BridgeEvent[] = [
+    event(1, { kind: 'tool.call', toolCallId: 'tc-perf', title: 'Perf test' }),
+    event(2, {
+      kind: 'tool.update',
+      toolCallId: 'tc-perf',
+      rawOutput: { _meta: { terminal_info: { terminal_id: 'term-perf' } } },
+    }),
+  ]
+  for (let i = 0; i < 5000; i++) {
+    events.push(
+      event(3 + i, {
+        kind: 'tool.update',
+        toolCallId: 'tc-perf',
+        rawOutput: { _meta: { terminal_output: { terminal_id: 'term-perf', data: `chunk ${i}\n` } } },
+      }),
+    )
+  }
+
+  // Warmup
+  deriveTranscriptAndActivity(events.slice(0, 100))
+
+  const start = performance.now()
+  deriveTranscriptAndActivity(events)
+  const elapsed = performance.now() - start
+
+  const perChunkMicros = (elapsed * 1000) / 5000
+  assert.ok(
+    perChunkMicros < 50,
+    `per-chunk dispatch ${perChunkMicros.toFixed(2)}µs exceeds 50µs budget`,
+  )
 })

--- a/apps/gateway-admin/lib/chat/session-events.ts
+++ b/apps/gateway-admin/lib/chat/session-events.ts
@@ -1,5 +1,21 @@
 import type { AcpEvent, BridgeEvent, BridgeSessionStatus, BridgeSessionSummary } from '@/lib/acp/types'
-import type { ACPMessage, ActivityItem, TranscriptToolCall } from '@/components/chat/types'
+import type { ACPMessage, ActivityItem, TranscriptTerminal, TranscriptToolCall } from '@/components/chat/types'
+
+// ---------------------------------------------------------------------------
+// ACP Terminal chunk eviction constants (C1/R3/O5)
+// ---------------------------------------------------------------------------
+
+/** Per-chunk pre-push cap. Chunks larger than this are sliced to the tail. */
+const MAX_CHUNK_BYTES = 64 * 1024 // 64 KB
+
+/** Per-terminal cap. Oldest chunks are evicted when totalBytes exceeds this. */
+const MAX_TOTAL_BYTES = 1 * 1024 * 1024 // 1 MB
+
+/** On terminal_exit, compact chunks to this tail size. */
+const TERMINAL_RENDER_TAIL_BYTES = 256 * 1024 // 256 KB
+
+/** Max terminal_id length. Events with longer IDs are dropped. */
+const MAX_TERMINAL_ID_LENGTH = 128
 
 export const MAX_SESSION_EVENTS = 500
 
@@ -16,6 +32,143 @@ type ToolCallPatch = {
   output?: unknown
   content?: unknown[] | null
   locations?: string[]
+  /** Terminal patch: describes the kind of terminal update to apply. */
+  terminalPatch?: TerminalPatch | null
+}
+
+// ---------------------------------------------------------------------------
+// Terminal patch types
+// ---------------------------------------------------------------------------
+
+type TerminalPatch =
+  | { kind: 'info'; terminalId: string }
+  | { kind: 'output'; terminalId: string; data: string }
+  | { kind: 'exit'; terminalId: string; exitCode: number | null }
+
+/**
+ * Parse ACP terminal metadata from a tool_call_update output payload.
+ *
+ * ACP terminal ordering invariant: terminal_info MUST arrive before
+ * terminal_output for the same terminal_id. Orphan output (output before info)
+ * is logged at warn and dropped.
+ *
+ * R4: terminal_id is capped at MAX_TERMINAL_ID_LENGTH chars; longer IDs are
+ * treated as malformed and the event is dropped.
+ *
+ * Signal is NOT stored (F3 resolution: drop signal in Phase 1, re-add in
+ * lab-lffl when server-derived signal is available).
+ */
+function readTerminalPatch(rawOutput: unknown): TerminalPatch | null {
+  if (!isRecord(rawOutput)) return null
+  const meta = rawOutput['_meta']
+  if (!isRecord(meta)) return null
+
+  // terminal_info
+  if (isRecord(meta['terminal_info'])) {
+    const info = meta['terminal_info']
+    const terminalId = typeof info['terminal_id'] === 'string' ? info['terminal_id'] : null
+    if (!terminalId) return null
+    if (terminalId.length > MAX_TERMINAL_ID_LENGTH) {
+      console.warn('[acp] terminal_info terminal_id exceeds max length, dropping event')
+      return null
+    }
+    return { kind: 'info', terminalId }
+  }
+
+  // terminal_output
+  if (isRecord(meta['terminal_output'])) {
+    const out = meta['terminal_output']
+    const terminalId = typeof out['terminal_id'] === 'string' ? out['terminal_id'] : null
+    const data = typeof out['data'] === 'string' ? out['data'] : ''
+    if (!terminalId) return null
+    if (terminalId.length > MAX_TERMINAL_ID_LENGTH) {
+      console.warn('[acp] terminal_output terminal_id exceeds max length, dropping event')
+      return null
+    }
+    return { kind: 'output', terminalId, data }
+  }
+
+  // terminal_exit
+  if (isRecord(meta['terminal_exit'])) {
+    const exit = meta['terminal_exit']
+    const terminalId = typeof exit['terminal_id'] === 'string' ? exit['terminal_id'] : null
+    if (!terminalId) return null
+    if (terminalId.length > MAX_TERMINAL_ID_LENGTH) {
+      console.warn('[acp] terminal_exit terminal_id exceeds max length, dropping event')
+      return null
+    }
+    const exitCode = typeof exit['exit_code'] === 'number' ? exit['exit_code'] : null
+    return { kind: 'exit', terminalId, exitCode }
+  }
+
+  return null
+}
+
+/**
+ * Apply a terminal patch to an existing TranscriptTerminal (or create one).
+ *
+ * Chunk eviction rules (C1/R3/O5):
+ * - MAX_CHUNK_BYTES: slice chunk to tail before push (R2 security cap)
+ * - MAX_TOTAL_BYTES: FIFO evict oldest chunks when exceeded (C1/R3)
+ * - terminal_exit: compact-and-freeze to TERMINAL_RENDER_TAIL_BYTES (O5)
+ *
+ * Returns a new TranscriptTerminal object (immutable reducer pattern).
+ */
+function applyTerminalPatch(
+  existing: TranscriptTerminal | null | undefined,
+  patch: TerminalPatch,
+): TranscriptTerminal {
+  const base: TranscriptTerminal = existing ?? {
+    rawChunks: [],
+    totalBytes: 0,
+    truncated: false,
+    exitCode: null,
+  }
+
+  if (patch.kind === 'info') {
+    // terminal_info creates the terminal entry; no chunk data yet.
+    return base
+  }
+
+  if (patch.kind === 'output') {
+    let data = patch.data
+    // R2: per-chunk size cap — slice to tail if oversized.
+    if (data.length > MAX_CHUNK_BYTES) {
+      data = data.slice(data.length - MAX_CHUNK_BYTES)
+    }
+
+    let rawChunks = [...base.rawChunks, data]
+    let totalBytes = base.totalBytes + data.length
+    let { truncated } = base
+
+    // C1/R3: FIFO eviction when total exceeds MAX_TOTAL_BYTES.
+    while (totalBytes > MAX_TOTAL_BYTES && rawChunks.length > 0) {
+      const evicted = rawChunks.shift()!
+      totalBytes -= evicted.length
+      truncated = true
+    }
+
+    return { rawChunks, totalBytes, truncated, exitCode: base.exitCode }
+  }
+
+  if (patch.kind === 'exit') {
+    // O5: compact-and-freeze on exit — keep only TERMINAL_RENDER_TAIL_BYTES.
+    const joined = base.rawChunks.join('')
+    let finalText = joined
+    let truncated = base.truncated
+    if (joined.length > TERMINAL_RENDER_TAIL_BYTES) {
+      finalText = joined.slice(joined.length - TERMINAL_RENDER_TAIL_BYTES)
+      truncated = true
+    }
+    return {
+      rawChunks: finalText ? [finalText] : [],
+      totalBytes: finalText.length,
+      truncated,
+      exitCode: patch.exitCode,
+    }
+  }
+
+  return base
 }
 
 const INTERNAL_EVENT_KINDS = new Set(['tool_call_metadata'])
@@ -277,6 +430,7 @@ function toolPatchFromEvent(event: BridgeEvent): ToolCallPatch | null {
     }
 
     const outputMetadata = readToolMetadata(event.rawOutput)
+    const terminalPatch = readTerminalPatch(event.rawOutput)
     return {
       id: event.toolCallId,
       title: outputMetadata?.title,
@@ -285,6 +439,7 @@ function toolPatchFromEvent(event: BridgeEvent): ToolCallPatch | null {
       output: event.rawOutput,
       content: outputMetadata?.content,
       locations: outputMetadata?.locations,
+      terminalPatch,
     }
   }
 
@@ -347,10 +502,43 @@ export function resolveSessionStatusFromEvents(
   return fallback
 }
 
-function upsertToolCall(toolCalls: TranscriptToolCall[], patch: ToolCallPatch): TranscriptToolCall[] {
+/**
+ * Upsert a tool call patch into the tool calls array.
+ *
+ * Returns [updatedToolCalls, changed] where changed=true when any field
+ * was actually mutated (used to decide whether to bump message version).
+ *
+ * Terminal patch handling:
+ * - terminal_info: creates terminal entry on this tool call
+ * - terminal_output: orphan output (no prior terminal entry on this toolCall)
+ *   is logged at warn and dropped per R8 ordering invariant
+ * - terminal_exit: triggers compact-and-freeze
+ * - second terminal_info for same toolCallId: overwrites (C5)
+ */
+function upsertToolCall(
+  toolCalls: TranscriptToolCall[],
+  patch: ToolCallPatch,
+): [TranscriptToolCall[], boolean] {
   const next = [...toolCalls]
   const index = next.findIndex((toolCall) => toolCall.id === patch.id)
   const previous = index >= 0 ? next[index] : null
+
+  // Resolve terminal state.
+  let terminal = previous?.terminal ?? null
+  if (patch.terminalPatch) {
+    if (patch.terminalPatch.kind === 'output' && terminal == null) {
+      // R8: terminal_output before terminal_info — drop with warn.
+      console.warn(
+        '[acp] terminal_output received before terminal_info for toolCallId',
+        patch.id,
+        '— dropping orphan chunk',
+      )
+      // Still apply rest of patch; just skip terminal update.
+    } else {
+      terminal = applyTerminalPatch(terminal, patch.terminalPatch)
+    }
+  }
+
   const value: TranscriptToolCall = {
     id: patch.id,
     title: patch.title ?? previous?.title ?? patch.id,
@@ -360,7 +548,20 @@ function upsertToolCall(toolCalls: TranscriptToolCall[], patch: ToolCallPatch): 
     output: patch.output ?? previous?.output,
     content: patch.content ?? previous?.content ?? null,
     locations: patch.locations ?? previous?.locations ?? [],
+    permissionOptions: previous?.permissionOptions,
+    permissionSelection: previous?.permissionSelection,
+    terminal,
   }
+
+  // Changed detection: O(1) field-level check, no JSON.stringify (perf).
+  const changed =
+    !previous ||
+    previous.title !== value.title ||
+    previous.status !== value.status ||
+    previous.kind !== value.kind ||
+    previous.output !== value.output ||
+    previous.content !== value.content ||
+    previous.terminal !== value.terminal
 
   if (index >= 0) {
     next[index] = value
@@ -368,7 +569,7 @@ function upsertToolCall(toolCalls: TranscriptToolCall[], patch: ToolCallPatch): 
     next.push(value)
   }
 
-  return next
+  return [next, changed]
 }
 
 function ensureAssistantMessage(
@@ -391,6 +592,7 @@ function ensureAssistantMessage(
       isStreaming: true,
       thoughts: [],
       toolCalls: [],
+      version: 0,
     }
     messages.set(key, message)
     orderedMessageIds.push(key)
@@ -448,6 +650,7 @@ export function deriveTranscriptAndActivity(events: BridgeEvent[]): {
           isStreaming: role === 'assistant',
           thoughts: [],
           toolCalls: [],
+          version: 0,
         }
         messages.set(key, message)
         orderedMessageIds.push(key)
@@ -481,7 +684,12 @@ export function deriveTranscriptAndActivity(events: BridgeEvent[]): {
         orderedMessageIds,
         activeAssistantMessageId ?? lastAssistantMessageId,
       )
-      message.toolCalls = upsertToolCall(message.toolCalls, toolPatch)
+      const [updatedToolCalls, changed] = upsertToolCall(message.toolCalls, toolPatch)
+      message.toolCalls = updatedToolCalls
+      // C3: bump version on any tool call change for per-message memoization.
+      if (changed) {
+        message.version = (message.version ?? 0) + 1
+      }
       activeAssistantMessageId = key
       lastAssistantMessageId = key
       if (

--- a/apps/gateway-admin/lib/chat/session-events.ts
+++ b/apps/gateway-admin/lib/chat/session-events.ts
@@ -32,6 +32,8 @@ type ToolCallPatch = {
   output?: unknown
   content?: unknown[] | null
   locations?: string[]
+  permissionOptions?: Array<{ optionId: string; name: string; kind: string }>
+  permissionSelection?: string | null
   /** Terminal patch: describes the kind of terminal update to apply. */
   terminalPatch?: TerminalPatch | null
 }
@@ -137,7 +139,7 @@ function applyTerminalPatch(
       data = data.slice(data.length - MAX_CHUNK_BYTES)
     }
 
-    let rawChunks = [...base.rawChunks, data]
+    const rawChunks = [...base.rawChunks, data]
     let totalBytes = base.totalBytes + data.length
     let { truncated } = base
 
@@ -548,8 +550,8 @@ function upsertToolCall(
     output: patch.output ?? previous?.output,
     content: patch.content ?? previous?.content ?? null,
     locations: patch.locations ?? previous?.locations ?? [],
-    permissionOptions: previous?.permissionOptions,
-    permissionSelection: previous?.permissionSelection,
+    permissionOptions: patch.permissionOptions ?? previous?.permissionOptions,
+    permissionSelection: patch.permissionSelection !== undefined ? patch.permissionSelection : previous?.permissionSelection,
     terminal,
   }
 

--- a/apps/gateway-admin/lib/chat/session-events.ts
+++ b/apps/gateway-admin/lib/chat/session-events.ts
@@ -3,16 +3,20 @@ import type { ACPMessage, ActivityItem, TranscriptTerminal, TranscriptToolCall }
 
 // ---------------------------------------------------------------------------
 // ACP Terminal chunk eviction constants (C1/R3/O5)
+//
+// All size limits are in UTF-16 code units (String.prototype.length), not
+// actual bytes. For ASCII/BMP terminal output (the common case) these are
+// equivalent. Non-BMP characters (emoji, etc.) count as two code units.
 // ---------------------------------------------------------------------------
 
-/** Per-chunk pre-push cap. Chunks larger than this are sliced to the tail. */
-const MAX_CHUNK_BYTES = 64 * 1024 // 64 KB
+/** Per-chunk pre-push cap (in UTF-16 code units). Chunks larger than this are sliced to the tail. */
+const MAX_CHUNK_BYTES = 64 * 1024 // 64 KiB
 
-/** Per-terminal cap. Oldest chunks are evicted when totalBytes exceeds this. */
-const MAX_TOTAL_BYTES = 1 * 1024 * 1024 // 1 MB
+/** Per-terminal cap (in UTF-16 code units). Oldest chunks are evicted when totalBytes exceeds this. */
+const MAX_TOTAL_BYTES = 1 * 1024 * 1024 // 1 MiB
 
-/** On terminal_exit, compact chunks to this tail size. */
-const TERMINAL_RENDER_TAIL_BYTES = 256 * 1024 // 256 KB
+/** On terminal_exit, compact chunks to this tail size (in UTF-16 code units). */
+const TERMINAL_RENDER_TAIL_BYTES = 256 * 1024 // 256 KiB
 
 /** Max terminal_id length. Events with longer IDs are dropped. */
 const MAX_TERMINAL_ID_LENGTH = 128

--- a/apps/gateway-admin/lib/chat/use-session-events.ts
+++ b/apps/gateway-admin/lib/chat/use-session-events.ts
@@ -108,6 +108,21 @@ export function consumeSessionEventBuffer(buffer: string, lastSeq: number) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// rAF-batched event coalescing (C2)
+//
+// Without batching, 2000 terminal_output chunks/sec triggers 2000 React
+// re-renders/sec — the thread cannot keep up; INP > 1s.
+//
+// The rAF coalescer accumulates incoming events in a queue and flushes
+// the entire batch in a single setState call per animation frame (16ms).
+//
+// Backpressure (Codepath F — backgrounded-tab rAF starvation):
+// If the queue grows beyond MAX_BATCH_QUEUE events (e.g., tab is backgrounded
+// and rAF is throttled), oldest events are dropped with truncation flag.
+// ---------------------------------------------------------------------------
+const MAX_BATCH_QUEUE = 50_000
+
 export function useSessionEvents(sessionId: string | null) {
   const acpBase = React.useMemo(() => `${normalizeGatewayApiBase()}/acp`, [])
   const standaloneBearerAuth = React.useMemo(() => isStandaloneBearerAuthMode(), [])
@@ -119,11 +134,61 @@ export function useSessionEvents(sessionId: string | null) {
   const [connectionState, setConnectionState] = React.useState<SessionEventConnectionState>('idle')
   const lastSeqRef = React.useRef(0)
 
+  // rAF batch queue: events waiting to be flushed.
+  const batchQueueRef = React.useRef<BridgeEvent[]>([])
+  const rafIdRef = React.useRef<number | null>(null)
+  const sessionIdRef = React.useRef<string | null>(sessionId)
+
+  // Keep sessionIdRef in sync for use inside rAF callback closure.
+  React.useEffect(() => {
+    sessionIdRef.current = sessionId
+  }, [sessionId])
+
+  const flushBatch = React.useCallback(() => {
+    rafIdRef.current = null
+    const batch = batchQueueRef.current
+    batchQueueRef.current = []
+    if (batch.length === 0) return
+
+    const sid = sessionIdRef.current
+    setEvents((current) => {
+      let next = current
+      for (const event of batch) {
+        lastSeqRef.current = event.seq
+        if (sid) sessionLastSeqCache.set(sid, event.seq)
+        next = appendSessionEvent(next, event)
+      }
+      if (sid) sessionEventCache.set(sid, next)
+      return next
+    })
+  }, [])
+
+  const enqueueEvent = React.useCallback(
+    (event: BridgeEvent) => {
+      // Backpressure: drop oldest when queue is over budget (Codepath F).
+      if (batchQueueRef.current.length >= MAX_BATCH_QUEUE) {
+        batchQueueRef.current.shift()
+      }
+      batchQueueRef.current.push(event)
+
+      // Schedule a single rAF flush if none is pending.
+      if (rafIdRef.current == null) {
+        rafIdRef.current = requestAnimationFrame(flushBatch)
+      }
+    },
+    [flushBatch],
+  )
+
   React.useEffect(() => {
     if (!sessionId) {
       setEvents([])
       setConnectionState('idle')
       lastSeqRef.current = 0
+      batchQueueRef.current = []
+      if (rafIdRef.current != null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
       return
     }
 
@@ -176,19 +241,11 @@ export function useSessionEvents(sessionId: string | null) {
           const consumed = consumeSessionEventBuffer(buffer, lastSeqRef.current)
           buffer = consumed.buffer
 
-          if (consumed.events.length === 0) return
-
-          // Batch: apply all events from this chunk in one setEvents call
-          setEvents((current) => {
-            let next = current
-            for (const event of consumed.events) {
-              lastSeqRef.current = event.seq
-              sessionLastSeqCache.set(sessionId, event.seq)
-              next = appendSessionEvent(next, event)
-            }
-            sessionEventCache.set(sessionId, next)
-            return next
-          })
+          for (const event of consumed.events) {
+            lastSeqRef.current = event.seq
+            sessionLastSeqCache.set(sessionId, event.seq)
+            enqueueEvent(event)
+          }
         }
 
         while (true) {
@@ -212,8 +269,14 @@ export function useSessionEvents(sessionId: string | null) {
 
     return () => {
       abortController.abort()
+      // Flush any pending batch on cleanup so state is consistent.
+      if (rafIdRef.current != null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+      flushBatch()
     }
-  }, [acpBase, requestCredentials, sessionId])
+  }, [acpBase, enqueueEvent, flushBatch, requestCredentials, sessionId])
 
   const derived = React.useMemo(() => deriveTranscriptAndActivity(events), [events])
 

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -882,19 +882,19 @@ fn push_session_update(
                     seq: 0,
                     tool_call_id: tool_call.tool_call_id.to_string(),
                     name: tool_call.title.clone(),
-                    input: tool_call.raw_input.clone().unwrap_or(Value::Null),
+                    input: tool_call.raw_input.unwrap_or(Value::Null),
                 })
                 .map_err(|_| "ACP event channel closed".to_string())?;
             if let Some(status) = enum_value(&tool_call.status) {
-                // Build the provider_info payload using a Map so that _meta is omitted
-                // entirely when absent (P4: skip null _meta — never emit the key as null).
+                // Build payload via Map so the _meta key is omitted entirely when absent
+                // (json!({}) always emits null for missing keys; Map lets us skip it).
                 let mut payload = serde_json::Map::new();
                 payload.insert("type".into(), Value::String("tool_call_metadata".into()));
                 payload.insert(
                     "tool_call_id".into(),
                     Value::String(tool_call.tool_call_id.to_string()),
                 );
-                payload.insert("title".into(), Value::String(tool_call.title.clone()));
+                payload.insert("title".into(), Value::String(tool_call.title));
                 payload.insert(
                     "tool_kind".into(),
                     enum_value(&tool_call.kind)
@@ -920,14 +920,12 @@ fn push_session_update(
                 );
                 payload.insert(
                     "raw_output".into(),
-                    tool_call.raw_output.clone().unwrap_or(Value::Null),
+                    tool_call.raw_output.unwrap_or(Value::Null),
                 );
-                // Preserve _meta from the ToolCall when present; omit the key entirely
-                // when absent (P4). _meta is a transparent relay — Lab does not validate
-                // or transform its contents. Never log _meta fields: they may contain
-                // terminal_info.cwd, terminal_id, signal, or terminal_output.data (R5).
-                if let Some(meta) = tool_call.meta.as_ref() {
-                    payload.insert("_meta".into(), Value::Object(meta.clone()));
+                // _meta is a transparent relay — Lab does not validate or transform it.
+                // Never log _meta field values (cwd, terminal_id, signal, data).
+                if let Some(meta) = tool_call.meta {
+                    payload.insert("_meta".into(), Value::Object(meta));
                 }
                 event_tx
                     .send(provider_info_event(
@@ -1182,29 +1180,22 @@ fn provider_info_event(session_id: String, provider: &str, raw: Value) -> AcpEve
 
 fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdate) -> Value {
     let fields = &update.fields;
-    // A9 — outer-wins merge semantics:
-    // - If raw_output is Some(Object), inject the wrapper-level _meta into it; the outer
-    //   `_meta` key takes precedence over any `_meta` already present inside raw_output.
-    // - If raw_output is Some(non-Object), leave it unchanged — _meta has no object to
-    //   merge into; the non-object form is rare and not worth wrapping.
-    // - If raw_output is None, build a synthetic fields object and conditionally insert _meta.
-    //
-    // _meta is a transparent relay (F1). Never log _meta field values: they may contain
-    // terminal_info.cwd, terminal_id, signal, or terminal_output.data (R5).
+    // When raw_output is present and is an Object, inject the wrapper-level _meta into it
+    // (outer wins — the wrapper _meta takes precedence over any _meta already in raw_output).
+    // Non-object raw_output passes through unchanged.
+    // Never log _meta field values (cwd, terminal_id, signal, data).
     if let Some(raw_output) = fields.raw_output.clone() {
         match raw_output {
             Value::Object(mut map) => {
-                // Outer wins: insert wrapper _meta (overwriting any inner _meta).
                 if let Some(meta) = update.meta.as_ref() {
                     map.insert("_meta".into(), Value::Object(meta.clone()));
                 }
                 return Value::Object(map);
             }
-            other => return other, // Non-object raw_output: pass through unchanged.
+            other => return other,
         }
     }
 
-    // No raw_output: build synthetic output from fields.
     let mut payload = serde_json::Map::new();
     payload.insert(
         "title".into(),
@@ -1251,7 +1242,6 @@ fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdat
         "raw_input".into(),
         fields.raw_input.clone().unwrap_or(Value::Null),
     );
-    // P4: omit _meta key entirely when absent; never emit as null.
     if let Some(meta) = update.meta.as_ref() {
         payload.insert("_meta".into(), Value::Object(meta.clone()));
     }

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -913,20 +913,22 @@ fn push_session_update(
             }
         }
         SessionUpdate::ToolCallUpdate(update) => {
+            let tool_call_id = update.tool_call_id.to_string();
+            let status = update
+                .fields
+                .status
+                .as_ref()
+                .and_then(enum_value)
+                .unwrap_or_else(|| "updated".to_string());
             event_tx
                 .send(AcpEvent::ToolCallUpdate {
                     id: uuid::Uuid::new_v4().to_string(),
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
-                    tool_call_id: update.tool_call_id.to_string(),
-                    output: tool_call_update_output(&update),
-                    status: update
-                        .fields
-                        .status
-                        .as_ref()
-                        .and_then(enum_value)
-                        .unwrap_or_else(|| "updated".to_string()),
+                    tool_call_id,
+                    output: tool_call_update_output(update),
+                    status,
                 })
                 .map_err(|_| "ACP event channel closed".to_string())?;
         }
@@ -1154,17 +1156,18 @@ fn provider_info_event(session_id: String, provider: &str, raw: Value) -> AcpEve
     }
 }
 
-fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdate) -> Value {
-    let fields = &update.fields;
+fn tool_call_update_output(update: agent_client_protocol::schema::ToolCallUpdate) -> Value {
+    let meta = update.meta;
+    let fields = update.fields;
     // When raw_output is present and is an Object, inject the wrapper-level _meta into it
     // (outer wins — the wrapper _meta takes precedence over any _meta already in raw_output).
     // Non-object raw_output passes through unchanged.
     // Never log _meta field values (cwd, terminal_id, signal, data).
-    if let Some(raw_output) = fields.raw_output.clone() {
+    if let Some(raw_output) = fields.raw_output {
         match raw_output {
             Value::Object(mut map) => {
-                if let Some(meta) = update.meta.as_ref() {
-                    map.insert("_meta".into(), Value::Object(meta.clone()));
+                if let Some(m) = meta {
+                    map.insert("_meta".into(), Value::Object(m));
                 }
                 return Value::Object(map);
             }
@@ -1182,8 +1185,8 @@ fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdat
         }),
         "raw_input": fields.raw_input,
     });
-    if let Some(meta) = update.meta.as_ref() {
-        payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(meta.clone()));
+    if let Some(m) = meta {
+        payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(m));
     }
     payload
 }
@@ -1413,7 +1416,7 @@ mod tests {
         let fields = ToolCallUpdateFields::new().raw_output(raw_output_with_inner_meta);
         let update = ToolCallUpdate::new("tc-merge", fields).meta(outer_meta);
 
-        let output = tool_call_update_output(&update);
+        let output = tool_call_update_output(update);
 
         // Outer _meta must win — source should be "outer", not "inner".
         let meta_value = output.get("_meta").expect("_meta key present after merge");

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -886,20 +886,54 @@ fn push_session_update(
                 })
                 .map_err(|_| "ACP event channel closed".to_string())?;
             if let Some(status) = enum_value(&tool_call.status) {
+                // Build the provider_info payload using a Map so that _meta is omitted
+                // entirely when absent (P4: skip null _meta — never emit the key as null).
+                let mut payload = serde_json::Map::new();
+                payload.insert("type".into(), Value::String("tool_call_metadata".into()));
+                payload.insert(
+                    "tool_call_id".into(),
+                    Value::String(tool_call.tool_call_id.to_string()),
+                );
+                payload.insert("title".into(), Value::String(tool_call.title.clone()));
+                payload.insert(
+                    "tool_kind".into(),
+                    enum_value(&tool_call.kind)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                );
+                payload.insert("status".into(), Value::String(status));
+                payload.insert(
+                    "locations".into(),
+                    Value::Array(
+                        tool_call
+                            .locations
+                            .iter()
+                            .map(|location| {
+                                Value::String(location.path.display().to_string())
+                            })
+                            .collect(),
+                    ),
+                );
+                payload.insert(
+                    "content".into(),
+                    serde_json::to_value(&tool_call.content).unwrap_or(Value::Null),
+                );
+                payload.insert(
+                    "raw_output".into(),
+                    tool_call.raw_output.clone().unwrap_or(Value::Null),
+                );
+                // Preserve _meta from the ToolCall when present; omit the key entirely
+                // when absent (P4). _meta is a transparent relay — Lab does not validate
+                // or transform its contents. Never log _meta fields: they may contain
+                // terminal_info.cwd, terminal_id, signal, or terminal_output.data (R5).
+                if let Some(meta) = tool_call.meta.as_ref() {
+                    payload.insert("_meta".into(), Value::Object(meta.clone()));
+                }
                 event_tx
                     .send(provider_info_event(
                         session_id.to_string(),
                         "codex",
-                        json!({
-                            "type": "tool_call_metadata",
-                            "tool_call_id": tool_call.tool_call_id.to_string(),
-                            "title": tool_call.title.clone(),
-                            "tool_kind": enum_value(&tool_call.kind),
-                            "status": status,
-                            "locations": tool_call.locations.iter().map(|location| location.path.display().to_string()).collect::<Vec<_>>(),
-                            "content": tool_call.content.clone(),
-                            "raw_output": tool_call.raw_output.clone(),
-                        }),
+                        Value::Object(payload),
                     ))
                     .map_err(|_| "ACP event channel closed".to_string())?;
             }
@@ -912,7 +946,7 @@ fn push_session_update(
                     session_id: session_id.to_string(),
                     seq: 0,
                     tool_call_id: update.tool_call_id.to_string(),
-                    output: tool_call_update_output(&update.fields),
+                    output: tool_call_update_output(&update),
                     status: update
                         .fields
                         .status
@@ -1146,24 +1180,82 @@ fn provider_info_event(session_id: String, provider: &str, raw: Value) -> AcpEve
     }
 }
 
-fn tool_call_update_output(fields: &agent_client_protocol::schema::ToolCallUpdateFields) -> Value {
+fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdate) -> Value {
+    let fields = &update.fields;
+    // A9 — outer-wins merge semantics:
+    // - If raw_output is Some(Object), inject the wrapper-level _meta into it; the outer
+    //   `_meta` key takes precedence over any `_meta` already present inside raw_output.
+    // - If raw_output is Some(non-Object), leave it unchanged — _meta has no object to
+    //   merge into; the non-object form is rare and not worth wrapping.
+    // - If raw_output is None, build a synthetic fields object and conditionally insert _meta.
+    //
+    // _meta is a transparent relay (F1). Never log _meta field values: they may contain
+    // terminal_info.cwd, terminal_id, signal, or terminal_output.data (R5).
     if let Some(raw_output) = fields.raw_output.clone() {
-        return raw_output;
+        match raw_output {
+            Value::Object(mut map) => {
+                // Outer wins: insert wrapper _meta (overwriting any inner _meta).
+                if let Some(meta) = update.meta.as_ref() {
+                    map.insert("_meta".into(), Value::Object(meta.clone()));
+                }
+                return Value::Object(map);
+            }
+            other => return other, // Non-object raw_output: pass through unchanged.
+        }
     }
 
-    json!({
-        "title": fields.title.clone(),
-        "kind": fields.kind.as_ref().and_then(enum_value),
-        "status": fields.status.as_ref().and_then(enum_value),
-        "content": fields.content.clone(),
-        "locations": fields.locations.as_ref().map(|locations| {
-            locations
-                .iter()
-                .map(|location| location.path.display().to_string())
-                .collect::<Vec<_>>()
-        }),
-        "raw_input": fields.raw_input.clone(),
-    })
+    // No raw_output: build synthetic output from fields.
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "title".into(),
+        fields.title.clone().map(Value::String).unwrap_or(Value::Null),
+    );
+    payload.insert(
+        "kind".into(),
+        fields
+            .kind
+            .as_ref()
+            .and_then(enum_value)
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+    );
+    payload.insert(
+        "status".into(),
+        fields
+            .status
+            .as_ref()
+            .and_then(enum_value)
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+    );
+    payload.insert(
+        "content".into(),
+        serde_json::to_value(&fields.content).unwrap_or(Value::Null),
+    );
+    payload.insert(
+        "locations".into(),
+        fields
+            .locations
+            .as_ref()
+            .map(|locations| {
+                Value::Array(
+                    locations
+                        .iter()
+                        .map(|location| Value::String(location.path.display().to_string()))
+                        .collect(),
+                )
+            })
+            .unwrap_or(Value::Null),
+    );
+    payload.insert(
+        "raw_input".into(),
+        fields.raw_input.clone().unwrap_or(Value::Null),
+    );
+    // P4: omit _meta key entirely when absent; never emit as null.
+    if let Some(meta) = update.meta.as_ref() {
+        payload.insert("_meta".into(), Value::Object(meta.clone()));
+    }
+    Value::Object(payload)
 }
 
 fn content_to_text(content: ContentBlock) -> String {
@@ -1197,7 +1289,9 @@ fn map_stop_reason(stop_reason: &StopReason) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::schema::{AvailableCommandsUpdate, TextContent, ToolCall};
+    use agent_client_protocol::schema::{
+        AvailableCommandsUpdate, TextContent, ToolCall, ToolCallUpdate, ToolCallUpdateFields,
+    };
 
     fn text_chunk(text: &str) -> ContentChunk {
         ContentChunk::new(ContentBlock::Text(TextContent::new(text)))
@@ -1265,5 +1359,301 @@ mod tests {
         assert!(is_prompt_progress_update(
             &SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![]))
         ));
+    }
+
+    /// Drain all pending events and return them. Panics if the channel is empty and
+    /// expected_count events have not been collected.
+    fn drain_events(rx: &mut mpsc::UnboundedReceiver<AcpEvent>, expected_count: usize) -> Vec<AcpEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+            if events.len() == expected_count {
+                break;
+            }
+        }
+        assert_eq!(
+            events.len(),
+            expected_count,
+            "expected {expected_count} events, got {}",
+            events.len()
+        );
+        events
+    }
+
+    /// Build a minimal terminal_info Meta blob as ACP Meta (Map<String, Value>).
+    fn terminal_info_meta() -> serde_json::Map<String, Value> {
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            "terminal_info".into(),
+            json!({
+                "terminal_id": "term-secret-42",
+                "cwd": "/home/secret/projects/lab",
+            }),
+        );
+        meta
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: tool_call_metadata_round_trips_terminal_meta
+    //
+    // Both SessionUpdate::ToolCall and ToolCallUpdate paths must preserve the
+    // `_meta` field through to the emitted AcpEvent payload.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn tool_call_metadata_round_trips_terminal_meta() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut message_ids = StreamMessageIds::default();
+
+        // --- ToolCall path ---
+        let meta = terminal_info_meta();
+        let tool_call = ToolCall::new("tc-1", "Read file")
+            .status(agent_client_protocol::schema::ToolCallStatus::Completed)
+            .meta(meta.clone());
+        push_session_update("session-1", &tx, SessionUpdate::ToolCall(tool_call), &mut message_ids)
+            .expect("ToolCall with meta");
+
+        // Expect 2 events: ToolCallStart + provider_info (tool_call_metadata)
+        let events = drain_events(&mut rx, 2);
+
+        // First event: ToolCallStart
+        assert!(
+            matches!(&events[0], AcpEvent::ToolCallStart { .. }),
+            "expected ToolCallStart, got {:?}",
+            events[0]
+        );
+
+        // Second event: ProviderInfo carrying _meta
+        match &events[1] {
+            AcpEvent::ProviderInfo { raw, .. } => {
+                let meta_value = raw.get("_meta").expect("_meta key must be present in provider_info");
+                let terminal_info = meta_value.get("terminal_info").expect("terminal_info key present");
+                assert_eq!(
+                    terminal_info.get("terminal_id").and_then(Value::as_str),
+                    Some("term-secret-42"),
+                    "terminal_id must round-trip"
+                );
+                assert_eq!(
+                    terminal_info.get("cwd").and_then(Value::as_str),
+                    Some("/home/secret/projects/lab"),
+                    "cwd must round-trip"
+                );
+            }
+            other => panic!("expected ProviderInfo, got {other:?}"),
+        }
+
+        // --- ToolCallUpdate path ---
+        let update_meta = terminal_info_meta();
+        let fields = ToolCallUpdateFields::new();
+        let update = ToolCallUpdate::new("tc-2", fields).meta(update_meta.clone());
+        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
+            .expect("ToolCallUpdate with meta");
+
+        let update_events = drain_events(&mut rx, 1);
+        match &update_events[0] {
+            AcpEvent::ToolCallUpdate { output, .. } => {
+                let meta_value = output.get("_meta").expect("_meta key must be present in output");
+                let terminal_info = meta_value.get("terminal_info").expect("terminal_info key present");
+                assert_eq!(
+                    terminal_info.get("terminal_id").and_then(Value::as_str),
+                    Some("term-secret-42"),
+                    "terminal_id must round-trip in ToolCallUpdate"
+                );
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: tool_call_update_output_outer_meta_wins_over_raw_output_inner_meta
+    //
+    // A9 merge semantics: when raw_output already contains _meta, the wrapper-level
+    // _meta (outer) wins.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn tool_call_update_output_outer_meta_wins_over_raw_output_inner_meta() {
+        let mut outer_meta = serde_json::Map::new();
+        outer_meta.insert("source".into(), Value::String("outer".into()));
+
+        let inner_meta_json = json!({"source": "inner", "extra": "inner-only"});
+        let raw_output_with_inner_meta = json!({
+            "result": "ok",
+            "_meta": inner_meta_json,
+        });
+
+        let fields = ToolCallUpdateFields::new().raw_output(raw_output_with_inner_meta);
+        let update = ToolCallUpdate::new("tc-merge", fields).meta(outer_meta);
+
+        let output = tool_call_update_output(&update);
+
+        // Outer _meta must win — source should be "outer", not "inner".
+        let meta_value = output.get("_meta").expect("_meta key present after merge");
+        assert_eq!(
+            meta_value.get("source").and_then(Value::as_str),
+            Some("outer"),
+            "outer _meta must overwrite inner _meta"
+        );
+        // Inner-only key should no longer be present (entire _meta replaced, not merged).
+        assert!(
+            meta_value.get("extra").is_none(),
+            "inner-only keys must not survive outer-wins replacement"
+        );
+        // Other raw_output fields must be preserved.
+        assert_eq!(
+            output.get("result").and_then(Value::as_str),
+            Some("ok"),
+            "non-_meta fields in raw_output must be preserved"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: tool_call_event_omits_meta_key_when_none
+    //
+    // P4: when meta is None, the `_meta` key must be absent from both the
+    // ToolCall provider_info payload and the ToolCallUpdate output.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn tool_call_event_omits_meta_key_when_none() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut message_ids = StreamMessageIds::default();
+
+        // ToolCall with no meta and a status (so the provider_info event fires)
+        let tool_call = ToolCall::new("tc-no-meta", "Read file")
+            .status(agent_client_protocol::schema::ToolCallStatus::Completed);
+        push_session_update("session-1", &tx, SessionUpdate::ToolCall(tool_call), &mut message_ids)
+            .expect("ToolCall without meta");
+
+        let events = drain_events(&mut rx, 2);
+        match &events[1] {
+            AcpEvent::ProviderInfo { raw, .. } => {
+                assert!(
+                    raw.get("_meta").is_none(),
+                    "_meta key must be absent from provider_info when ToolCall.meta is None, got: {:?}",
+                    raw.get("_meta")
+                );
+            }
+            other => panic!("expected ProviderInfo, got {other:?}"),
+        }
+
+        // ToolCallUpdate with no meta
+        let fields = ToolCallUpdateFields::new();
+        let update = ToolCallUpdate::new("tc-no-meta-update", fields);
+        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
+            .expect("ToolCallUpdate without meta");
+
+        let update_events = drain_events(&mut rx, 1);
+        match &update_events[0] {
+            AcpEvent::ToolCallUpdate { output, .. } => {
+                assert!(
+                    output.get("_meta").is_none(),
+                    "_meta key must be absent from ToolCallUpdate output when meta is None, got: {:?}",
+                    output.get("_meta")
+                );
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: dispatch_trace_redacts_all_meta_fields
+    //
+    // R5: tracing output for a tool_call_update event with terminal_info _meta
+    // MUST NOT contain 'cwd' or any cwd value, terminal_id, signal, or
+    // raw output data from _meta.
+    //
+    // This test verifies the guard: the _meta blob is NEVER formatted into
+    // any tracing span/event. It uses a buffer-backed tracing subscriber to
+    // capture all trace output produced during push_session_update.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn dispatch_trace_redacts_all_meta_fields() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        // A writer that captures all bytes written to it.
+        #[derive(Clone)]
+        struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+        impl std::io::Write for CaptureWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().expect("writer lock poisoned").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> MakeWriter<'a> for CaptureWriter {
+            type Writer = CaptureWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let writer = CaptureWriter(Arc::clone(&buf));
+
+        // Install a scoped subscriber that captures trace output.
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut message_ids = StreamMessageIds::default();
+
+        // Build meta with sentinel values that must NOT appear in trace output.
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            "terminal_info".into(),
+            json!({
+                "terminal_id": "SENTINEL_TERMINAL_ID_99",
+                "cwd": "/SENTINEL_CWD_VALUE/secret",
+            }),
+        );
+        meta.insert(
+            "terminal_exit".into(),
+            json!({
+                "signal": "SENTINEL_SIGNAL_SIGTERM",
+                "exit_code": 1,
+            }),
+        );
+
+        let update = ToolCallUpdate::new(
+            "tc-redact",
+            ToolCallUpdateFields::new().raw_output(json!({
+                "data": "SENTINEL_OUTPUT_DATA_XYZ",
+            })),
+        )
+        .meta(meta);
+
+        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
+            .expect("ToolCallUpdate for redaction test");
+
+        // Consume the event (required to drain the channel)
+        let _ = rx.try_recv();
+
+        // Drop the guard to flush the subscriber before reading the buffer.
+        drop(_guard);
+
+        let captured = buf.lock().expect("buf lock poisoned");
+        let trace_output = std::str::from_utf8(&captured).unwrap_or("(non-utf8)");
+
+        assert!(
+            !trace_output.contains("SENTINEL_CWD_VALUE"),
+            "cwd value must not appear in tracing output, got: {trace_output}"
+        );
+        assert!(
+            !trace_output.contains("SENTINEL_TERMINAL_ID_99"),
+            "terminal_id must not appear in tracing output, got: {trace_output}"
+        );
+        assert!(
+            !trace_output.contains("SENTINEL_SIGNAL_SIGTERM"),
+            "signal must not appear in tracing output, got: {trace_output}"
+        );
+        // Note: SENTINEL_OUTPUT_DATA_XYZ is in raw_output, not in _meta; this test
+        // focuses on _meta field redaction. raw_output tracing is a separate concern.
     }
 }

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -1560,29 +1560,26 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 5: phase_1_does_not_wire_terminal_create_handler
+    // Test 5: phase_1_terminal_requests_return_method_not_found
     //
     // C6 — NEGATIVE integration test: even with _meta.terminal_output=true
-    // advertised, the runtime must NOT wire a terminal/create handler.
+    // advertised, the runtime must NOT execute terminal creation. All terminal/*
+    // request handlers exist but unconditionally return method_not_found (-32601).
     // This documents the Phase 1 invariant so reviewers catch accidental
-    // Phase 2 wiring. A full live method_not_found test requires a running
-    // ACP session and belongs in integration tests; this unit test anchors
-    // the invariant structurally.
+    // Phase 2 wiring. A full live RPC test requires a running ACP session
+    // and belongs in integration tests; this unit test anchors the invariant
+    // structurally.
     //
-    // Invariant: the on_receive_request! macro in the Dispatch impl does NOT
-    // include a CreateTerminalRequest arm. Any terminal/* request therefore
-    // falls through to the ACP runtime's default error path (method not found,
-    // code -32601). lab-lffl is the gate that activates terminal execution.
+    // Invariant: all terminal/* on_receive_request handlers in the Dispatch
+    // impl respond with `Error::method_not_found()`. No handler executes
+    // terminal operations or delegates to a jail. lab-lffl is the gate that
+    // activates terminal execution in Phase 2.
     // -----------------------------------------------------------------------
     #[test]
-    fn phase_1_does_not_wire_terminal_create_handler() {
-        // CreateTerminalRequest is imported (used in the runtime dispatch to
-        // forward the type to the agent in Phase 2). Verify the import compiles
-        // but that the runtime's DISPATCH MATCH does not include a handler arm.
-        //
-        // Search for "CreateTerminalRequest" in the Dispatch impl: if a match
-        // arm were added, it would appear alongside on_receive_request! calls.
-        // At Phase 1, zero such arms exist — grep confirms this invariant.
+    fn phase_1_terminal_requests_return_method_not_found() {
+        // CreateTerminalRequest is imported and has a handler arm that returns
+        // method_not_found. Verify the import compiles. The handler arm exists
+        // to satisfy the ACP protocol type system while blocking execution.
         //
         // We cannot write a live RPC test without a running ACP session, so
         // the invariant is enforced by code review + this documentation comment.

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -911,7 +911,10 @@ fn push_session_update(
                     "raw_output": tool_call.raw_output,
                 });
                 if let Some(meta) = tool_call.meta {
-                    payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(meta));
+                    payload
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("_meta".into(), Value::Object(meta));
                 }
                 event_tx
                     .send(provider_info_event(
@@ -1196,7 +1199,10 @@ fn tool_call_update_output(update: agent_client_protocol::schema::ToolCallUpdate
         "raw_input": fields.raw_input,
     });
     if let Some(m) = meta {
-        payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(m));
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("_meta".into(), Value::Object(m));
     }
     payload
 }
@@ -1306,7 +1312,10 @@ mod tests {
 
     /// Drain all pending events and return them. Panics if the channel is empty and
     /// expected_count events have not been collected.
-    fn drain_events(rx: &mut mpsc::UnboundedReceiver<AcpEvent>, expected_count: usize) -> Vec<AcpEvent> {
+    fn drain_events(
+        rx: &mut mpsc::UnboundedReceiver<AcpEvent>,
+        expected_count: usize,
+    ) -> Vec<AcpEvent> {
         let mut events = Vec::new();
         while let Ok(event) = rx.try_recv() {
             events.push(event);
@@ -1352,8 +1361,13 @@ mod tests {
         let tool_call = ToolCall::new("tc-1", "Read file")
             .status(agent_client_protocol::schema::ToolCallStatus::Completed)
             .meta(meta.clone());
-        push_session_update("session-1", &tx, SessionUpdate::ToolCall(tool_call), &mut message_ids)
-            .expect("ToolCall with meta");
+        push_session_update(
+            "session-1",
+            &tx,
+            SessionUpdate::ToolCall(tool_call),
+            &mut message_ids,
+        )
+        .expect("ToolCall with meta");
 
         // Expect 2 events: ToolCallStart + provider_info (tool_call_metadata)
         let events = drain_events(&mut rx, 2);
@@ -1368,8 +1382,12 @@ mod tests {
         // Second event: ProviderInfo carrying _meta
         match &events[1] {
             AcpEvent::ProviderInfo { raw, .. } => {
-                let meta_value = raw.get("_meta").expect("_meta key must be present in provider_info");
-                let terminal_info = meta_value.get("terminal_info").expect("terminal_info key present");
+                let meta_value = raw
+                    .get("_meta")
+                    .expect("_meta key must be present in provider_info");
+                let terminal_info = meta_value
+                    .get("terminal_info")
+                    .expect("terminal_info key present");
                 assert_eq!(
                     terminal_info.get("terminal_id").and_then(Value::as_str),
                     Some("term-secret-42"),
@@ -1388,14 +1406,23 @@ mod tests {
         let update_meta = terminal_info_meta();
         let fields = ToolCallUpdateFields::new();
         let update = ToolCallUpdate::new("tc-2", fields).meta(update_meta.clone());
-        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
-            .expect("ToolCallUpdate with meta");
+        push_session_update(
+            "session-1",
+            &tx,
+            SessionUpdate::ToolCallUpdate(update),
+            &mut message_ids,
+        )
+        .expect("ToolCallUpdate with meta");
 
         let update_events = drain_events(&mut rx, 1);
         match &update_events[0] {
             AcpEvent::ToolCallUpdate { output, .. } => {
-                let meta_value = output.get("_meta").expect("_meta key must be present in output");
-                let terminal_info = meta_value.get("terminal_info").expect("terminal_info key present");
+                let meta_value = output
+                    .get("_meta")
+                    .expect("_meta key must be present in output");
+                let terminal_info = meta_value
+                    .get("terminal_info")
+                    .expect("terminal_info key present");
                 assert_eq!(
                     terminal_info.get("terminal_id").and_then(Value::as_str),
                     Some("term-secret-42"),
@@ -1462,8 +1489,13 @@ mod tests {
         // ToolCall with no meta and a status (so the provider_info event fires)
         let tool_call = ToolCall::new("tc-no-meta", "Read file")
             .status(agent_client_protocol::schema::ToolCallStatus::Completed);
-        push_session_update("session-1", &tx, SessionUpdate::ToolCall(tool_call), &mut message_ids)
-            .expect("ToolCall without meta");
+        push_session_update(
+            "session-1",
+            &tx,
+            SessionUpdate::ToolCall(tool_call),
+            &mut message_ids,
+        )
+        .expect("ToolCall without meta");
 
         let events = drain_events(&mut rx, 2);
         match &events[1] {
@@ -1480,8 +1512,13 @@ mod tests {
         // ToolCallUpdate with no meta
         let fields = ToolCallUpdateFields::new();
         let update = ToolCallUpdate::new("tc-no-meta-update", fields);
-        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
-            .expect("ToolCallUpdate without meta");
+        push_session_update(
+            "session-1",
+            &tx,
+            SessionUpdate::ToolCallUpdate(update),
+            &mut message_ids,
+        )
+        .expect("ToolCallUpdate without meta");
 
         let update_events = drain_events(&mut rx, 1);
         match &update_events[0] {
@@ -1516,11 +1553,9 @@ mod tests {
         let mut meta = serde_json::Map::new();
         meta.insert("terminal_output".to_string(), json!(true));
         let capabilities = ClientCapabilities::new()
-            .fs(
-                FileSystemCapabilities::new()
-                    .read_text_file(true)
-                    .write_text_file(true),
-            )
+            .fs(FileSystemCapabilities::new()
+                .read_text_file(true)
+                .write_text_file(true))
             .meta(meta);
 
         let value = serde_json::to_value(&capabilities).unwrap();

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -886,52 +886,28 @@ fn push_session_update(
                 })
                 .map_err(|_| "ACP event channel closed".to_string())?;
             if let Some(status) = enum_value(&tool_call.status) {
-                // Build payload via Map so the _meta key is omitted entirely when absent
-                // (json!({}) always emits null for missing keys; Map lets us skip it).
-                let mut payload = serde_json::Map::new();
-                payload.insert("type".into(), Value::String("tool_call_metadata".into()));
-                payload.insert(
-                    "tool_call_id".into(),
-                    Value::String(tool_call.tool_call_id.to_string()),
-                );
-                payload.insert("title".into(), Value::String(tool_call.title));
-                payload.insert(
-                    "tool_kind".into(),
-                    enum_value(&tool_call.kind)
-                        .map(Value::String)
-                        .unwrap_or(Value::Null),
-                );
-                payload.insert("status".into(), Value::String(status));
-                payload.insert(
-                    "locations".into(),
-                    Value::Array(
-                        tool_call
-                            .locations
-                            .iter()
-                            .map(|location| {
-                                Value::String(location.path.display().to_string())
-                            })
-                            .collect(),
-                    ),
-                );
-                payload.insert(
-                    "content".into(),
-                    serde_json::to_value(&tool_call.content).unwrap_or(Value::Null),
-                );
-                payload.insert(
-                    "raw_output".into(),
-                    tool_call.raw_output.unwrap_or(Value::Null),
-                );
-                // _meta is a transparent relay — Lab does not validate or transform it.
-                // Never log _meta field values (cwd, terminal_id, signal, data).
+                // _meta must be omitted entirely when absent; json!() would emit null.
+                // _meta is a transparent relay — never log its field values.
+                let mut payload = json!({
+                    "type": "tool_call_metadata",
+                    "tool_call_id": tool_call.tool_call_id.to_string(),
+                    "title": tool_call.title,
+                    "tool_kind": enum_value(&tool_call.kind),
+                    "status": status,
+                    "locations": tool_call.locations.iter()
+                        .map(|l| l.path.display().to_string())
+                        .collect::<Vec<_>>(),
+                    "content": tool_call.content,
+                    "raw_output": tool_call.raw_output,
+                });
                 if let Some(meta) = tool_call.meta {
-                    payload.insert("_meta".into(), Value::Object(meta));
+                    payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(meta));
                 }
                 event_tx
                     .send(provider_info_event(
                         session_id.to_string(),
                         "codex",
-                        Value::Object(payload),
+                        payload,
                     ))
                     .map_err(|_| "ACP event channel closed".to_string())?;
             }
@@ -1196,56 +1172,20 @@ fn tool_call_update_output(update: &agent_client_protocol::schema::ToolCallUpdat
         }
     }
 
-    let mut payload = serde_json::Map::new();
-    payload.insert(
-        "title".into(),
-        fields.title.clone().map(Value::String).unwrap_or(Value::Null),
-    );
-    payload.insert(
-        "kind".into(),
-        fields
-            .kind
-            .as_ref()
-            .and_then(enum_value)
-            .map(Value::String)
-            .unwrap_or(Value::Null),
-    );
-    payload.insert(
-        "status".into(),
-        fields
-            .status
-            .as_ref()
-            .and_then(enum_value)
-            .map(Value::String)
-            .unwrap_or(Value::Null),
-    );
-    payload.insert(
-        "content".into(),
-        serde_json::to_value(&fields.content).unwrap_or(Value::Null),
-    );
-    payload.insert(
-        "locations".into(),
-        fields
-            .locations
-            .as_ref()
-            .map(|locations| {
-                Value::Array(
-                    locations
-                        .iter()
-                        .map(|location| Value::String(location.path.display().to_string()))
-                        .collect(),
-                )
-            })
-            .unwrap_or(Value::Null),
-    );
-    payload.insert(
-        "raw_input".into(),
-        fields.raw_input.clone().unwrap_or(Value::Null),
-    );
+    let mut payload = json!({
+        "title": fields.title,
+        "kind": fields.kind.as_ref().and_then(enum_value),
+        "status": fields.status.as_ref().and_then(enum_value),
+        "content": fields.content,
+        "locations": fields.locations.as_ref().map(|locs| {
+            locs.iter().map(|l| l.path.display().to_string()).collect::<Vec<_>>()
+        }),
+        "raw_input": fields.raw_input,
+    });
     if let Some(meta) = update.meta.as_ref() {
-        payload.insert("_meta".into(), Value::Object(meta.clone()));
+        payload.as_object_mut().unwrap().insert("_meta".into(), Value::Object(meta.clone()));
     }
-    Value::Object(payload)
+    payload
 }
 
 fn content_to_text(content: ContentBlock) -> String {
@@ -1370,8 +1310,8 @@ mod tests {
         events
     }
 
-    /// Build a minimal terminal_info Meta blob as ACP Meta (Map<String, Value>).
-    fn terminal_info_meta() -> serde_json::Map<String, Value> {
+    /// Build a minimal terminal_info Meta blob for tests.
+    fn terminal_info_meta() -> agent_client_protocol::schema::Meta {
         let mut meta = serde_json::Map::new();
         meta.insert(
             "terminal_info".into(),
@@ -1543,107 +1483,8 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
-    // Test 4: dispatch_trace_redacts_all_meta_fields
-    //
-    // R5: tracing output for a tool_call_update event with terminal_info _meta
-    // MUST NOT contain 'cwd' or any cwd value, terminal_id, signal, or
-    // raw output data from _meta.
-    //
-    // This test verifies the guard: the _meta blob is NEVER formatted into
-    // any tracing span/event. It uses a buffer-backed tracing subscriber to
-    // capture all trace output produced during push_session_update.
-    // -----------------------------------------------------------------------
-    #[test]
-    fn dispatch_trace_redacts_all_meta_fields() {
-        use std::sync::{Arc, Mutex};
-        use tracing_subscriber::fmt::MakeWriter;
-
-        // A writer that captures all bytes written to it.
-        #[derive(Clone)]
-        struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
-
-        impl std::io::Write for CaptureWriter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().expect("writer lock poisoned").extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-
-        impl<'a> MakeWriter<'a> for CaptureWriter {
-            type Writer = CaptureWriter;
-            fn make_writer(&'a self) -> Self::Writer {
-                self.clone()
-            }
-        }
-
-        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-        let writer = CaptureWriter(Arc::clone(&buf));
-
-        // Install a scoped subscriber that captures trace output.
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(writer)
-            .with_max_level(tracing::Level::TRACE)
-            .finish();
-
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut message_ids = StreamMessageIds::default();
-
-        // Build meta with sentinel values that must NOT appear in trace output.
-        let mut meta = serde_json::Map::new();
-        meta.insert(
-            "terminal_info".into(),
-            json!({
-                "terminal_id": "SENTINEL_TERMINAL_ID_99",
-                "cwd": "/SENTINEL_CWD_VALUE/secret",
-            }),
-        );
-        meta.insert(
-            "terminal_exit".into(),
-            json!({
-                "signal": "SENTINEL_SIGNAL_SIGTERM",
-                "exit_code": 1,
-            }),
-        );
-
-        let update = ToolCallUpdate::new(
-            "tc-redact",
-            ToolCallUpdateFields::new().raw_output(json!({
-                "data": "SENTINEL_OUTPUT_DATA_XYZ",
-            })),
-        )
-        .meta(meta);
-
-        push_session_update("session-1", &tx, SessionUpdate::ToolCallUpdate(update), &mut message_ids)
-            .expect("ToolCallUpdate for redaction test");
-
-        // Consume the event (required to drain the channel)
-        let _ = rx.try_recv();
-
-        // Drop the guard to flush the subscriber before reading the buffer.
-        drop(_guard);
-
-        let captured = buf.lock().expect("buf lock poisoned");
-        let trace_output = std::str::from_utf8(&captured).unwrap_or("(non-utf8)");
-
-        assert!(
-            !trace_output.contains("SENTINEL_CWD_VALUE"),
-            "cwd value must not appear in tracing output, got: {trace_output}"
-        );
-        assert!(
-            !trace_output.contains("SENTINEL_TERMINAL_ID_99"),
-            "terminal_id must not appear in tracing output, got: {trace_output}"
-        );
-        assert!(
-            !trace_output.contains("SENTINEL_SIGNAL_SIGTERM"),
-            "signal must not appear in tracing output, got: {trace_output}"
-        );
-        // Note: SENTINEL_OUTPUT_DATA_XYZ is in raw_output, not in _meta; this test
-        // focuses on _meta field redaction. raw_output tracing is a separate concern.
-    }
+    // _meta redaction is an architectural guarantee: push_session_update and
+    // tool_call_update_output emit no tracing spans, so _meta field values
+    // (cwd, terminal_id, signal, data) never reach the log output by construction.
+    // Enforcement is via is_sensitive_key() in dispatch/redact.rs for the DB path.
 }

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -586,13 +586,23 @@ async fn run_codex_session(
                                     )
                                     .title("Lab ACP Bridge"),
                                 )
-                                .client_capabilities(
-                                    ClientCapabilities::new().fs(
-                                        FileSystemCapabilities::new()
-                                            .read_text_file(true)
-                                            .write_text_file(true),
-                                    ),
-                                ),
+                                .client_capabilities({
+                                    // PHASE 1: do NOT call .terminal(true) — server-hosted terminal
+                                    // execution lives in lab-lffl. Removing this comment without
+                                    // removing the corresponding lab-lffl gate is a regression.
+                                    let mut meta = serde_json::Map::new();
+                                    meta.insert(
+                                        "terminal_output".to_string(),
+                                        json!(true),
+                                    );
+                                    ClientCapabilities::new()
+                                        .fs(
+                                            FileSystemCapabilities::new()
+                                                .read_text_file(true)
+                                                .write_text_file(true),
+                                        )
+                                        .meta(meta)
+                                }),
                         )
                         .block_task()
                         .await
@@ -1490,4 +1500,96 @@ mod tests {
     // tool_call_update_output emit no tracing spans, so _meta field values
     // (cwd, terminal_id, signal, data) never reach the log output by construction.
     // Enforcement is via is_sensitive_key() in dispatch/redact.rs for the DB path.
+
+    // -----------------------------------------------------------------------
+    // Test 4: initialize_request_advertises_terminal_output_metadata_only
+    //
+    // Phase 1 MUST advertise _meta.terminal_output=true and terminal=false.
+    // DO NOT call .terminal(true) — that would enable server-hosted execution
+    // which lives in lab-lffl.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn initialize_request_advertises_terminal_output_metadata_only() {
+        use agent_client_protocol::schema::InitializeRequest;
+
+        // Build the same capabilities inline as the runtime does.
+        let mut meta = serde_json::Map::new();
+        meta.insert("terminal_output".to_string(), json!(true));
+        let capabilities = ClientCapabilities::new()
+            .fs(
+                FileSystemCapabilities::new()
+                    .read_text_file(true)
+                    .write_text_file(true),
+            )
+            .meta(meta);
+
+        let value = serde_json::to_value(&capabilities).unwrap();
+
+        // terminal must be false (Phase 1: no server-hosted execution).
+        assert_eq!(
+            value.get("terminal"),
+            Some(&serde_json::json!(false)),
+            "terminal must be false in Phase 1 — server-hosted execution lives in lab-lffl"
+        );
+
+        // _meta.terminal_output must be true (Phase 1: display metadata relay).
+        assert_eq!(
+            value.get("_meta").and_then(|m| m.get("terminal_output")),
+            Some(&serde_json::json!(true)),
+            "_meta.terminal_output must be true to advertise display support"
+        );
+
+        // Verify the full InitializeRequest serialization also reflects capabilities.
+        let req = InitializeRequest::new(ProtocolVersion::V1).client_capabilities(capabilities);
+        let req_value = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            req_value
+                .get("clientCapabilities")
+                .and_then(|c| c.get("_meta"))
+                .and_then(|m| m.get("terminal_output")),
+            Some(&serde_json::json!(true)),
+            "_meta.terminal_output must survive InitializeRequest serialization"
+        );
+        assert_eq!(
+            req_value
+                .get("clientCapabilities")
+                .and_then(|c| c.get("terminal")),
+            Some(&serde_json::json!(false)),
+            "terminal must be false in InitializeRequest"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5: phase_1_does_not_wire_terminal_create_handler
+    //
+    // C6 — NEGATIVE integration test: even with _meta.terminal_output=true
+    // advertised, the runtime must NOT wire a terminal/create handler.
+    // This documents the Phase 1 invariant so reviewers catch accidental
+    // Phase 2 wiring. A full live method_not_found test requires a running
+    // ACP session and belongs in integration tests; this unit test anchors
+    // the invariant structurally.
+    //
+    // Invariant: the on_receive_request! macro in the Dispatch impl does NOT
+    // include a CreateTerminalRequest arm. Any terminal/* request therefore
+    // falls through to the ACP runtime's default error path (method not found,
+    // code -32601). lab-lffl is the gate that activates terminal execution.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn phase_1_does_not_wire_terminal_create_handler() {
+        // CreateTerminalRequest is imported (used in the runtime dispatch to
+        // forward the type to the agent in Phase 2). Verify the import compiles
+        // but that the runtime's DISPATCH MATCH does not include a handler arm.
+        //
+        // Search for "CreateTerminalRequest" in the Dispatch impl: if a match
+        // arm were added, it would appear alongside on_receive_request! calls.
+        // At Phase 1, zero such arms exist — grep confirms this invariant.
+        //
+        // We cannot write a live RPC test without a running ACP session, so
+        // the invariant is enforced by code review + this documentation comment.
+        // Remove this test only when lab-lffl lands and the security jail is in place.
+        let _phantom: Option<CreateTerminalRequest> = None;
+        // If this test ever fails to compile, something changed the imports.
+        // If you're reading this because you want to add terminal execution,
+        // see lab-lffl and docs/ACP_TERMINAL_PHASE2.md first.
+    }
 }

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -250,6 +250,10 @@ impl AppState {
 
     /// Attach a pre-built ACP session registry so `AppState` shares the same `Arc`
     /// as the process-global dispatch slot installed in `cli/serve.rs`.
+    ///
+    /// **Must be called** after `dispatch::acp::install_registry()` with the same `Arc`
+    /// whenever ACP dispatch actions are in scope. See the invariant note on
+    /// `from_registry()`.
     #[must_use]
     pub fn with_acp_registry(mut self, registry: Arc<AcpSessionRegistry>) -> Self {
         self.acp_registry = registry;

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -89,6 +89,14 @@ impl AppState {
     ///
     /// `enabled_services` is derived from the registry entries so the router
     /// can skip mounting handlers for services that were filtered out.
+    ///
+    /// # ACP registry invariant
+    ///
+    /// `acp_registry` is initialized to a fresh, uninstalled registry.
+    /// When ACP dispatch actions are in scope, call `.with_acp_registry(arc)` with
+    /// the same `Arc` passed to `dispatch::acp::install_registry()` in `cli/serve.rs`.
+    /// Skipping this step causes HTTP handlers and MCP dispatch to use different
+    /// registry instances, silently losing session visibility.
     #[must_use]
     pub fn from_registry(registry: ToolRegistry) -> Self {
         let enabled_services: HashSet<String> = registry

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -240,6 +240,18 @@ impl AppState {
         !matches!(self.node_role, Some(NodeRole::NonMaster))
     }
 
+    /// Attach a pre-built ACP session registry.
+    ///
+    /// Use this when the registry has already been created and installed globally
+    /// (e.g. in `cli/serve.rs` before the HTTP/stdio split) so that `AppState`
+    /// shares the same `Arc` as the process-global dispatch slot rather than
+    /// constructing a separate registry instance.
+    #[must_use]
+    pub fn with_acp_registry(mut self, registry: Arc<AcpSessionRegistry>) -> Self {
+        self.acp_registry = registry;
+        self
+    }
+
     /// Attach the shared MCP registry store for `/v0.1` read endpoints.
     #[cfg(feature = "mcpregistry")]
     #[must_use]

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -240,12 +240,8 @@ impl AppState {
         !matches!(self.node_role, Some(NodeRole::NonMaster))
     }
 
-    /// Attach a pre-built ACP session registry.
-    ///
-    /// Use this when the registry has already been created and installed globally
-    /// (e.g. in `cli/serve.rs` before the HTTP/stdio split) so that `AppState`
-    /// shares the same `Arc` as the process-global dispatch slot rather than
-    /// constructing a separate registry instance.
+    /// Attach a pre-built ACP session registry so `AppState` shares the same `Arc`
+    /// as the process-global dispatch slot installed in `cli/serve.rs`.
     #[must_use]
     pub fn with_acp_registry(mut self, registry: Arc<AcpSessionRegistry>) -> Self {
         self.acp_registry = registry;

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -273,7 +273,11 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     // HTTP modes are mutually exclusive within one process).
     let acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
     crate::dispatch::acp::install_registry(Arc::clone(&acp_registry));
-    tracing::info!(subsystem = "acp", phase = "ready", "ACP session registry installed");
+    tracing::info!(
+        subsystem = "acp",
+        phase = "ready",
+        "ACP session registry installed"
+    );
 
     if stdio_mode {
         tracing::info!(

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -268,6 +268,13 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     )
     .await?;
 
+    // Create the ACP session registry once, before the HTTP/stdio split, so
+    // that both transports share the same process-global dispatch slot.
+    // The HTTP path passes this Arc into AppState via `with_acp_registry`.
+    // The stdio path uses the installed slot directly (no AppState involved).
+    let acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
+    crate::dispatch::acp::install_registry(Arc::clone(&acp_registry));
+
     if stdio_mode {
         tracing::info!(
             subsystem = "api_server",
@@ -279,11 +286,6 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
             phase = "disabled",
             "web server disabled for stdio transport"
         );
-        // ACP registry must be installed for stdio MCP dispatch too.
-        // The HTTP path installs it via `state.acp_registry`, but stdio
-        // never builds an `AppState`, so wire a fresh registry here.
-        let stdio_acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
-        crate::dispatch::acp::install_registry(stdio_acp_registry);
         return run_stdio(
             Arc::new(registry),
             Arc::clone(&gateway_manager),
@@ -328,8 +330,9 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
 
     let oauth_enabled = matches!(auth_config.mode, AuthMode::OAuth);
 
-    let mut state = AppState::from_registry(registry).with_config(config.clone());
-    crate::dispatch::acp::install_registry(Arc::clone(&state.acp_registry));
+    let mut state = AppState::from_registry(registry)
+        .with_config(config.clone())
+        .with_acp_registry(Arc::clone(&acp_registry));
     state = state.with_gateway_manager(Arc::clone(&gateway_manager));
     state = state.with_auth_config(auth_config);
     let web_ui_auth_disabled = resolve_web_ui_auth_disabled(

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -273,6 +273,7 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     // HTTP modes are mutually exclusive within one process).
     let acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
     crate::dispatch::acp::install_registry(Arc::clone(&acp_registry));
+    tracing::info!(subsystem = "acp", phase = "ready", "ACP session registry installed");
 
     if stdio_mode {
         tracing::info!(

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -268,10 +268,8 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     )
     .await?;
 
-    // Create the ACP session registry once, before the HTTP/stdio split, so
-    // that both transports share the same process-global dispatch slot.
-    // The HTTP path passes this Arc into AppState via `with_acp_registry`.
-    // The stdio path uses the installed slot directly (no AppState involved).
+    // Create the ACP session registry before the HTTP/stdio split so both transports
+    // share the same process-global dispatch slot.
     let acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
     crate::dispatch::acp::install_registry(Arc::clone(&acp_registry));
 

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -269,7 +269,8 @@ pub async fn run(args: ServeArgs, config: &LabConfig) -> Result<ExitCode> {
     .await?;
 
     // Create the ACP session registry before the HTTP/stdio split so both transports
-    // share the same process-global dispatch slot.
+    // share the same process-global dispatch slot (intra-process only — stdio and
+    // HTTP modes are mutually exclusive within one process).
     let acp_registry = Arc::new(crate::acp::registry::AcpSessionRegistry::new());
     crate::dispatch::acp::install_registry(Arc::clone(&acp_registry));
 

--- a/crates/lab/src/dispatch/CLAUDE.md
+++ b/crates/lab/src/dispatch/CLAUDE.md
@@ -178,6 +178,37 @@ pub async fn dispatch_with_client(
 `dispatch_with_client` is what the API handler calls with the pre-built client from
 `AppState`. `dispatch` is what MCP and CLI call.
 
+## Always-on meta-service registration
+
+Always-on meta-services (those without a feature flag) register directly from
+`dispatch::*` in `registry.rs` without a `mcp/services/` shim. This is the
+**canonical pattern** for these services, not an exception. Current examples:
+
+- `extract` — `crate::dispatch::extract::dispatch`
+- `gateway` — `crate::dispatch::gateway::dispatch`
+- `doctor` — `crate::dispatch::doctor::dispatch`
+- `logs` — `crate::dispatch::logs::dispatch`
+- `marketplace` — `crate::dispatch::marketplace::dispatch`
+- `acp` — `crate::dispatch::acp::dispatch::dispatch`
+
+`mcp/services/` is the **exception layer**, not the default. An adapter lives
+there only when it needs MCP-specific behavior that cannot be represented in
+shared dispatch alone — for example:
+
+- `deploy` sets the MCP elicitation context (`McpContext`) before calling the
+  shared dispatch, a protocol detail meaningless to CLI/API.
+- `fs` filters `fs.preview` out of MCP discovery.
+- `nodes` owns MCP-only enrollment actions with no CLI/API equivalent.
+
+Do not add a `mcp/services/<service>.rs` shim for a service unless it genuinely
+needs MCP-specific behavior. A pass-through shim that only delegates to dispatch
+adds indirection without value.
+
+There is no `Category::Acp` variant. ACP uses `Category::Ai` (set in
+`lab_apis::acp::META`), which is coherent: ACP is the agent protocol layer
+that fronts AI providers. Adding a new category variant for a single service
+would violate the stable 10-variant catalog defined in `core/plugin.rs`.
+
 ## `fs` registration
 
 `fs` registers unconditionally when the `fs` feature is enabled; runtime

--- a/crates/lab/src/dispatch/acp/catalog.rs
+++ b/crates/lab/src/dispatch/acp/catalog.rs
@@ -192,7 +192,7 @@ pub const ACTIONS: &[ActionSpec] = &[
                      not inject it. ToolCallUpdate events carry merged '_meta' (outer wrapper \
                      wins over any '_meta' already present in raw_output).",
         destructive: false,
-        returns: "Vec<AcpEvent>",
+        returns: r#"{ "events": AcpEvent[], "count": number }"#,
         params: &[
             ParamSpec {
                 name: "session_id",

--- a/crates/lab/src/dispatch/acp/catalog.rs
+++ b/crates/lab/src/dispatch/acp/catalog.rs
@@ -188,7 +188,10 @@ pub const ACTIONS: &[ActionSpec] = &[
         name: "session.events",
         description: "Get stored events for a session",
         destructive: false,
-        returns: "Value",
+        returns: "Vec<AcpEvent> — ProviderInfo events of type 'tool_call_metadata' carry \
+                 an optional '_meta' object relayed transparently from the originating agent; \
+                 key is absent (not null) when the agent did not inject it. \
+                 ToolCallUpdate events carry merged '_meta' (outer wrapper wins over raw_output).",
         params: &[
             ParamSpec {
                 name: "session_id",

--- a/crates/lab/src/dispatch/acp/catalog.rs
+++ b/crates/lab/src/dispatch/acp/catalog.rs
@@ -186,12 +186,13 @@ pub const ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "session.events",
-        description: "Get stored events for a session",
+        description: "Get stored events for a session. ProviderInfo events of type \
+                     'tool_call_metadata' carry an optional '_meta' object relayed transparently \
+                     from the originating agent; the key is absent (not null) when the agent did \
+                     not inject it. ToolCallUpdate events carry merged '_meta' (outer wrapper \
+                     wins over any '_meta' already present in raw_output).",
         destructive: false,
-        returns: "Vec<AcpEvent> — ProviderInfo events of type 'tool_call_metadata' carry \
-                 an optional '_meta' object relayed transparently from the originating agent; \
-                 key is absent (not null) when the agent did not inject it. \
-                 ToolCallUpdate events carry merged '_meta' (outer wrapper wins over raw_output).",
+        returns: "Vec<AcpEvent>",
         params: &[
             ParamSpec {
                 name: "session_id",

--- a/crates/lab/src/dispatch/acp/client.rs
+++ b/crates/lab/src/dispatch/acp/client.rs
@@ -17,12 +17,21 @@ fn registry_slot() -> &'static RwLock<Option<Arc<AcpSessionRegistry>>> {
 /// Install the shared registry into the process-global slot.
 ///
 /// Called once at startup (e.g. `cli/serve.rs`) with the same `Arc<AcpSessionRegistry>`
-/// that is stored in `AppState`. Panics if called a second time — use `#[cfg(test)]`
-/// helpers if tests need teardown.
+/// that is stored in `AppState`. Panics if called a second time; tests that need a fresh
+/// registry should call `reset_registry_for_testing()` between runs.
 pub fn install_registry(registry: Arc<AcpSessionRegistry>) {
     let mut slot = registry_slot().write().expect("ACP registry lock poisoned");
     assert!(slot.is_none(), "ACP registry installed twice");
     *slot = Some(registry);
+}
+
+/// Clear the process-global registry slot.
+///
+/// **For tests only.** Allows a test that called `install_registry` to reset state so
+/// subsequent calls in other tests do not panic on the double-install assert.
+#[cfg(test)]
+pub fn reset_registry_for_testing() {
+    *registry_slot().write().expect("ACP registry lock poisoned") = None;
 }
 
 /// Return the installed registry, or a structured error if not yet installed.

--- a/crates/lab/src/dispatch/acp/client.rs
+++ b/crates/lab/src/dispatch/acp/client.rs
@@ -17,9 +17,12 @@ fn registry_slot() -> &'static RwLock<Option<Arc<AcpSessionRegistry>>> {
 /// Install the shared registry into the process-global slot.
 ///
 /// Called once at startup (e.g. `cli/serve.rs`) with the same `Arc<AcpSessionRegistry>`
-/// that is stored in `AppState`. Subsequent `require_registry()` calls return this Arc.
+/// that is stored in `AppState`. Panics if called a second time — use `#[cfg(test)]`
+/// helpers if tests need teardown.
 pub fn install_registry(registry: Arc<AcpSessionRegistry>) {
-    *registry_slot().write().expect("ACP registry lock poisoned") = Some(registry);
+    let mut slot = registry_slot().write().expect("ACP registry lock poisoned");
+    assert!(slot.is_none(), "ACP registry installed twice");
+    *slot = Some(registry);
 }
 
 /// Return the installed registry, or a structured error if not yet installed.

--- a/crates/lab/src/dispatch/acp/client.rs
+++ b/crates/lab/src/dispatch/acp/client.rs
@@ -30,6 +30,7 @@ pub fn install_registry(registry: Arc<AcpSessionRegistry>) {
 /// **For tests only.** Allows a test that called `install_registry` to reset state so
 /// subsequent calls in other tests do not panic on the double-install assert.
 #[cfg(test)]
+#[allow(dead_code)]
 pub fn reset_registry_for_testing() {
     *registry_slot().write().expect("ACP registry lock poisoned") = None;
 }

--- a/crates/lab/src/dispatch/acp/persistence.rs
+++ b/crates/lab/src/dispatch/acp/persistence.rs
@@ -810,6 +810,10 @@ fn load_or_generate_hmac_key() -> Vec<u8> {
         }
     }
     tracing::warn!(
+        surface = "acp",
+        service = "persistence",
+        action = "hmac_key_init",
+        kind = "ephemeral_key",
         "LAB_ACP_HMAC_SECRET is not set; using an ephemeral non-random HMAC key. \
          Set LAB_ACP_HMAC_SECRET in ~/.lab/.env for persistent, \
          cryptographically-random protection."

--- a/crates/lab/src/dispatch/acp/persistence.rs
+++ b/crates/lab/src/dispatch/acp/persistence.rs
@@ -809,9 +809,13 @@ fn load_or_generate_hmac_key() -> Vec<u8> {
             return secret.into_bytes();
         }
     }
+    tracing::warn!(
+        "LAB_ACP_HMAC_SECRET is not set; using an ephemeral non-random HMAC key. \
+         Set LAB_ACP_HMAC_SECRET in ~/.lab/.env for persistent, \
+         cryptographically-random protection."
+    );
     // Derive a 32-byte key from process ID + monotonic time via SHA-256.
-    // This is NOT cryptographically random but is unique per process
-    // instance. For production, set LAB_ACP_HMAC_SECRET.
+    // NOT cryptographically random — unique per process instance only.
     use sha2::Digest;
     let pid = std::process::id();
     let now = std::time::SystemTime::now()

--- a/crates/lab/src/dispatch/redact.rs
+++ b/crates/lab/src/dispatch/redact.rs
@@ -22,6 +22,10 @@ pub fn is_sensitive_key(key: &str) -> bool {
             | "session_id"
             | "cookie"
             | "code"
+            | "cwd"
+            | "terminal_id"
+            | "signal"
+            | "data"
     ) || normalized.ends_with("_token")
         || normalized.ends_with("_secret")
         || normalized.ends_with("_password")

--- a/crates/lab/src/dispatch/redact.rs
+++ b/crates/lab/src/dispatch/redact.rs
@@ -24,8 +24,6 @@ pub fn is_sensitive_key(key: &str) -> bool {
             | "code"
             | "cwd"
             | "terminal_id"
-            | "signal"
-            | "data"
     ) || normalized.ends_with("_token")
         || normalized.ends_with("_secret")
         || normalized.ends_with("_password")

--- a/docs/acp/research-findings.md
+++ b/docs/acp/research-findings.md
@@ -153,13 +153,18 @@ mismatch. A unified `Provider` trait must either make these fields `Option<T>` o
 distinct session lifecycle models.
 
 **Best-practices finding:** `async fn in trait` is stable (Rust 1.75+) but `dyn Trait` with `async
-fn` is NOT object-safe (no stable solution as of 2026). Recommended approach: **enum dispatch** for
-the known provider set (Codex, Claude, Gemini, Copilot, OpenCode) via the `enum_dispatch` crate.
+fn` is NOT object-safe (no stable solution as of 2026). Recommended approach: **concrete types or
+generics** for the known provider set (Codex, Claude, Gemini, Copilot, OpenCode), with **enum
+dispatch** (`enum_dispatch` crate) as an ergonomic option for the closed set.
 
-The repository rule in `CLAUDE.md` forbids `Box<dyn ServiceClient>` and `#[async_trait]`: prefer
-generics or concrete types over dynamic dispatch. For a dynamic-registry path, keep enum dispatch
-for the closed provider set and use a dedicated extension-boundary adapter (for example, a
-`dynosaur`-style erased trait) instead of widening this into `Box<dyn ServiceClient>`.
+Repository conventions in `CLAUDE.md` are precise about what is forbidden: `Box<dyn ServiceClient>`
+is banned outright, `#[async_trait]` is banned, and `Box<dyn Trait>` is disfavored where `impl
+Trait` or generics are sufficient. These rules do not ban all dynamic dispatch — they ban the
+`ServiceClient` trait in particular from being object-erased. For a dynamic-registry extension path
+(third-party or plugin providers not in the closed set), an erased-trait adapter using a crate like
+`dynosaur` is acceptable at the extension boundary, precisely because it is not a `Box<dyn
+ServiceClient>`. Use concrete/enum dispatch for all known providers; reserve the erased adapter for
+the extension slot only.
 
 ---
 


### PR DESCRIPTION
## Summary

- **docs/acp/research-findings.md**: Fixed internal inconsistency in dynamic-registry guidance — the prohibition now accurately targets `Box<dyn ServiceClient>` and `#[async_trait]` (per CLAUDE.md), not all `Box<dyn Trait>`; `dynosaur` remains acceptable at the extension boundary (closes lab-0x7n, lab-c3pn, lab-ikhq)
- **apps/gateway-admin/README.md**: Added ACP stream lifecycle contract section covering ordering (monotonic seq), replay/resume (`?since=<seq>`), retention (SQLite authoritative, 10k-event cap, 500-event in-memory fallback), and backpressure (64-slot mpsc, eviction + synthetic event) (closes lab-kvji.20)
- **crates/lab-apis/src/acp_registry.rs**: `ACP_REGISTRY_URL` already in `META.optional_env`; `health()` already correctly maps network errors → unreachable, others → degraded (closes lab-f2b5, lab-kvuc — were pre-existing)
- **crates/lab/src/cli/serve.rs + api/state.rs**: Moved ACP registry initialization before HTTP/stdio split so MCP stdio mode has access (closes lab-ugux)
- **crates/lab/src/dispatch/CLAUDE.md**: Documented that always-on meta-services (ACP, gateway, extract, etc.) register directly from `dispatch::*` — this is the correct pattern, not a bypass (closes lab-kvhi.18)
- **crates/lab/src/acp/runtime.rs**: Preserve `_meta` from `ToolCall`/`ToolCallUpdate` through to AcpEvent payloads; P4 null-skip (omit `_meta` key when None); A9 outer-wins merge semantics; R5 full redaction of all `_meta` field values from tracing spans (closes lab-qn84.1)

## Skipped / blocked

- **lab-vwxg.4 / lab-vwxg.4.1**: Blocked by lab-vwxg.1.4 and lab-vwxg.2.3 (both open)
- **lab-lffl / lab-lffl.3 / lab-lffl.4**: Explicitly deferred — activation criteria not met
- **lab-l4xn / lab-brq8**: Swarm molecules for already-closed epics — closed directly

## Test plan

- [ ] `cargo check --workspace --all-features` passes
- [ ] `cargo test --all-features acp::runtime::tests` — 6 tests pass including 4 new ones (round-trip, outer-wins, null-skip, trace-redaction)
- [ ] Verify ACP actions work in MCP stdio mode (`lab --stdio`) after serve.rs change
- [ ] Confirm ACP stream lifecycle section in gateway-admin/README.md matches runtime.rs implementation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 1 ACP terminal display is live: we relay `_meta.terminal_output` (no server-hosted terminals) and stream output into Gateway Admin with safe, batched rendering. This also fixes registry wiring across HTTP/stdio, clarifies the stream lifecycle, and tightens redaction.

- **New Features**
  - ACP runtime: preserve `_meta`, omit when absent, and outer-wins merge into `raw_output`; advertise `_meta.terminal_output=true` while keeping `terminal=false`.
  - Gateway Admin: derive terminal state from `_meta`; strip OSC/ANSI with a 256KB tail cap; rAF-batched coalescing with backpressure and a 50k drop-oldest queue; prefer streamed terminal over raw; size caps (64KB/chunk, 1MB total); bounded terminal panel; per-message `version` for memoization; new artifact fields (`terminalOutput`, `webPreviewUrl`, `fileTreePaths`, `codeBlock`); permission kind takes precedence in presentation.
  - Docs: add ACP stream lifecycle contract (ordering, replay/resume with `?since=<seq>`, retention, backpressure) and clarify type/dispatch conventions in research findings; document UTF-16 code-unit semantics for terminal size limits.

- **Bug Fixes**
  - Chat terminal rendering: fix tail-cap for single-chunk inputs; preserve visible text when stripping OSC; prefer ACP terminal chunks when present; merge `permissionOptions`/`permissionSelection` from patches.
  - Registry: create one `AcpSessionRegistry` before the HTTP/stdio split and thread the same `Arc` via `with_acp_registry`; assert on double install; add `reset_registry_for_testing()`.
  - Docs/contract: redaction applies to the full persisted event JSON; `session.events` returns `{ events: AcpEvent[], count: number }`.
  - Runtime/hardening: remove a deep JSON clone in `tool_call_update_output`; never log `_meta` fields; clearer HMAC warning; add `cwd` and `terminal_id` to redaction keys.

<sup>Written for commit 3ae1d960ad34aa496e019a1ab03880eb3907c882. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/lab/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Terminal streaming per-call with chunking, tail-bounded rendering, sanitization, web-preview/file insights, permission metadata, and message versioning.

* **Improvements**
  - Bounded terminal panel with internal scroll; rAF event batching with queue backpressure/drop-oldest; clearer HMAC fallback warnings; expanded redaction keys (cwd, terminal_id); unified in-process session registry and backpressure signaling for subscribers.

* **Documentation**
  - Expanded ACP stream, replay, retention, and _meta semantics.

* **Tests**
  - Extensive terminal, streaming, sanitization, and performance tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->