### PR TITLE
feat: beads task tracking in Web UI via Dolt MySQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,12 +898,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1469,6 +1511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1738,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1950,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1898,6 +1964,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2687,6 +2762,7 @@ name = "lab-apis"
 version = "0.11.1"
 dependencies = [
  "base64",
+ "chrono",
  "futures",
  "insta",
  "jiff",
@@ -2699,6 +2775,8 @@ dependencies = [
  "russh-sftp",
  "serde",
  "serde_json",
+ "sqlx-core",
+ "sqlx-mysql",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2864,6 +2942,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "md5"
@@ -4222,7 +4310,7 @@ dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.11.0",
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
@@ -4995,6 +5083,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap 2.13.1",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array 0.14.7",
+ "hex",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa 0.9.10",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,6 +5210,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -5697,6 +5871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,6 +5890,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/apps/gateway-admin/app/(admin)/tasks/page.tsx
+++ b/apps/gateway-admin/app/(admin)/tasks/page.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { isErrorLike } from '@/lib/utils'
+import { BeadsError } from '@/lib/api/beads-client'
 import type { IssueListParams, IssueStatus, IssueType } from '@/lib/types/beads'
 
 const STATUS_OPTIONS: { value: IssueStatus | 'all'; label: string }[] = [
@@ -36,30 +37,9 @@ const TYPE_OPTIONS: { value: IssueType | 'all'; label: string }[] = [
   { value: 'chore', label: 'Chore' },
 ]
 
-function TaskDetailSkeleton() {
-  return (
-    <Card className="animate-pulse">
-      <CardHeader className="space-y-3">
-        <div className="h-3 w-1/4 rounded bg-muted" />
-        <div className="h-6 w-3/4 rounded bg-muted" />
-        <div className="flex gap-2">
-          <div className="h-5 w-16 rounded bg-muted" />
-          <div className="h-5 w-24 rounded bg-muted" />
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          <div className="h-3 w-full rounded bg-muted" />
-          <div className="h-3 w-5/6 rounded bg-muted" />
-          <div className="h-3 w-2/3 rounded bg-muted" />
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
 function TaskDetailView({ id }: { id: string }) {
   const { data: issue, isLoading, error } = useBead(id)
+  const notFound = error instanceof BeadsError && error.status === 404
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -72,25 +52,43 @@ function TaskDetailView({ id }: { id: string }) {
         </Button>
       </div>
 
-      {isLoading && !issue && <TaskDetailSkeleton />}
-
-      {error !== undefined && (
-        <Card>
-          <CardContent className="p-6 text-sm">
-            <p className="font-medium text-foreground">Could not load task</p>
-            <p className="mt-1 text-muted-foreground">
-              {isErrorLike(error) ? error.message : `Task ${id} could not be loaded.`}
-            </p>
+      {isLoading && !issue && (
+        <Card className="animate-pulse">
+          <CardHeader className="space-y-3">
+            <div className="h-3 w-1/4 rounded bg-muted" />
+            <div className="h-6 w-3/4 rounded bg-muted" />
+            <div className="flex gap-2">
+              <div className="h-5 w-16 rounded bg-muted" />
+              <div className="h-5 w-24 rounded bg-muted" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="h-3 w-full rounded bg-muted" />
+              <div className="h-3 w-5/6 rounded bg-muted" />
+              <div className="h-3 w-2/3 rounded bg-muted" />
+            </div>
           </CardContent>
         </Card>
       )}
 
-      {!isLoading && !error && !issue && (
+      {notFound && (
         <Card>
           <CardContent className="p-6 text-sm">
             <p className="font-medium text-foreground">Task not found</p>
             <p className="mt-1 text-muted-foreground">
               No task with id <code>{id}</code>.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {error !== undefined && !notFound && (
+        <Card>
+          <CardContent className="p-6 text-sm">
+            <p className="font-medium text-foreground">Could not load task</p>
+            <p className="mt-1 text-muted-foreground">
+              {isErrorLike(error) ? error.message : `Task ${id} could not be loaded.`}
             </p>
           </CardContent>
         </Card>
@@ -111,8 +109,7 @@ function TaskListView() {
 
   const { data: issues, isLoading, error } = useBeads(params)
 
-  const unavailable =
-    error !== undefined && isErrorLike(error) && error.code === 'beads_unavailable'
+  const unavailable = error instanceof BeadsError && error.code === 'beads_unavailable'
 
   return (
     <div className="flex flex-col gap-6 p-6">

--- a/apps/gateway-admin/app/(admin)/tasks/page.tsx
+++ b/apps/gateway-admin/app/(admin)/tasks/page.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { isErrorLike } from '@/lib/utils'
 import type { IssueListParams, IssueStatus, IssueType } from '@/lib/types/beads'
 
 const STATUS_OPTIONS: { value: IssueStatus | 'all'; label: string }[] = [
@@ -34,15 +35,6 @@ const TYPE_OPTIONS: { value: IssueType | 'all'; label: string }[] = [
   { value: 'feature', label: 'Feature' },
   { value: 'chore', label: 'Chore' },
 ]
-
-function isErrorLike(e: unknown): e is { message: string; code?: string } {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    'message' in e &&
-    typeof (e as { message: unknown }).message === 'string'
-  )
-}
 
 function TaskDetailSkeleton() {
   return (

--- a/apps/gateway-admin/app/(admin)/tasks/page.tsx
+++ b/apps/gateway-admin/app/(admin)/tasks/page.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import Link from 'next/link'
+import { Suspense, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+
+import { useBead, useBeads } from '@/lib/hooks/use-beads'
+import { TaskList } from '@/components/tasks/task-list'
+import { TaskDetail } from '@/components/tasks/task-detail'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { IssueListParams, IssueStatus, IssueType } from '@/lib/types/beads'
+
+const STATUS_OPTIONS: { value: IssueStatus | 'all'; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'closed', label: 'Closed' },
+]
+
+const TYPE_OPTIONS: { value: IssueType | 'all'; label: string }[] = [
+  { value: 'all', label: 'All types' },
+  { value: 'task', label: 'Task' },
+  { value: 'epic', label: 'Epic' },
+  { value: 'bug', label: 'Bug' },
+  { value: 'feature', label: 'Feature' },
+  { value: 'chore', label: 'Chore' },
+]
+
+function isErrorLike(e: unknown): e is { message: string; code?: string } {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'message' in e &&
+    typeof (e as { message: unknown }).message === 'string'
+  )
+}
+
+function TaskDetailSkeleton() {
+  return (
+    <Card className="animate-pulse">
+      <CardHeader className="space-y-3">
+        <div className="h-3 w-1/4 rounded bg-muted" />
+        <div className="h-6 w-3/4 rounded bg-muted" />
+        <div className="flex gap-2">
+          <div className="h-5 w-16 rounded bg-muted" />
+          <div className="h-5 w-24 rounded bg-muted" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <div className="h-3 w-full rounded bg-muted" />
+          <div className="h-3 w-5/6 rounded bg-muted" />
+          <div className="h-3 w-2/3 rounded bg-muted" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function TaskDetailView({ id }: { id: string }) {
+  const { data: issue, isLoading, error } = useBead(id)
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div>
+        <Button asChild variant="ghost" size="sm" className="-ml-2">
+          <Link href="/tasks/">
+            <ChevronLeft className="size-4" />
+            Back to tasks
+          </Link>
+        </Button>
+      </div>
+
+      {isLoading && !issue && <TaskDetailSkeleton />}
+
+      {error !== undefined && (
+        <Card>
+          <CardContent className="p-6 text-sm">
+            <p className="font-medium text-foreground">Could not load task</p>
+            <p className="mt-1 text-muted-foreground">
+              {isErrorLike(error) ? error.message : `Task ${id} could not be loaded.`}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !error && !issue && (
+        <Card>
+          <CardContent className="p-6 text-sm">
+            <p className="font-medium text-foreground">Task not found</p>
+            <p className="mt-1 text-muted-foreground">
+              No task with id <code>{id}</code>.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {issue && <TaskDetail issue={issue} />}
+    </div>
+  )
+}
+
+function TaskListView() {
+  const [status, setStatus] = useState<IssueStatus | 'all'>('open')
+  const [issueType, setIssueType] = useState<IssueType | 'all'>('all')
+
+  const params: IssueListParams = {}
+  if (status !== 'all') params.status = status
+  if (issueType !== 'all') params.issue_type = issueType
+
+  const { data: issues, isLoading, error } = useBeads(params)
+
+  const unavailable =
+    error !== undefined && isErrorLike(error) && error.code === 'beads_unavailable'
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Tasks</h1>
+        <p className="text-sm text-muted-foreground">
+          Read-only view of beads issues backed by the local Dolt MySQL server.
+        </p>
+      </header>
+
+      {unavailable && (
+        <Card>
+          <CardContent className="p-4 text-sm">
+            <p className="font-medium">Beads database unavailable</p>
+            <p className="mt-1 text-muted-foreground">
+              The Dolt server is not running, or its port file (
+              <code>.beads/dolt-server.port</code>) could not be found. Start the bd server
+              and reload this page.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Select value={status} onValueChange={(v) => setStatus(v as IssueStatus | 'all')}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={issueType} onValueChange={(v) => setIssueType(v as IssueType | 'all')}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <TaskList issues={issues} isLoading={isLoading} error={error} />
+    </div>
+  )
+}
+
+function TasksPageInner() {
+  const searchParams = useSearchParams()
+  const id = searchParams?.get('id') ?? null
+  if (id) return <TaskDetailView id={id} />
+  return <TaskListView />
+}
+
+export default function TasksPage() {
+  return (
+    <Suspense fallback={<div className="p-6">Loading…</div>}>
+      <TasksPageInner />
+    </Suspense>
+  )
+}

--- a/apps/gateway-admin/components/app-sidebar.tsx
+++ b/apps/gateway-admin/components/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Cable,
   MessageSquareText,
   LayoutDashboard,
+  ListTodo,
   Package,
   ShoppingBag,
   Settings,
@@ -47,6 +48,11 @@ export const primarySidebarNavigation = [
     title: 'Gateways',
     url: '/gateways',
     icon: Cable,
+  },
+  {
+    title: 'Tasks',
+    url: '/tasks',
+    icon: ListTodo,
   },
   {
     title: 'Registry',

--- a/apps/gateway-admin/components/tasks/task-card.tsx
+++ b/apps/gateway-admin/components/tasks/task-card.tsx
@@ -1,38 +1,15 @@
 import Link from 'next/link'
-import { Bug, BookOpen, CheckSquare, Settings, Zap } from 'lucide-react'
 
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TaskStatusBadge } from './task-status-badge'
 import { TaskPriorityBadge } from './task-priority-badge'
-import type { IssueSummary, IssueType } from '@/lib/types/beads'
-
-const TYPE_ICON: Record<IssueType, typeof Bug> = {
-  task: CheckSquare,
-  epic: BookOpen,
-  bug: Bug,
-  feature: Zap,
-  chore: Settings,
-}
-
-function formatRelativeTime(iso: string): string {
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return iso
-  const now = Date.now()
-  const diff = now - date.getTime()
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return date.toISOString().slice(0, 10)
-}
+import { TYPE_ICON } from './task-icons'
+import { formatUiRelativeTime } from '@/lib/format-ui-time'
+import type { IssueSummary } from '@/lib/types/beads'
 
 export function TaskCard({ issue }: { issue: IssueSummary }) {
-  const TypeIcon = TYPE_ICON[issue.issue_type] ?? CheckSquare
+  const TypeIcon = TYPE_ICON[issue.issue_type]
   return (
     <Link href={`/tasks/?id=${encodeURIComponent(issue.id)}`} className="block">
       <Card className="hover:bg-muted/40 transition-colors h-full">
@@ -40,7 +17,7 @@ export function TaskCard({ issue }: { issue: IssueSummary }) {
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <TypeIcon className="size-3" />
             <span className="font-mono">{issue.id}</span>
-            <span className="ml-auto">{formatRelativeTime(issue.updated_at)}</span>
+            <span className="ml-auto">{formatUiRelativeTime(issue.updated_at)}</span>
           </div>
           <h3 className="font-medium text-sm leading-snug line-clamp-2">{issue.title}</h3>
         </CardHeader>

--- a/apps/gateway-admin/components/tasks/task-card.tsx
+++ b/apps/gateway-admin/components/tasks/task-card.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link'
+import { Bug, BookOpen, CheckSquare, Settings, Zap } from 'lucide-react'
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { TaskStatusBadge } from './task-status-badge'
+import { TaskPriorityBadge } from './task-priority-badge'
+import type { IssueSummary, IssueType } from '@/lib/types/beads'
+
+const TYPE_ICON: Record<IssueType, typeof Bug> = {
+  task: CheckSquare,
+  epic: BookOpen,
+  bug: Bug,
+  feature: Zap,
+  chore: Settings,
+}
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  const now = Date.now()
+  const diff = now - date.getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return date.toISOString().slice(0, 10)
+}
+
+export function TaskCard({ issue }: { issue: IssueSummary }) {
+  const TypeIcon = TYPE_ICON[issue.issue_type] ?? CheckSquare
+  return (
+    <Link href={`/tasks/?id=${encodeURIComponent(issue.id)}`} className="block">
+      <Card className="hover:bg-muted/40 transition-colors h-full">
+        <CardHeader className="space-y-2 pb-2">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <TypeIcon className="size-3" />
+            <span className="font-mono">{issue.id}</span>
+            <span className="ml-auto">{formatRelativeTime(issue.updated_at)}</span>
+          </div>
+          <h3 className="font-medium text-sm leading-snug line-clamp-2">{issue.title}</h3>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2 pt-0">
+          <TaskStatusBadge status={issue.status} />
+          <TaskPriorityBadge priority={issue.priority} />
+          {issue.owner && (
+            <Badge variant="outline" className="font-mono text-xs">
+              {issue.owner}
+            </Badge>
+          )}
+          {issue.labels.slice(0, 3).map((label) => (
+            <Badge key={label} variant="secondary" className="text-xs">
+              {label}
+            </Badge>
+          ))}
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/apps/gateway-admin/components/tasks/task-detail.tsx
+++ b/apps/gateway-admin/components/tasks/task-detail.tsx
@@ -70,29 +70,39 @@ export function TaskDetail({ issue }: { issue: Issue }) {
         <TabsContent value="description">
           <Card>
             <CardContent className="p-6">
-              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
-                {issue.description || <span className="text-muted-foreground">No description.</span>}
-              </pre>
+              {issue.description ? (
+                <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                  {issue.description}
+                </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">No description.</p>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
         <TabsContent value="design">
           <Card>
             <CardContent className="p-6">
-              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
-                {issue.design || <span className="text-muted-foreground">No design notes.</span>}
-              </pre>
+              {issue.design ? (
+                <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                  {issue.design}
+                </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">No design notes.</p>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
         <TabsContent value="acceptance">
           <Card>
             <CardContent className="p-6">
-              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
-                {issue.acceptance_criteria || (
-                  <span className="text-muted-foreground">No acceptance criteria.</span>
-                )}
-              </pre>
+              {issue.acceptance_criteria ? (
+                <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                  {issue.acceptance_criteria}
+                </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">No acceptance criteria.</p>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/apps/gateway-admin/components/tasks/task-detail.tsx
+++ b/apps/gateway-admin/components/tasks/task-detail.tsx
@@ -1,29 +1,14 @@
-import { Bug, BookOpen, CheckSquare, Settings, Zap } from 'lucide-react'
-
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { TaskStatusBadge } from './task-status-badge'
 import { TaskPriorityBadge } from './task-priority-badge'
-import type { Issue, IssueType } from '@/lib/types/beads'
-
-const TYPE_ICON: Record<IssueType, typeof Bug> = {
-  task: CheckSquare,
-  epic: BookOpen,
-  bug: Bug,
-  feature: Zap,
-  chore: Settings,
-}
-
-function formatTime(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleString()
-}
+import { TYPE_ICON } from './task-icons'
+import { formatUiDateTime } from '@/lib/format-ui-time'
+import type { Issue } from '@/lib/types/beads'
 
 export function TaskDetail({ issue }: { issue: Issue }) {
-  const TypeIcon = TYPE_ICON[issue.issue_type] ?? CheckSquare
+  const TypeIcon = TYPE_ICON[issue.issue_type]
   return (
     <div className="flex flex-col gap-6">
       <Card>
@@ -55,16 +40,16 @@ export function TaskDetail({ issue }: { issue: Issue }) {
           </div>
           <div>
             <div className="text-xs text-muted-foreground">Created</div>
-            <div>{formatTime(issue.created_at)}</div>
+            <div>{formatUiDateTime(issue.created_at)}</div>
           </div>
           <div>
             <div className="text-xs text-muted-foreground">Updated</div>
-            <div>{formatTime(issue.updated_at)}</div>
+            <div>{formatUiDateTime(issue.updated_at)}</div>
           </div>
           {issue.closed_at && (
             <div>
               <div className="text-xs text-muted-foreground">Closed</div>
-              <div>{formatTime(issue.closed_at)}</div>
+              <div>{formatUiDateTime(issue.closed_at)}</div>
             </div>
           )}
           {issue.spec_id && (

--- a/apps/gateway-admin/components/tasks/task-detail.tsx
+++ b/apps/gateway-admin/components/tasks/task-detail.tsx
@@ -1,0 +1,117 @@
+import { Bug, BookOpen, CheckSquare, Settings, Zap } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { TaskStatusBadge } from './task-status-badge'
+import { TaskPriorityBadge } from './task-priority-badge'
+import type { Issue, IssueType } from '@/lib/types/beads'
+
+const TYPE_ICON: Record<IssueType, typeof Bug> = {
+  task: CheckSquare,
+  epic: BookOpen,
+  bug: Bug,
+  feature: Zap,
+  chore: Settings,
+}
+
+function formatTime(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString()
+}
+
+export function TaskDetail({ issue }: { issue: Issue }) {
+  const TypeIcon = TYPE_ICON[issue.issue_type] ?? CheckSquare
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader className="space-y-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <TypeIcon className="size-4" />
+            <span className="font-mono">{issue.id}</span>
+            <span className="capitalize">{issue.issue_type}</span>
+          </div>
+          <h1 className="text-xl font-semibold leading-snug">{issue.title}</h1>
+          <div className="flex flex-wrap gap-2">
+            <TaskStatusBadge status={issue.status} />
+            <TaskPriorityBadge priority={issue.priority} />
+            {issue.labels.map((label) => (
+              <Badge key={label} variant="secondary" className="text-xs">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div>
+            <div className="text-xs text-muted-foreground">Owner</div>
+            <div className="font-mono">{issue.owner ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Assignee</div>
+            <div className="font-mono">{issue.assignee ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Created</div>
+            <div>{formatTime(issue.created_at)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Updated</div>
+            <div>{formatTime(issue.updated_at)}</div>
+          </div>
+          {issue.closed_at && (
+            <div>
+              <div className="text-xs text-muted-foreground">Closed</div>
+              <div>{formatTime(issue.closed_at)}</div>
+            </div>
+          )}
+          {issue.spec_id && (
+            <div className="col-span-2">
+              <div className="text-xs text-muted-foreground">Spec</div>
+              <div className="font-mono text-xs break-all">{issue.spec_id}</div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="description" className="w-full">
+        <TabsList>
+          <TabsTrigger value="description">Description</TabsTrigger>
+          <TabsTrigger value="design">Design</TabsTrigger>
+          <TabsTrigger value="acceptance">Acceptance Criteria</TabsTrigger>
+        </TabsList>
+        <TabsContent value="description">
+          <Card>
+            <CardContent className="p-6">
+              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                {issue.description || <span className="text-muted-foreground">No description.</span>}
+              </pre>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="design">
+          <Card>
+            <CardContent className="p-6">
+              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                {issue.design || <span className="text-muted-foreground">No design notes.</span>}
+              </pre>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="acceptance">
+          <Card>
+            <CardContent className="p-6">
+              <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                {issue.acceptance_criteria || (
+                  <span className="text-muted-foreground">No acceptance criteria.</span>
+                )}
+              </pre>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/apps/gateway-admin/components/tasks/task-icons.ts
+++ b/apps/gateway-admin/components/tasks/task-icons.ts
@@ -1,0 +1,11 @@
+import { Bug, BookOpen, CheckSquare, Settings, Zap } from 'lucide-react'
+import type { IssueType } from '@/lib/types/beads'
+
+/** Map each issue type to its lucide icon component. */
+export const TYPE_ICON: Record<IssueType, typeof Bug> = {
+  task: CheckSquare,
+  epic: BookOpen,
+  bug: Bug,
+  feature: Zap,
+  chore: Settings,
+}

--- a/apps/gateway-admin/components/tasks/task-list.tsx
+++ b/apps/gateway-admin/components/tasks/task-list.tsx
@@ -1,16 +1,12 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { TaskCard } from './task-card'
+import { isErrorLike } from '@/lib/utils'
 import type { IssueSummary } from '@/lib/types/beads'
 
 interface TaskListProps {
   issues: IssueSummary[] | undefined
   isLoading: boolean
   error: unknown
-}
-
-function isErrorLike(e: unknown): e is { message: string } {
-  return typeof e === 'object' && e !== null && 'message' in e &&
-    typeof (e as { message: unknown }).message === 'string'
 }
 
 function TaskCardSkeleton() {

--- a/apps/gateway-admin/components/tasks/task-list.tsx
+++ b/apps/gateway-admin/components/tasks/task-list.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { TaskCard } from './task-card'
+import type { IssueSummary } from '@/lib/types/beads'
+
+interface TaskListProps {
+  issues: IssueSummary[] | undefined
+  isLoading: boolean
+  error: unknown
+}
+
+function isErrorLike(e: unknown): e is { message: string } {
+  return typeof e === 'object' && e !== null && 'message' in e &&
+    typeof (e as { message: unknown }).message === 'string'
+}
+
+function TaskCardSkeleton() {
+  return (
+    <Card className="h-32 animate-pulse">
+      <CardHeader className="space-y-2 pb-2">
+        <div className="h-3 w-1/3 rounded bg-muted" />
+        <div className="h-4 w-3/4 rounded bg-muted" />
+      </CardHeader>
+      <CardContent className="flex gap-2 pt-0">
+        <div className="h-5 w-16 rounded bg-muted" />
+        <div className="h-5 w-20 rounded bg-muted" />
+      </CardContent>
+    </Card>
+  )
+}
+
+export function TaskList({ issues, isLoading, error }: TaskListProps) {
+  if (isLoading && !issues) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <TaskCardSkeleton key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    const msg = isErrorLike(error) ? error.message : 'Failed to load tasks'
+    return (
+      <Card>
+        <CardContent className="p-6 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">Could not load tasks</p>
+          <p className="mt-1">{msg}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!issues || issues.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-12 text-center text-muted-foreground">
+          No tasks match the current filters.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {issues.map((issue) => (
+        <TaskCard key={issue.id} issue={issue} />
+      ))}
+    </div>
+  )
+}

--- a/apps/gateway-admin/components/tasks/task-priority-badge.tsx
+++ b/apps/gateway-admin/components/tasks/task-priority-badge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from '@/components/ui/badge'
+
+const PRIORITY_CONFIG: Record<number, { label: string; status: 'default' | 'warn' | 'error' }> = {
+  0: { label: 'P0 · Critical', status: 'error' },
+  1: { label: 'P1 · High', status: 'error' },
+  2: { label: 'P2 · Medium', status: 'warn' },
+  3: { label: 'P3 · Low', status: 'default' },
+  4: { label: 'P4 · Backlog', status: 'default' },
+}
+
+export function TaskPriorityBadge({ priority }: { priority: number }) {
+  const config = PRIORITY_CONFIG[priority] ?? PRIORITY_CONFIG[2]
+  return (
+    <Badge variant="outline" status={config.status}>
+      {config.label}
+    </Badge>
+  )
+}

--- a/apps/gateway-admin/components/tasks/task-status-badge.tsx
+++ b/apps/gateway-admin/components/tasks/task-status-badge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from '@/components/ui/badge'
+import type { IssueStatus } from '@/lib/types/beads'
+
+const STATUS_CONFIG: Record<IssueStatus, { label: string; status: 'default' | 'warn' | 'success' }> = {
+  open: { label: 'Open', status: 'default' },
+  in_progress: { label: 'In Progress', status: 'warn' },
+  closed: { label: 'Closed', status: 'success' },
+}
+
+export function TaskStatusBadge({ status }: { status: IssueStatus }) {
+  const config = STATUS_CONFIG[status] ?? STATUS_CONFIG.open
+  return (
+    <Badge variant="pill" status={config.status}>
+      {config.label}
+    </Badge>
+  )
+}

--- a/apps/gateway-admin/lib/api/beads-client.ts
+++ b/apps/gateway-admin/lib/api/beads-client.ts
@@ -1,0 +1,78 @@
+import { beadsActionUrl } from './gateway-config.ts'
+import { performServiceAction, type ServiceActionError } from './service-action-client.ts'
+import {
+  IssueSchema,
+  IssueListResponseSchema,
+  type Issue,
+  type IssueSummary,
+  type IssueListParams,
+} from '../types/beads'
+
+// TODO(lab-5t4b.5): write functions (createIssue, updateIssue, closeIssue,
+// reopenIssue, addComment, listLabels) are deferred — v1 is read-only.
+
+export class BeadsError extends Error implements ServiceActionError {
+  status: number
+  code?: string
+
+  constructor(message: string, status: number, code?: string) {
+    super(message)
+    this.name = 'BeadsError'
+    this.status = status
+    this.code = code
+  }
+}
+
+async function beadsAction<T>(
+  action: string,
+  params: object = {},
+  signal?: AbortSignal,
+): Promise<T> {
+  return performServiceAction<T, BeadsError>({
+    action,
+    params,
+    signal,
+    serviceLabel: 'Beads',
+    url: beadsActionUrl(),
+    createError: (msg, status, code) => new BeadsError(msg, status, code),
+  })
+}
+
+/**
+ * List issues with optional filters.
+ *
+ * Validates the response shape via the Zod schema using `safeParse` — any
+ * fields the backend doesn't recognise are dropped silently rather than
+ * forcing the whole call to fail.
+ */
+export async function listIssues(
+  params: IssueListParams = {},
+  signal?: AbortSignal,
+): Promise<IssueSummary[]> {
+  const raw = await beadsAction<unknown>('issue.list', params, signal)
+  const parsed = IssueListResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    throw new BeadsError(
+      `Beads issue.list response did not match schema: ${parsed.error.message}`,
+      502,
+      'decode_error',
+    )
+  }
+  return parsed.data.issues
+}
+
+/**
+ * Fetch one issue by id.
+ */
+export async function getIssue(id: string, signal?: AbortSignal): Promise<Issue> {
+  const raw = await beadsAction<unknown>('issue.get', { id }, signal)
+  const parsed = IssueSchema.safeParse(raw)
+  if (!parsed.success) {
+    throw new BeadsError(
+      `Beads issue.get response did not match schema: ${parsed.error.message}`,
+      502,
+      'decode_error',
+    )
+  }
+  return parsed.data
+}

--- a/apps/gateway-admin/lib/api/gateway-config.ts
+++ b/apps/gateway-admin/lib/api/gateway-config.ts
@@ -15,6 +15,10 @@ export function marketplaceActionUrl(baseUrl?: string): string {
   return `${normalizeGatewayApiBase(baseUrl)}/marketplace`
 }
 
+export function beadsActionUrl(baseUrl?: string): string {
+  return `${normalizeGatewayApiBase(baseUrl)}/beads`
+}
+
 export function nodesUrl(baseUrl?: string): string {
   return `${normalizeGatewayApiBase(baseUrl)}/nodes`
 }

--- a/apps/gateway-admin/lib/hooks/use-beads.ts
+++ b/apps/gateway-admin/lib/hooks/use-beads.ts
@@ -69,9 +69,9 @@ export function useBeads(params: IssueListParams = {}) {
   const key = `beads:list:${stableParams(params as Record<string, unknown>)}`
   return useSWR<IssueSummary[]>(
     key,
-    (_key: string, { signal }: { signal: AbortSignal }) => {
+    (_key: string) => {
       if (MOCK_DATA_ENABLED) return Promise.resolve(MOCK_ISSUES)
-      return beadsApi.listIssues(params, signal)
+      return beadsApi.listIssues(params)
     },
     {
       refreshInterval: 30_000,
@@ -84,14 +84,14 @@ export function useBead(id: string | null) {
   const key = id ? `beads:detail:${id}` : null
   return useSWR<Issue | undefined>(
     key,
-    (_key: string, { signal }: { signal: AbortSignal }) => {
+    (_key: string) => {
       // SWR never invokes the fetcher when key is null, so `id` is non-null
       // here. The closure still captures the latest `id` because the cache
       // key changes whenever it does.
       if (MOCK_DATA_ENABLED) {
         return Promise.resolve(MOCK_DETAIL.id === id ? MOCK_DETAIL : undefined)
       }
-      return beadsApi.getIssue(id as string, signal)
+      return beadsApi.getIssue(id as string)
     },
     {
       refreshInterval: 30_000,

--- a/apps/gateway-admin/lib/hooks/use-beads.ts
+++ b/apps/gateway-admin/lib/hooks/use-beads.ts
@@ -15,10 +15,7 @@ function stableParams(params: Record<string, unknown>): string {
   const entries = Object.entries(params)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => a.localeCompare(b))
-  if (entries.length === 0) return ''
-  const obj: Record<string, unknown> = {}
-  for (const [k, v] of entries) obj[k] = v
-  return JSON.stringify(obj)
+  return entries.length === 0 ? '' : JSON.stringify(Object.fromEntries(entries))
 }
 
 const MOCK_ISSUES: IssueSummary[] = [
@@ -29,8 +26,8 @@ const MOCK_ISSUES: IssueSummary[] = [
     priority: 2,
     issue_type: 'epic' as IssueType,
     owner: 'jmagar@gmail.com',
-    created_at: '2026-04-26T22:00:00',
-    updated_at: '2026-04-26T22:00:00',
+    created_at: '2026-04-26T22:00:00Z',
+    updated_at: '2026-04-26T22:00:00Z',
     labels: [],
   },
   {
@@ -40,8 +37,8 @@ const MOCK_ISSUES: IssueSummary[] = [
     priority: 2,
     issue_type: 'task' as IssueType,
     owner: 'jmagar@gmail.com',
-    created_at: '2026-04-26T22:30:00',
-    updated_at: '2026-04-26T22:30:00',
+    created_at: '2026-04-26T22:30:00Z',
+    updated_at: '2026-04-26T22:30:00Z',
     labels: [],
   },
   {
@@ -51,8 +48,8 @@ const MOCK_ISSUES: IssueSummary[] = [
     priority: 2,
     issue_type: 'task' as IssueType,
     owner: 'jmagar@gmail.com',
-    created_at: '2026-04-26T22:45:00',
-    updated_at: '2026-04-26T22:45:00',
+    created_at: '2026-04-26T22:45:00Z',
+    updated_at: '2026-04-26T22:45:00Z',
     labels: [],
   },
 ]
@@ -72,9 +69,9 @@ export function useBeads(params: IssueListParams = {}) {
   const key = `beads:list:${stableParams(params as Record<string, unknown>)}`
   return useSWR<IssueSummary[]>(
     key,
-    async () => {
-      if (MOCK_DATA_ENABLED) return MOCK_ISSUES
-      return beadsApi.listIssues(params)
+    (_key: string, { signal }: { signal: AbortSignal }) => {
+      if (MOCK_DATA_ENABLED) return Promise.resolve(MOCK_ISSUES)
+      return beadsApi.listIssues(params, signal)
     },
     {
       refreshInterval: 30_000,
@@ -85,16 +82,20 @@ export function useBeads(params: IssueListParams = {}) {
 
 export function useBead(id: string | null) {
   const key = id ? `beads:detail:${id}` : null
-  return useSWR<Issue | null>(
+  return useSWR<Issue | undefined>(
     key,
-    async () => {
-      if (!id) return null
+    (_key: string, { signal }: { signal: AbortSignal }) => {
+      // SWR never invokes the fetcher when key is null, so `id` is non-null
+      // here. The closure still captures the latest `id` because the cache
+      // key changes whenever it does.
       if (MOCK_DATA_ENABLED) {
-        return MOCK_DETAIL.id === id ? MOCK_DETAIL : null
+        return Promise.resolve(MOCK_DETAIL.id === id ? MOCK_DETAIL : undefined)
       }
-      return beadsApi.getIssue(id)
+      return beadsApi.getIssue(id as string, signal)
     },
     {
+      refreshInterval: 30_000,
+      revalidateOnMount: true,
       revalidateOnFocus: false,
     },
   )

--- a/apps/gateway-admin/lib/hooks/use-beads.ts
+++ b/apps/gateway-admin/lib/hooks/use-beads.ts
@@ -1,0 +1,101 @@
+'use client'
+
+import useSWR from 'swr'
+import * as beadsApi from '../api/beads-client'
+import type { Issue, IssueSummary, IssueListParams, IssueStatus, IssueType } from '../types/beads'
+
+const MOCK_DATA_ENABLED = process.env.NEXT_PUBLIC_MOCK_DATA === 'true'
+
+/**
+ * Sort and JSON-stringify a params object, dropping `undefined` values so
+ * that two filter sets that differ only in undefined keys produce the same
+ * SWR cache key. Project convention is STRING keys for SWR.
+ */
+function stableParams(params: Record<string, unknown>): string {
+  const entries = Object.entries(params)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+  if (entries.length === 0) return ''
+  const obj: Record<string, unknown> = {}
+  for (const [k, v] of entries) obj[k] = v
+  return JSON.stringify(obj)
+}
+
+const MOCK_ISSUES: IssueSummary[] = [
+  {
+    id: 'lab-5t4b',
+    title: 'feat: beads task tracking in Web UI via Dolt MySQL backend',
+    status: 'open' as IssueStatus,
+    priority: 2,
+    issue_type: 'epic' as IssueType,
+    owner: 'jmagar@gmail.com',
+    created_at: '2026-04-26T22:00:00',
+    updated_at: '2026-04-26T22:00:00',
+    labels: [],
+  },
+  {
+    id: 'lab-5t4b.1',
+    title: 'Add sqlx MySQL dependency and beads service to lab-apis',
+    status: 'closed' as IssueStatus,
+    priority: 2,
+    issue_type: 'task' as IssueType,
+    owner: 'jmagar@gmail.com',
+    created_at: '2026-04-26T22:30:00',
+    updated_at: '2026-04-26T22:30:00',
+    labels: [],
+  },
+  {
+    id: 'lab-5t4b.2',
+    title: 'Add beads dispatch layer and wire into lab CLI/API/registry',
+    status: 'in_progress' as IssueStatus,
+    priority: 2,
+    issue_type: 'task' as IssueType,
+    owner: 'jmagar@gmail.com',
+    created_at: '2026-04-26T22:45:00',
+    updated_at: '2026-04-26T22:45:00',
+    labels: [],
+  },
+]
+
+const MOCK_DETAIL: Issue = {
+  ...MOCK_ISSUES[0],
+  description: 'Track and view beads issues directly from the gateway-admin UI.',
+  design: '',
+  acceptance_criteria: '',
+  assignee: null,
+  created_by: null,
+  closed_at: null,
+  spec_id: null,
+}
+
+export function useBeads(params: IssueListParams = {}) {
+  const key = `beads:list:${stableParams(params as Record<string, unknown>)}`
+  return useSWR<IssueSummary[]>(
+    key,
+    async () => {
+      if (MOCK_DATA_ENABLED) return MOCK_ISSUES
+      return beadsApi.listIssues(params)
+    },
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: false,
+    },
+  )
+}
+
+export function useBead(id: string | null) {
+  const key = id ? `beads:detail:${id}` : null
+  return useSWR<Issue | null>(
+    key,
+    async () => {
+      if (!id) return null
+      if (MOCK_DATA_ENABLED) {
+        return MOCK_DETAIL.id === id ? MOCK_DETAIL : null
+      }
+      return beadsApi.getIssue(id)
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  )
+}

--- a/apps/gateway-admin/lib/types/beads.ts
+++ b/apps/gateway-admin/lib/types/beads.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+// Status values from the bd tool. `.catch('open')` keeps the schema tolerant
+// when the backend introduces new states without forcing a hard parse error.
+export const IssueStatusSchema = z.enum(['open', 'closed', 'in_progress']).catch('open')
+export type IssueStatus = z.infer<typeof IssueStatusSchema>
+
+export const IssueTypeSchema = z
+  .enum(['task', 'epic', 'bug', 'feature', 'chore'])
+  .catch('task')
+export type IssueType = z.infer<typeof IssueTypeSchema>
+
+export const IssueSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: IssueStatusSchema,
+  priority: z.number().int().min(0).max(4),
+  issue_type: IssueTypeSchema,
+  owner: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  // Always [] from list endpoint; populated only by issue.get.
+  labels: z.array(z.string()).default([]),
+})
+export type IssueSummary = z.infer<typeof IssueSummarySchema>
+
+export const IssueSchema = IssueSummarySchema.extend({
+  description: z.string().default(''),
+  design: z.string().default(''),
+  acceptance_criteria: z.string().default(''),
+  assignee: z.string().nullable().default(null),
+  created_by: z.string().nullable().default(null),
+  closed_at: z.string().nullable().default(null),
+  spec_id: z.string().nullable().default(null),
+})
+export type Issue = z.infer<typeof IssueSchema>
+
+export const IssueListResponseSchema = z.object({
+  issues: z.array(IssueSummarySchema).default([]),
+})
+export type IssueListResponse = z.infer<typeof IssueListResponseSchema>
+
+export interface IssueListParams {
+  status?: IssueStatus
+  issue_type?: IssueType
+  owner?: string
+  label?: string
+  limit?: number
+  offset?: number
+}

--- a/apps/gateway-admin/lib/utils.ts
+++ b/apps/gateway-admin/lib/utils.ts
@@ -11,3 +11,16 @@ export function getErrorMessage(error: unknown, fallback: string) {
   }
   return fallback
 }
+
+/**
+ * Narrow `unknown` to an object with a string `message` field (and optional
+ * string `code` field). Useful for narrowing SWR errors before rendering.
+ */
+export function isErrorLike(e: unknown): e is { message: string; code?: string } {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'message' in e &&
+    typeof (e as { message: unknown }).message === 'string'
+  )
+}

--- a/apps/gateway-admin/next-env.d.ts
+++ b/apps/gateway-admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/gateway-admin/next.config.mjs
+++ b/apps/gateway-admin/next.config.mjs
@@ -14,8 +14,16 @@ if (process.env.LAB_ALLOWED_DEV_ORIGINS) {
   }
 }
 
+const LAB_BACKEND = process.env.LAB_BACKEND_URL ?? 'http://localhost:8765'
+
 const nextConfig = {
   output: 'export',
+  async rewrites() {
+    return [
+      { source: '/v1/:path*', destination: `${LAB_BACKEND}/v1/:path*` },
+      { source: '/auth/:path*', destination: `${LAB_BACKEND}/auth/:path*` },
+    ]
+  },
   turbopack: {
     root: dirname,
   },

--- a/crates/lab-apis/Cargo.toml
+++ b/crates/lab-apis/Cargo.toml
@@ -29,6 +29,9 @@ russh-config.workspace = true
 quick-xml.workspace    = true
 rusqlite.workspace     = true
 tempfile.workspace     = true
+chrono                 = { version = "0.4", default-features = false, features = ["serde", "clock"], optional = true }
+sqlx-core              = { version = "0.8.6", default-features = false, features = ["_rt-tokio", "_tls-rustls-aws-lc-rs"], optional = true }
+sqlx-mysql             = { version = "0.8.6", default-features = false, features = ["chrono"], optional = true }
 
 [dev-dependencies]
 tokio       = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
@@ -58,6 +61,7 @@ openai      = []
 qdrant      = []
 tei         = []
 apprise     = []
+beads       = ["dep:sqlx-core", "dep:sqlx-mysql", "dep:chrono"]
 deploy      = []
 mcpregistry  = []
 acp_registry = []
@@ -69,6 +73,7 @@ all = [
     "memos", "bytestash", "paperless",
     "arcane", "unraid", "unifi",
     "gotify", "openai", "qdrant", "tei", "apprise",
+    "beads",
     "deploy", "mcpregistry", "acp_registry",
 ]
 

--- a/crates/lab-apis/src/beads.rs
+++ b/crates/lab-apis/src/beads.rs
@@ -1,0 +1,35 @@
+//! Beads — local task and issue tracker backed by Dolt MySQL.
+//!
+//! Connects to a local Dolt server (MySQL wire protocol) running on a port
+//! discovered at runtime from `.beads/dolt-server.port`. The default database
+//! is `lab` with user `root` and no password.
+//!
+//! Read-only v1 — list and get issues. Writes (create, update, close, comment)
+//! are deferred to a follow-up bead.
+
+/// `BeadsClient` — Dolt MySQL access for the beads schema.
+pub mod client;
+
+/// Beads error taxonomy.
+pub mod error;
+
+/// Request/response types.
+pub mod types;
+
+pub use client::BeadsClient;
+pub use error::BeadsError;
+
+use crate::core::plugin::{Category, PluginMeta};
+
+/// Compile-time metadata for the beads module.
+pub const META: PluginMeta = PluginMeta {
+    name: "beads",
+    display_name: "Beads",
+    description: "Local task and issue tracker backed by Dolt MySQL",
+    category: Category::Bootstrap,
+    docs_url: "https://github.com/steveyegge/beads",
+    required_env: &[],
+    optional_env: &[],
+    default_port: None,
+    supports_multi_instance: false,
+};

--- a/crates/lab-apis/src/beads/client.rs
+++ b/crates/lab-apis/src/beads/client.rs
@@ -175,10 +175,16 @@ impl BeadsClient {
     /// Returns `BeadsError::NotFound` when the id does not match a row,
     /// `BeadsError::Database` on connection or query failure.
     pub async fn get_issue(&self, id: &str) -> Result<Issue, BeadsError> {
+        // Pin both the SET SESSION and the SELECT to the same pool connection.
+        // sqlx pools may otherwise hand out a different connection for the
+        // SELECT, in which case the per-session group_concat_max_len bump has
+        // no effect and labels silently truncate at 1024 bytes.
+        let mut conn = self.pool.acquire().await?;
+
         // group_concat truncates by default at 1024 bytes — extend the per-
         // session limit so issues with many labels do not silently truncate.
         sqlx_core::query::query("SET SESSION group_concat_max_len = 65536")
-            .execute(&self.pool)
+            .execute(&mut *conn)
             .await?;
 
         let row = sqlx_core::query::query(
@@ -190,7 +196,7 @@ impl BeadsClient {
              WHERE i.id = ? GROUP BY i.id LIMIT 1",
         )
         .bind(id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *conn)
         .await?;
 
         let row = row.ok_or_else(|| BeadsError::NotFound { id: id.to_string() })?;
@@ -220,48 +226,4 @@ impl BeadsClient {
         })
     }
 
-    /// Search issues by title or description substring.
-    ///
-    /// `%` and `_` in `term` are escaped so they cannot act as wildcards.
-    ///
-    /// # Errors
-    ///
-    /// Returns `BeadsError::Database` on connection or query failure.
-    pub async fn search_issues(
-        &self,
-        term: &str,
-        limit: i64,
-    ) -> Result<Vec<IssueSummary>, BeadsError> {
-        let safe = term.replace('\\', r"\\").replace('%', r"\%").replace('_', r"\_");
-        let pattern = format!("%{safe}%");
-        let limit = limit.clamp(1, MAX_LIST_LIMIT);
-
-        let rows = sqlx_core::query::query(
-            "SELECT i.id, i.title, i.status, i.priority, i.issue_type, i.owner, \
-             i.created_at, i.updated_at FROM issues i \
-             WHERE i.title LIKE ? ESCAPE '\\\\' OR i.description LIKE ? ESCAPE '\\\\' \
-             ORDER BY i.updated_at DESC LIMIT ?",
-        )
-        .bind(&pattern)
-        .bind(&pattern)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-
-        let mut out = Vec::with_capacity(rows.len());
-        for row in rows {
-            out.push(IssueSummary {
-                id: row.try_get("id")?,
-                title: row.try_get("title")?,
-                status: row.try_get("status")?,
-                priority: row.try_get("priority")?,
-                issue_type: row.try_get("issue_type")?,
-                owner: row.try_get::<Option<String>, _>("owner")?,
-                created_at: row.try_get("created_at")?,
-                updated_at: row.try_get("updated_at")?,
-                labels: Vec::new(),
-            });
-        }
-        Ok(out)
-    }
 }

--- a/crates/lab-apis/src/beads/client.rs
+++ b/crates/lab-apis/src/beads/client.rs
@@ -1,0 +1,267 @@
+//! Beads MySQL client.
+//!
+//! Connects to a Dolt MySQL server, dispatched per-bead to the local lab
+//! database. The schema is the bd tool's issues table — see the `types`
+//! module for the columns we project.
+//!
+//! Connection pool, runtime queries, no compile-time macros (no
+//! DATABASE_URL required). The pool is constructed once at startup and
+//! shared via `Arc` from `AppState`.
+
+use sqlx_core::pool::PoolOptions;
+use sqlx_core::row::Row;
+use sqlx_mysql::{MySql, MySqlPool};
+use std::time::Duration;
+
+type MySqlPoolOptions = PoolOptions<MySql>;
+
+use super::error::BeadsError;
+use super::types::{Issue, IssueListParams, IssueSummary};
+
+/// Allowlisted ORDER BY columns for list queries.
+///
+/// User input is matched against this list before being interpolated into
+/// the SQL string — never interpolate raw column names.
+const ORDER_COLUMNS: &[&str] = &["created_at", "updated_at", "title", "priority", "status"];
+
+/// Default LIMIT applied when callers do not specify one.
+const DEFAULT_LIST_LIMIT: i64 = 50;
+/// Hard upper bound on `limit`.
+const MAX_LIST_LIMIT: i64 = 200;
+
+/// MySQL connection pool wrapping the Dolt server.
+#[derive(Clone)]
+pub struct BeadsClient {
+    pool: MySqlPool,
+}
+
+impl std::fmt::Debug for BeadsClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BeadsClient").finish_non_exhaustive()
+    }
+}
+
+impl BeadsClient {
+    /// Construct a client from a fully-formed MySQL DSN.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BeadsError::Database` when pool construction fails.
+    pub async fn connect(dsn: &str) -> Result<Self, BeadsError> {
+        let pool = MySqlPoolOptions::new()
+            .max_connections(5)
+            .min_connections(1)
+            .acquire_timeout(Duration::from_secs(5))
+            .idle_timeout(Some(Duration::from_secs(30)))
+            .connect(dsn)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    /// Construct a client wrapping an existing pool — useful in tests.
+    #[must_use]
+    pub fn from_pool(pool: MySqlPool) -> Self {
+        Self { pool }
+    }
+
+    /// Construct a client with a lazily-connected pool.
+    ///
+    /// The pool does not open a TCP connection until the first query.
+    /// Suitable for startup paths that must not block on a Dolt round-trip.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BeadsError::Database` when the DSN is malformed.
+    pub fn lazy(dsn: &str) -> Result<Self, BeadsError> {
+        let pool = MySqlPoolOptions::new()
+            .max_connections(5)
+            .min_connections(0)
+            .acquire_timeout(Duration::from_secs(5))
+            .idle_timeout(Some(Duration::from_secs(30)))
+            .connect_lazy(dsn)?;
+        Ok(Self { pool })
+    }
+
+    /// Borrow the underlying pool.
+    #[must_use]
+    pub fn pool(&self) -> &MySqlPool {
+        &self.pool
+    }
+
+    /// List issues with optional filters and pagination.
+    ///
+    /// Labels are NOT joined — every returned `IssueSummary` has
+    /// `labels = vec![]`. Use `get_issue` for full label data.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BeadsError::Database` on connection or query failure.
+    pub async fn list_issues(
+        &self,
+        params: &IssueListParams,
+    ) -> Result<Vec<IssueSummary>, BeadsError> {
+        let limit = params
+            .limit
+            .unwrap_or(DEFAULT_LIST_LIMIT)
+            .clamp(1, MAX_LIST_LIMIT);
+        let offset = params.offset.unwrap_or(0).max(0);
+
+        // Default ordering — priority ASC then updated_at DESC. Always validated
+        // against the static allowlist; we never interpolate user-supplied
+        // column names.
+        debug_assert!(ORDER_COLUMNS.contains(&"priority"));
+        debug_assert!(ORDER_COLUMNS.contains(&"updated_at"));
+
+        // Construct the WHERE clause dynamically. We use sqlx_core::query::query and
+        // .bind() for every parameter — no string interpolation of user input.
+        let mut sql = String::from(
+            "SELECT i.id, i.title, i.status, i.priority, i.issue_type, i.owner, \
+             i.created_at, i.updated_at \
+             FROM issues i WHERE 1=1",
+        );
+
+        if params.status.is_some() {
+            sql.push_str(" AND i.status = ?");
+        }
+        if params.issue_type.is_some() {
+            sql.push_str(" AND i.issue_type = ?");
+        }
+        if params.owner.is_some() {
+            sql.push_str(" AND i.owner = ?");
+        }
+        if params.label.is_some() {
+            // Use IN subquery to avoid duplicating rows on labels join.
+            sql.push_str(" AND i.id IN (SELECT issue_id FROM labels WHERE label = ?)");
+        }
+        sql.push_str(" ORDER BY i.priority ASC, i.updated_at DESC LIMIT ? OFFSET ?");
+
+        let mut q = sqlx_core::query::query(&sql);
+        if let Some(s) = &params.status {
+            q = q.bind(s);
+        }
+        if let Some(t) = &params.issue_type {
+            q = q.bind(t);
+        }
+        if let Some(o) = &params.owner {
+            q = q.bind(o);
+        }
+        if let Some(l) = &params.label {
+            q = q.bind(l);
+        }
+        q = q.bind(limit).bind(offset);
+
+        let rows = q.fetch_all(&self.pool).await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(IssueSummary {
+                id: row.try_get("id")?,
+                title: row.try_get("title")?,
+                status: row.try_get("status")?,
+                priority: row.try_get("priority")?,
+                issue_type: row.try_get("issue_type")?,
+                owner: row.try_get::<Option<String>, _>("owner")?,
+                created_at: row.try_get("created_at")?,
+                updated_at: row.try_get("updated_at")?,
+                labels: Vec::new(),
+            });
+        }
+        Ok(out)
+    }
+
+    /// Fetch one issue by id, joining its labels via `GROUP_CONCAT`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BeadsError::NotFound` when the id does not match a row,
+    /// `BeadsError::Database` on connection or query failure.
+    pub async fn get_issue(&self, id: &str) -> Result<Issue, BeadsError> {
+        // group_concat truncates by default at 1024 bytes — extend the per-
+        // session limit so issues with many labels do not silently truncate.
+        sqlx_core::query::query("SET SESSION group_concat_max_len = 65536")
+            .execute(&self.pool)
+            .await?;
+
+        let row = sqlx_core::query::query(
+            "SELECT i.id, i.title, i.description, i.design, i.acceptance_criteria, \
+             i.status, i.priority, i.issue_type, i.owner, i.assignee, i.created_by, \
+             i.created_at, i.updated_at, i.closed_at, i.spec_id, \
+             COALESCE(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR '\u{1f}'), '') AS labels \
+             FROM issues i LEFT JOIN labels l ON l.issue_id = i.id \
+             WHERE i.id = ? GROUP BY i.id LIMIT 1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let row = row.ok_or_else(|| BeadsError::NotFound { id: id.to_string() })?;
+        let labels_raw: String = row.try_get("labels")?;
+        let labels = if labels_raw.is_empty() {
+            Vec::new()
+        } else {
+            labels_raw.split('\u{1f}').map(str::to_string).collect()
+        };
+        Ok(Issue {
+            id: row.try_get("id")?,
+            title: row.try_get("title")?,
+            description: row.try_get("description")?,
+            design: row.try_get("design")?,
+            acceptance_criteria: row.try_get("acceptance_criteria")?,
+            status: row.try_get("status")?,
+            priority: row.try_get("priority")?,
+            issue_type: row.try_get("issue_type")?,
+            owner: row.try_get::<Option<String>, _>("owner")?,
+            assignee: row.try_get::<Option<String>, _>("assignee")?,
+            created_by: row.try_get::<Option<String>, _>("created_by")?,
+            created_at: row.try_get("created_at")?,
+            updated_at: row.try_get("updated_at")?,
+            closed_at: row.try_get::<Option<_>, _>("closed_at")?,
+            spec_id: row.try_get::<Option<String>, _>("spec_id")?,
+            labels,
+        })
+    }
+
+    /// Search issues by title or description substring.
+    ///
+    /// `%` and `_` in `term` are escaped so they cannot act as wildcards.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BeadsError::Database` on connection or query failure.
+    pub async fn search_issues(
+        &self,
+        term: &str,
+        limit: i64,
+    ) -> Result<Vec<IssueSummary>, BeadsError> {
+        let safe = term.replace('\\', r"\\").replace('%', r"\%").replace('_', r"\_");
+        let pattern = format!("%{safe}%");
+        let limit = limit.clamp(1, MAX_LIST_LIMIT);
+
+        let rows = sqlx_core::query::query(
+            "SELECT i.id, i.title, i.status, i.priority, i.issue_type, i.owner, \
+             i.created_at, i.updated_at FROM issues i \
+             WHERE i.title LIKE ? ESCAPE '\\\\' OR i.description LIKE ? ESCAPE '\\\\' \
+             ORDER BY i.updated_at DESC LIMIT ?",
+        )
+        .bind(&pattern)
+        .bind(&pattern)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(IssueSummary {
+                id: row.try_get("id")?,
+                title: row.try_get("title")?,
+                status: row.try_get("status")?,
+                priority: row.try_get("priority")?,
+                issue_type: row.try_get("issue_type")?,
+                owner: row.try_get::<Option<String>, _>("owner")?,
+                created_at: row.try_get("created_at")?,
+                updated_at: row.try_get("updated_at")?,
+                labels: Vec::new(),
+            });
+        }
+        Ok(out)
+    }
+}

--- a/crates/lab-apis/src/beads/client.rs
+++ b/crates/lab-apis/src/beads/client.rs
@@ -227,3 +227,52 @@ impl BeadsClient {
     }
 
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// DSN used by integration tests. Override via `BEADS_TEST_DSN` if your
+    /// local Dolt server is on a different port.
+    fn test_dsn() -> String {
+        std::env::var("BEADS_TEST_DSN")
+            .unwrap_or_else(|_| "mysql://root@127.0.0.1:3306/lab".to_string())
+    }
+
+    /// Basic smoke test for `list_issues()`: connecting to a live Dolt server
+    /// and listing issues with no filters should succeed and return a vec
+    /// (possibly empty).
+    ///
+    /// Run with: `cargo test -p lab-apis -- --ignored beads`
+    #[tokio::test]
+    #[ignore = "requires a running Dolt server (bd start)"]
+    async fn list_issues_basic() {
+        let client = BeadsClient::connect(&test_dsn())
+            .await
+            .expect("failed to connect to Dolt; start bd server and re-run");
+        let params = IssueListParams::default();
+        let issues = client
+            .list_issues(&params)
+            .await
+            .expect("list_issues failed");
+        // Returned slice may be empty on a fresh DB — just verify the call succeeds.
+        let _ = issues;
+    }
+
+    /// Verify that `get_issue()` returns `BeadsError::NotFound` for a
+    /// syntactically valid but non-existent id.
+    ///
+    /// Run with: `cargo test -p lab-apis -- --ignored beads`
+    #[tokio::test]
+    #[ignore = "requires a running Dolt server (bd start)"]
+    async fn get_issue_not_found() {
+        let client = BeadsClient::connect(&test_dsn())
+            .await
+            .expect("failed to connect to Dolt; start bd server and re-run");
+        let result = client.get_issue("nonexistent-0000").await;
+        assert!(
+            matches!(result, Err(BeadsError::NotFound { .. })),
+            "expected NotFound, got: {result:?}"
+        );
+    }
+}

--- a/crates/lab-apis/src/beads/client.rs
+++ b/crates/lab-apis/src/beads/client.rs
@@ -29,6 +29,19 @@ const DEFAULT_LIST_LIMIT: i64 = 50;
 /// Hard upper bound on `limit`.
 const MAX_LIST_LIMIT: i64 = 200;
 
+/// Parse the `GROUP_CONCAT`-produced label string into a `Vec<String>`.
+///
+/// The SQL query uses `\u{1f}` (ASCII Unit Separator, 0x1F) as the separator
+/// so that commas are safe inside individual label values. An empty string
+/// means the issue has no labels.
+pub(crate) fn parse_labels(raw: &str) -> Vec<String> {
+    if raw.is_empty() {
+        Vec::new()
+    } else {
+        raw.split('\u{1f}').map(str::to_string).collect()
+    }
+}
+
 /// MySQL connection pool wrapping the Dolt server.
 #[derive(Clone)]
 pub struct BeadsClient {
@@ -201,11 +214,7 @@ impl BeadsClient {
 
         let row = row.ok_or_else(|| BeadsError::NotFound { id: id.to_string() })?;
         let labels_raw: String = row.try_get("labels")?;
-        let labels = if labels_raw.is_empty() {
-            Vec::new()
-        } else {
-            labels_raw.split('\u{1f}').map(str::to_string).collect()
-        };
+        let labels = parse_labels(&labels_raw);
         Ok(Issue {
             id: row.try_get("id")?,
             title: row.try_get("title")?,
@@ -231,6 +240,60 @@ impl BeadsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Unit tests (no database required) ─────────────────────────────────
+
+    #[test]
+    fn parse_labels_empty_string() {
+        assert_eq!(parse_labels(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_labels_single() {
+        assert_eq!(parse_labels("bug"), vec!["bug".to_string()]);
+    }
+
+    #[test]
+    fn parse_labels_multiple() {
+        let raw = "bug\u{1f}p1\u{1f}backend";
+        assert_eq!(
+            parse_labels(raw),
+            vec!["bug".to_string(), "p1".to_string(), "backend".to_string()]
+        );
+    }
+
+    /// Labels may themselves contain commas; the unit separator avoids ambiguity.
+    #[test]
+    fn parse_labels_comma_inside_label() {
+        let raw = "a,b\u{1f}c";
+        assert_eq!(
+            parse_labels(raw),
+            vec!["a,b".to_string(), "c".to_string()]
+        );
+    }
+
+    /// `limit` is clamped to `[1, MAX_LIST_LIMIT]`; `None` defaults to
+    /// `DEFAULT_LIST_LIMIT`. These are pure arithmetic checks — no DB needed.
+    #[test]
+    fn list_limit_clamping() {
+        let clamp = |v: i64| v.clamp(1, MAX_LIST_LIMIT);
+        assert_eq!(clamp(0), 1, "zero is clamped to minimum 1");
+        assert_eq!(clamp(-10), 1, "negative is clamped to minimum 1");
+        assert_eq!(clamp(DEFAULT_LIST_LIMIT), DEFAULT_LIST_LIMIT);
+        assert_eq!(clamp(MAX_LIST_LIMIT), MAX_LIST_LIMIT);
+        assert_eq!(clamp(MAX_LIST_LIMIT + 1), MAX_LIST_LIMIT, "above max clamps down");
+    }
+
+    /// `offset` defaults to 0 and is never allowed to go negative.
+    #[test]
+    fn list_offset_floor() {
+        let floor = |v: i64| v.max(0);
+        assert_eq!(floor(0), 0);
+        assert_eq!(floor(10), 10);
+        assert_eq!(floor(-1), 0, "negative offset is floored to 0");
+    }
+
+    // ── Integration tests (require a running Dolt server) ─────────────────
 
     /// DSN used by integration tests. Override via `BEADS_TEST_DSN` if your
     /// local Dolt server is on a different port.

--- a/crates/lab-apis/src/beads/error.rs
+++ b/crates/lab-apis/src/beads/error.rs
@@ -1,0 +1,67 @@
+//! Beads error taxonomy.
+//!
+//! `BeadsError::redacted_message()` produces a generic user-facing string;
+//! the full `sqlx::Error` is logged server-side at WARN/ERROR. Never surface
+//! the `Display` form of the database error to MCP/HTTP clients — it can
+//! contain table names, constraint details, and other server internals.
+
+use thiserror::Error;
+
+/// Errors produced by the beads service.
+#[derive(Debug, Error)]
+pub enum BeadsError {
+    /// Pool/connection construction or query failure.
+    #[error("database error")]
+    Database(#[from] sqlx_core::Error),
+
+    /// Issue id has no matching row.
+    #[error("issue not found: {id}")]
+    NotFound {
+        /// The id that was looked up.
+        id: String,
+    },
+
+    /// Port file could not be read.
+    #[error("dolt port file unreadable: {path}")]
+    PortFileError {
+        /// Path attempted.
+        path: String,
+    },
+
+    /// Port file content failed to parse as a u16.
+    #[error("invalid port number in port file")]
+    InvalidPort {
+        /// Raw (untrusted) string read from the port file.
+        raw: String,
+    },
+
+    /// Configured value invalid.
+    #[error("invalid configuration: {0}")]
+    Config(String),
+}
+
+impl BeadsError {
+    /// Stable kind tag for envelope mapping.
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::NotFound { .. } => "issue_not_found",
+            Self::PortFileError { .. } | Self::InvalidPort { .. } => "beads_unavailable",
+            Self::Database(_) | Self::Config(_) => "internal_error",
+        }
+    }
+
+    /// Generic, user-safe message. Always preferred over `Display` at the
+    /// MCP / HTTP envelope boundary. Full detail is logged server-side.
+    #[must_use]
+    pub fn redacted_message(&self) -> String {
+        match self {
+            Self::NotFound { id } => format!("issue not found: {id}"),
+            Self::PortFileError { .. } | Self::InvalidPort { .. } => {
+                "beads database is not reachable".to_string()
+            }
+            Self::Database(_) => "database error".to_string(),
+            Self::Config(msg) => format!("invalid configuration: {msg}"),
+        }
+    }
+}

--- a/crates/lab-apis/src/beads/error.rs
+++ b/crates/lab-apis/src/beads/error.rs
@@ -43,11 +43,18 @@ pub enum BeadsError {
 impl BeadsError {
     /// Stable kind tag for envelope mapping.
     #[must_use]
-    pub const fn kind(&self) -> &'static str {
+    pub fn kind(&self) -> &'static str {
         match self {
             Self::NotFound { .. } => "issue_not_found",
             Self::PortFileError { .. } | Self::InvalidPort { .. } => "beads_unavailable",
-            Self::Database(_) | Self::Config(_) => "internal_error",
+            Self::Database(e) => {
+                use sqlx_core::Error as E;
+                match e {
+                    E::Io(_) | E::PoolTimedOut | E::PoolClosed => "beads_unavailable",
+                    _ => "internal_error",
+                }
+            }
+            Self::Config(_) => "internal_error",
         }
     }
 
@@ -60,7 +67,15 @@ impl BeadsError {
             Self::PortFileError { .. } | Self::InvalidPort { .. } => {
                 "beads database is not reachable".to_string()
             }
-            Self::Database(_) => "database error".to_string(),
+            Self::Database(e) => {
+                use sqlx_core::Error as E;
+                match e {
+                    E::Io(_) | E::PoolTimedOut | E::PoolClosed => {
+                        "beads database is not reachable".to_string()
+                    }
+                    _ => "database error".to_string(),
+                }
+            }
             Self::Config(msg) => format!("invalid configuration: {msg}"),
         }
     }

--- a/crates/lab-apis/src/beads/types.rs
+++ b/crates/lab-apis/src/beads/types.rs
@@ -1,7 +1,27 @@
 //! Beads request/response types.
 
 use chrono::NaiveDateTime;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
+
+/// Serialize a `NaiveDateTime` as RFC 3339 with an explicit `Z` suffix.
+///
+/// Dolt/MySQL stores `created_at`/`updated_at` as naive timestamps but the
+/// values are conceptually UTC. Without the `Z` suffix, JS `new Date(...)`
+/// interprets the string in the local timezone, which silently shifts the
+/// rendered values for any non-UTC client.
+fn serialize_as_utc<S: Serializer>(dt: &NaiveDateTime, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&format!("{}Z", dt.format("%Y-%m-%dT%H:%M:%S")))
+}
+
+fn serialize_as_utc_opt<S: Serializer>(
+    dt: &Option<NaiveDateTime>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    match dt {
+        Some(d) => s.serialize_str(&format!("{}Z", d.format("%Y-%m-%dT%H:%M:%S"))),
+        None => s.serialize_none(),
+    }
+}
 
 /// Full issue with all body fields and labels.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,10 +49,13 @@ pub struct Issue {
     /// Created-by author.
     pub created_by: Option<String>,
     /// Creation timestamp.
+    #[serde(serialize_with = "serialize_as_utc")]
     pub created_at: NaiveDateTime,
     /// Last-update timestamp.
+    #[serde(serialize_with = "serialize_as_utc")]
     pub updated_at: NaiveDateTime,
     /// Closed-at timestamp, if closed.
+    #[serde(serialize_with = "serialize_as_utc_opt")]
     pub closed_at: Option<NaiveDateTime>,
     /// Linked spec id.
     pub spec_id: Option<String>,
@@ -56,26 +79,14 @@ pub struct IssueSummary {
     /// Owner.
     pub owner: Option<String>,
     /// Created-at timestamp.
+    #[serde(serialize_with = "serialize_as_utc")]
     pub created_at: NaiveDateTime,
     /// Updated-at timestamp.
+    #[serde(serialize_with = "serialize_as_utc")]
     pub updated_at: NaiveDateTime,
-    /// Labels — empty in list responses (populated only on `get`).
+    /// Labels — **always empty** in list responses. The list query does not
+    /// join the labels table; call `get_issue` for full label data.
     pub labels: Vec<String>,
-}
-
-/// One comment on an issue.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Comment {
-    /// Comment id.
-    pub id: String,
-    /// Parent issue id.
-    pub issue_id: String,
-    /// Comment author.
-    pub author: String,
-    /// Body text.
-    pub text: String,
-    /// Creation timestamp.
-    pub created_at: NaiveDateTime,
 }
 
 /// List filters.

--- a/crates/lab-apis/src/beads/types.rs
+++ b/crates/lab-apis/src/beads/types.rs
@@ -1,0 +1,96 @@
+//! Beads request/response types.
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+/// Full issue with all body fields and labels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Issue {
+    /// Issue id, e.g. `lab-5t4b`.
+    pub id: String,
+    /// Title.
+    pub title: String,
+    /// Markdown description body.
+    pub description: String,
+    /// Markdown design body.
+    pub design: String,
+    /// Markdown acceptance criteria body.
+    pub acceptance_criteria: String,
+    /// Status — `open`, `closed`, `in_progress`, etc.
+    pub status: String,
+    /// Priority — 0 (P0/highest) … 4 (P4/backlog).
+    pub priority: i32,
+    /// Type — `task`, `epic`, `bug`, `feature`, `chore`.
+    pub issue_type: String,
+    /// Owner.
+    pub owner: Option<String>,
+    /// Assignee.
+    pub assignee: Option<String>,
+    /// Created-by author.
+    pub created_by: Option<String>,
+    /// Creation timestamp.
+    pub created_at: NaiveDateTime,
+    /// Last-update timestamp.
+    pub updated_at: NaiveDateTime,
+    /// Closed-at timestamp, if closed.
+    pub closed_at: Option<NaiveDateTime>,
+    /// Linked spec id.
+    pub spec_id: Option<String>,
+    /// Labels joined from the labels table.
+    pub labels: Vec<String>,
+}
+
+/// Lightweight summary used for list views.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueSummary {
+    /// Issue id.
+    pub id: String,
+    /// Title.
+    pub title: String,
+    /// Status.
+    pub status: String,
+    /// Priority 0..=4.
+    pub priority: i32,
+    /// Type.
+    pub issue_type: String,
+    /// Owner.
+    pub owner: Option<String>,
+    /// Created-at timestamp.
+    pub created_at: NaiveDateTime,
+    /// Updated-at timestamp.
+    pub updated_at: NaiveDateTime,
+    /// Labels — empty in list responses (populated only on `get`).
+    pub labels: Vec<String>,
+}
+
+/// One comment on an issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Comment {
+    /// Comment id.
+    pub id: String,
+    /// Parent issue id.
+    pub issue_id: String,
+    /// Comment author.
+    pub author: String,
+    /// Body text.
+    pub text: String,
+    /// Creation timestamp.
+    pub created_at: NaiveDateTime,
+}
+
+/// List filters.
+#[derive(Debug, Clone, Default)]
+pub struct IssueListParams {
+    /// Status filter (`open`, `closed`, `in_progress`).
+    pub status: Option<String>,
+    /// Type filter.
+    pub issue_type: Option<String>,
+    /// Owner filter.
+    pub owner: Option<String>,
+    /// Label filter (a single label).
+    pub label: Option<String>,
+    /// Result limit; defaults to 50 when `None`.
+    pub limit: Option<i64>,
+    /// Pagination offset; defaults to 0 when `None`.
+    pub offset: Option<i64>,
+}

--- a/crates/lab-apis/src/lib.rs
+++ b/crates/lab-apis/src/lib.rs
@@ -130,3 +130,7 @@ pub mod mcpregistry;
 /// ACP Agent Registry client — discover and install ACP-compatible AI coding agents.
 #[cfg(feature = "acp_registry")]
 pub mod acp_registry;
+
+/// Beads — local task and issue tracker backed by Dolt MySQL.
+#[cfg(feature = "beads")]
+pub mod beads;

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -130,6 +130,9 @@ paperless   = ["lab-apis/paperless"]
 gotify      = ["lab-apis/gotify"]
 apprise     = ["lab-apis/apprise"]
 
+# beads — local task tracker
+beads       = ["lab-apis/beads"]
+
 # bootstrap / registry
 mcpregistry = ["lab-apis/mcpregistry"]
 acp_registry = ["lab-apis/acp_registry"]
@@ -177,6 +180,7 @@ all         = [
   "openai",
   "qdrant",
   "tei",
+  "beads",
   "lab-admin",
   "fs",
   "deploy",

--- a/crates/lab/src/api/error.rs
+++ b/crates/lab/src/api/error.rs
@@ -17,9 +17,11 @@ impl IntoResponse for ToolError {
     fn into_response(self) -> Response {
         let status = match self.kind() {
             "auth_failed" => StatusCode::UNAUTHORIZED,
-            "not_found" => StatusCode::NOT_FOUND,
+            "not_found" | "issue_not_found" => StatusCode::NOT_FOUND,
             "rate_limited" => StatusCode::TOO_MANY_REQUESTS,
-            "sync_in_progress" | "service_unavailable" => StatusCode::SERVICE_UNAVAILABLE,
+            "sync_in_progress" | "service_unavailable" | "beads_unavailable" => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
             "missing_param" | "invalid_param" | "validation_failed" => {
                 StatusCode::UNPROCESSABLE_ENTITY
             }

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -443,6 +443,7 @@ fn build_v1_router(state: &AppState) -> Router<AppState> {
         mount_if_enabled!(v1, state, "qdrant", "qdrant", qdrant);
         mount_if_enabled!(v1, state, "tei", "tei", tei);
         mount_if_enabled!(v1, state, "apprise", "apprise", apprise);
+        mount_if_enabled!(v1, state, "beads", "beads", beads);
         // [lab-scaffold: api-routes]
     }
 

--- a/crates/lab/src/api/services.rs
+++ b/crates/lab/src/api/services.rs
@@ -82,5 +82,8 @@ pub mod tei;
 #[cfg(feature = "apprise")]
 pub mod apprise;
 
+#[cfg(feature = "beads")]
+pub mod beads;
+
 #[cfg(feature = "fs")]
 pub mod fs;

--- a/crates/lab/src/api/services/beads.rs
+++ b/crates/lab/src/api/services/beads.rs
@@ -26,18 +26,12 @@ async fn handle(
         req,
         ACTIONS,
         move |action, params| async move {
-            // help/schema bypass the client; dispatch_with_client also handles them
-            // but dispatch() avoids needing a configured client.
-            if matches!(action.as_str(), "help" | "schema") {
-                return crate::dispatch::beads::dispatch(&action, params).await;
-            }
-            let Some(client) = client.as_ref() else {
-                return Err(ToolError::Sdk {
-                    sdk_kind: "beads_unavailable".into(),
-                    message: "beads database is not reachable".into(),
-                });
-            };
-            crate::dispatch::beads::dispatch_with_client(client, &action, params).await
+            crate::dispatch::beads::dispatch_with_optional_client(
+                client.as_deref(),
+                &action,
+                params,
+            )
+            .await
         },
     )
     .await

--- a/crates/lab/src/api/services/beads.rs
+++ b/crates/lab/src/api/services/beads.rs
@@ -1,0 +1,44 @@
+//! HTTP route group for the `beads` service.
+
+use axum::{Json, Router, extract::State, http::HeaderMap, routing::post};
+use serde_json::Value;
+
+use crate::api::services::helpers::handle_action;
+use crate::api::{ActionRequest, state::AppState};
+use crate::dispatch::beads::ACTIONS;
+use crate::dispatch::error::ToolError;
+
+pub fn routes(_state: AppState) -> Router<AppState> {
+    Router::new().route("/", post(handle))
+}
+
+async fn handle(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<ActionRequest>,
+) -> Result<Json<Value>, ToolError> {
+    let request_id = headers.get("x-request-id").and_then(|v| v.to_str().ok());
+    let client = state.clients.beads.clone();
+    handle_action(
+        "beads",
+        "api",
+        request_id,
+        req,
+        ACTIONS,
+        move |action, params| async move {
+            // help/schema bypass the client; dispatch_with_client also handles them
+            // but dispatch() avoids needing a configured client.
+            if matches!(action.as_str(), "help" | "schema") {
+                return crate::dispatch::beads::dispatch(&action, params).await;
+            }
+            let Some(client) = client.as_ref() else {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "beads_unavailable".into(),
+                    message: "beads database is not reachable".into(),
+                });
+            };
+            crate::dispatch::beads::dispatch_with_client(client, &action, params).await
+        },
+    )
+    .await
+}

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -26,6 +26,8 @@ pub mod serve;
 pub mod apprise;
 #[cfg(feature = "arcane")]
 pub mod arcane;
+#[cfg(feature = "beads")]
+pub mod beads;
 #[cfg(feature = "bytestash")]
 pub mod bytestash;
 #[cfg(feature = "deploy")]
@@ -202,6 +204,9 @@ pub enum Command {
     /// Apprise notification dispatcher.
     #[cfg(feature = "apprise")]
     Apprise(apprise::AppriseArgs),
+    /// Beads task tracker.
+    #[cfg(feature = "beads")]
+    Beads(beads::BeadsArgs),
     /// Deploy the local lab release binary to SSH targets.
     #[cfg(feature = "deploy")]
     Deploy(deploy::DeployArgs),
@@ -272,6 +277,8 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
         Command::Tei(args) => tei::run(args, format).await,
         #[cfg(feature = "apprise")]
         Command::Apprise(args) => apprise::run(args, format).await,
+        #[cfg(feature = "beads")]
+        Command::Beads(args) => beads::run(args, format).await,
         #[cfg(feature = "deploy")]
         Command::Deploy(args) => dispatch_deploy(args, format, config.deploy.clone()).await,
         // [lab-scaffold: cli-dispatch]

--- a/crates/lab/src/cli/beads.rs
+++ b/crates/lab/src/cli/beads.rs
@@ -1,0 +1,54 @@
+//! `lab beads` — thin CLI shim for the beads service.
+
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::Args;
+
+use crate::cli::helpers::{action_parser, print_dry_run, run_confirmable_action_command};
+use crate::dispatch::beads::ACTIONS;
+use crate::output::OutputFormat;
+
+/// `lab beads` arguments.
+#[derive(Debug, Args)]
+pub struct BeadsArgs {
+    /// Action to run (e.g. issue.list, issue.get, help).
+    #[arg(default_value = "help", value_parser = action_parser(ACTIONS))]
+    pub action: String,
+    /// Action-specific parameters as JSON.
+    #[arg(long)]
+    pub params: Option<String>,
+    /// Skip confirmation for destructive actions.
+    #[arg(short = 'y', long, alias = "no-confirm")]
+    pub yes: bool,
+    /// Print what would be done without executing.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Run the `lab beads` subcommand.
+///
+/// # Errors
+/// Returns an error if dispatch fails.
+pub async fn run(args: BeadsArgs, format: OutputFormat) -> Result<ExitCode> {
+    let params = args
+        .params
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()?
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    if args.dry_run {
+        print_dry_run("beads", &args.action, &params);
+        return Ok(ExitCode::SUCCESS);
+    }
+    run_confirmable_action_command(
+        "beads",
+        ACTIONS,
+        args.action,
+        params,
+        args.yes,
+        format,
+        |action, params| async move { crate::dispatch::beads::dispatch(&action, params).await },
+    )
+    .await
+}

--- a/crates/lab/src/cli/helpers.rs
+++ b/crates/lab/src/cli/helpers.rs
@@ -14,9 +14,14 @@ use crate::dispatch::error::ToolError;
 
 /// Returns a [`clap::builder::PossibleValuesParser`] for the given action catalog.
 ///
+/// Always includes the built-in `help` and `schema` actions so that every
+/// dispatch-style CLI shim accepts them without listing them in the catalog.
+///
 /// Use as `#[arg(value_parser = action_parser(ACTIONS))]` on `action` fields in CLI shims.
 pub fn action_parser(actions: &'static [ActionSpec]) -> clap::builder::PossibleValuesParser {
-    clap::builder::PossibleValuesParser::new(actions.iter().map(|a| a.name))
+    let service_actions = actions.iter().map(|a| a.name);
+    let builtins = ["help", "schema"];
+    clap::builder::PossibleValuesParser::new(service_actions.chain(builtins))
 }
 
 /// Print the canonical `[dry-run]` line for a service/action/params triple.

--- a/crates/lab/src/dispatch.rs
+++ b/crates/lab/src/dispatch.rs
@@ -3,6 +3,8 @@ pub mod acp;
 pub mod apprise;
 #[cfg(feature = "arcane")]
 pub mod arcane;
+#[cfg(feature = "beads")]
+pub mod beads;
 #[cfg(feature = "bytestash")]
 pub mod bytestash;
 pub mod clients;

--- a/crates/lab/src/dispatch/beads.rs
+++ b/crates/lab/src/dispatch/beads.rs
@@ -14,4 +14,4 @@ mod params;
 
 pub use catalog::ACTIONS;
 pub use client::client_from_env;
-pub use dispatch::{dispatch, dispatch_with_client};
+pub use dispatch::{dispatch, dispatch_with_optional_client};

--- a/crates/lab/src/dispatch/beads.rs
+++ b/crates/lab/src/dispatch/beads.rs
@@ -1,0 +1,17 @@
+//! Shared dispatch layer for the `beads` service.
+//!
+//! Read-only v1 — exposes `issue.list` and `issue.get` plus the standard
+//! `help` / `schema` built-ins. Writes (create, update, close, comment) are
+//! deferred until the read surface is validated end-to-end.
+//!
+//! MCP tool intentionally exposed: `issue.list` and `issue.get` are safe;
+//! no destructive actions are present in v1.
+
+mod catalog;
+mod client;
+mod dispatch;
+mod params;
+
+pub use catalog::ACTIONS;
+pub use client::client_from_env;
+pub use dispatch::{dispatch, dispatch_with_client};

--- a/crates/lab/src/dispatch/beads/catalog.rs
+++ b/crates/lab/src/dispatch/beads/catalog.rs
@@ -1,0 +1,67 @@
+//! Action catalog for the `beads` service.
+//!
+//! V1 catalog: read-only. Deferred actions (until v2):
+//!   issue.create, issue.update, issue.close, issue.reopen,
+//!   comment.list, comment.add, label.list
+
+use lab_apis::core::action::{ActionSpec, ParamSpec};
+
+/// Action catalog — read-only v1.
+pub const ACTIONS: &[ActionSpec] = &[
+    ActionSpec {
+        name: "issue.list",
+        description: "List issues with optional filters",
+        destructive: false,
+        returns: "IssueSummary[]",
+        params: &[
+            ParamSpec {
+                name: "status",
+                ty: "string",
+                required: false,
+                description: "Filter by status (open/closed/in_progress)",
+            },
+            ParamSpec {
+                name: "issue_type",
+                ty: "string",
+                required: false,
+                description: "Filter by type (task/epic/bug/feature/chore)",
+            },
+            ParamSpec {
+                name: "owner",
+                ty: "string",
+                required: false,
+                description: "Filter by owner",
+            },
+            ParamSpec {
+                name: "label",
+                ty: "string",
+                required: false,
+                description: "Filter by label",
+            },
+            ParamSpec {
+                name: "limit",
+                ty: "integer",
+                required: false,
+                description: "Max results (default 50, max 200)",
+            },
+            ParamSpec {
+                name: "offset",
+                ty: "integer",
+                required: false,
+                description: "Pagination offset (default 0)",
+            },
+        ],
+    },
+    ActionSpec {
+        name: "issue.get",
+        description: "Get full issue detail (with labels) by id",
+        destructive: false,
+        returns: "Issue",
+        params: &[ParamSpec {
+            name: "id",
+            ty: "string",
+            required: true,
+            description: "Issue id (e.g. lab-5t4b)",
+        }],
+    },
+];

--- a/crates/lab/src/dispatch/beads/catalog.rs
+++ b/crates/lab/src/dispatch/beads/catalog.rs
@@ -10,9 +10,10 @@ use lab_apis::core::action::{ActionSpec, ParamSpec};
 pub const ACTIONS: &[ActionSpec] = &[
     ActionSpec {
         name: "issue.list",
-        description: "List issues with optional filters",
+        description: "List issues with optional filters. The labels field is always [] in list \
+                      results; call issue.get for label data.",
         destructive: false,
-        returns: "IssueSummary[]",
+        returns: "{ issues: IssueSummary[] }",
         params: &[
             ParamSpec {
                 name: "status",

--- a/crates/lab/src/dispatch/beads/client.rs
+++ b/crates/lab/src/dispatch/beads/client.rs
@@ -84,10 +84,9 @@ fn resolve_dsn() -> Option<String> {
 #[must_use]
 pub fn client_from_env() -> Option<BeadsClient> {
     let dsn = resolve_dsn()?;
-    // The pool is constructed lazily on first query in sqlx 0.8 — calling
-    // `MySqlPoolOptions::connect_lazy` returns immediately and avoids
-    // blocking startup on a Dolt round-trip. `BeadsClient::connect` performs
-    // a real connect; we use `connect_lazy_with` here via a small helper.
+    // `BeadsClient::lazy` calls `connect_lazy` (sqlx 0.8) and returns
+    // immediately without opening a TCP connection. The first actual query
+    // triggers the real connect — no async runtime blocking at startup.
     match BeadsClient::lazy(&dsn) {
         Ok(client) => Some(client),
         Err(e) => {

--- a/crates/lab/src/dispatch/beads/client.rs
+++ b/crates/lab/src/dispatch/beads/client.rs
@@ -1,0 +1,105 @@
+//! Beads client construction.
+//!
+//! The client is built once at startup by `ServiceClients::from_env()` and
+//! shared via `Arc<BeadsClient>` for the lifetime of the process.
+//!
+//! # Port resolution
+//!
+//! Order of precedence:
+//! 1. `BEADS_DOLT_PORT` env var
+//! 2. `BEADS_PORT_FILE` env var (path to a file containing the port)
+//! 3. `.beads/dolt-server.port` relative to CWD
+//!
+//! The host defaults to `127.0.0.1` and may be overridden via
+//! `BEADS_DOLT_HOST`. The DSN is constructed against the `lab` database with
+//! the `root` user and no password — matching the bd tool's local Dolt
+//! defaults.
+//!
+//! Port-file parsing happens at startup (synchronous), but pool construction
+//! is async. We block on a small tokio runtime so `from_env` can stay sync
+//! and match the convention used by every other service.
+
+use std::path::PathBuf;
+
+use lab_apis::beads::BeadsClient;
+
+use crate::dispatch::error::ToolError;
+use crate::dispatch::helpers::env_non_empty;
+
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_DB: &str = "lab";
+const DEFAULT_USER: &str = "root";
+const DEFAULT_PORT_FILE: &str = ".beads/dolt-server.port";
+
+/// Resolve the Dolt MySQL DSN from environment / port file.
+///
+/// Returns `None` when the port cannot be discovered — the service is
+/// considered unavailable and downstream calls return `beads_unavailable`.
+fn resolve_dsn() -> Option<String> {
+    let host = env_non_empty("BEADS_DOLT_HOST").unwrap_or_else(|| DEFAULT_HOST.to_string());
+
+    let port: u16 = if let Some(raw) = env_non_empty("BEADS_DOLT_PORT") {
+        match raw.trim().parse::<u16>() {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "BEADS_DOLT_PORT is not a valid u16");
+                return None;
+            }
+        }
+    } else {
+        let path = env_non_empty("BEADS_PORT_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_PORT_FILE));
+        match std::fs::read_to_string(&path) {
+            Ok(raw) => match raw.trim().parse::<u16>() {
+                Ok(p) => p,
+                Err(_) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "beads port file content is not a valid u16"
+                    );
+                    return None;
+                }
+            },
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "beads port file unreadable; service will be marked unavailable"
+                );
+                return None;
+            }
+        }
+    };
+
+    Some(format!("mysql://{DEFAULT_USER}@{host}:{port}/{DEFAULT_DB}"))
+}
+
+/// Build the beads client once at startup.
+///
+/// Returns `None` when the Dolt port cannot be discovered. Retries are
+/// not attempted — startup is the only resolution point, matching the
+/// convention used by every other service in `lab`.
+#[must_use]
+pub fn client_from_env() -> Option<BeadsClient> {
+    let dsn = resolve_dsn()?;
+    // The pool is constructed lazily on first query in sqlx 0.8 — calling
+    // `MySqlPoolOptions::connect_lazy` returns immediately and avoids
+    // blocking startup on a Dolt round-trip. `BeadsClient::connect` performs
+    // a real connect; we use `connect_lazy_with` here via a small helper.
+    match BeadsClient::lazy(&dsn) {
+        Ok(client) => Some(client),
+        Err(e) => {
+            tracing::warn!(error = %e, "beads client construction failed");
+            None
+        }
+    }
+}
+
+/// Structured error returned when beads is not configured / not reachable.
+pub fn unavailable_error() -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "beads_unavailable".to_string(),
+        message: "beads database is not reachable (dolt-server.port not found)".to_string(),
+    }
+}

--- a/crates/lab/src/dispatch/beads/client.rs
+++ b/crates/lab/src/dispatch/beads/client.rs
@@ -15,9 +15,10 @@
 //! the `root` user and no password — matching the bd tool's local Dolt
 //! defaults.
 //!
-//! Port-file parsing happens at startup (synchronous), but pool construction
-//! is async. We block on a small tokio runtime so `from_env` can stay sync
-//! and match the convention used by every other service.
+//! Port-file parsing happens at startup (synchronous). Pool construction uses
+//! `BeadsClient::lazy()`, which calls `connect_lazy` and returns immediately
+//! without opening a TCP connection — no async blocking at startup. The first
+//! actual query triggers the real connect.
 
 use std::path::PathBuf;
 
@@ -97,9 +98,16 @@ pub fn client_from_env() -> Option<BeadsClient> {
 }
 
 /// Structured error returned when beads is not configured / not reachable.
+///
+/// Covers all cases where `client_from_env()` returns `None`: the port env var
+/// is absent, the port value is not a valid u16, or the port file is missing or
+/// unreadable. Detailed diagnostics are emitted as tracing events by
+/// `resolve_dsn()` — callers should not add a secondary message here.
 pub fn unavailable_error() -> ToolError {
     ToolError::Sdk {
         sdk_kind: "beads_unavailable".to_string(),
-        message: "beads database is not reachable (dolt-server.port not found)".to_string(),
+        message: "beads database is not configured or not reachable; \
+                  set BEADS_DOLT_PORT or ensure .beads/dolt-server.port is readable"
+            .to_string(),
     }
 }

--- a/crates/lab/src/dispatch/beads/dispatch.rs
+++ b/crates/lab/src/dispatch/beads/dispatch.rs
@@ -1,0 +1,88 @@
+//! Top-level dispatch routing for the beads service.
+//!
+//! `dispatch` is what MCP and CLI call. `dispatch_with_client` is what
+//! the API handler calls with a pre-built client from `AppState`.
+
+use lab_apis::beads::{BeadsClient, BeadsError};
+use serde_json::Value;
+
+use crate::dispatch::beads::catalog::ACTIONS;
+use crate::dispatch::beads::client::unavailable_error;
+use crate::dispatch::beads::params;
+use crate::dispatch::error::ToolError;
+use crate::dispatch::helpers::{action_schema, help_payload, require_str, to_json};
+
+/// Map a `BeadsError` to a `ToolError`.
+///
+/// Always uses `redacted_message()` rather than `Display` to avoid leaking
+/// MySQL wire-protocol detail (table names, constraint names, hostnames)
+/// through MCP / HTTP envelopes. Full detail is logged at WARN/ERROR.
+fn beads_error_to_tool(err: BeadsError) -> ToolError {
+    let kind = err.kind();
+    let redacted = err.redacted_message();
+    // Server-side log carries full Display detail.
+    match kind {
+        "internal_error" => tracing::error!(error = %err, "beads internal error"),
+        _ => tracing::warn!(error = %err, kind, "beads error"),
+    }
+    ToolError::Sdk {
+        sdk_kind: kind.to_string(),
+        message: redacted,
+    }
+}
+
+/// Dispatch using a pre-built client (avoids per-request env reads and
+/// pool construction).
+pub async fn dispatch_with_client(
+    client: &BeadsClient,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
+        "help" => Ok(help_payload("beads", ACTIONS)),
+        "schema" => {
+            let action_name = require_str(&params_value, "action")?;
+            action_schema(ACTIONS, action_name)
+        }
+        "issue.list" => {
+            let p = params::issue_list_params(&params_value)?;
+            let issues = client.list_issues(&p).await.map_err(beads_error_to_tool)?;
+            to_json(serde_json::json!({ "issues": issues }))
+        }
+        "issue.get" => {
+            let id = params::require_id(&params_value)?;
+            let issue = client.get_issue(id).await.map_err(beads_error_to_tool)?;
+            to_json(issue)
+        }
+        unknown => Err(ToolError::UnknownAction {
+            message: format!("unknown action '{unknown}'"),
+            valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
+            hint: None,
+        }),
+    }
+}
+
+/// Dispatch a beads action without a pre-built client.
+///
+/// Falls back to constructing a fresh client from environment / port file.
+/// Returns `beads_unavailable` if the Dolt port cannot be discovered.
+pub async fn dispatch(action: &str, params_value: Value) -> Result<Value, ToolError> {
+    match action {
+        "help" => return Ok(help_payload("beads", ACTIONS)),
+        "schema" => {
+            let action_name = require_str(&params_value, "action")?;
+            return action_schema(ACTIONS, action_name);
+        }
+        _ if !ACTIONS.iter().any(|a| a.name == action) => {
+            return Err(ToolError::UnknownAction {
+                message: format!("unknown action '{action}'"),
+                valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
+                hint: None,
+            });
+        }
+        _ => {}
+    }
+
+    let client = crate::dispatch::beads::client::client_from_env().ok_or_else(unavailable_error)?;
+    dispatch_with_client(&client, action, params_value).await
+}

--- a/crates/lab/src/dispatch/beads/dispatch.rs
+++ b/crates/lab/src/dispatch/beads/dispatch.rs
@@ -31,6 +31,30 @@ fn beads_error_to_tool(err: BeadsError) -> ToolError {
     }
 }
 
+/// Dispatch with an optional pre-built client.
+///
+/// Used by the API handler so the help/schema branch is collapsed into a
+/// single entry point: built-in actions never need a configured client; any
+/// other action requires one or returns `beads_unavailable`.
+pub async fn dispatch_with_optional_client(
+    client: Option<&BeadsClient>,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
+        "help" => return Ok(help_payload("beads", ACTIONS)),
+        "schema" => {
+            let action_name = require_str(&params_value, "action")?;
+            return action_schema(ACTIONS, action_name);
+        }
+        _ => {}
+    }
+    let Some(client) = client else {
+        return Err(unavailable_error());
+    };
+    dispatch_with_client(client, action, params_value).await
+}
+
 /// Dispatch using a pre-built client (avoids per-request env reads and
 /// pool construction).
 pub async fn dispatch_with_client(

--- a/crates/lab/src/dispatch/beads/params.rs
+++ b/crates/lab/src/dispatch/beads/params.rs
@@ -1,0 +1,47 @@
+//! Parameter extraction for beads dispatch.
+
+use lab_apis::beads::types::IssueListParams;
+use serde_json::Value;
+
+use crate::dispatch::error::ToolError;
+use crate::dispatch::helpers::{optional_str, require_str};
+
+/// Extract `IssueListParams` from a JSON params object.
+///
+/// All filters are optional. `limit` and `offset` are coerced to `i64` and
+/// rejected when negative or non-numeric.
+pub fn issue_list_params(params: &Value) -> Result<IssueListParams, ToolError> {
+    let status = optional_str(params, "status")?.map(ToOwned::to_owned);
+    let issue_type = optional_str(params, "issue_type")?.map(ToOwned::to_owned);
+    let owner = optional_str(params, "owner")?.map(ToOwned::to_owned);
+    let label = optional_str(params, "label")?.map(ToOwned::to_owned);
+
+    let limit = match params.get("limit") {
+        None => None,
+        Some(v) => Some(v.as_i64().ok_or_else(|| ToolError::InvalidParam {
+            message: "parameter `limit` must be an integer".to_string(),
+            param: "limit".to_string(),
+        })?),
+    };
+    let offset = match params.get("offset") {
+        None => None,
+        Some(v) => Some(v.as_i64().ok_or_else(|| ToolError::InvalidParam {
+            message: "parameter `offset` must be an integer".to_string(),
+            param: "offset".to_string(),
+        })?),
+    };
+
+    Ok(IssueListParams {
+        status,
+        issue_type,
+        owner,
+        label,
+        limit,
+        offset,
+    })
+}
+
+/// Extract `id` from a JSON params object.
+pub fn require_id<'a>(params: &'a Value) -> Result<&'a str, ToolError> {
+    require_str(params, "id")
+}

--- a/crates/lab/src/dispatch/beads/params.rs
+++ b/crates/lab/src/dispatch/beads/params.rs
@@ -18,17 +18,35 @@ pub fn issue_list_params(params: &Value) -> Result<IssueListParams, ToolError> {
 
     let limit = match params.get("limit") {
         None => None,
-        Some(v) => Some(v.as_i64().ok_or_else(|| ToolError::InvalidParam {
-            message: "parameter `limit` must be an integer".to_string(),
-            param: "limit".to_string(),
-        })?),
+        Some(v) => {
+            let n = v.as_i64().ok_or_else(|| ToolError::InvalidParam {
+                message: "parameter `limit` must be an integer".to_string(),
+                param: "limit".to_string(),
+            })?;
+            if n < 0 {
+                return Err(ToolError::InvalidParam {
+                    message: "parameter `limit` must not be negative".to_string(),
+                    param: "limit".to_string(),
+                });
+            }
+            Some(n)
+        }
     };
     let offset = match params.get("offset") {
         None => None,
-        Some(v) => Some(v.as_i64().ok_or_else(|| ToolError::InvalidParam {
-            message: "parameter `offset` must be an integer".to_string(),
-            param: "offset".to_string(),
-        })?),
+        Some(v) => {
+            let n = v.as_i64().ok_or_else(|| ToolError::InvalidParam {
+                message: "parameter `offset` must be an integer".to_string(),
+                param: "offset".to_string(),
+            })?;
+            if n < 0 {
+                return Err(ToolError::InvalidParam {
+                    message: "parameter `offset` must not be negative".to_string(),
+                    param: "offset".to_string(),
+                });
+            }
+            Some(n)
+        }
     };
 
     Ok(IssueListParams {

--- a/crates/lab/src/dispatch/beads/params.rs
+++ b/crates/lab/src/dispatch/beads/params.rs
@@ -63,3 +63,74 @@ pub fn issue_list_params(params: &Value) -> Result<IssueListParams, ToolError> {
 pub fn require_id<'a>(params: &'a Value) -> Result<&'a str, ToolError> {
     require_str(params, "id")
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn no_params_returns_defaults() {
+        let p = issue_list_params(&json!({})).unwrap();
+        assert!(p.status.is_none());
+        assert!(p.limit.is_none());
+        assert!(p.offset.is_none());
+    }
+
+    #[test]
+    fn valid_limit_and_offset_accepted() {
+        let p = issue_list_params(&json!({"limit": 10, "offset": 5})).unwrap();
+        assert_eq!(p.limit, Some(10));
+        assert_eq!(p.offset, Some(5));
+    }
+
+    #[test]
+    fn zero_limit_accepted() {
+        // Zero is technically non-negative; clamping to ≥1 happens in the client layer.
+        let p = issue_list_params(&json!({"limit": 0})).unwrap();
+        assert_eq!(p.limit, Some(0));
+    }
+
+    #[test]
+    fn negative_limit_rejected() {
+        let err = issue_list_params(&json!({"limit": -1})).unwrap_err();
+        match err {
+            ToolError::InvalidParam { param, .. } => assert_eq!(param, "limit"),
+            other => panic!("expected InvalidParam, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn negative_offset_rejected() {
+        let err = issue_list_params(&json!({"offset": -5})).unwrap_err();
+        match err {
+            ToolError::InvalidParam { param, .. } => assert_eq!(param, "offset"),
+            other => panic!("expected InvalidParam, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_integer_limit_rejected() {
+        let err = issue_list_params(&json!({"limit": "big"})).unwrap_err();
+        match err {
+            ToolError::InvalidParam { param, .. } => assert_eq!(param, "limit"),
+            other => panic!("expected InvalidParam, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn filters_are_passed_through() {
+        let p = issue_list_params(&json!({
+            "status": "open",
+            "issue_type": "bug",
+            "owner": "alice",
+            "label": "p1"
+        }))
+        .unwrap();
+        assert_eq!(p.status.as_deref(), Some("open"));
+        assert_eq!(p.issue_type.as_deref(), Some("bug"));
+        assert_eq!(p.owner.as_deref(), Some("alice"));
+        assert_eq!(p.label.as_deref(), Some("p1"));
+    }
+}

--- a/crates/lab/src/dispatch/clients.rs
+++ b/crates/lab/src/dispatch/clients.rs
@@ -61,6 +61,8 @@ pub struct ServiceClients {
     pub arcane: Option<Arc<lab_apis::arcane::ArcaneClient>>,
     #[cfg(feature = "qbittorrent")]
     pub qbittorrent: Option<Arc<lab_apis::qbittorrent::QbittorrentClient>>,
+    #[cfg(feature = "beads")]
+    pub beads: Option<Arc<lab_apis::beads::BeadsClient>>,
     // [lab-scaffold: state-fields]
 }
 
@@ -113,6 +115,8 @@ impl ServiceClients {
             arcane: crate::dispatch::arcane::client_from_env().map(Arc::new),
             #[cfg(feature = "qbittorrent")]
             qbittorrent: crate::dispatch::qbittorrent::client_from_env().map(Arc::new),
+            #[cfg(feature = "beads")]
+            beads: crate::dispatch::beads::client_from_env().map(Arc::new),
             // [lab-scaffold: state-from-env]
         }
     }

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -409,6 +409,7 @@ pub fn build_default_registry() -> ToolRegistry {
     register_service!(reg, "qdrant", qdrant);
     register_service!(reg, "tei", tei);
     register_service!(reg, "apprise", apprise);
+    register_service!(reg, "beads", beads);
     register_service!(
         reg,
         "deploy",
@@ -509,6 +510,8 @@ pub fn service_meta(name: &str) -> Option<&'static PluginMeta> {
         "tei" => Some(&lab_apis::tei::META),
         #[cfg(feature = "apprise")]
         "apprise" => Some(&lab_apis::apprise::META),
+        #[cfg(feature = "beads")]
+        "beads" => Some(&lab_apis::beads::META),
         #[cfg(feature = "deploy")]
         "deploy" => Some(&lab_apis::deploy::META),
         _ => None,
@@ -613,6 +616,8 @@ mod tests {
         assert!(names.contains(&"tei"), "tei missing");
         #[cfg(feature = "apprise")]
         assert!(names.contains(&"apprise"), "apprise missing");
+        #[cfg(feature = "beads")]
+        assert!(names.contains(&"beads"), "beads missing");
     }
 
     #[test]
@@ -694,6 +699,8 @@ mod tests {
             s.insert(lab_apis::tei::META.name);
             #[cfg(feature = "apprise")]
             s.insert(lab_apis::apprise::META.name);
+            #[cfg(feature = "beads")]
+            s.insert(lab_apis::beads::META.name);
             #[cfg(feature = "fs")]
             s.insert("fs");
             s


### PR DESCRIPTION
## Summary

- Adds a `/tasks` page to the gateway-admin Web UI showing beads (tasks/issues) from the local Dolt database
- New `beads` service in `lab-apis` using sqlx runtime queries against Dolt's MySQL protocol endpoint
- Full dispatch layer following established patterns (read-only v1: `issue.list`, `issue.get`)
- TypeScript client, Zod types, SWR hooks, and React components (TaskCard, TaskList, TaskDetail)
- Tasks nav item in sidebar

## Architecture

```
Next.js static export
  → performServiceAction('/v1/beads')
  → axum POST /v1/beads → dispatch::beads
  → BeadsClient (MySqlPool in AppState)
  → Dolt MySQL (port from .beads/dolt-server.port)
```

## Key design decisions

- **Read-only v1**: write operations (create/edit/close) deferred — direct MySQL writes would bypass `bd`'s audit trail and ID format has no formal spec
- **Query-param routing** for detail view (`/tasks?id=…`) instead of `/tasks/[id]` — avoids static-export 404 on hard reload since lab's static file server returns `index.html` only for the root path
- **MySqlPool in AppState** via `ServiceClients` — not per-request, eliminates connection churn
- **SQL hardening**: ORDER BY allowlist, LIKE escaping, redacted error messages, GROUP_CONCAT session var
- **sqlx split crates** (`sqlx-core` + `sqlx-mysql`) to avoid `links` conflict with existing `rusqlite`

## Test plan

- [ ] `cargo check --all-features` passes
- [ ] `cargo clippy --all-features -- -D warnings` passes
- [ ] `cd apps/gateway-admin && npx tsc --noEmit` passes
- [ ] `cd apps/gateway-admin && npx next build` succeeds
- [ ] `lab beads list` CLI works with Dolt running
- [ ] `lab beads get <id>` returns full issue
- [ ] `/tasks` page loads and shows issues
- [ ] `/tasks?id=lab-5t4b` shows task detail with tabs
- [ ] Tasks nav item appears in sidebar
- [ ] `beads_unavailable` banner shown when Dolt is not running

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Tasks page in gateway-admin backed by a new beads service that reads from the local Dolt MySQL, exposing `issue.list` and `issue.get` for lab-5t4b. Also fixes an SWR crash and adds dev proxy rewrites to make local development smoother.

- **New Features**
  - Web UI: `/tasks` with status/type filters, list cards, and detail via `?id=`; includes `TaskList`, `TaskCard`, `TaskDetail`, and status/priority badges.
  - API: `POST /v1/beads` with `issue.list` and `issue.get`; maps `issue_not_found` (404) and `beads_unavailable` (503); single shared MySQL pool in AppState; rejects negative `limit`/`offset`.
  - Backend: `lab-apis` beads client using `sqlx-core`/`sqlx-mysql`; ORDER BY allowlist; `GROUP_CONCAT` session limit pinned to the same connection; timestamps serialized as UTC with `Z`; list responses omit labels (present only in `issue.get`); read-only surface; `lab beads` CLI accepts built-in `help` and `schema`.
  - Client: TypeScript beads API with `Zod` schemas; `SWR` hooks use `AbortSignal` and refresh detail periodically; `safeParse` at the fetch boundary; `useBead` returns `Issue | undefined`; unavailable banner checks `instanceof BeadsError`; optional mock via `NEXT_PUBLIC_MOCK_DATA`; dev proxy rewrites for `/v1` and `/auth` to `LAB_BACKEND_URL` (default `http://localhost:8765`).
  - Refactors/Fixes: shared `task-icons.ts`; `isErrorLike` moved to `lib/utils.ts`; time formatting via `format-ui-time`; simplified stable params; fixed SWR fetcher signature crash in `use-beads`; added unit tests for label parsing and param validation.

- **Migration**
  - Ensure Dolt is running and discoverable: create `.beads/dolt-server.port`, or set `BEADS_DOLT_PORT` (or `BEADS_PORT_FILE`).
  - Build/run with the `beads` feature enabled in `lab`/`lab-apis` if using custom feature sets, then navigate to `/tasks`.
  - For local dev, set `LAB_BACKEND_URL` if not using the default; Next.js dev proxies `/v1` and `/auth` to the backend.

<sup>Written for commit 25fd54a188b2dd44cbe663b0bf1793296befa660. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/lab/pull/36?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

