### PR TITLE
Add Gateway Admin command palette

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,8 @@ todo         = "warn"
 unimplemented = "warn"
 dbg_macro    = "warn"
 print_stderr = "allow"
-mod_module_files = "warn"   # forbid mod.rs — enforce foo.rs sibling to foo/ style
+mod_module_files  = "deny"  # forbid mod.rs — enforce foo.rs sibling to foo/ style
+disallowed_macros = "deny"  # see /clippy.toml — bans `#[async_trait]` in our code
 
 # allow some pedantic noise
 module_name_repetitions = "allow"

--- a/apps/gateway-admin/app/(admin)/layout.tsx
+++ b/apps/gateway-admin/app/(admin)/layout.tsx
@@ -1,6 +1,7 @@
 import { AuthBootstrap } from '@/components/auth/auth-bootstrap'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
+import { AppCommandPalette } from '@/components/app-command-palette'
 import { Toaster } from '@/components/ui/sonner'
 
 export default function AdminLayout({
@@ -13,6 +14,7 @@ export default function AdminLayout({
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset>{children}</SidebarInset>
+        <AppCommandPalette />
         <Toaster />
       </SidebarProvider>
     </AuthBootstrap>

--- a/apps/gateway-admin/app/dev/layout.tsx
+++ b/apps/gateway-admin/app/dev/layout.tsx
@@ -1,4 +1,5 @@
 import { AppSidebar } from '@/components/app-sidebar'
+import { AppCommandPalette } from '@/components/app-command-palette'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 
@@ -16,6 +17,7 @@ export default function DevLayout({
         </div>
         {children}
       </SidebarInset>
+      <AppCommandPalette />
       <Toaster />
     </SidebarProvider>
   )

--- a/apps/gateway-admin/components/app-command-palette.tsx
+++ b/apps/gateway-admin/components/app-command-palette.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import {
+  Activity,
+  BookOpen,
+  Cable,
+  LayoutDashboard,
+  Logs,
+  MessageSquareText,
+  Package,
+  Search,
+  Settings,
+  ShoppingBag,
+  WandSparkles,
+  type LucideIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from '@/components/ui/command'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { cn } from '@/lib/utils'
+import {
+  type AppCommandIconKey,
+  type AppCommandItem,
+  buildAppCommandState,
+  findAppCommandItemById,
+} from '@/lib/app-command-palette'
+
+const ICONS: Record<AppCommandIconKey, LucideIcon> = {
+  activity: Activity,
+  chat: MessageSquareText,
+  docs: BookOpen,
+  gateway: Cable,
+  logs: Logs,
+  marketplace: ShoppingBag,
+  overview: LayoutDashboard,
+  registry: Package,
+  settings: Settings,
+  setup: WandSparkles,
+}
+
+const KIND_LABELS: Record<AppCommandItem['kind'], string> = {
+  action: 'Action',
+  destination: 'Destination',
+}
+
+const OPEN_COMMAND_PALETTE_EVENT = 'labby:open-command-palette'
+
+function isCommandK(event: KeyboardEvent): boolean {
+  return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k'
+}
+
+export function AppCommandPaletteTrigger() {
+  return (
+    <button
+      type="button"
+      onClick={() => window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT))}
+      className="hidden min-w-[220px] items-center justify-between gap-3 rounded-aurora-1 border border-aurora-border-default bg-aurora-control-surface px-3 py-1.5 text-left text-xs text-aurora-text-muted transition hover:border-aurora-border-strong hover:bg-aurora-hover-bg hover:text-aurora-text-primary md:flex"
+      aria-label="Open command palette"
+    >
+      <span className="inline-flex items-center gap-2">
+        <Search className="size-3.5" />
+        Search or jump...
+      </span>
+      <KbdGroup>
+        <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
+          Cmd
+        </Kbd>
+        <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
+          K
+        </Kbd>
+      </KbdGroup>
+    </button>
+  )
+}
+
+export function AppCommandPalette() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const state = useMemo(() => buildAppCommandState(query), [query])
+  const [activeItemId, setActiveItemId] = useState<string | null>(state.activeItemId)
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!isCommandK(event)) return
+      event.preventDefault()
+      setOpen((current) => !current)
+    }
+    function onOpenPalette() {
+      setOpen(true)
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, onOpenPalette)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, onOpenPalette)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    setActiveItemId((current) => {
+      if (current && state.items.some((item) => item.id === current)) return current
+      return state.activeItemId
+    })
+  }, [open, state.activeItemId, state.items])
+
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  function executeCommand(item: AppCommandItem | null) {
+    if (!item) return
+
+    setOpen(false)
+    setQuery('')
+    router.push(item.href)
+
+    if (item.kind === 'action') {
+      toast.message(item.title, {
+        description: item.description,
+      })
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    if (!nextOpen) setQuery('')
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent
+          className="top-[18%] translate-y-0 border-aurora-border-strong bg-aurora-panel-strong p-0 shadow-[var(--aurora-shadow-strong),var(--aurora-highlight-strong)] sm:max-w-2xl"
+          showCloseButton={false}
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>Command Palette</DialogTitle>
+            <DialogDescription>
+              Search Labby destinations and actions.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Command
+            shouldFilter={false}
+            value={activeItemId ?? undefined}
+            onValueChange={setActiveItemId}
+            className="bg-transparent text-aurora-text-primary"
+          >
+            <div className="border-b border-aurora-border-strong px-4 py-3">
+              <CommandInput
+                autoFocus
+                value={query}
+                onValueChange={setQuery}
+                aria-label="Search command palette"
+                name="app-command-palette-search"
+                placeholder="Search pages, actions, and operational context..."
+                className="text-aurora-text-primary placeholder:text-aurora-text-muted"
+              />
+            </div>
+
+            <CommandList className="aurora-scrollbar max-h-[420px] px-4 py-4">
+              {state.items.length ? (
+                state.groups.map((group) => (
+                  <CommandGroup
+                    key={group.key}
+                    heading={group.label}
+                    className="mb-3 overflow-visible p-0 [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-0 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-bold [&_[cmdk-group-heading]]:tracking-[0.18em] [&_[cmdk-group-heading]]:text-aurora-text-muted [&_[cmdk-group-heading]]:uppercase"
+                  >
+                    <div className="grid gap-2">
+                      {group.items.map((item) => (
+                        <AppCommandPaletteRow
+                          key={item.id}
+                          item={item}
+                          active={item.id === activeItemId}
+                          onSelect={(itemId) => {
+                            executeCommand(findAppCommandItemById(itemId, state.items))
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </CommandGroup>
+                ))
+              ) : (
+                <CommandEmpty className="rounded-aurora-2 border border-aurora-border-strong bg-aurora-control-surface px-5 py-6 text-left">
+                  <p className="text-sm font-semibold text-aurora-text-primary">
+                    No matching commands
+                  </p>
+                  <p className="mt-2 text-sm text-aurora-text-muted">
+                    Try gateway, logs, setup, registry, marketplace, or settings.
+                  </p>
+                </CommandEmpty>
+              )}
+            </CommandList>
+          </Command>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+type AppCommandPaletteRowProps = {
+  item: AppCommandItem
+  active: boolean
+  onSelect: (itemId: string) => void
+}
+
+function AppCommandPaletteRow({
+  item,
+  active,
+  onSelect,
+}: AppCommandPaletteRowProps) {
+  const Icon = ICONS[item.icon]
+
+  return (
+    <CommandItem
+      value={item.id}
+      keywords={item.keywords}
+      onSelect={() => onSelect(item.id)}
+      className={cn(
+        'rounded-aurora-2 border border-aurora-border-strong/80 bg-aurora-control-surface px-3 py-3 text-aurora-text-primary transition-[border-color,background-color,box-shadow] hover:bg-aurora-hover-bg',
+        active
+          ? 'border-aurora-accent-primary/40 bg-aurora-panel-medium shadow-[var(--aurora-active-glow)]'
+          : '',
+      )}
+    >
+      <div className="flex size-9 items-center justify-center rounded-aurora-1 border border-aurora-border-strong bg-aurora-panel-medium text-aurora-accent-strong">
+        <Icon className="size-4" />
+      </div>
+      <div className="grid min-w-0 flex-1 gap-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-[13px] font-semibold leading-[1.2] text-aurora-text-primary">
+            {item.title}
+          </span>
+          <Badge
+            variant="pill"
+            status={item.kind === 'action' ? 'success' : 'default'}
+            className="border-aurora-border-strong bg-aurora-panel-medium text-[11px] text-aurora-text-muted"
+          >
+            {KIND_LABELS[item.kind]}
+          </Badge>
+        </div>
+        <span className="truncate text-[12px] leading-[1.45] text-aurora-text-muted">
+          {item.description}
+        </span>
+      </div>
+      <CommandShortcut className="text-[11px] tracking-[0.08em] text-aurora-text-muted">
+        {item.actionHint}
+      </CommandShortcut>
+    </CommandItem>
+  )
+}

--- a/apps/gateway-admin/components/app-command-palette.tsx
+++ b/apps/gateway-admin/components/app-command-palette.tsx
@@ -68,7 +68,13 @@ function isCommandK(event: KeyboardEvent): boolean {
   return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k'
 }
 
+/** Returns true when running on macOS/iOS — safe in this 'use client' static-export component. */
+function isMacOS(): boolean {
+  return typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+}
+
 export function AppCommandPaletteTrigger() {
+  const modKey = isMacOS() ? '⌘' : 'Ctrl'
   return (
     <button
       type="button"
@@ -82,7 +88,7 @@ export function AppCommandPaletteTrigger() {
       </span>
       <KbdGroup>
         <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
-          Cmd
+          {modKey}
         </Kbd>
         <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
           K

--- a/apps/gateway-admin/components/app-header.tsx
+++ b/apps/gateway-admin/components/app-header.tsx
@@ -3,6 +3,7 @@
 import { Fragment } from 'react'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
+import { AppCommandPaletteTrigger } from '@/components/app-command-palette'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -47,11 +48,10 @@ export function AppHeader({ breadcrumbs = [], actions }: AppHeaderProps) {
         </Breadcrumb>
       )}
 
-      {actions && (
-        <div className="ml-auto flex items-center gap-2">
-          {actions}
-        </div>
-      )}
+      <div className="ml-auto flex items-center gap-2">
+        <AppCommandPaletteTrigger />
+        {actions}
+      </div>
     </header>
   )
 }

--- a/apps/gateway-admin/lib/app-command-palette.test.ts
+++ b/apps/gateway-admin/lib/app-command-palette.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  appCommandItems,
+  buildAppCommandState,
+  findAppCommandItemById,
+} from './app-command-palette'
+
+test('app command palette ranks gateway searches first', () => {
+  const state = buildAppCommandState('gateway')
+
+  assert.equal(state.activeItemId, 'destination-gateways')
+  assert.equal(state.groups[0]?.key, 'best-match')
+  assert.equal(state.groups[0]?.items[0]?.href, '/gateways')
+})
+
+test('app command palette includes core admin destinations', () => {
+  const hrefs = new Set(appCommandItems.map((item) => item.href))
+
+  for (const href of [
+    '/',
+    '/gateways',
+    '/registry',
+    '/marketplace',
+    '/chat',
+    '/setup',
+    '/activity',
+    '/logs',
+    '/settings',
+    '/docs',
+  ]) {
+    assert.equal(hrefs.has(href), true, `${href} should be searchable`)
+  }
+})
+
+test('app command palette reports empty state for unmatched queries', () => {
+  const state = buildAppCommandState('zzzz-no-match')
+
+  assert.equal(state.activeItemId, null)
+  assert.deepEqual(state.items, [])
+  assert.deepEqual(state.groups, [])
+})
+
+test('findAppCommandItemById returns matching command item', () => {
+  const item = findAppCommandItemById('destination-logs', appCommandItems)
+
+  assert.equal(item?.title, 'Logs')
+  assert.equal(item?.href, '/logs')
+})

--- a/apps/gateway-admin/lib/app-command-palette.ts
+++ b/apps/gateway-admin/lib/app-command-palette.ts
@@ -1,0 +1,319 @@
+export type AppCommandKind = 'destination' | 'action'
+
+export type AppCommandGroupKey = 'best-match' | 'actions' | 'destinations'
+
+export type AppCommandIconKey =
+  | 'activity'
+  | 'chat'
+  | 'docs'
+  | 'gateway'
+  | 'logs'
+  | 'marketplace'
+  | 'overview'
+  | 'registry'
+  | 'settings'
+  | 'setup'
+
+export type AppCommandItem = {
+  id: string
+  kind: AppCommandKind
+  title: string
+  description: string
+  keywords: string[]
+  group: AppCommandGroupKey
+  icon: AppCommandIconKey
+  href: string
+  actionHint: string
+  priority: number
+}
+
+export type AppCommandGroup = {
+  key: AppCommandGroupKey
+  label: string
+  items: AppCommandItem[]
+}
+
+export type AppCommandState = {
+  items: AppCommandItem[]
+  groups: AppCommandGroup[]
+  activeItemId: string | null
+}
+
+const GROUP_LABELS: Record<AppCommandGroupKey, string> = {
+  'best-match': 'Best match',
+  actions: 'Actions',
+  destinations: 'Destinations',
+}
+
+export const appCommandItems: AppCommandItem[] = [
+  {
+    id: 'destination-overview',
+    kind: 'destination',
+    title: 'Overview',
+    description: 'Open the Labby dashboard with gateway health, activity, and quick actions.',
+    keywords: ['home', 'dashboard', 'overview', 'summary'],
+    group: 'destinations',
+    icon: 'overview',
+    href: '/',
+    actionHint: 'Open',
+    priority: 100,
+  },
+  {
+    id: 'destination-gateways',
+    kind: 'destination',
+    title: 'Gateways',
+    description: 'Manage gateway routes, upstream servers, policies, and runtime exposure.',
+    keywords: ['gateway', 'gateways', 'routes', 'upstream', 'policy', 'server'],
+    group: 'destinations',
+    icon: 'gateway',
+    href: '/gateways',
+    actionHint: 'Open',
+    priority: 98,
+  },
+  {
+    id: 'destination-registry',
+    kind: 'destination',
+    title: 'Registry',
+    description: 'Search MCP registry servers and inspect installability metadata.',
+    keywords: ['registry', 'mcp', 'servers', 'catalog', 'packages'],
+    group: 'destinations',
+    icon: 'registry',
+    href: '/registry',
+    actionHint: 'Open',
+    priority: 92,
+  },
+  {
+    id: 'destination-marketplace',
+    kind: 'destination',
+    title: 'Marketplace',
+    description: 'Browse available plugins, MCP servers, and ACP agents.',
+    keywords: ['marketplace', 'plugin', 'plugins', 'install', 'agents', 'mcp'],
+    group: 'destinations',
+    icon: 'marketplace',
+    href: '/marketplace',
+    actionHint: 'Open',
+    priority: 90,
+  },
+  {
+    id: 'destination-chat',
+    kind: 'destination',
+    title: 'Chat',
+    description: 'Open the ACP chat workspace for agent sessions and tool activity.',
+    keywords: ['chat', 'agent', 'assistant', 'acp', 'session'],
+    group: 'destinations',
+    icon: 'chat',
+    href: '/chat',
+    actionHint: 'Open',
+    priority: 88,
+  },
+  {
+    id: 'destination-setup',
+    kind: 'destination',
+    title: 'Setup',
+    description: 'Run environment discovery, scan local services, and review setup results.',
+    keywords: ['setup', 'onboarding', 'doctor', 'extract', 'environment', 'env'],
+    group: 'destinations',
+    icon: 'setup',
+    href: '/setup',
+    actionHint: 'Open',
+    priority: 86,
+  },
+  {
+    id: 'destination-activity',
+    kind: 'destination',
+    title: 'Activity',
+    description: 'Review recent gateway events, jobs, and operator activity.',
+    keywords: ['activity', 'events', 'jobs', 'review', 'history'],
+    group: 'destinations',
+    icon: 'activity',
+    href: '/activity',
+    actionHint: 'Open',
+    priority: 84,
+  },
+  {
+    id: 'destination-logs',
+    kind: 'destination',
+    title: 'Logs',
+    description: 'Open the operational log stream with filtering and event inspection.',
+    keywords: ['logs', 'log', 'tail', 'events', 'observability', 'errors'],
+    group: 'destinations',
+    icon: 'logs',
+    href: '/logs',
+    actionHint: 'Open',
+    priority: 82,
+  },
+  {
+    id: 'destination-settings',
+    kind: 'destination',
+    title: 'Settings',
+    description: 'Review auth mode, environment configuration, and control-plane defaults.',
+    keywords: ['settings', 'config', 'configuration', 'auth', 'preferences'],
+    group: 'destinations',
+    icon: 'settings',
+    href: '/settings',
+    actionHint: 'Open',
+    priority: 80,
+  },
+  {
+    id: 'destination-docs',
+    kind: 'destination',
+    title: 'Documentation',
+    description: 'Read Labby docs, setup guidance, conventions, and operator references.',
+    keywords: ['docs', 'documentation', 'help', 'reference', 'guide'],
+    group: 'destinations',
+    icon: 'docs',
+    href: '/docs',
+    actionHint: 'Open',
+    priority: 78,
+  },
+  {
+    id: 'action-tail-logs',
+    kind: 'action',
+    title: 'Tail logs',
+    description: 'Jump directly to the log console to continue watching runtime events.',
+    keywords: ['tail', 'logs', 'stream', 'follow', 'errors'],
+    group: 'actions',
+    icon: 'logs',
+    href: '/logs',
+    actionHint: 'Run',
+    priority: 89,
+  },
+  {
+    id: 'action-review-gateways',
+    kind: 'action',
+    title: 'Review gateways',
+    description: 'Open gateway management to inspect routes, upstreams, and exposure state.',
+    keywords: ['review', 'gateway', 'gateways', 'health', 'runtime'],
+    group: 'actions',
+    icon: 'gateway',
+    href: '/gateways',
+    actionHint: 'Run',
+    priority: 87,
+  },
+  {
+    id: 'action-check-setup',
+    kind: 'action',
+    title: 'Check setup',
+    description: 'Open setup validation and environment discovery results.',
+    keywords: ['check', 'setup', 'doctor', 'validate', 'env'],
+    group: 'actions',
+    icon: 'setup',
+    href: '/setup',
+    actionHint: 'Run',
+    priority: 85,
+  },
+]
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function scoreItem(item: AppCommandItem, query: string): { baseScore: number; totalScore: number } {
+  if (!query) {
+    return { baseScore: 0, totalScore: item.priority }
+  }
+
+  const normalizedTitle = item.title.toLowerCase()
+  const normalizedDescription = item.description.toLowerCase()
+  let baseScore = 0
+  let matched = false
+
+  if (normalizedTitle === query) {
+    baseScore += 220
+    matched = true
+  }
+  if (normalizedTitle.startsWith(query)) {
+    baseScore += 130
+    matched = true
+  }
+  if (normalizedTitle.includes(query)) {
+    baseScore += 80
+    matched = true
+  }
+  if (normalizedDescription.includes(query)) {
+    baseScore += 20
+    matched = true
+  }
+
+  for (const keyword of item.keywords) {
+    const normalizedKeyword = keyword.toLowerCase()
+    if (normalizedKeyword === query) {
+      baseScore += 100
+      matched = true
+    } else if (normalizedKeyword.startsWith(query)) {
+      baseScore += 58
+      matched = true
+    } else if (normalizedKeyword.includes(query)) {
+      baseScore += 32
+      matched = true
+    }
+  }
+
+  if (!matched) return { baseScore: 0, totalScore: 0 }
+
+  let totalScore = baseScore + item.priority
+  if (item.kind === 'destination') totalScore += 6
+  if (item.kind === 'action') totalScore += 3
+
+  return { baseScore, totalScore }
+}
+
+function filterItems(query: string, items: AppCommandItem[]): AppCommandItem[] {
+  const normalizedQuery = normalize(query)
+  if (!normalizedQuery) {
+    return [...items].sort((a, b) => b.priority - a.priority)
+  }
+
+  return [...items]
+    .map((item) => ({ item, ...scoreItem(item, normalizedQuery) }))
+    .filter(({ baseScore }) => baseScore > 40)
+    .sort((a, b) => b.totalScore - a.totalScore)
+    .map(({ item }) => item)
+}
+
+export function buildAppCommandState(
+  query: string,
+  items: AppCommandItem[] = appCommandItems,
+): AppCommandState {
+  const ranked = filterItems(query, items)
+  if (!ranked.length) {
+    return {
+      items: [],
+      groups: [],
+      activeItemId: null,
+    }
+  }
+
+  const [bestMatch, ...rest] = ranked
+  const grouped = new Map<AppCommandGroupKey, AppCommandItem[]>([
+    ['best-match', [bestMatch]],
+    ['actions', []],
+    ['destinations', []],
+  ])
+
+  for (const item of rest) {
+    grouped.get(item.group)?.push(item)
+  }
+
+  const groups = [...grouped.entries()]
+    .filter(([, groupItems]) => groupItems.length > 0)
+    .map(([key, groupItems]) => ({
+      key,
+      label: GROUP_LABELS[key],
+      items: groupItems,
+    }))
+
+  return {
+    items: ranked,
+    groups,
+    activeItemId: bestMatch.id,
+  }
+}
+
+export function findAppCommandItemById(
+  itemId: string | null,
+  items: AppCommandItem[],
+): AppCommandItem | null {
+  if (!itemId) return null
+  return items.find((item) => item.id === itemId) ?? null
+}

--- a/apps/gateway-admin/package.json
+++ b/apps/gateway-admin/package.json
@@ -9,7 +9,7 @@
     "start": "python3 -m http.server 3000 -d out",
     "preview": "python3 -m http.server 3000 -d out",
     "lint": "eslint .",
-    "test": "tsx --test lib/server/**/*.test.ts lib/api/**/*.test.ts lib/dashboard/**/*.test.ts lib/fs/**/*.test.ts lib/dev/**/*.test.ts components/**/*.test.tsx",
+    "test": "tsx --test lib/*.test.ts lib/server/**/*.test.ts lib/api/**/*.test.ts lib/dashboard/**/*.test.ts lib/fs/**/*.test.ts lib/dev/**/*.test.ts components/**/*.test.tsx",
     "test:browser": "node --test --experimental-strip-types lib/browser/**/*.test.ts"
   },
   "dependencies": {

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,15 @@
+# Workspace-level clippy config.
+#
+# Convention enforcement that complements deny.toml:
+# `async-trait` is pulled in transitively by `rmcp`, so we can't ban
+# the crate at the dep-graph level. Instead we ban *writing*
+# `#[async_trait]` in our own code. The repo rule is "we use native
+# `async fn in trait` (Rust 1.75+)," not "no crate in the universe
+# uses async-trait."
+#
+# Activated via `disallowed_macros = "deny"` in [workspace.lints.clippy]
+# in /Cargo.toml.
+
+disallowed-macros = [
+    { path = "async_trait::async_trait", reason = "Use native `async fn in trait` (Rust 1.75+). See crates/lab-apis/CLAUDE.md." },
+]

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,41 @@ allow = [
 multiple-versions = "warn"
 wildcards = "allow"
 
+# Convention enforcement — codifies rules from /CLAUDE.md and
+# crates/lab-apis/CLAUDE.md that clippy can't enforce on its own.
+# `wrappers` whitelists *direct* dep-graph parents allowed to pull the
+# banned crate in. Any other crate in the workspace doing so fails.
+#
+# Note: `async-trait` is *not* banned here because `rmcp` pulls it in
+# transitively. Writing `#[async_trait]` in our own code is forbidden
+# via `clippy::disallowed_macros` instead — see clippy.toml at the
+# workspace root.
+
+[[bans.deny]]
+name = "clap"
+wrappers = ["lab", "clap_complete"]
+reason = "Binary-only: lab-apis must stay pure. CLI parsing lives in `lab`."
+
+[[bans.deny]]
+name = "rmcp"
+wrappers = ["lab", "agent-client-protocol"]
+reason = "Binary-only: lab-apis must stay pure. MCP server lives in `lab`."
+
+[[bans.deny]]
+name = "ratatui"
+wrappers = ["lab"]
+reason = "Binary-only: lab-apis must stay pure. TUI lives in `lab`."
+
+[[bans.deny]]
+name = "anyhow"
+wrappers = ["lab", "agent-client-protocol", "agent-client-protocol-schema"]
+reason = "lab-apis uses `thiserror`. anyhow is for the binary only."
+
+[[bans.deny]]
+name = "tabled"
+wrappers = ["lab"]
+reason = "Binary-only: table formatting happens in `lab/src/output.rs`, not lab-apis."
+
 [sources]
 unknown-registry = "deny"
 unknown-git = "warn"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,14 @@ pre-commit:
       # Convention enforcement: bans clap/rmcp/ratatui/anyhow/tabled in
       # lab-apis/lab-auth (per crates/lab-apis/CLAUDE.md). Just `bans` —
       # CI runs the full check (advisories/licenses/sources).
-      run: cargo deny check bans
+      # Guard: skip gracefully if cargo-deny is not installed locally.
+      # Install: cargo install cargo-deny
+      run: |
+        if ! command -v cargo-deny >/dev/null 2>&1; then
+          echo "cargo-deny not installed — skipping bans check (install with: cargo install cargo-deny)"
+          exit 0
+        fi
+        cargo deny check bans
     aurora-radius:
       glob: "{apps/gateway-admin/*.{ts,tsx,css},apps/gateway-admin/**/*.{ts,tsx,css}}"
       run: |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,11 @@ pre-commit:
       run: cargo fmt --all --check
     clippy:
       run: cargo clippy --workspace --all-features -- -D warnings
+    cargo-deny-bans:
+      # Convention enforcement: bans clap/rmcp/ratatui/anyhow/tabled in
+      # lab-apis/lab-auth (per crates/lab-apis/CLAUDE.md). Just `bans` —
+      # CI runs the full check (advisories/licenses/sources).
+      run: cargo deny check bans
     aurora-radius:
       glob: "{apps/gateway-admin/*.{ts,tsx,css},apps/gateway-admin/**/*.{ts,tsx,css}}"
       run: |


### PR DESCRIPTION
## Summary
- add an app-wide Cmd/Ctrl+K command palette to Gateway Admin
- wire the palette into admin and dev layouts with a header trigger
- add searchable command data/model coverage and include root lib tests in the app test script

## Verification
- pnpm test
- pnpm lint
- pnpm build

Note: pnpm exec tsc --noEmit was attempted before PR creation and is blocked by pre-existing unrelated type errors outside the new palette files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command palette to gateway admin interface with Cmd/Ctrl+K keyboard shortcut for quick access to commands and navigation.
  * Integrated command palette trigger button in the header for easy access.

* **Tests**
  * Added test coverage for command palette search and command selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an app‑wide command palette to Gateway Admin for faster navigation and actions via Cmd/Ctrl+K and a header trigger.

- New Features
  - App-wide palette (Cmd/Ctrl+K) with a header trigger; enabled in both admin and dev layouts.
  - Searchable commands with simple ranking and grouping; best match preselected; Enter to navigate; action picks show a small toast.
  - Shows the correct modifier key (⌘ on macOS/iOS, Ctrl on Windows/Linux).
  - Added tests for ranking and item lookup; updated the app test script to include root `lib/*.test.ts`.

- Refactors
  - Enforced workspace conventions: added `clippy.toml`, expanded `deny.toml` bans, and integrated `cargo-deny` bans check into `lefthook` with an install guard.
  - Tightened lints in workspace `Cargo.toml` (deny `mod_module_files` and `disallowed_macros`, banning `#[async_trait]` in our code).

<sup>Written for commit d657e1665efcf89eefe862111fd5064daa090c4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

