### PR TITLE
feat(floating-chat): global floating chat popover with full /chat parity

### DIFF
--- a/apps/gateway-admin/app/(admin)/layout.tsx
+++ b/apps/gateway-admin/app/(admin)/layout.tsx
@@ -3,6 +3,7 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
 import { AppCommandPalette } from '@/components/app-command-palette'
 import { Toaster } from '@/components/ui/sonner'
+import { AdminLayoutClient } from '@/components/admin-layout-client'
 
 export default function AdminLayout({
   children,
@@ -13,7 +14,11 @@ export default function AdminLayout({
     <AuthBootstrap>
       <SidebarProvider>
         <AppSidebar />
-        <SidebarInset>{children}</SidebarInset>
+        <SidebarInset>
+          <AdminLayoutClient>
+            {children}
+          </AdminLayoutClient>
+        </SidebarInset>
         <AppCommandPalette />
         <Toaster />
       </SidebarProvider>

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -17,7 +17,12 @@ import { FloatingChatFab } from '@/components/floating-chat-fab'
 import { FloatingChatPopover } from '@/components/floating-chat-popover'
 import { FloatingChatShell } from '@/components/floating-chat-shell'
 import { PageContextSync } from '@/components/page-context-sync'
-import type { PersistConfig } from '@/components/floating-chat-popover'
+import {
+  readPersistedState,
+  patchPersistedState,
+  DEFAULT_CONFIG,
+  type PersistConfig,
+} from '@/components/floating-chat-popover'
 
 export function AdminLayoutClient({
   children,
@@ -26,22 +31,20 @@ export function AdminLayoutClient({
 }) {
   const [open, setOpen] = React.useState(() => {
     try {
-      const raw = typeof localStorage !== 'undefined'
-        ? localStorage.getItem('labby:floating-chat:state')
-        : null
-      if (!raw) return false
-      const parsed = JSON.parse(raw) as { open?: boolean; config?: PersistConfig }
-      return Boolean(parsed?.config?.persistOpen && parsed?.open)
+      const persisted = readPersistedState()
+      return Boolean(persisted.config?.persistOpen && persisted.open)
     } catch {
       return false
     }
   })
 
-  const [config, setConfig] = React.useState<PersistConfig>({
-    persistOpen: true,
-    persistPosition: true,
-    persistSize: true,
-    sendPageContext: false,
+  // lab-gych.15: initialize config from localStorage
+  const [config, setConfig] = React.useState<PersistConfig>(() => {
+    try {
+      return readPersistedState().config ?? DEFAULT_CONFIG
+    } catch {
+      return DEFAULT_CONFIG
+    }
   })
 
   // openModals ref — shared between FAB and CommandPalette
@@ -50,8 +53,16 @@ export function AdminLayoutClient({
   // First-open ref — ChatSessionProvider registers its callback here
   const onFirstOpenRef = React.useRef<(() => void) | null>(null)
   const hasOpenedOnce = React.useRef(false)
-  // State-based lazy mount for FloatingChatShell
-  const [shellMounted, setShellMounted] = React.useState(false)
+
+  // lab-gych.7: initialize shellMounted from the same localStorage check as `open`
+  const [shellMounted, setShellMounted] = React.useState(() => {
+    try {
+      const persisted = readPersistedState()
+      return Boolean(persisted.config?.persistOpen && persisted.open)
+    } catch {
+      return false
+    }
+  })
 
   const [isMobileViewport, setIsMobileViewport] = React.useState(false)
 
@@ -63,42 +74,39 @@ export function AdminLayoutClient({
     return () => media.removeEventListener('change', sync)
   }, [])
 
+  // lab-gych.7: when hydrating with open=true on first mount, seed hasOpenedOnce
+  // and fire the stream-start callback
+  React.useEffect(() => {
+    if (open && !hasOpenedOnce.current) {
+      hasOpenedOnce.current = true
+      onFirstOpenRef.current?.()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // intentionally runs once on mount
+
+  // lab-gych.8: side effects (stream start, shellMounted, localStorage write) live
+  // in a useEffect watching `open`, NOT inside the setState updater
+  React.useEffect(() => {
+    // First open: trigger stream start and mount shell
+    if (open && !hasOpenedOnce.current) {
+      hasOpenedOnce.current = true
+      onFirstOpenRef.current?.()
+      setShellMounted(true)
+    } else if (open && !shellMounted) {
+      setShellMounted(true)
+    }
+
+    // Persist open state
+    patchPersistedState({ open })
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleToggle = React.useCallback(() => {
-    setOpen((prev) => {
-      const next = !prev
-      // First open: trigger stream start and mount shell
-      if (next && !hasOpenedOnce.current) {
-        hasOpenedOnce.current = true
-        onFirstOpenRef.current?.()
-        setShellMounted(true)
-      }
-      // Persist open state
-      try {
-        const raw = localStorage.getItem('labby:floating-chat:state')
-        const parsed = raw ? JSON.parse(raw) : {}
-        localStorage.setItem(
-          'labby:floating-chat:state',
-          JSON.stringify({ ...parsed, open: next }),
-        )
-      } catch {
-        // localStorage unavailable
-      }
-      return next
-    })
+    // lab-gych.8: pure updater — no side effects inside setState
+    setOpen((prev) => !prev)
   }, [])
 
   const handleClose = React.useCallback(() => {
     setOpen(false)
-    try {
-      const raw = localStorage.getItem('labby:floating-chat:state')
-      const parsed = raw ? JSON.parse(raw) : {}
-      localStorage.setItem(
-        'labby:floating-chat:state',
-        JSON.stringify({ ...parsed, open: false }),
-      )
-    } catch {
-      // localStorage unavailable
-    }
   }, [])
 
   return (

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -5,10 +5,6 @@
  *
  * Hosts ChatSessionProvider, FloatingChatFab, and FloatingChatPopover.
  * Keeps the layout.tsx file a server component (no 'use client' in the layout).
- *
- * Stream lifecycle:
- * - onFirstOpenRef callback is passed to FAB and fired on first click
- * - ChatSessionProvider starts SSE only after first FAB click
  */
 
 import * as React from 'react'
@@ -21,7 +17,7 @@ import {
   readPersistedState,
   patchPersistedState,
   DEFAULT_CONFIG,
-  type PersistConfig,
+  type ChatConfig,
 } from '@/components/floating-chat-popover'
 
 export function AdminLayoutClient({
@@ -31,15 +27,13 @@ export function AdminLayoutClient({
 }) {
   const [open, setOpen] = React.useState(() => {
     try {
-      const persisted = readPersistedState()
-      return Boolean(persisted.config?.persistOpen && persisted.open)
+      return Boolean(readPersistedState().open)
     } catch {
       return false
     }
   })
 
-  // lab-gych.15: initialize config from localStorage
-  const [config, setConfig] = React.useState<PersistConfig>(() => {
+  const [config, setConfig] = React.useState<ChatConfig>(() => {
     try {
       return readPersistedState().config ?? DEFAULT_CONFIG
     } catch {
@@ -49,20 +43,6 @@ export function AdminLayoutClient({
 
   // openModals ref — shared between FAB and CommandPalette
   const openModals = React.useRef<Set<string>>(new Set())
-
-  // First-open ref — ChatSessionProvider registers its callback here
-  const onFirstOpenRef = React.useRef<(() => void) | null>(null)
-  const hasOpenedOnce = React.useRef(false)
-
-  // lab-gych.7: initialize shellMounted from the same localStorage check as `open`
-  const [shellMounted, setShellMounted] = React.useState(() => {
-    try {
-      const persisted = readPersistedState()
-      return Boolean(persisted.config?.persistOpen && persisted.open)
-    } catch {
-      return false
-    }
-  })
 
   const [isMobileViewport, setIsMobileViewport] = React.useState(false)
 
@@ -74,34 +54,11 @@ export function AdminLayoutClient({
     return () => media.removeEventListener('change', sync)
   }, [])
 
-  // lab-gych.7: when hydrating with open=true on first mount, seed hasOpenedOnce
-  // and fire the stream-start callback
   React.useEffect(() => {
-    if (open && !hasOpenedOnce.current) {
-      hasOpenedOnce.current = true
-      onFirstOpenRef.current?.()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // intentionally runs once on mount
-
-  // lab-gych.8: side effects (stream start, shellMounted, localStorage write) live
-  // in a useEffect watching `open`, NOT inside the setState updater
-  React.useEffect(() => {
-    // First open: trigger stream start and mount shell
-    if (open && !hasOpenedOnce.current) {
-      hasOpenedOnce.current = true
-      onFirstOpenRef.current?.()
-      setShellMounted(true)
-    } else if (open && !shellMounted) {
-      setShellMounted(true)
-    }
-
-    // Persist open state
     patchPersistedState({ open })
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open])
 
   const handleToggle = React.useCallback(() => {
-    // lab-gych.8: pure updater — no side effects inside setState
     setOpen((prev) => !prev)
   }, [])
 
@@ -110,10 +67,7 @@ export function AdminLayoutClient({
   }, [])
 
   return (
-    <ChatSessionProvider
-      onFirstOpenRef={onFirstOpenRef}
-      isMobileViewport={isMobileViewport}
-    >
+    <ChatSessionProvider isMobileViewport={isMobileViewport}>
       <PageContextSync />
       {children}
       <FloatingChatFab
@@ -127,8 +81,7 @@ export function AdminLayoutClient({
         config={config}
         onConfigChange={setConfig}
       >
-        {/* FloatingChatShell mounts lazily on first FAB click, stays mounted permanently */}
-        {shellMounted && <FloatingChatShell config={config} />}
+        <FloatingChatShell config={config} />
       </FloatingChatPopover>
     </ChatSessionProvider>
   )

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -15,6 +15,7 @@ import * as React from 'react'
 import { ChatSessionProvider } from '@/lib/chat/chat-session-provider'
 import { FloatingChatFab } from '@/components/floating-chat-fab'
 import { FloatingChatPopover } from '@/components/floating-chat-popover'
+import { FloatingChatShell } from '@/components/floating-chat-shell'
 import type { PersistConfig } from '@/components/floating-chat-popover'
 
 export function AdminLayoutClient({
@@ -48,6 +49,8 @@ export function AdminLayoutClient({
   // First-open ref — ChatSessionProvider registers its callback here
   const onFirstOpenRef = React.useRef<(() => void) | null>(null)
   const hasOpenedOnce = React.useRef(false)
+  // State-based lazy mount for FloatingChatShell
+  const [shellMounted, setShellMounted] = React.useState(false)
 
   const [isMobileViewport, setIsMobileViewport] = React.useState(false)
 
@@ -62,10 +65,11 @@ export function AdminLayoutClient({
   const handleToggle = React.useCallback(() => {
     setOpen((prev) => {
       const next = !prev
-      // First open: trigger stream start
+      // First open: trigger stream start and mount shell
       if (next && !hasOpenedOnce.current) {
         hasOpenedOnce.current = true
         onFirstOpenRef.current?.()
+        setShellMounted(true)
       }
       // Persist open state
       try {
@@ -112,7 +116,10 @@ export function AdminLayoutClient({
         onClose={handleClose}
         config={config}
         onConfigChange={setConfig}
-      />
+      >
+        {/* FloatingChatShell mounts lazily on first FAB click, stays mounted permanently */}
+        {shellMounted && <FloatingChatShell config={config} />}
+      </FloatingChatPopover>
     </ChatSessionProvider>
   )
 }

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+/**
+ * AdminLayoutClient — client-side wrapper for the admin layout.
+ *
+ * Hosts ChatSessionProvider, FloatingChatFab, and FloatingChatPopover.
+ * Keeps the layout.tsx file a server component (no 'use client' in the layout).
+ *
+ * Stream lifecycle:
+ * - onFirstOpenRef callback is passed to FAB and fired on first click
+ * - ChatSessionProvider starts SSE only after first FAB click
+ */
+
+import * as React from 'react'
+import { ChatSessionProvider } from '@/lib/chat/chat-session-provider'
+import { FloatingChatFab } from '@/components/floating-chat-fab'
+import { FloatingChatPopover } from '@/components/floating-chat-popover'
+import type { PersistConfig } from '@/components/floating-chat-popover'
+
+export function AdminLayoutClient({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = React.useState(() => {
+    try {
+      const raw = typeof localStorage !== 'undefined'
+        ? localStorage.getItem('labby:floating-chat:state')
+        : null
+      if (!raw) return false
+      const parsed = JSON.parse(raw) as { open?: boolean; config?: PersistConfig }
+      return Boolean(parsed?.config?.persistOpen && parsed?.open)
+    } catch {
+      return false
+    }
+  })
+
+  const [config, setConfig] = React.useState<PersistConfig>({
+    persistOpen: true,
+    persistPosition: true,
+    persistSize: true,
+    sendPageContext: false,
+  })
+
+  // openModals ref — shared between FAB and CommandPalette
+  const openModals = React.useRef<Set<string>>(new Set())
+
+  // First-open ref — ChatSessionProvider registers its callback here
+  const onFirstOpenRef = React.useRef<(() => void) | null>(null)
+  const hasOpenedOnce = React.useRef(false)
+
+  const [isMobileViewport, setIsMobileViewport] = React.useState(false)
+
+  React.useEffect(() => {
+    const media = window.matchMedia('(max-width: 767px)')
+    const sync = () => setIsMobileViewport(media.matches)
+    sync()
+    media.addEventListener('change', sync)
+    return () => media.removeEventListener('change', sync)
+  }, [])
+
+  const handleToggle = React.useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev
+      // First open: trigger stream start
+      if (next && !hasOpenedOnce.current) {
+        hasOpenedOnce.current = true
+        onFirstOpenRef.current?.()
+      }
+      // Persist open state
+      try {
+        const raw = localStorage.getItem('labby:floating-chat:state')
+        const parsed = raw ? JSON.parse(raw) : {}
+        localStorage.setItem(
+          'labby:floating-chat:state',
+          JSON.stringify({ ...parsed, open: next }),
+        )
+      } catch {
+        // localStorage unavailable
+      }
+      return next
+    })
+  }, [])
+
+  const handleClose = React.useCallback(() => {
+    setOpen(false)
+    try {
+      const raw = localStorage.getItem('labby:floating-chat:state')
+      const parsed = raw ? JSON.parse(raw) : {}
+      localStorage.setItem(
+        'labby:floating-chat:state',
+        JSON.stringify({ ...parsed, open: false }),
+      )
+    } catch {
+      // localStorage unavailable
+    }
+  }, [])
+
+  return (
+    <ChatSessionProvider
+      onFirstOpenRef={onFirstOpenRef}
+      isMobileViewport={isMobileViewport}
+    >
+      {children}
+      <FloatingChatFab
+        open={open}
+        onToggle={handleToggle}
+        openModals={openModals}
+      />
+      <FloatingChatPopover
+        open={open}
+        onClose={handleClose}
+        config={config}
+        onConfigChange={setConfig}
+      />
+    </ChatSessionProvider>
+  )
+}

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -16,6 +16,7 @@ import { ChatSessionProvider } from '@/lib/chat/chat-session-provider'
 import { FloatingChatFab } from '@/components/floating-chat-fab'
 import { FloatingChatPopover } from '@/components/floating-chat-popover'
 import { FloatingChatShell } from '@/components/floating-chat-shell'
+import { PageContextSync } from '@/components/page-context-sync'
 import type { PersistConfig } from '@/components/floating-chat-popover'
 
 export function AdminLayoutClient({
@@ -105,6 +106,7 @@ export function AdminLayoutClient({
       onFirstOpenRef={onFirstOpenRef}
       isMobileViewport={isMobileViewport}
     >
+      <PageContextSync />
       {children}
       <FloatingChatFab
         open={open}

--- a/apps/gateway-admin/components/design-system/design-system-shell.tsx
+++ b/apps/gateway-admin/components/design-system/design-system-shell.tsx
@@ -11,6 +11,7 @@ import { ControlsSection } from './controls-section'
 import { CommandPaletteSection } from './command-palette-section'
 import { DataDisplaySection } from './data-display-section'
 import { FeedbackSection } from './feedback-section'
+import { FloatingChatSection } from './floating-chat-section'
 import { FoundationsSection } from './foundations-section'
 import { NavigationSection } from './navigation-section'
 import { PatternsSection } from './patterns-section'
@@ -50,6 +51,9 @@ export function DesignSystemShell() {
           </div>
           <div className="xl:col-span-2">
             <CommandPaletteSection />
+          </div>
+          <div className="xl:col-span-2">
+            <FloatingChatSection />
           </div>
           <div className="xl:col-span-2">
             <DataDisplaySection />

--- a/apps/gateway-admin/components/design-system/floating-chat-section.tsx
+++ b/apps/gateway-admin/components/design-system/floating-chat-section.tsx
@@ -118,28 +118,16 @@ function PopoverDemo({ state }: { state: PopoverDemoState }) {
       {/* Gear config panel */}
       {isGearOpen && (
         <div className="border-b border-aurora-border-strong bg-aurora-panel-medium px-4 py-3">
-          <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-aurora-text-muted">
-            Persistence
-          </p>
           <div className="flex flex-col gap-2">
-            {(
-              [
-                { key: 'persistOpen', label: 'Restore open state', defaultChecked: true },
-                { key: 'persistPosition', label: 'Restore position', defaultChecked: true },
-                { key: 'persistSize', label: 'Restore size', defaultChecked: true },
-                { key: 'sendPageContext', label: 'Send page context', defaultChecked: false },
-              ] as const
-            ).map(({ key, label, defaultChecked }) => (
-              <label key={key} className="flex items-center gap-2.5">
-                <input
-                  type="checkbox"
-                  defaultChecked={defaultChecked}
-                  className="size-3.5 accent-aurora-accent-primary"
-                  readOnly
-                />
-                <span className="text-[12px] text-aurora-text-primary">{label}</span>
-              </label>
-            ))}
+            <label className="flex items-center gap-2.5">
+              <input
+                type="checkbox"
+                defaultChecked={false}
+                className="size-3.5 accent-aurora-accent-primary"
+                readOnly
+              />
+              <span className="text-[12px] text-aurora-text-primary">Send page context</span>
+            </label>
           </div>
         </div>
       )}
@@ -167,9 +155,6 @@ const PERSISTENCE_SCHEMA = `Key: "${PERSIST_KEY}"
   position: { x: number, y: number },
   size: { w: number, h: number },
   config: {
-    persistOpen: boolean,    // default: ${DEFAULT_CONFIG.persistOpen}
-    persistPosition: boolean, // default: ${DEFAULT_CONFIG.persistPosition}
-    persistSize: boolean,    // default: ${DEFAULT_CONFIG.persistSize}
     sendPageContext: boolean  // default: ${DEFAULT_CONFIG.sendPageContext}
   }
 }`

--- a/apps/gateway-admin/components/design-system/floating-chat-section.tsx
+++ b/apps/gateway-admin/components/design-system/floating-chat-section.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+/**
+ * FloatingChatSection — Design system sandbox for the floating chat pattern.
+ *
+ * Documents FAB states, popover states, drag/resize mechanics, persistence
+ * schema, hotkey reference, and mobile sheet behaviour using local fake state.
+ * No live backend required.
+ */
+
+import * as React from 'react'
+import { MessageSquare, Settings2, X, GripHorizontal } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  AURORA_DISPLAY_2,
+  AURORA_MUTED_LABEL,
+  AURORA_STRONG_PANEL,
+} from '@/components/aurora/tokens'
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { PERSIST_KEY, DEFAULT_CONFIG } from '@/components/floating-chat-popover'
+
+// ---- FAB state demo ----
+
+type FabDemoState = 'default' | 'with-badge' | 'active'
+
+function FabDemo({
+  state,
+  connectionState,
+}: {
+  state: FabDemoState
+  connectionState?: 'connecting' | 'error' | 'open'
+}) {
+  const isOpen = state === 'active'
+  const badgeCount = state === 'with-badge' ? 3 : 0
+
+  const connectionRingClass = connectionState === 'connecting'
+    ? 'ring-2 ring-aurora-accent-primary/40 animate-pulse'
+    : ''
+
+  return (
+    <div className="flex items-center">
+      <button
+        type="button"
+        aria-label={isOpen ? 'Close chat (demo)' : 'Open chat (demo)'}
+        aria-expanded={isOpen}
+        className={cn(
+          'relative flex items-center gap-2 rounded-full border border-aurora-border-strong',
+          'bg-aurora-panel-strong text-aurora-text-muted',
+          'hover:text-aurora-text-primary hover:bg-aurora-hover-bg',
+          'px-4 py-2.5 text-sm font-medium',
+          'transition-all duration-150',
+          connectionRingClass,
+          isOpen && 'border-aurora-accent-primary/40 bg-aurora-panel-strong text-aurora-text-primary',
+        )}
+      >
+        <MessageSquare className="size-4" />
+        <span>Chat</span>
+
+        {badgeCount > 0 && (
+          <span
+            aria-label={`${badgeCount} unread`}
+            className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-aurora-accent-primary text-[10px] font-bold text-white"
+          >
+            {badgeCount}
+          </span>
+        )}
+
+        {connectionState === 'error' && (
+          <span
+            aria-hidden="true"
+            className="absolute -right-1 -top-1 size-2.5 rounded-full bg-amber-400"
+          />
+        )}
+      </button>
+    </div>
+  )
+}
+
+// ---- Popover demo ----
+
+type PopoverDemoState = 'default' | 'gear-open' | 'compact'
+
+function PopoverDemo({ state }: { state: PopoverDemoState }) {
+  const isCompact = state === 'compact'
+  const isGearOpen = state === 'gear-open'
+  const w = isCompact ? 320 : 420
+  const h = isCompact ? 280 : 420
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-aurora-3 border border-aurora-border-strong bg-aurora-panel-strong shadow-[var(--aurora-shadow-strong)]"
+      style={{ width: w, height: h }}
+    >
+      {/* Header */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-aurora-border-strong bg-aurora-panel-strong px-3 select-none">
+        <GripHorizontal className="size-3.5 text-aurora-text-muted/60" aria-hidden="true" />
+        <span className="flex-1 truncate text-[13px] font-semibold text-aurora-text-primary">Chat</span>
+        <button
+          type="button"
+          aria-label="Chat settings (demo)"
+          className={cn(
+            'flex size-6 items-center justify-center rounded text-aurora-text-muted/60',
+            'hover:bg-aurora-hover-bg hover:text-aurora-text-primary',
+            isGearOpen && 'bg-aurora-hover-bg text-aurora-text-primary',
+          )}
+        >
+          <Settings2 className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Close chat (demo)"
+          className="flex size-6 items-center justify-center rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      {/* Gear config panel */}
+      {isGearOpen && (
+        <div className="border-b border-aurora-border-strong bg-aurora-panel-medium px-4 py-3">
+          <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-aurora-text-muted">
+            Persistence
+          </p>
+          <div className="flex flex-col gap-2">
+            {(
+              [
+                { key: 'persistOpen', label: 'Restore open state', defaultChecked: true },
+                { key: 'persistPosition', label: 'Restore position', defaultChecked: true },
+                { key: 'persistSize', label: 'Restore size', defaultChecked: true },
+                { key: 'sendPageContext', label: 'Send page context', defaultChecked: false },
+              ] as const
+            ).map(({ key, label, defaultChecked }) => (
+              <label key={key} className="flex items-center gap-2.5">
+                <input
+                  type="checkbox"
+                  defaultChecked={defaultChecked}
+                  className="size-3.5 accent-aurora-accent-primary"
+                  readOnly
+                />
+                <span className="text-[12px] text-aurora-text-primary">{label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content placeholder */}
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-aurora-text-muted">Chat content area</p>
+      </div>
+
+      {/* Resize handle */}
+      <div className="absolute bottom-0 right-0 size-4 cursor-se-resize" aria-hidden="true">
+        <svg viewBox="0 0 16 16" fill="none" className="size-full text-aurora-text-muted/30">
+          <path d="M14 2L2 14M14 8L8 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </div>
+    </div>
+  )
+}
+
+// ---- Persistence schema display ----
+
+const PERSISTENCE_SCHEMA = `Key: "${PERSIST_KEY}"
+{
+  open: boolean,
+  position: { x: number, y: number },
+  size: { w: number, h: number },
+  config: {
+    persistOpen: boolean,    // default: ${DEFAULT_CONFIG.persistOpen}
+    persistPosition: boolean, // default: ${DEFAULT_CONFIG.persistPosition}
+    persistSize: boolean,    // default: ${DEFAULT_CONFIG.persistSize}
+    sendPageContext: boolean  // default: ${DEFAULT_CONFIG.sendPageContext}
+  }
+}`
+
+// ---- Main section ----
+
+export function FloatingChatSection() {
+  return (
+    <section className={cn(AURORA_STRONG_PANEL, 'overflow-hidden')}>
+      <div className="border-b border-aurora-border-strong px-5 py-4">
+        <p className={AURORA_MUTED_LABEL}>Application Patterns</p>
+        <h2 className={cn(AURORA_DISPLAY_2, 'mt-2 text-aurora-text-primary')}>
+          Floating Chat
+        </h2>
+        <p className="mt-2 max-w-2xl text-sm text-aurora-text-muted">
+          Global floating chat surface available on every admin page. A fixed pill FAB opens
+          a draggable/resizable popover with full /chat feature parity. Backed by shared session
+          context. Non-chat pages pay zero SSE cost until the first FAB click.
+        </p>
+      </div>
+
+      <div className="space-y-8 px-5 py-6">
+        {/* FAB states */}
+        <div>
+          <p className={cn(AURORA_MUTED_LABEL, 'mb-4')}>FAB States</p>
+          <div className="flex flex-wrap items-end gap-8">
+            <div className="flex flex-col items-start gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Default</p>
+              <FabDemo state="default" />
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="text-[12px] text-aurora-text-muted">With badge (count=3)</p>
+              <FabDemo state="with-badge" />
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Active / open</p>
+              <FabDemo state="active" />
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Connecting (pulsing ring)</p>
+              <FabDemo state="default" connectionState="connecting" />
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Error (amber dot)</p>
+              <FabDemo state="default" connectionState="error" />
+            </div>
+          </div>
+        </div>
+
+        {/* Popover states */}
+        <div>
+          <p className={cn(AURORA_MUTED_LABEL, 'mb-4')}>Popover States</p>
+          <div className="flex flex-wrap items-start gap-8">
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Default (bottom-right)</p>
+              <PopoverDemo state="default" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Gear config panel open</p>
+              <PopoverDemo state="gear-open" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] text-aurora-text-muted">Compact (minimum size)</p>
+              <PopoverDemo state="compact" />
+            </div>
+          </div>
+        </div>
+
+        {/* Persistence schema */}
+        <div>
+          <p className={cn(AURORA_MUTED_LABEL, 'mb-3')}>Persistence Schema</p>
+          <pre className="overflow-x-auto rounded-aurora-2 border border-aurora-border-strong bg-aurora-control-surface p-4 font-mono text-[12px] leading-relaxed text-aurora-text-primary">
+            {PERSISTENCE_SCHEMA}
+          </pre>
+        </div>
+
+        {/* Hotkey reference */}
+        <div>
+          <p className={cn(AURORA_MUTED_LABEL, 'mb-3')}>Hotkey</p>
+          <div className="flex items-center gap-3">
+            <KbdGroup>
+              <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
+                ⌘
+              </Kbd>
+              <Kbd className="border border-aurora-border-default bg-aurora-panel-medium text-[10px] text-aurora-text-muted">
+                /
+              </Kbd>
+            </KbdGroup>
+            <span className="text-sm text-aurora-text-muted">
+              Toggle floating chat open/closed
+            </span>
+          </div>
+          <p className="mt-2 text-[12px] text-aurora-text-muted">
+            On Windows/Linux: Ctrl+/. Skipped when focus is in an input, textarea, or contentEditable.
+          </p>
+        </div>
+
+        {/* Mobile sheet note */}
+        <div>
+          <p className={cn(AURORA_MUTED_LABEL, 'mb-2')}>Mobile Behaviour</p>
+          <p className="text-sm text-aurora-text-muted">
+            On viewports &lt; 768px the floating popover renders as a full-screen bottom{' '}
+            <strong className="text-aurora-text-primary">Sheet</strong> instead of a fixed
+            overlay. Drag and resize mechanics are disabled in Sheet mode. The FAB remains
+            fixed in the bottom-right corner.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/gateway-admin/components/floating-chat-fab.tsx
+++ b/apps/gateway-admin/components/floating-chat-fab.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+/**
+ * FloatingChatFab — Fixed pill FAB (bottom-right) that opens the floating chat popover.
+ *
+ * - Fixed position, hidden (visibility:hidden) on /chat route — NOT unmounted
+ * - Cmd/Ctrl+/ hotkey toggles open/closed
+ * - Ambient connection indicator from ChatSessionConnectionContext
+ * - Modal stack guard: registers in openModals ref when open
+ * - Respects prefers-reduced-motion
+ */
+
+import * as React from 'react'
+import { MessageSquare } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+export type FloatingChatFabProps = {
+  /** Whether the popover is currently open */
+  open: boolean
+  /** Toggle the popover open/closed */
+  onToggle: () => void
+  /** Connection state from ChatSessionConnectionContext (only populated after first open) */
+  connectionState?: 'idle' | 'connecting' | 'open' | 'error'
+  /** Whether a session is currently streaming (running) */
+  isStreaming?: boolean
+  /** Ref to a set of open modal IDs — FAB registers 'floating-chat' when popover opens */
+  openModals?: React.RefObject<Set<string>>
+  /** Unread count badge — shows dot until notification system exists */
+  unreadCount?: number
+}
+
+export function FloatingChatFab({
+  open,
+  onToggle,
+  connectionState,
+  isStreaming,
+  openModals,
+  unreadCount = 0,
+}: FloatingChatFabProps) {
+  const pathname = usePathname()
+  const isOnChatPage = pathname === '/chat'
+
+  // Register/deregister from modal stack
+  React.useEffect(() => {
+    if (!openModals) return
+    if (open) {
+      openModals.current.add('floating-chat')
+    } else {
+      openModals.current.delete('floating-chat')
+    }
+    return () => {
+      openModals.current.delete('floating-chat')
+    }
+  }, [open, openModals])
+
+  // Hotkey: Cmd/Ctrl+/ — skip when focused in inputs
+  React.useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!(event.metaKey || event.ctrlKey)) return
+      if (event.key !== '/') return
+      const target = event.target as Element | null
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable)
+      ) {
+        return
+      }
+      // Don't open if another modal is focused
+      if (openModals?.current && openModals.current.size > 0 && !open) return
+      event.preventDefault()
+      onToggle()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onToggle, open, openModals])
+
+  // Connection indicator classes
+  const connectionRingClass = connectionState === 'connecting'
+    ? 'ring-2 ring-aurora-accent-primary/40 animate-pulse'
+    : connectionState === 'error'
+    ? ''
+    : ''
+
+  const isStreamingPulse = isStreaming && connectionState === 'open'
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-5 right-5 z-40',
+        // CSS-hidden (not unmounted) when on /chat route
+        isOnChatPage && 'invisible pointer-events-none',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls="floating-chat-panel"
+        aria-label={open ? 'Close chat' : 'Open chat'}
+        className={cn(
+          'relative flex items-center gap-2 rounded-full border border-aurora-border-strong',
+          'bg-aurora-panel-strong text-aurora-text-muted',
+          'hover:text-aurora-text-primary hover:bg-aurora-hover-bg',
+          'px-4 py-2.5 text-sm font-medium',
+          'transition-all duration-150',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aurora-accent-primary',
+          // Connection ring indicator (only after first open — when connectionState is set)
+          connectionRingClass,
+          // Streaming pulse — soft
+          isStreamingPulse && 'motion-safe:animate-pulse',
+          // Active state
+          open && 'border-aurora-accent-primary/40 bg-aurora-panel-strong text-aurora-text-primary',
+        )}
+      >
+        <MessageSquare className="size-4" />
+        <span>Chat</span>
+
+        {/* Unread count badge — dot until notification system */}
+        {unreadCount > 0 && (
+          <span
+            aria-label={`${unreadCount} unread`}
+            className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-aurora-accent-primary text-[10px] font-bold text-white"
+          >
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+
+        {/* Error indicator dot */}
+        {connectionState === 'error' && (
+          <span
+            aria-hidden="true"
+            className="absolute -right-1 -top-1 size-2.5 rounded-full bg-amber-400"
+          />
+        )}
+      </button>
+    </div>
+  )
+}

--- a/apps/gateway-admin/components/floating-chat-popover.tsx
+++ b/apps/gateway-admin/components/floating-chat-popover.tsx
@@ -1,0 +1,521 @@
+'use client'
+
+/**
+ * FloatingChatPopover — Draggable/resizable popover shell for floating chat.
+ *
+ * - Default: 420×600px; min: 320×420; max: 800×900
+ * - Drag via DOM ref + rAF (NOT React state) — no re-renders during drag
+ * - Resize via react-resizable-panels (bottom-right handle)
+ * - Viewport hard-clamp on drag commit and window resize
+ * - Position/size/open-state persisted to localStorage
+ * - Accessibility: role=dialog, aria-modal, focus trap, Escape closes, HTML inert
+ * - Mobile: full-screen Sheet (viewport < 768px)
+ * - CSS-hidden (visibility:hidden) when on /chat route — NOT unmounted
+ * - Respects prefers-reduced-motion
+ */
+
+import * as React from 'react'
+import { X, GripHorizontal, Settings2 } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+
+// ---- Persistence key + types ----
+
+const PERSIST_KEY = 'labby:floating-chat:state'
+
+type Position = { x: number; y: number }
+type Size = { w: number; h: number }
+type PersistConfig = {
+  persistOpen: boolean
+  persistPosition: boolean
+  persistSize: boolean
+  sendPageContext: boolean
+}
+
+type PersistedState = {
+  open?: boolean
+  position?: Position
+  size?: Size
+  config?: PersistConfig
+}
+
+const DEFAULT_SIZE: Size = { w: 420, h: 600 }
+const MIN_SIZE: Size = { w: 320, h: 420 }
+const MAX_SIZE: Size = { w: 800, h: 900 }
+const DEFAULT_CONFIG: PersistConfig = {
+  persistOpen: true,
+  persistPosition: true,
+  persistSize: true,
+  sendPageContext: false,
+}
+
+function readPersistedState(): PersistedState {
+  try {
+    const raw = typeof localStorage !== 'undefined'
+      ? localStorage.getItem(PERSIST_KEY)
+      : null
+    if (!raw) return {}
+    return JSON.parse(raw) as PersistedState
+  } catch {
+    return {}
+  }
+}
+
+function writePersistedState(state: PersistedState) {
+  try {
+    localStorage.setItem(PERSIST_KEY, JSON.stringify(state))
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+function clampPosition(x: number, y: number, w: number, h: number): Position {
+  if (typeof window === 'undefined') return { x, y }
+  return {
+    x: Math.max(0, Math.min(x, window.innerWidth - w)),
+    y: Math.max(0, Math.min(y, window.innerHeight - h)),
+  }
+}
+
+function clampSize(w: number, h: number): Size {
+  return {
+    w: Math.max(MIN_SIZE.w, Math.min(MAX_SIZE.w, w)),
+    h: Math.max(MIN_SIZE.h, Math.min(MAX_SIZE.h, h)),
+  }
+}
+
+// ---- Component ----
+
+export type FloatingChatPopoverProps = {
+  open: boolean
+  onClose: () => void
+  /** The content to render inside the popover (chat shell) */
+  children?: React.ReactNode
+  /** Config getter/setter for page context toggle */
+  config?: PersistConfig
+  onConfigChange?: (config: PersistConfig) => void
+}
+
+export function FloatingChatPopover({
+  open,
+  onClose,
+  children,
+  config: externalConfig,
+  onConfigChange,
+}: FloatingChatPopoverProps) {
+  const pathname = usePathname()
+  const isOnChatPage = pathname === '/chat'
+
+  // ---- Local state ----
+  const [isMobileViewport, setIsMobileViewport] = React.useState(false)
+  const [size, setSize] = React.useState<Size>(() => {
+    const persisted = readPersistedState()
+    const cfg = persisted.config ?? DEFAULT_CONFIG
+    if (cfg.persistSize && persisted.size) {
+      return clampSize(persisted.size.w, persisted.size.h)
+    }
+    return DEFAULT_SIZE
+  })
+  const [position, setPosition] = React.useState<Position>({ x: 0, y: 0 })
+  const [positionInitialized, setPositionInitialized] = React.useState(false)
+  const [gearOpen, setGearOpen] = React.useState(false)
+  const [config, setConfig] = React.useState<PersistConfig>(() => {
+    const persisted = readPersistedState()
+    return persisted.config ?? DEFAULT_CONFIG
+  })
+
+  // Sync external config if provided
+  const effectiveConfig = externalConfig ?? config
+
+  // ---- Refs ----
+  const panelRef = React.useRef<HTMLDivElement>(null)
+  const headerRef = React.useRef<HTMLDivElement>(null)
+  const dragRef = React.useRef<{
+    active: boolean
+    startX: number
+    startY: number
+    startPosX: number
+    startPosY: number
+    pointerId: number
+    rafId?: number
+    pendingX: number
+    pendingY: number
+  } | null>(null)
+  const resizeRef = React.useRef<{
+    active: boolean
+    startX: number
+    startY: number
+    startW: number
+    startH: number
+  } | null>(null)
+
+  // ---- Mobile viewport detection ----
+  React.useEffect(() => {
+    const media = window.matchMedia('(max-width: 767px)')
+    const sync = () => setIsMobileViewport(media.matches)
+    sync()
+    media.addEventListener('change', sync)
+    return () => media.removeEventListener('change', sync)
+  }, [])
+
+  // ---- Initialize position after hydration ----
+  React.useEffect(() => {
+    if (positionInitialized) return
+    const persisted = readPersistedState()
+    const cfg = persisted.config ?? DEFAULT_CONFIG
+    if (cfg.persistPosition && persisted.position) {
+      setPosition(clampPosition(
+        persisted.position.x,
+        persisted.position.y,
+        size.w,
+        size.h,
+      ))
+    } else {
+      // Default: bottom-right
+      setPosition(clampPosition(
+        window.innerWidth - size.w - 20,
+        window.innerHeight - size.h - 80,
+        size.w,
+        size.h,
+      ))
+    }
+    setPositionInitialized(true)
+  }, [positionInitialized, size.w, size.h])
+
+  // ---- Window resize clamp (debounced) ----
+  React.useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+    function onResize() {
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        setPosition((pos) => clampPosition(pos.x, pos.y, size.w, size.h))
+      }, 100)
+    }
+    window.addEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+      clearTimeout(timer)
+    }
+  }, [size.w, size.h])
+
+  // ---- Focus trap ----
+  React.useEffect(() => {
+    if (!open || isMobileViewport) return
+    const panel = panelRef.current
+    if (!panel) return
+
+    // Focus the panel itself
+    panel.focus()
+
+    // Inert the rest of the page
+    const appRoot = document.querySelector('#__next') as HTMLElement | null
+    if (appRoot) {
+      appRoot.inert = true
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+
+      // Tab trap
+      if (event.key !== 'Tab') return
+      const focusable = panel?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (!focusable || focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      if (appRoot) {
+        appRoot.inert = false
+      }
+    }
+  }, [open, onClose, isMobileViewport])
+
+  // ---- Drag handlers (DOM ref + rAF, not React state) ----
+  const onPointerDownHeader = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+    dragRef.current = {
+      active: true,
+      startX: event.clientX,
+      startY: event.clientY,
+      startPosX: position.x,
+      startPosY: position.y,
+      pointerId: event.pointerId,
+      pendingX: position.x,
+      pendingY: position.y,
+    }
+  }, [position.x, position.y])
+
+  const onPointerMoveHeader = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current?.active) return
+    const dx = event.clientX - dragRef.current.startX
+    const dy = event.clientY - dragRef.current.startY
+    const newX = dragRef.current.startPosX + dx
+    const newY = dragRef.current.startPosY + dy
+
+    dragRef.current.pendingX = newX
+    dragRef.current.pendingY = newY
+
+    if (dragRef.current.rafId != null) return
+    dragRef.current.rafId = requestAnimationFrame(() => {
+      if (!dragRef.current || !panelRef.current) return
+      dragRef.current.rafId = undefined
+      const clamped = clampPosition(dragRef.current.pendingX, dragRef.current.pendingY, size.w, size.h)
+      panelRef.current.style.transform = `translate3d(${clamped.x}px, ${clamped.y}px, 0)`
+    })
+  }, [size.w, size.h])
+
+  const onPointerUpHeader = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current?.active) return
+    dragRef.current.active = false
+    if (dragRef.current.rafId != null) {
+      cancelAnimationFrame(dragRef.current.rafId)
+      dragRef.current.rafId = undefined
+    }
+
+    const clamped = clampPosition(dragRef.current.pendingX, dragRef.current.pendingY, size.w, size.h)
+
+    if (panelRef.current) {
+      panelRef.current.style.transform = ''
+    }
+
+    setPosition(clamped)
+
+    // Persist if configured
+    const persisted = readPersistedState()
+    const cfg = persisted.config ?? DEFAULT_CONFIG
+    if (cfg.persistPosition) {
+      writePersistedState({ ...persisted, position: clamped })
+    }
+
+    dragRef.current = null
+    ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+  }, [size.w, size.h])
+
+  // ---- Resize handlers (corner handle) ----
+  const onResizePointerDown = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+    resizeRef.current = {
+      active: true,
+      startX: event.clientX,
+      startY: event.clientY,
+      startW: size.w,
+      startH: size.h,
+    }
+  }, [size.w, size.h])
+
+  const onResizePointerMove = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!resizeRef.current?.active) return
+    const dx = event.clientX - resizeRef.current.startX
+    const dy = event.clientY - resizeRef.current.startY
+    const newSize = clampSize(resizeRef.current.startW + dx, resizeRef.current.startH + dy)
+    setSize(newSize)
+  }, [])
+
+  const onResizePointerUp = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!resizeRef.current?.active) return
+    resizeRef.current.active = false
+
+    // Persist size
+    const persisted = readPersistedState()
+    const cfg = persisted.config ?? DEFAULT_CONFIG
+    if (cfg.persistSize) {
+      writePersistedState({ ...persisted, size })
+    }
+
+    resizeRef.current = null
+    ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+  }, [size])
+
+  // ---- Config change handler ----
+  const handleConfigChange = React.useCallback((key: keyof PersistConfig, value: boolean) => {
+    const newConfig = { ...effectiveConfig, [key]: value }
+    setConfig(newConfig)
+    onConfigChange?.(newConfig)
+
+    const persisted = readPersistedState()
+    writePersistedState({ ...persisted, config: newConfig })
+  }, [effectiveConfig, onConfigChange])
+
+  // ---- Mobile Sheet ----
+  if (isMobileViewport) {
+    return (
+      <Sheet open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+        <SheetContent side="bottom" className="h-[90dvh] bg-aurora-panel-strong p-0">
+          <SheetHeader className="border-b border-aurora-border-strong px-4 py-3">
+            <SheetTitle className="text-sm font-semibold text-aurora-text-primary">Chat</SheetTitle>
+          </SheetHeader>
+          <div className="flex h-full flex-col overflow-hidden">
+            {children}
+          </div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  // ---- Desktop Popover ----
+  return (
+    <div
+      id="floating-chat-panel"
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="floating-chat-title"
+      tabIndex={-1}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: `${size.w}px`,
+        height: `${size.h}px`,
+        transform: positionInitialized ? `translate3d(${position.x}px, ${position.y}px, 0)` : undefined,
+        zIndex: 50,
+        // CSS-hidden (not unmounted) on /chat page or when closed
+        visibility: isOnChatPage || !open ? 'hidden' : 'visible',
+        pointerEvents: isOnChatPage || !open ? 'none' : 'auto',
+      }}
+      className={cn(
+        'flex flex-col overflow-hidden rounded-aurora-3',
+        'border border-aurora-border-strong',
+        'bg-aurora-panel-strong',
+        'shadow-[var(--aurora-shadow-strong),var(--aurora-highlight-strong)]',
+        'outline-none',
+        // Open/close animation — respect reduced motion
+        'motion-safe:transition-[opacity,scale] motion-safe:duration-150',
+        open && !isOnChatPage ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
+      )}
+    >
+      {/* ---- Header (drag handle) ---- */}
+      <div
+        ref={headerRef}
+        onPointerDown={onPointerDownHeader}
+        onPointerMove={onPointerMoveHeader}
+        onPointerUp={onPointerUpHeader}
+        onPointerCancel={onPointerUpHeader}
+        className="flex h-12 shrink-0 cursor-grab items-center gap-2 border-b border-aurora-border-strong bg-aurora-panel-strong px-3 select-none active:cursor-grabbing"
+        style={{ touchAction: 'none' }}
+      >
+        <GripHorizontal className="size-3.5 text-aurora-text-muted/60" aria-hidden="true" />
+        <span
+          id="floating-chat-title"
+          className="flex-1 truncate text-[13px] font-semibold text-aurora-text-primary"
+        >
+          Chat
+        </span>
+
+        {/* Gear config toggle */}
+        <button
+          type="button"
+          onClick={() => setGearOpen((prev) => !prev)}
+          aria-label="Chat settings"
+          aria-expanded={gearOpen}
+          className={cn(
+            'flex size-6 items-center justify-center rounded text-aurora-text-muted/60',
+            'hover:bg-aurora-hover-bg hover:text-aurora-text-primary',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aurora-accent-primary',
+            gearOpen && 'bg-aurora-hover-bg text-aurora-text-primary',
+          )}
+        >
+          <Settings2 className="size-3.5" />
+        </button>
+
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close chat"
+          className="flex size-6 items-center justify-center rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aurora-accent-primary"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      {/* ---- Gear config panel ---- */}
+      {gearOpen && (
+        <div className="shrink-0 border-b border-aurora-border-strong bg-aurora-panel-medium px-4 py-3">
+          <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-aurora-text-muted">
+            Persistence
+          </p>
+          <div className="flex flex-col gap-2">
+            {(
+              [
+                { key: 'persistOpen', label: 'Restore open state' },
+                { key: 'persistPosition', label: 'Restore position' },
+                { key: 'persistSize', label: 'Restore size' },
+                { key: 'sendPageContext', label: 'Send page context' },
+              ] as { key: keyof PersistConfig; label: string }[]
+            ).map(({ key, label }) => (
+              <label key={key} className="flex cursor-pointer items-center gap-2.5">
+                <input
+                  type="checkbox"
+                  checked={effectiveConfig[key]}
+                  onChange={(e) => handleConfigChange(key, e.target.checked)}
+                  className="size-3.5 accent-aurora-accent-primary"
+                />
+                <span className="text-[12px] text-aurora-text-primary">{label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ---- Content area ---- */}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {children}
+      </div>
+
+      {/* ---- Resize handle (bottom-right corner) ---- */}
+      <div
+        onPointerDown={onResizePointerDown}
+        onPointerMove={onResizePointerMove}
+        onPointerUp={onResizePointerUp}
+        onPointerCancel={onResizePointerUp}
+        className="absolute bottom-0 right-0 size-4 cursor-se-resize"
+        style={{ touchAction: 'none' }}
+        aria-hidden="true"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          className="size-full text-aurora-text-muted/30"
+          aria-hidden="true"
+        >
+          <path
+            d="M14 2L2 14M14 8L8 14M14 14H14"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+    </div>
+  )
+}
+
+// Export persistence types for use in design system
+export type { PersistConfig, Position, Size }
+export { PERSIST_KEY, DEFAULT_CONFIG, DEFAULT_SIZE, MIN_SIZE, MAX_SIZE }

--- a/apps/gateway-admin/components/floating-chat-popover.tsx
+++ b/apps/gateway-admin/components/floating-chat-popover.tsx
@@ -208,10 +208,15 @@ export function FloatingChatPopover({
     // Focus the panel itself
     panel.focus()
 
-    // Inert the rest of the page
-    const appRoot = document.querySelector('#__next') as HTMLElement | null
-    if (appRoot) {
-      appRoot.inert = true
+    // Inert all direct body children except the panel itself (App Router compatible).
+    // document.body.inert would block the panel too since it's a descendant.
+    const toRestore: HTMLElement[] = []
+    for (const child of Array.from(document.body.children)) {
+      const el = child as HTMLElement
+      if (el !== panel && !el.contains(panel)) {
+        el.inert = true
+        toRestore.push(el)
+      }
     }
 
     function onKeyDown(event: KeyboardEvent) {
@@ -245,8 +250,8 @@ export function FloatingChatPopover({
     document.addEventListener('keydown', onKeyDown)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      if (appRoot) {
-        appRoot.inert = false
+      for (const el of toRestore) {
+        el.inert = false
       }
     }
   }, [open, onClose, isMobileViewport])

--- a/apps/gateway-admin/components/floating-chat-popover.tsx
+++ b/apps/gateway-admin/components/floating-chat-popover.tsx
@@ -50,24 +50,43 @@ const DEFAULT_CONFIG: PersistConfig = {
   sendPageContext: false,
 }
 
-function readPersistedState(): PersistedState {
+/** In-memory cache so concurrent callers read the same base state. */
+let _persistedStateCache: PersistedState | null = null
+
+export function readPersistedState(): PersistedState {
+  if (_persistedStateCache !== null) return _persistedStateCache
   try {
     const raw = typeof localStorage !== 'undefined'
       ? localStorage.getItem(PERSIST_KEY)
       : null
-    if (!raw) return {}
-    return JSON.parse(raw) as PersistedState
+    if (!raw) {
+      _persistedStateCache = {}
+      return {}
+    }
+    _persistedStateCache = JSON.parse(raw) as PersistedState
+    return _persistedStateCache
   } catch {
+    _persistedStateCache = {}
     return {}
   }
 }
 
-function writePersistedState(state: PersistedState) {
+export function writePersistedState(state: PersistedState) {
+  _persistedStateCache = state
   try {
     localStorage.setItem(PERSIST_KEY, JSON.stringify(state))
   } catch {
     // localStorage may be unavailable
   }
+}
+
+/**
+ * Atomically patch the persisted state using an in-memory cache.
+ * Prevents concurrent read-modify-write races across components.
+ */
+export function patchPersistedState(patch: Partial<PersistedState>) {
+  const current = readPersistedState()
+  writePersistedState({ ...current, ...patch })
 }
 
 function clampPosition(x: number, y: number, w: number, h: number): Position {
@@ -185,7 +204,7 @@ export function FloatingChatPopover({
 
   // ---- Window resize clamp (debounced) ----
   React.useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>
+    let timer: ReturnType<typeof setTimeout> | undefined
     function onResize() {
       clearTimeout(timer)
       timer = setTimeout(() => {
@@ -309,10 +328,8 @@ export function FloatingChatPopover({
     setPosition(clamped)
 
     // Persist if configured
-    const persisted = readPersistedState()
-    const cfg = persisted.config ?? DEFAULT_CONFIG
-    if (cfg.persistPosition) {
-      writePersistedState({ ...persisted, position: clamped })
+    if ((readPersistedState().config ?? DEFAULT_CONFIG).persistPosition) {
+      patchPersistedState({ position: clamped })
     }
 
     dragRef.current = null
@@ -346,10 +363,8 @@ export function FloatingChatPopover({
     resizeRef.current.active = false
 
     // Persist size
-    const persisted = readPersistedState()
-    const cfg = persisted.config ?? DEFAULT_CONFIG
-    if (cfg.persistSize) {
-      writePersistedState({ ...persisted, size })
+    if ((readPersistedState().config ?? DEFAULT_CONFIG).persistSize) {
+      patchPersistedState({ size })
     }
 
     resizeRef.current = null
@@ -362,8 +377,7 @@ export function FloatingChatPopover({
     setConfig(newConfig)
     onConfigChange?.(newConfig)
 
-    const persisted = readPersistedState()
-    writePersistedState({ ...persisted, config: newConfig })
+    patchPersistedState({ config: newConfig })
   }, [effectiveConfig, onConfigChange])
 
   // ---- Mobile Sheet ----

--- a/apps/gateway-admin/components/floating-chat-popover.tsx
+++ b/apps/gateway-admin/components/floating-chat-popover.tsx
@@ -26,10 +26,7 @@ const PERSIST_KEY = 'labby:floating-chat:state'
 
 type Position = { x: number; y: number }
 type Size = { w: number; h: number }
-type PersistConfig = {
-  persistOpen: boolean
-  persistPosition: boolean
-  persistSize: boolean
+type ChatConfig = {
   sendPageContext: boolean
 }
 
@@ -37,16 +34,13 @@ type PersistedState = {
   open?: boolean
   position?: Position
   size?: Size
-  config?: PersistConfig
+  config?: ChatConfig
 }
 
 const DEFAULT_SIZE: Size = { w: 420, h: 600 }
 const MIN_SIZE: Size = { w: 320, h: 420 }
 const MAX_SIZE: Size = { w: 800, h: 900 }
-const DEFAULT_CONFIG: PersistConfig = {
-  persistOpen: true,
-  persistPosition: true,
-  persistSize: true,
+const DEFAULT_CONFIG: ChatConfig = {
   sendPageContext: false,
 }
 
@@ -112,8 +106,8 @@ export type FloatingChatPopoverProps = {
   /** The content to render inside the popover (chat shell) */
   children?: React.ReactNode
   /** Config getter/setter for page context toggle */
-  config?: PersistConfig
-  onConfigChange?: (config: PersistConfig) => void
+  config?: ChatConfig
+  onConfigChange?: (config: ChatConfig) => void
 }
 
 export function FloatingChatPopover({
@@ -130,8 +124,7 @@ export function FloatingChatPopover({
   const [isMobileViewport, setIsMobileViewport] = React.useState(false)
   const [size, setSize] = React.useState<Size>(() => {
     const persisted = readPersistedState()
-    const cfg = persisted.config ?? DEFAULT_CONFIG
-    if (cfg.persistSize && persisted.size) {
+    if (persisted.size) {
       return clampSize(persisted.size.w, persisted.size.h)
     }
     return DEFAULT_SIZE
@@ -139,7 +132,7 @@ export function FloatingChatPopover({
   const [position, setPosition] = React.useState<Position>({ x: 0, y: 0 })
   const [positionInitialized, setPositionInitialized] = React.useState(false)
   const [gearOpen, setGearOpen] = React.useState(false)
-  const [config, setConfig] = React.useState<PersistConfig>(() => {
+  const [config, setConfig] = React.useState<ChatConfig>(() => {
     const persisted = readPersistedState()
     return persisted.config ?? DEFAULT_CONFIG
   })
@@ -167,6 +160,9 @@ export function FloatingChatPopover({
     startY: number
     startW: number
     startH: number
+    rafId?: number
+    pendingW: number
+    pendingH: number
   } | null>(null)
 
   // ---- Mobile viewport detection ----
@@ -182,8 +178,7 @@ export function FloatingChatPopover({
   React.useEffect(() => {
     if (positionInitialized) return
     const persisted = readPersistedState()
-    const cfg = persisted.config ?? DEFAULT_CONFIG
-    if (cfg.persistPosition && persisted.position) {
+    if (persisted.position) {
       setPosition(clampPosition(
         persisted.position.x,
         persisted.position.y,
@@ -326,11 +321,7 @@ export function FloatingChatPopover({
     }
 
     setPosition(clamped)
-
-    // Persist if configured
-    if ((readPersistedState().config ?? DEFAULT_CONFIG).persistPosition) {
-      patchPersistedState({ position: clamped })
-    }
+    patchPersistedState({ position: clamped })
 
     dragRef.current = null
     ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
@@ -347,6 +338,8 @@ export function FloatingChatPopover({
       startY: event.clientY,
       startW: size.w,
       startH: size.h,
+      pendingW: size.w,
+      pendingH: size.h,
     }
   }, [size.w, size.h])
 
@@ -354,25 +347,45 @@ export function FloatingChatPopover({
     if (!resizeRef.current?.active) return
     const dx = event.clientX - resizeRef.current.startX
     const dy = event.clientY - resizeRef.current.startY
-    const newSize = clampSize(resizeRef.current.startW + dx, resizeRef.current.startH + dy)
-    setSize(newSize)
+    const clamped = clampSize(resizeRef.current.startW + dx, resizeRef.current.startH + dy)
+
+    resizeRef.current.pendingW = clamped.w
+    resizeRef.current.pendingH = clamped.h
+
+    if (resizeRef.current.rafId != null) return
+    resizeRef.current.rafId = requestAnimationFrame(() => {
+      if (!resizeRef.current || !panelRef.current) return
+      resizeRef.current.rafId = undefined
+      panelRef.current.style.width = `${resizeRef.current.pendingW}px`
+      panelRef.current.style.height = `${resizeRef.current.pendingH}px`
+    })
   }, [])
 
   const onResizePointerUp = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!resizeRef.current?.active) return
     resizeRef.current.active = false
-
-    // Persist size
-    if ((readPersistedState().config ?? DEFAULT_CONFIG).persistSize) {
-      patchPersistedState({ size })
+    if (resizeRef.current.rafId != null) {
+      cancelAnimationFrame(resizeRef.current.rafId)
+      resizeRef.current.rafId = undefined
     }
+
+    const committed = clampSize(resizeRef.current.pendingW, resizeRef.current.pendingH)
+
+    // Clear direct style overrides so React's inline style prop takes over
+    if (panelRef.current) {
+      panelRef.current.style.width = ''
+      panelRef.current.style.height = ''
+    }
+
+    setSize(committed)
+    patchPersistedState({ size: committed })
 
     resizeRef.current = null
     ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
-  }, [size])
+  }, [])
 
   // ---- Config change handler ----
-  const handleConfigChange = React.useCallback((key: keyof PersistConfig, value: boolean) => {
+  const handleConfigChange = React.useCallback((key: keyof ChatConfig, value: boolean) => {
     const newConfig = { ...effectiveConfig, [key]: value }
     setConfig(newConfig)
     onConfigChange?.(newConfig)
@@ -476,28 +489,16 @@ export function FloatingChatPopover({
       {/* ---- Gear config panel ---- */}
       {gearOpen && (
         <div className="shrink-0 border-b border-aurora-border-strong bg-aurora-panel-medium px-4 py-3">
-          <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-aurora-text-muted">
-            Persistence
-          </p>
           <div className="flex flex-col gap-2">
-            {(
-              [
-                { key: 'persistOpen', label: 'Restore open state' },
-                { key: 'persistPosition', label: 'Restore position' },
-                { key: 'persistSize', label: 'Restore size' },
-                { key: 'sendPageContext', label: 'Send page context' },
-              ] as { key: keyof PersistConfig; label: string }[]
-            ).map(({ key, label }) => (
-              <label key={key} className="flex cursor-pointer items-center gap-2.5">
-                <input
-                  type="checkbox"
-                  checked={effectiveConfig[key]}
-                  onChange={(e) => handleConfigChange(key, e.target.checked)}
-                  className="size-3.5 accent-aurora-accent-primary"
-                />
-                <span className="text-[12px] text-aurora-text-primary">{label}</span>
-              </label>
-            ))}
+            <label className="flex cursor-pointer items-center gap-2.5">
+              <input
+                type="checkbox"
+                checked={effectiveConfig.sendPageContext}
+                onChange={(e) => handleConfigChange('sendPageContext', e.target.checked)}
+                className="size-3.5 accent-aurora-accent-primary"
+              />
+              <span className="text-[12px] text-aurora-text-primary">Send page context</span>
+            </label>
           </div>
         </div>
       )}
@@ -535,6 +536,6 @@ export function FloatingChatPopover({
   )
 }
 
-// Export persistence types for use in design system
-export type { PersistConfig, Position, Size }
+// Export types for use in design system
+export type { ChatConfig, Position, Size }
 export { PERSIST_KEY, DEFAULT_CONFIG, DEFAULT_SIZE, MIN_SIZE, MAX_SIZE }

--- a/apps/gateway-admin/components/floating-chat-shell.tsx
+++ b/apps/gateway-admin/components/floating-chat-shell.tsx
@@ -34,12 +34,12 @@ import {
   useChatSessionConnection,
   useChatSessionStream,
 } from '@/lib/chat/chat-session-provider'
-import type { PersistConfig } from '@/components/floating-chat-popover'
+import type { ChatConfig } from '@/components/floating-chat-popover'
 import type { ChatInputPayload } from '@/components/chat/chat-input'
 import type { AttachmentRef } from '@/lib/fs/types'
 
 export type FloatingChatShellProps = {
-  config?: PersistConfig
+  config?: ChatConfig
 }
 
 export function FloatingChatShell({

--- a/apps/gateway-admin/components/floating-chat-shell.tsx
+++ b/apps/gateway-admin/components/floating-chat-shell.tsx
@@ -50,7 +50,7 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
   // ---- Context consumers ----
   const { runs, selectedRun, selectedRunId, providerHealth, providers, agents, projects, pageContext } =
     useChatSessionData()
-  const { createSession, selectRun, refreshSessions } = useChatSessionActions()
+  const { createSession, selectRun, refreshSessions, selectAgent } = useChatSessionActions()
   const { connectionState } = useChatSessionConnection()
   const { messages } = useChatSessionStream()
 
@@ -129,11 +129,6 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
       // providerHealth.message carries the failure detail
     }
   }, [createSession])
-
-  const selectAgent = React.useCallback((_providerId: string) => {
-    // provider selection is handled by useChatSessionActions.selectAgent
-    // local agent selection just for visual state in this shell
-  }, [])
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">

--- a/apps/gateway-admin/components/floating-chat-shell.tsx
+++ b/apps/gateway-admin/components/floating-chat-shell.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+/**
+ * FloatingChatShell — Wires all /chat features into the floating chat popover.
+ *
+ * Lazy-mounts on first FAB click, stays mounted permanently.
+ * Consumes the 4 ChatSession contexts provided by ChatSessionProvider.
+ *
+ * Lifecycle:
+ * - Provider starts SSE on first FAB click (streamEnabled = true)
+ * - This shell mounts when the provider signals first-open
+ * - Visibility is controlled by the popover (CSS visibility:hidden when closed)
+ * - Dual-stream impossible: FAB hidden on /chat, FloatingChatShell never mounts there
+ *
+ * pageContext:
+ * - Reads sendPageContext from config prop
+ * - When enabled AND pageContext is non-null: includes pageContext in prompt body
+ * - When disabled or null: omits field entirely (zero token cost)
+ */
+
+import * as React from 'react'
+import { Plus, Settings2, SidebarOpen, Zap } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Separator } from '@/components/ui/separator'
+import { SessionSidebar } from '@/components/chat/session-sidebar'
+import { MessageThread } from '@/components/chat/message-thread'
+import { ChatInput } from '@/components/chat/chat-input'
+import { SettingsPanel } from '@/components/chat/settings-panel'
+import { ACP_AGENT, ensurePromptRunId } from '@/lib/chat/use-chat-session-controller'
+import { createAcpFetcher } from '@/lib/acp/fetch'
+import {
+  useChatSessionData,
+  useChatSessionActions,
+  useChatSessionConnection,
+  useChatSessionStream,
+} from '@/lib/chat/chat-session-provider'
+import type { PersistConfig } from '@/components/floating-chat-popover'
+import type { ChatInputPayload } from '@/components/chat/chat-input'
+import type { AttachmentRef } from '@/lib/fs/types'
+
+export type FloatingChatShellProps = {
+  config?: PersistConfig
+}
+
+export const FloatingChatShell = React.memo(function FloatingChatShell({
+  config,
+}: FloatingChatShellProps) {
+  // ---- Context consumers ----
+  const { runs, selectedRun, selectedRunId, providerHealth, providers, agents, projects, pageContext } =
+    useChatSessionData()
+  const { createSession, selectRun, refreshSessions } = useChatSessionActions()
+  const { connectionState } = useChatSessionConnection()
+  const { messages } = useChatSessionStream()
+
+  // ---- Local state ----
+  const [sessionPanelOpen, setSessionPanelOpen] = React.useState(true)
+  const [settingsOpen, setSettingsOpen] = React.useState(false)
+  const [isMobileViewport, setIsMobileViewport] = React.useState(false)
+  const [systemPrompt, setSystemPrompt] = React.useState('')
+  const [temperature, setTemperature] = React.useState(0.7)
+  const [maxTokens, setMaxTokens] = React.useState(8192)
+
+  const providerReady = Boolean(providerHealth?.ready)
+
+  const selectedAgent = selectedRun
+    ? (agents.find((agent) => agent.id === selectedRun.provider) ?? {
+        ...ACP_AGENT,
+        id: selectedRun.provider,
+        name: selectedRun.provider,
+      })
+    : (agents[0] ?? ACP_AGENT)
+
+  // ---- Mobile viewport detection ----
+  React.useEffect(() => {
+    const media = window.matchMedia('(max-width: 767px)')
+    const sync = () => {
+      setIsMobileViewport(media.matches)
+      setSessionPanelOpen((open) => (media.matches ? false : open))
+    }
+    sync()
+    media.addEventListener('change', sync)
+    return () => media.removeEventListener('change', sync)
+  }, [])
+
+  // ---- sendPrompt (reads pageContext from provider + config) ----
+  const sendPrompt = React.useCallback(
+    async (payload: ChatInputPayload) => {
+      try {
+        const runId = await ensurePromptRunId(selectedRunId, createSession, isMobileViewport)
+        const fetchAcp = createAcpFetcher()
+
+        // Include pageContext only if config.sendPageContext is true AND context is non-null
+        const includePageContext = config?.sendPageContext && pageContext !== null
+
+        const body: {
+          prompt: string
+          attachments?: AttachmentRef[]
+          pageContext?: typeof pageContext
+        } = {
+          prompt: payload.text,
+          ...(payload.attachments.length > 0 && { attachments: payload.attachments }),
+          ...(includePageContext && pageContext && { pageContext }),
+        }
+
+        const response = await fetchAcp(`/sessions/${runId}/prompt`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        })
+
+        if (!response.ok) {
+          // Non-fatal — providerHealth messaging handles this
+          return
+        }
+
+        await refreshSessions()
+      } catch {
+        // Keep UI responsive; provider health message carries the failure detail
+      }
+    },
+    [config?.sendPageContext, createSession, isMobileViewport, pageContext, refreshSessions, selectedRunId],
+  )
+
+  const createRun = React.useCallback(async () => {
+    try {
+      await createSession()
+    } catch {
+      // providerHealth.message carries the failure detail
+    }
+  }, [createSession])
+
+  const selectAgent = React.useCallback((_providerId: string) => {
+    // provider selection is handled by useChatSessionActions.selectAgent
+    // local agent selection just for visual state in this shell
+  }, [])
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {/* ---- Compact header (48px) ---- */}
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-aurora-border-default bg-aurora-nav-bg px-2.5">
+        <TooltipProvider delayDuration={400}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Toggle sessions"
+                onClick={() => setSessionPanelOpen((open) => !open)}
+                className={cn(
+                  'size-7 rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary',
+                  sessionPanelOpen && 'bg-aurora-hover-bg text-aurora-text-primary',
+                )}
+              >
+                <SidebarOpen className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">Toggle sessions</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {selectedRun && (
+          <div className="ml-1 flex min-w-0 flex-1 items-center gap-1.5 text-[12px] text-aurora-text-muted">
+            <span className="max-w-[160px] truncate text-aurora-text-primary">{selectedRun.title}</span>
+          </div>
+        )}
+
+        <div className="ml-auto flex items-center gap-1.5">
+          <TooltipProvider delayDuration={400}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Start new session"
+                  onClick={() => void createRun()}
+                  disabled={!providerReady}
+                  className="size-7 rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
+                >
+                  <Plus className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">New session</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          <div
+            className="flex items-center gap-1 rounded-full border border-aurora-border-default bg-aurora-control-surface px-1.5 py-0.5"
+            title={providerReady ? 'ACP live' : 'ACP unavailable'}
+          >
+            <Zap className="size-3 text-aurora-accent-primary/70" />
+            <span className="text-[11px] text-aurora-text-muted">
+              {providerReady ? 'ACP' : '—'}
+            </span>
+          </div>
+
+          <Separator orientation="vertical" className="h-4 bg-aurora-border-default" />
+
+          <TooltipProvider delayDuration={400}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={settingsOpen ? 'Close settings' : 'Open settings'}
+                  onClick={() => setSettingsOpen((open) => !open)}
+                  className={cn(
+                    'size-7 rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary',
+                    settingsOpen && 'bg-aurora-hover-bg text-aurora-text-primary',
+                  )}
+                >
+                  <Settings2 className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">Settings</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      </header>
+
+      {/* ---- Session sidebar + message thread ---- */}
+      <div className="flex min-h-0 flex-1">
+        {sessionPanelOpen && (
+          <SessionSidebar
+            className="hidden w-[180px] shrink-0 md:flex"
+            projects={projects}
+            runs={runs}
+            selectedRunId={selectedRunId}
+            selectedProjectId="workspace"
+            onSelectRun={(runId, _projectId) => selectRun(runId)}
+            onNewRun={() => void createRun()}
+          />
+        )}
+
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {/* Message thread — React.memo'd, only re-renders when messages changes */}
+          <MessageThread run={selectedRun} messages={messages} />
+
+          {/* Chat input */}
+          <ChatInput
+            onSend={sendPrompt}
+            disabled={!providerReady}
+            selectedAgent={selectedAgent}
+            agents={agents.length > 0 ? agents : [selectedAgent]}
+            onSelectAgent={selectAgent}
+          />
+        </div>
+
+        {settingsOpen && (
+          <SettingsPanel
+            agent={selectedAgent}
+            onClose={() => setSettingsOpen(false)}
+            systemPrompt={systemPrompt}
+            onSystemPromptChange={setSystemPrompt}
+            temperature={temperature}
+            onTemperatureChange={setTemperature}
+            maxTokens={maxTokens}
+            onMaxTokensChange={setMaxTokens}
+          />
+        )}
+      </div>
+    </div>
+  )
+})

--- a/apps/gateway-admin/components/floating-chat-shell.tsx
+++ b/apps/gateway-admin/components/floating-chat-shell.tsx
@@ -19,15 +19,13 @@
  */
 
 import * as React from 'react'
-import { Plus, Settings2, SidebarOpen, Zap } from 'lucide-react'
+import { Plus, SidebarOpen, Zap } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Separator } from '@/components/ui/separator'
 import { SessionSidebar } from '@/components/chat/session-sidebar'
 import { MessageThread } from '@/components/chat/message-thread'
 import { ChatInput } from '@/components/chat/chat-input'
-import { SettingsPanel } from '@/components/chat/settings-panel'
 import { ACP_AGENT, ensurePromptRunId } from '@/lib/chat/use-chat-session-controller'
 import { createAcpFetcher } from '@/lib/acp/fetch'
 import {
@@ -44,7 +42,7 @@ export type FloatingChatShellProps = {
   config?: PersistConfig
 }
 
-export const FloatingChatShell = React.memo(function FloatingChatShell({
+export function FloatingChatShell({
   config,
 }: FloatingChatShellProps) {
   // ---- Context consumers ----
@@ -56,11 +54,7 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
 
   // ---- Local state ----
   const [sessionPanelOpen, setSessionPanelOpen] = React.useState(true)
-  const [settingsOpen, setSettingsOpen] = React.useState(false)
   const [isMobileViewport, setIsMobileViewport] = React.useState(false)
-  const [systemPrompt, setSystemPrompt] = React.useState('')
-  const [temperature, setTemperature] = React.useState(0.7)
-  const [maxTokens, setMaxTokens] = React.useState(8192)
 
   const providerReady = Boolean(providerHealth?.ready)
 
@@ -97,7 +91,7 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
         const body: {
           prompt: string
           attachments?: AttachmentRef[]
-          pageContext?: typeof pageContext
+          pageContext?: NonNullable<typeof pageContext>
         } = {
           prompt: payload.text,
           ...(payload.attachments.length > 0 && { attachments: payload.attachments }),
@@ -189,27 +183,6 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
             </span>
           </div>
 
-          <Separator orientation="vertical" className="h-4 bg-aurora-border-default" />
-
-          <TooltipProvider delayDuration={400}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label={settingsOpen ? 'Close settings' : 'Open settings'}
-                  onClick={() => setSettingsOpen((open) => !open)}
-                  className={cn(
-                    'size-7 rounded text-aurora-text-muted/60 hover:bg-aurora-hover-bg hover:text-aurora-text-primary',
-                    settingsOpen && 'bg-aurora-hover-bg text-aurora-text-primary',
-                  )}
-                >
-                  <Settings2 className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-xs">Settings</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
         </div>
       </header>
 
@@ -241,19 +214,7 @@ export const FloatingChatShell = React.memo(function FloatingChatShell({
           />
         </div>
 
-        {settingsOpen && (
-          <SettingsPanel
-            agent={selectedAgent}
-            onClose={() => setSettingsOpen(false)}
-            systemPrompt={systemPrompt}
-            onSystemPromptChange={setSystemPrompt}
-            temperature={temperature}
-            onTemperatureChange={setTemperature}
-            maxTokens={maxTokens}
-            onMaxTokensChange={setMaxTokens}
-          />
-        )}
       </div>
     </div>
   )
-})
+}

--- a/apps/gateway-admin/components/page-context-sync.tsx
+++ b/apps/gateway-admin/components/page-context-sync.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+/**
+ * PageContextSync — Drives usePageContextSync inside the ChatSessionProvider tree.
+ * Must be a child of AdminLayoutClient (which provides ChatSessionActionsContext).
+ */
+
+import { usePageContextSync } from '@/lib/chat/use-page-context-sync'
+
+export function PageContextSync() {
+  usePageContextSync()
+  return null
+}

--- a/apps/gateway-admin/lib/acp/fetch.ts
+++ b/apps/gateway-admin/lib/acp/fetch.ts
@@ -1,0 +1,41 @@
+'use client'
+
+/**
+ * Standalone ACP fetch utility — derives acpBase and requestCredentials
+ * per call so callers don't need to hold these as state.
+ *
+ * Internal to provider; surface hooks import directly.
+ * NOT exported from context values.
+ */
+
+import { normalizeGatewayApiBase } from '@/lib/api/gateway-config'
+import { gatewayHeaders } from '@/lib/api/gateway-request'
+import { isStandaloneBearerAuthMode } from '@/lib/auth/auth-mode'
+
+function getAcpBase(): string {
+  return `${normalizeGatewayApiBase()}/acp`
+}
+
+function getRequestCredentials(): RequestCredentials {
+  return isStandaloneBearerAuthMode() ? 'omit' : 'include'
+}
+
+export function createAcpFetcher() {
+  const acpBase = getAcpBase()
+  const requestCredentials = getRequestCredentials()
+
+  return async function fetchAcp(path: string, init?: RequestInit): Promise<Response> {
+    const headers = new Headers(init?.headers ?? {})
+    const authHeaders = gatewayHeaders()
+    for (const [key, value] of Object.entries(authHeaders)) {
+      headers.set(key, value)
+    }
+
+    return fetch(`${acpBase}${path}`, {
+      ...init,
+      headers,
+      credentials: requestCredentials,
+      cache: 'no-store',
+    })
+  }
+}

--- a/apps/gateway-admin/lib/acp/fetch.ts
+++ b/apps/gateway-admin/lib/acp/fetch.ts
@@ -31,6 +31,11 @@ export function createAcpFetcher() {
       headers.set(key, value)
     }
 
+    // Set Content-Type for requests with a body, unless the caller already set it.
+    if (init?.body != null && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
+
     return fetch(`${acpBase}${path}`, {
       ...init,
       headers,

--- a/apps/gateway-admin/lib/chat/acp-normalizers.ts
+++ b/apps/gateway-admin/lib/chat/acp-normalizers.ts
@@ -1,0 +1,142 @@
+'use client'
+
+/**
+ * Shared ACP normalization helpers.
+ *
+ * Extracted from `chat-session-provider.tsx` and `use-chat-session-controller.ts`
+ * to eliminate duplication. Both files import from here.
+ */
+
+import type { ACPRun } from '@/components/chat/types'
+import type { BridgeSessionSummary, ProviderHealth } from '@/lib/acp/types'
+
+// ---- Shared payload shape types ----
+
+export type ProviderListPayload = {
+  providers?: Array<{
+    name?: string
+    available?: boolean
+    version?: string | null
+    error?: string | null
+    command?: string | null
+    args?: string[] | null
+  }>
+  provider?: ProviderHealth
+}
+
+export type SessionCreatePayload = {
+  session?: RawSessionSummary
+} & RawSessionSummary
+
+export type ErrorPayload = {
+  message?: string
+  error?: string
+  kind?: string
+}
+
+export type RawSessionSummary = {
+  id: string
+  provider: string
+  title: string
+  cwd: string
+  status?: string
+  state?: string
+  createdAt?: string
+  updatedAt?: string
+  providerSessionId?: string
+  agentName?: string
+  agentVersion?: string
+  created_at?: string
+  updated_at?: string
+  provider_session_id?: string
+  agent_name?: string
+  agent_version?: string
+}
+
+// ---- Normalization helpers ----
+
+export function normalizeSessionSummary(session: RawSessionSummary): BridgeSessionSummary {
+  return {
+    id: session.id,
+    provider: session.provider,
+    title: session.title,
+    cwd: session.cwd,
+    status: (session.status ?? session.state ?? 'idle') as BridgeSessionSummary['status'],
+    createdAt: session.createdAt ?? session.created_at ?? '',
+    updatedAt: session.updatedAt ?? session.updated_at ?? '',
+    providerSessionId: session.providerSessionId ?? session.provider_session_id ?? '',
+    agentName: session.agentName ?? session.agent_name ?? 'Codex',
+    agentVersion: session.agentVersion ?? session.agent_version ?? 'unknown',
+  }
+}
+
+export function toRun(session: RawSessionSummary): ACPRun {
+  const normalized = normalizeSessionSummary(session)
+  return {
+    id: normalized.id,
+    projectId: 'workspace',
+    agentId: normalized.provider,
+    provider: normalized.provider,
+    title: normalized.title,
+    createdAt: new Date(normalized.createdAt),
+    updatedAt: new Date(normalized.updatedAt),
+    status: normalized.status,
+    providerSessionId: normalized.providerSessionId,
+    cwd: normalized.cwd,
+  }
+}
+
+export function normalizeProviderHealth(payload: ProviderListPayload): ProviderHealth {
+  if (payload.provider) {
+    return payload.provider
+  }
+
+  const provider = payload.providers?.[0]
+  return {
+    provider: provider?.name ?? 'codex',
+    ready: Boolean(provider?.available),
+    command: '',
+    args: [],
+    message: provider?.error ?? '',
+  }
+}
+
+export function normalizeProviderList(payload: ProviderListPayload): ProviderHealth[] {
+  if (payload.provider) {
+    return [payload.provider]
+  }
+
+  return (payload.providers ?? []).map((provider) => ({
+    provider: provider.name ?? 'codex-acp',
+    ready: Boolean(provider.available),
+    command: provider.command ?? '',
+    args: provider.args ?? [],
+    message: provider.error ?? '',
+  }))
+}
+
+export function extractCreatedSession(payload: SessionCreatePayload): RawSessionSummary {
+  return payload.session ?? payload
+}
+
+export async function readJsonSafe<T>(response: Response): Promise<T | null> {
+  const text = await response.text()
+  if (!text) {
+    return null
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    return null
+  }
+}
+
+export function errorMessageFromPayload(payload: ErrorPayload | null, fallback: string): string {
+  return payload?.message ?? payload?.error ?? fallback
+}
+
+export function sameProviderList(a: ProviderHealth[], b: ProviderHealth[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((item, i) => item.provider === b[i]?.provider && item.ready === b[i]?.ready)
+}

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -31,9 +31,22 @@ import {
 import {
   consumeSessionEventBuffer,
 } from './use-session-events'
+import { sessionEventCache, sessionLastSeqCache } from './session-event-cache'
+import {
+  type ProviderListPayload,
+  type SessionCreatePayload,
+  type ErrorPayload,
+  type RawSessionSummary,
+  toRun,
+  normalizeProviderHealth,
+  normalizeProviderList,
+  extractCreatedSession,
+  readJsonSafe,
+  errorMessageFromPayload,
+  sameProviderList,
+} from './acp-normalizers'
 import type { ACPAgent, ACPRun, ACPProject } from '@/components/chat/types'
 import type { BridgeSessionSummary, ProviderHealth, BridgeEvent } from '@/lib/acp/types'
-import type { AttachmentRef } from '@/lib/fs/types'
 import type { SessionEventConnectionState } from './use-session-events'
 import {
   ACP_AGENT,
@@ -123,145 +136,6 @@ export function useChatSessionStream(): ChatSessionStreamContextValue {
   if (!ctx) throw new Error('useChatSessionStream must be used within ChatSessionProvider')
   return ctx
 }
-
-// ---- Helper types ----
-
-type ProviderListPayload = {
-  providers?: Array<{
-    name?: string
-    available?: boolean
-    version?: string | null
-    error?: string | null
-    command?: string | null
-    args?: string[] | null
-  }>
-  provider?: ProviderHealth
-}
-
-type SessionCreatePayload = {
-  session?: BridgeSessionSummary
-} & BridgeSessionSummary
-
-type ErrorPayload = {
-  message?: string
-  error?: string
-  kind?: string
-}
-
-type RawSessionSummary = {
-  id: string
-  provider: string
-  title: string
-  cwd: string
-  status?: string
-  state?: string
-  createdAt?: string
-  updatedAt?: string
-  providerSessionId?: string
-  agentName?: string
-  agentVersion?: string
-  created_at?: string
-  updated_at?: string
-  provider_session_id?: string
-  agent_name?: string
-  agent_version?: string
-}
-
-// ---- Helper functions (not in context values) ----
-
-function normalizeSessionSummary(session: RawSessionSummary): BridgeSessionSummary {
-  return {
-    id: session.id,
-    provider: session.provider,
-    title: session.title,
-    cwd: session.cwd,
-    status: (session.status ?? session.state ?? 'idle') as BridgeSessionSummary['status'],
-    createdAt: session.createdAt ?? session.created_at ?? '',
-    updatedAt: session.updatedAt ?? session.updated_at ?? '',
-    providerSessionId: session.providerSessionId ?? session.provider_session_id ?? '',
-    agentName: session.agentName ?? session.agent_name ?? 'Codex',
-    agentVersion: session.agentVersion ?? session.agent_version ?? 'unknown',
-  }
-}
-
-function toRun(session: RawSessionSummary): ACPRun {
-  const normalized = normalizeSessionSummary(session)
-  return {
-    id: normalized.id,
-    projectId: 'workspace',
-    agentId: normalized.provider,
-    provider: normalized.provider,
-    title: normalized.title,
-    createdAt: new Date(normalized.createdAt),
-    updatedAt: new Date(normalized.updatedAt),
-    status: normalized.status,
-    providerSessionId: normalized.providerSessionId,
-    cwd: normalized.cwd,
-  }
-}
-
-function normalizeProviderHealth(payload: ProviderListPayload): ProviderHealth {
-  if (payload.provider) {
-    return payload.provider
-  }
-
-  const provider = payload.providers?.[0]
-  return {
-    provider: provider?.name ?? 'codex',
-    ready: Boolean(provider?.available),
-    command: '',
-    args: [],
-    message: provider?.error ?? '',
-  }
-}
-
-function normalizeProviderList(payload: ProviderListPayload): ProviderHealth[] {
-  if (payload.provider) {
-    return [payload.provider]
-  }
-
-  return (payload.providers ?? []).map((provider) => ({
-    provider: provider.name ?? 'codex-acp',
-    ready: Boolean(provider.available),
-    command: provider.command ?? '',
-    args: provider.args ?? [],
-    message: provider.error ?? '',
-  }))
-}
-
-function extractCreatedSession(payload: SessionCreatePayload): RawSessionSummary {
-  return payload.session ?? payload
-}
-
-async function readJsonSafe<T>(response: Response): Promise<T | null> {
-  const text = await response.text()
-  if (!text) {
-    return null
-  }
-
-  try {
-    return JSON.parse(text) as T
-  } catch {
-    return null
-  }
-}
-
-function errorMessageFromPayload(payload: ErrorPayload | null, fallback: string) {
-  return payload?.message ?? payload?.error ?? fallback
-}
-
-function sameProviderList(a: ProviderHealth[], b: ProviderHealth[]): boolean {
-  if (a.length !== b.length) return false
-  return a.every((item, i) => item.provider === b[i]?.provider && item.ready === b[i]?.ready)
-}
-
-// ---- Module-level SSE caches (shared with useSessionEvents) ----
-// These must stay in sync with the caches in use-session-events.ts.
-// We use them here only for reading initial state when streamEnabled toggles.
-// The actual SSE subscription is managed inside the provider.
-
-const sessionEventCache = new Map<string, BridgeEvent[]>()
-const sessionLastSeqCache = new Map<string, number>()
 
 // ---- Provider props ----
 
@@ -446,6 +320,12 @@ export function ChatSessionProvider({
           }))
           throw new Error(message)
         }
+        // Narrow: if payload has an `id` field it is a SessionCreatePayload; otherwise ErrorPayload
+        const isSessionPayload = 'id' in payload || ('session' in payload && payload.session != null)
+        if (!isSessionPayload) {
+          const message = errorMessageFromPayload(payload as ErrorPayload, 'Failed to create ACP session.')
+          throw new Error(message)
+        }
         const run = toRun(extractCreatedSession(payload as SessionCreatePayload))
         setRuns((current) => integrateCreatedRun(current, run))
         setSelectedRunId(run.id)
@@ -515,19 +395,26 @@ export function ChatSessionProvider({
     }
   }, [providers, selectedProviderId])
 
-  // Auto-bootstrap first session — only after first FAB click (streamEnabled)
+  // Auto-bootstrap first session — only after first FAB click (streamEnabled) and
+  // after sessions have been loaded so we don't race with refreshSessions.
   React.useEffect(() => {
-    if (!streamEnabled) return
+    if (!streamEnabled || !sessionsLoaded) return
     if (!shouldAutoCreateInitialRun(Boolean(providerHealth?.ready), runs.length, selectedRunId)) return
 
+    const abortController = new AbortController()
     void (async () => {
       try {
-        await createSession()
+        if (!abortController.signal.aborted) {
+          await createSession()
+        }
       } catch {
         // providerHealth.message carries the failure detail
       }
     })()
-  }, [createSession, providerHealth?.ready, runs.length, selectedRunId, streamEnabled])
+    return () => {
+      abortController.abort()
+    }
+  }, [createSession, providerHealth?.ready, runs.length, selectedRunId, sessionsLoaded, streamEnabled])
 
   // Update run status from session events (bail-out setter for re-render efficiency)
   React.useEffect(() => {
@@ -596,15 +483,19 @@ export function ChatSessionProvider({
           const consumed = consumeSessionEventBuffer(buffer, lastSeqRef.current)
           buffer = consumed.buffer
 
-          for (const event of consumed.events) {
-            lastSeqRef.current = event.seq
-            sessionLastSeqCache.set(selectedRunId, event.seq)
-            setEvents((current) => {
-              const next = appendSessionEvent(current, event)
-              sessionEventCache.set(selectedRunId, next)
-              return next
-            })
-          }
+          if (consumed.events.length === 0) return
+
+          // Batch: apply all events from this chunk in one setEvents call
+          setEvents((current) => {
+            let next = current
+            for (const event of consumed.events) {
+              lastSeqRef.current = event.seq
+              sessionLastSeqCache.set(selectedRunId, event.seq)
+              next = appendSessionEvent(next, event)
+            }
+            sessionEventCache.set(selectedRunId, next)
+            return next
+          })
         }
 
         while (true) {

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -397,23 +397,18 @@ export function ChatSessionProvider({
 
   // Auto-bootstrap first session — only after first FAB click (streamEnabled) and
   // after sessions have been loaded so we don't race with refreshSessions.
+  // NOTE(phase-2): wire AbortController once createSession accepts a signal.
   React.useEffect(() => {
     if (!streamEnabled || !sessionsLoaded) return
     if (!shouldAutoCreateInitialRun(Boolean(providerHealth?.ready), runs.length, selectedRunId)) return
 
-    const abortController = new AbortController()
     void (async () => {
       try {
-        if (!abortController.signal.aborted) {
-          await createSession()
-        }
+        await createSession()
       } catch {
         // providerHealth.message carries the failure detail
       }
     })()
-    return () => {
-      abortController.abort()
-    }
   }, [createSession, providerHealth?.ready, runs.length, selectedRunId, sessionsLoaded, streamEnabled])
 
   // Update run status from session events (bail-out setter for re-render efficiency)

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -15,8 +15,8 @@
  *
  * Non-chat pages consume NONE of these contexts — zero re-render cost.
  *
- * Stream lifecycle — truly lazy:
- * Stream starts only on first FAB click. Users who never open chat pay zero SSE cost.
+ * Stream lifecycle:
+ * SSE stream opens whenever selectedRunId is non-null.
  */
 
 import * as React from 'react'
@@ -141,8 +141,6 @@ export function useChatSessionStream(): ChatSessionStreamContextValue {
 
 export type ChatSessionProviderProps = {
   children: React.ReactNode
-  /** Called from FAB on first click — provider enables SSE stream */
-  onFirstOpenRef?: React.MutableRefObject<(() => void) | null>
   isMobileViewport?: boolean
   onSessionPanelClose?: () => void
 }
@@ -151,7 +149,6 @@ export type ChatSessionProviderProps = {
 
 export function ChatSessionProvider({
   children,
-  onFirstOpenRef,
   isMobileViewport = false,
   onSessionPanelClose,
 }: ChatSessionProviderProps) {
@@ -173,10 +170,7 @@ export function ChatSessionProvider({
   const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
   const [pageContext, setPageContext] = React.useState<PageContext>(null)
 
-  // Stream is lazy — only enabled on first FAB click
-  const [streamEnabled, setStreamEnabled] = React.useState(false)
-
-  // SSE state (only active when streamEnabled)
+  // SSE state
   const [events, setEvents] = React.useState<BridgeEvent[]>([])
   const [connectionState, setConnectionState] = React.useState<SessionEventConnectionState>('idle')
   const lastSeqRef = React.useRef(0)
@@ -191,14 +185,6 @@ export function ChatSessionProvider({
     (path: string, init?: RequestInit) => fetchAcpRef.current(path, init),
     [],
   )
-
-  // ---- Expose first-open callback to FAB ----
-  React.useLayoutEffect(() => {
-    if (!onFirstOpenRef) return
-    onFirstOpenRef.current = () => {
-      setStreamEnabled(true)
-    }
-  }, [onFirstOpenRef])
 
   // ---- Derived values ----
   const selectedRun = React.useMemo(
@@ -398,11 +384,10 @@ export function ChatSessionProvider({
     }
   }, [providers, selectedProviderId])
 
-  // Auto-bootstrap first session — only after first FAB click (streamEnabled) and
-  // after sessions have been loaded so we don't race with refreshSessions.
+  // Auto-bootstrap first session — after sessions have been loaded so we don't race with refreshSessions.
   // NOTE(phase-2): wire AbortController once createSession accepts a signal.
   React.useEffect(() => {
-    if (!streamEnabled || !sessionsLoaded) return
+    if (!sessionsLoaded) return
     if (!shouldAutoCreateInitialRun(Boolean(providerHealth?.ready), runs.length, selectedRunId)) return
 
     void (async () => {
@@ -412,7 +397,7 @@ export function ChatSessionProvider({
         // providerHealth.message carries the failure detail
       }
     })()
-  }, [createSession, providerHealth?.ready, runs.length, selectedRunId, sessionsLoaded, streamEnabled])
+  }, [createSession, providerHealth?.ready, runs.length, selectedRunId, sessionsLoaded])
 
   // Update run status from session events (bail-out setter for re-render efficiency)
   React.useEffect(() => {
@@ -427,15 +412,13 @@ export function ChatSessionProvider({
     )
   }, [selectedRunId, sessionStatus, events.length])
 
-  // ---- SSE stream management (lazy — only when streamEnabled) ----
+  // ---- SSE stream management (active whenever selectedRunId is non-null) ----
 
   React.useEffect(() => {
-    if (!streamEnabled || !selectedRunId) {
-      if (!streamEnabled) {
-        setEvents([])
-        setConnectionState('idle')
-        lastSeqRef.current = 0
-      }
+    if (!selectedRunId) {
+      setEvents([])
+      setConnectionState('idle')
+      lastSeqRef.current = 0
       return
     }
 
@@ -458,11 +441,10 @@ export function ChatSessionProvider({
     lastSeqRef.current = cachedLastSeq
 
     const abortController = new AbortController()
-    const fetchAcpNow = createAcpFetcher()
 
     void (async () => {
       try {
-        const response = await fetchAcpNow(`/sessions/${selectedRunId}/events?since=${lastSeqRef.current}`, {
+        const response = await fetchAcpRef.current(`/sessions/${selectedRunId}/events?since=${lastSeqRef.current}`, {
           signal: abortController.signal,
         })
 
@@ -515,7 +497,7 @@ export function ChatSessionProvider({
     return () => {
       abortController.abort()
     }
-  }, [streamEnabled, selectedRunId])
+  }, [selectedRunId])
 
   // ---- Context values ----
 

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -1,0 +1,689 @@
+'use client'
+
+/**
+ * ChatSessionProvider — 4-context React provider for shared chat session state.
+ *
+ * Lifts shared session state out of useChatSessionController into the admin layout.
+ * Enables the floating chat popover to share session state with the /chat route
+ * without duplicating the controller.
+ *
+ * 4-context split for re-render isolation:
+ * - ChatSessionDataContext: runs, selectedRunId, providers, etc. (changes per interaction)
+ * - ChatSessionActionsContext: stable callbacks (almost never re-renders)
+ * - ChatSessionConnectionContext: connectionState, sessionStatus (2-3x per session)
+ * - ChatSessionStreamContext: messages, events, activity (per token — only chat surfaces)
+ *
+ * Non-chat pages consume NONE of these contexts — zero re-render cost.
+ *
+ * Stream lifecycle — truly lazy:
+ * Stream starts only on first FAB click. Users who never open chat pay zero SSE cost.
+ */
+
+import * as React from 'react'
+import { createAcpFetcher } from '@/lib/acp/fetch'
+import {
+  toProjects,
+  appendSessionEvent,
+  resolveLastSessionEventSeq,
+  resolveSessionStatusFromEvents,
+  deriveTranscriptAndActivity,
+} from './session-events'
+import {
+  consumeSessionEventBuffer,
+} from './use-session-events'
+import type { ACPAgent, ACPRun, ACPProject } from '@/components/chat/types'
+import type { BridgeSessionSummary, ProviderHealth, BridgeEvent } from '@/lib/acp/types'
+import type { AttachmentRef } from '@/lib/fs/types'
+import type { SessionEventConnectionState } from './use-session-events'
+import {
+  ACP_AGENT,
+  integrateCreatedRun,
+  shouldAutoCreateInitialRun,
+  ensurePromptRunId,
+  type CreateSessionFn,
+  type CreateSessionOptions,
+  type SessionCreationIntent,
+} from './use-chat-session-controller'
+
+const USE_MOCK_DATA = process.env.NEXT_PUBLIC_MOCK_DATA === 'true'
+
+// ---- PageContext type ----
+
+/** Optional page context slot — off by default. */
+export type PageContext = {
+  route: string
+  entityType?: string
+  entityId?: string
+} | null
+
+// ---- Context value types ----
+
+export type ChatSessionDataContextValue = {
+  runs: ACPRun[]
+  selectedRunId: string | null
+  selectedRun: ACPRun | null
+  providerHealth: ProviderHealth | null
+  providers: ProviderHealth[]
+  selectedProviderId: string | null
+  agents: ACPAgent[]
+  projects: ACPProject[]
+  sessionsLoaded: boolean
+  pageContext: PageContext
+}
+
+export type ChatSessionActionsContextValue = {
+  createSession: CreateSessionFn
+  selectRun: (runId: string) => void
+  refreshSessions: () => Promise<void>
+  refreshProvider: () => Promise<void>
+  selectAgent: (providerId: string) => void
+  setPageContext: (ctx: PageContext) => void
+}
+
+export type ChatSessionConnectionContextValue = {
+  connectionState: SessionEventConnectionState
+  sessionStatus: BridgeSessionSummary['status']
+}
+
+export type ChatSessionStreamContextValue = {
+  messages: ReturnType<typeof deriveTranscriptAndActivity>['messages']
+  events: BridgeEvent[]
+  activity: ReturnType<typeof deriveTranscriptAndActivity>['activity']
+}
+
+// ---- Contexts ----
+
+const ChatSessionDataContext = React.createContext<ChatSessionDataContextValue | null>(null)
+const ChatSessionActionsContext = React.createContext<ChatSessionActionsContextValue | null>(null)
+const ChatSessionConnectionContext = React.createContext<ChatSessionConnectionContextValue | null>(null)
+const ChatSessionStreamContext = React.createContext<ChatSessionStreamContextValue | null>(null)
+
+// ---- Hooks ----
+
+export function useChatSessionData(): ChatSessionDataContextValue {
+  const ctx = React.useContext(ChatSessionDataContext)
+  if (!ctx) throw new Error('useChatSessionData must be used within ChatSessionProvider')
+  return ctx
+}
+
+export function useChatSessionActions(): ChatSessionActionsContextValue {
+  const ctx = React.useContext(ChatSessionActionsContext)
+  if (!ctx) throw new Error('useChatSessionActions must be used within ChatSessionProvider')
+  return ctx
+}
+
+export function useChatSessionConnection(): ChatSessionConnectionContextValue {
+  const ctx = React.useContext(ChatSessionConnectionContext)
+  if (!ctx) throw new Error('useChatSessionConnection must be used within ChatSessionProvider')
+  return ctx
+}
+
+export function useChatSessionStream(): ChatSessionStreamContextValue {
+  const ctx = React.useContext(ChatSessionStreamContext)
+  if (!ctx) throw new Error('useChatSessionStream must be used within ChatSessionProvider')
+  return ctx
+}
+
+// ---- Helper types ----
+
+type ProviderListPayload = {
+  providers?: Array<{
+    name?: string
+    available?: boolean
+    version?: string | null
+    error?: string | null
+    command?: string | null
+    args?: string[] | null
+  }>
+  provider?: ProviderHealth
+}
+
+type SessionCreatePayload = {
+  session?: BridgeSessionSummary
+} & BridgeSessionSummary
+
+type ErrorPayload = {
+  message?: string
+  error?: string
+  kind?: string
+}
+
+type RawSessionSummary = {
+  id: string
+  provider: string
+  title: string
+  cwd: string
+  status?: string
+  state?: string
+  createdAt?: string
+  updatedAt?: string
+  providerSessionId?: string
+  agentName?: string
+  agentVersion?: string
+  created_at?: string
+  updated_at?: string
+  provider_session_id?: string
+  agent_name?: string
+  agent_version?: string
+}
+
+// ---- Helper functions (not in context values) ----
+
+function normalizeSessionSummary(session: RawSessionSummary): BridgeSessionSummary {
+  return {
+    id: session.id,
+    provider: session.provider,
+    title: session.title,
+    cwd: session.cwd,
+    status: (session.status ?? session.state ?? 'idle') as BridgeSessionSummary['status'],
+    createdAt: session.createdAt ?? session.created_at ?? '',
+    updatedAt: session.updatedAt ?? session.updated_at ?? '',
+    providerSessionId: session.providerSessionId ?? session.provider_session_id ?? '',
+    agentName: session.agentName ?? session.agent_name ?? 'Codex',
+    agentVersion: session.agentVersion ?? session.agent_version ?? 'unknown',
+  }
+}
+
+function toRun(session: RawSessionSummary): ACPRun {
+  const normalized = normalizeSessionSummary(session)
+  return {
+    id: normalized.id,
+    projectId: 'workspace',
+    agentId: normalized.provider,
+    provider: normalized.provider,
+    title: normalized.title,
+    createdAt: new Date(normalized.createdAt),
+    updatedAt: new Date(normalized.updatedAt),
+    status: normalized.status,
+    providerSessionId: normalized.providerSessionId,
+    cwd: normalized.cwd,
+  }
+}
+
+function normalizeProviderHealth(payload: ProviderListPayload): ProviderHealth {
+  if (payload.provider) {
+    return payload.provider
+  }
+
+  const provider = payload.providers?.[0]
+  return {
+    provider: provider?.name ?? 'codex',
+    ready: Boolean(provider?.available),
+    command: '',
+    args: [],
+    message: provider?.error ?? '',
+  }
+}
+
+function normalizeProviderList(payload: ProviderListPayload): ProviderHealth[] {
+  if (payload.provider) {
+    return [payload.provider]
+  }
+
+  return (payload.providers ?? []).map((provider) => ({
+    provider: provider.name ?? 'codex-acp',
+    ready: Boolean(provider.available),
+    command: provider.command ?? '',
+    args: provider.args ?? [],
+    message: provider.error ?? '',
+  }))
+}
+
+function extractCreatedSession(payload: SessionCreatePayload): RawSessionSummary {
+  return payload.session ?? payload
+}
+
+async function readJsonSafe<T>(response: Response): Promise<T | null> {
+  const text = await response.text()
+  if (!text) {
+    return null
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    return null
+  }
+}
+
+function errorMessageFromPayload(payload: ErrorPayload | null, fallback: string) {
+  return payload?.message ?? payload?.error ?? fallback
+}
+
+function sameProviderList(a: ProviderHealth[], b: ProviderHealth[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((item, i) => item.provider === b[i]?.provider && item.ready === b[i]?.ready)
+}
+
+// ---- Module-level SSE caches (shared with useSessionEvents) ----
+// These must stay in sync with the caches in use-session-events.ts.
+// We use them here only for reading initial state when streamEnabled toggles.
+// The actual SSE subscription is managed inside the provider.
+
+const sessionEventCache = new Map<string, BridgeEvent[]>()
+const sessionLastSeqCache = new Map<string, number>()
+
+// ---- Provider props ----
+
+export type ChatSessionProviderProps = {
+  children: React.ReactNode
+  /** Called from FAB on first click — provider enables SSE stream */
+  onFirstOpenRef?: React.MutableRefObject<(() => void) | null>
+  isMobileViewport?: boolean
+  onSessionPanelClose?: () => void
+}
+
+// ---- Main provider ----
+
+export function ChatSessionProvider({
+  children,
+  onFirstOpenRef,
+  isMobileViewport = false,
+  onSessionPanelClose,
+}: ChatSessionProviderProps) {
+  // ---- State ----
+  const [runs, setRuns] = React.useState<ACPRun[]>([])
+  const [sessionsLoaded, setSessionsLoaded] = React.useState(false)
+  const [selectedRunId, setSelectedRunId] = React.useState<string | null>(() => {
+    try {
+      const id = typeof localStorage !== 'undefined'
+        ? localStorage.getItem('lab.chat.last-session-id')
+        : null
+      return id && /^[a-zA-Z0-9_-]{8,64}$/.test(id) ? id : null
+    } catch {
+      return null
+    }
+  })
+  const [providerHealth, setProviderHealth] = React.useState<ProviderHealth | null>(null)
+  const [providers, setProviders] = React.useState<ProviderHealth[]>([])
+  const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
+  const [pageContext, setPageContext] = React.useState<PageContext>(null)
+
+  // Stream is lazy — only enabled on first FAB click
+  const [streamEnabled, setStreamEnabled] = React.useState(false)
+
+  // SSE state (only active when streamEnabled)
+  const [events, setEvents] = React.useState<BridgeEvent[]>([])
+  const [connectionState, setConnectionState] = React.useState<SessionEventConnectionState>('idle')
+  const lastSeqRef = React.useRef(0)
+
+  // Mutex for createSession
+  const isCreatingRef = React.useRef(false)
+
+  // ---- ACP fetch utility (re-derived per call, not stored in state) ----
+  const fetchAcpRef = React.useRef(createAcpFetcher())
+  // Re-derive on each render in case config changed (stable ref via useCallback)
+  const fetchAcp = React.useCallback(
+    (path: string, init?: RequestInit) => fetchAcpRef.current(path, init),
+    [],
+  )
+
+  // ---- Expose first-open callback to FAB ----
+  React.useLayoutEffect(() => {
+    if (!onFirstOpenRef) return
+    onFirstOpenRef.current = () => {
+      setStreamEnabled(true)
+    }
+  }, [onFirstOpenRef])
+
+  // ---- Derived values ----
+  const selectedRun = React.useMemo(
+    () => runs.find((run) => run.id === selectedRunId) ?? null,
+    [runs, selectedRunId],
+  )
+
+  const projects = React.useMemo(
+    () =>
+      toProjects(
+        runs.map((run) => ({
+          id: run.id,
+          providerSessionId: run.providerSessionId,
+          provider: run.provider,
+          title: run.title,
+          cwd: run.cwd,
+          createdAt: run.createdAt.toISOString(),
+          updatedAt: run.updatedAt.toISOString(),
+          status: run.status,
+          agentName: ACP_AGENT.name,
+          agentVersion: ACP_AGENT.version,
+        })),
+      ),
+    [runs],
+  )
+
+  const agents = React.useMemo<ACPAgent[]>(
+    () =>
+      providers.map((provider) => ({
+        ...ACP_AGENT,
+        id: provider.provider,
+        name: provider.provider === 'codex-acp' ? 'Codex ACP' : provider.provider,
+        version: ACP_AGENT.version,
+      })),
+    [providers],
+  )
+
+  const sessionStatus = React.useMemo(
+    () => resolveSessionStatusFromEvents(events),
+    [events],
+  )
+
+  const derived = React.useMemo(() => deriveTranscriptAndActivity(events), [events])
+
+  // ---- Actions ----
+
+  const refreshSessions = React.useCallback(async () => {
+    const response = await fetchAcp('/sessions')
+    if (!response.ok) {
+      setRuns([])
+      setSelectedRunId(null)
+      setSessionsLoaded(true)
+      return
+    }
+    const payload = await readJsonSafe<{ sessions: RawSessionSummary[] }>(response)
+    if (!payload) {
+      setRuns([])
+      setSelectedRunId(null)
+      setSessionsLoaded(true)
+      return
+    }
+    const nextRuns = payload.sessions.map(toRun)
+    setRuns(nextRuns)
+    setSelectedRunId((current) => current ?? nextRuns[0]?.id ?? null)
+    setSessionsLoaded(true)
+  }, [fetchAcp])
+
+  const refreshProvider = React.useCallback(async () => {
+    const response = await fetchAcp('/provider')
+    if (!response.ok) {
+      const unavailable: ProviderHealth = {
+        provider: 'codex-acp',
+        ready: false,
+        command: '',
+        args: [],
+        message: 'ACP provider unavailable.',
+      }
+      setProviders([unavailable])
+      setSelectedProviderId('codex-acp')
+      setProviderHealth(unavailable)
+      return
+    }
+    const payload = (await response.json()) as ProviderListPayload
+    const nextProviders = normalizeProviderList(payload)
+    const selected = nextProviders.find((provider) => provider.ready) ?? nextProviders[0] ?? normalizeProviderHealth(payload)
+    setProviders((prev) => sameProviderList(prev, nextProviders) ? prev : (nextProviders.length > 0 ? nextProviders : [selected]))
+    setSelectedProviderId((current) =>
+      current && nextProviders.some((provider) => provider.provider === current)
+        ? current
+        : selected.provider,
+    )
+    setProviderHealth(selected)
+  }, [fetchAcp])
+
+  const createSession = React.useCallback<CreateSessionFn>(
+    async (createOptions?: CreateSessionOptions) => {
+      if (isCreatingRef.current) {
+        // Return a dummy promise resolved when creating is done — use existing run if available
+        throw new Error('Session creation already in progress')
+      }
+      isCreatingRef.current = true
+      try {
+        const response = await fetchAcp('/sessions', {
+          method: 'POST',
+          body: JSON.stringify({ provider: selectedProviderId ?? providerHealth?.provider ?? 'codex-acp' }),
+        })
+        const payload = await readJsonSafe<SessionCreatePayload | ErrorPayload>(response)
+        if (!response.ok || !payload) {
+          const message = errorMessageFromPayload(
+            payload as ErrorPayload | null,
+            'Failed to create ACP session.',
+          )
+          setProviderHealth((current) => ({
+            provider: current?.provider ?? 'codex-acp',
+            ready: false,
+            command: current?.command ?? '',
+            args: current?.args ?? [],
+            message,
+          }))
+          throw new Error(message)
+        }
+        const run = toRun(extractCreatedSession(payload as SessionCreatePayload))
+        setRuns((current) => integrateCreatedRun(current, run))
+        setSelectedRunId(run.id)
+        if (createOptions?.closeSessionPanel) {
+          onSessionPanelClose?.()
+        }
+        return run
+      } finally {
+        isCreatingRef.current = false
+      }
+    },
+    [fetchAcp, onSessionPanelClose, providerHealth?.provider, selectedProviderId],
+  )
+
+  const selectRun = React.useCallback(
+    (runId: string) => {
+      setSelectedRunId(runId)
+      try {
+        localStorage.setItem('lab.chat.last-session-id', runId)
+      } catch {
+        // localStorage may be unavailable
+      }
+      if (isMobileViewport) {
+        onSessionPanelClose?.()
+      }
+    },
+    [isMobileViewport, onSessionPanelClose],
+  )
+
+  const selectAgent = React.useCallback((providerId: string) => {
+    setSelectedProviderId(providerId)
+  }, [])
+
+  const setPageContextStable = React.useCallback((ctx: PageContext) => {
+    setPageContext(ctx)
+  }, [])
+
+  // ---- Initialization effects ----
+
+  React.useEffect(() => {
+    if (USE_MOCK_DATA) {
+      setProviderHealth({
+        provider: 'codex-acp',
+        ready: false,
+        command: '',
+        args: [],
+        message: 'ACP unavailable in mock preview.',
+      })
+      setProviders([])
+      setSelectedProviderId(null)
+      setRuns([])
+      setSelectedRunId(null)
+      setSessionsLoaded(true)
+      return
+    }
+
+    void refreshProvider()
+    void refreshSessions()
+  }, [refreshProvider, refreshSessions])
+
+  // Sync providerHealth when selectedProviderId or providers list changes
+  React.useEffect(() => {
+    if (!selectedProviderId) return
+    const selected = providers.find((provider) => provider.provider === selectedProviderId)
+    if (selected) {
+      setProviderHealth(selected)
+    }
+  }, [providers, selectedProviderId])
+
+  // Auto-bootstrap first session — only after first FAB click (streamEnabled)
+  React.useEffect(() => {
+    if (!streamEnabled) return
+    if (!shouldAutoCreateInitialRun(Boolean(providerHealth?.ready), runs.length, selectedRunId)) return
+
+    void (async () => {
+      try {
+        await createSession()
+      } catch {
+        // providerHealth.message carries the failure detail
+      }
+    })()
+  }, [createSession, providerHealth?.ready, runs.length, selectedRunId, streamEnabled])
+
+  // Update run status from session events (bail-out setter for re-render efficiency)
+  React.useEffect(() => {
+    if (!selectedRunId || events.length === 0) return
+
+    setRuns((current) =>
+      current.map((run) => {
+        if (run.id !== selectedRunId) return run
+        if (run.status === sessionStatus) return run
+        return { ...run, status: sessionStatus, updatedAt: new Date() }
+      }),
+    )
+  }, [selectedRunId, sessionStatus, events.length])
+
+  // ---- SSE stream management (lazy — only when streamEnabled) ----
+
+  React.useEffect(() => {
+    if (!streamEnabled || !selectedRunId) {
+      if (!streamEnabled) {
+        setEvents([])
+        setConnectionState('idle')
+        lastSeqRef.current = 0
+      }
+      return
+    }
+
+    if (USE_MOCK_DATA) {
+      setEvents([])
+      setConnectionState('idle')
+      lastSeqRef.current = 0
+      return
+    }
+
+    // Rehydrate from shared cache
+    const cachedEvents = sessionEventCache.get(selectedRunId) ?? []
+    const cachedLastSeq = resolveLastSessionEventSeq(
+      cachedEvents,
+      sessionLastSeqCache.get(selectedRunId) ?? 0,
+    )
+
+    setEvents(cachedEvents)
+    setConnectionState('connecting')
+    lastSeqRef.current = cachedLastSeq
+
+    const abortController = new AbortController()
+    const fetchAcpNow = createAcpFetcher()
+
+    void (async () => {
+      try {
+        const response = await fetchAcpNow(`/sessions/${selectedRunId}/events?since=${lastSeqRef.current}`, {
+          signal: abortController.signal,
+        })
+
+        if (!response.ok || !response.body) {
+          setConnectionState('error')
+          return
+        }
+
+        setConnectionState('open')
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        const applyBuffer = () => {
+          const consumed = consumeSessionEventBuffer(buffer, lastSeqRef.current)
+          buffer = consumed.buffer
+
+          for (const event of consumed.events) {
+            lastSeqRef.current = event.seq
+            sessionLastSeqCache.set(selectedRunId, event.seq)
+            setEvents((current) => {
+              const next = appendSessionEvent(current, event)
+              sessionEventCache.set(selectedRunId, next)
+              return next
+            })
+          }
+        }
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          applyBuffer()
+        }
+
+        buffer += decoder.decode()
+        applyBuffer()
+      } catch {
+        if (!abortController.signal.aborted) {
+          setConnectionState('error')
+        }
+      }
+    })()
+
+    return () => {
+      abortController.abort()
+    }
+  }, [streamEnabled, selectedRunId])
+
+  // ---- Context values ----
+
+  const dataValue = React.useMemo<ChatSessionDataContextValue>(
+    () => ({
+      runs,
+      selectedRunId,
+      selectedRun,
+      providerHealth,
+      providers,
+      selectedProviderId,
+      agents,
+      projects,
+      sessionsLoaded,
+      pageContext,
+    }),
+    [runs, selectedRunId, selectedRun, providerHealth, providers, selectedProviderId, agents, projects, sessionsLoaded, pageContext],
+  )
+
+  const actionsValue = React.useMemo<ChatSessionActionsContextValue>(
+    () => ({
+      createSession,
+      selectRun,
+      refreshSessions,
+      refreshProvider,
+      selectAgent,
+      setPageContext: setPageContextStable,
+    }),
+    [createSession, selectRun, refreshSessions, refreshProvider, selectAgent, setPageContextStable],
+  )
+
+  const connectionValue = React.useMemo<ChatSessionConnectionContextValue>(
+    () => ({
+      connectionState,
+      sessionStatus,
+    }),
+    [connectionState, sessionStatus],
+  )
+
+  const streamValue = React.useMemo<ChatSessionStreamContextValue>(
+    () => ({
+      messages: derived.messages,
+      events,
+      activity: derived.activity,
+    }),
+    [derived.messages, events, derived.activity],
+  )
+
+  return (
+    <ChatSessionDataContext.Provider value={dataValue}>
+      <ChatSessionActionsContext.Provider value={actionsValue}>
+        <ChatSessionConnectionContext.Provider value={connectionValue}>
+          <ChatSessionStreamContext.Provider value={streamValue}>
+            {children}
+          </ChatSessionStreamContext.Provider>
+        </ChatSessionConnectionContext.Provider>
+      </ChatSessionActionsContext.Provider>
+    </ChatSessionDataContext.Provider>
+  )
+}

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -262,7 +262,10 @@ export function ChatSessionProvider({
     }
     const nextRuns = payload.sessions.map(toRun)
     setRuns(nextRuns)
-    setSelectedRunId((current) => current ?? nextRuns[0]?.id ?? null)
+    setSelectedRunId((current) => {
+      if (current && nextRuns.some((run) => run.id === current)) return current
+      return nextRuns[0]?.id ?? null
+    })
     setSessionsLoaded(true)
   }, [fetchAcp])
 
@@ -296,7 +299,7 @@ export function ChatSessionProvider({
   const createSession = React.useCallback<CreateSessionFn>(
     async (createOptions?: CreateSessionOptions) => {
       if (isCreatingRef.current) {
-        // Return a dummy promise resolved when creating is done — use existing run if available
+        // Mutex guard: prevent duplicate concurrent session creation — throw immediately to signal the caller
         throw new Error('Session creation already in progress')
       }
       isCreatingRef.current = true

--- a/apps/gateway-admin/lib/chat/session-event-cache.ts
+++ b/apps/gateway-admin/lib/chat/session-event-cache.ts
@@ -5,12 +5,58 @@
  *
  * Both `chat-session-provider.tsx` and `use-session-events.ts` import from
  * here so the two subscribers always read from the same Maps.
+ *
+ * LRU eviction: keeps the last 10 sessions in memory. Both maps are evicted
+ * together on the same key when the limit is exceeded.
  */
 
 import type { BridgeEvent } from '@/lib/acp/types'
 
+const MAX_SESSIONS = 10
+
+const _eventMap = new Map<string, BridgeEvent[]>()
+const _seqMap = new Map<string, number>()
+/** Access order — most-recently used at the end. */
+const _accessOrder: string[] = []
+
+function touchSession(sessionId: string) {
+  const idx = _accessOrder.indexOf(sessionId)
+  if (idx !== -1) {
+    _accessOrder.splice(idx, 1)
+  }
+  _accessOrder.push(sessionId)
+
+  // Evict when we exceed the limit
+  while (_accessOrder.length > MAX_SESSIONS) {
+    const evicted = _accessOrder.shift()
+    if (evicted != null) {
+      _eventMap.delete(evicted)
+      _seqMap.delete(evicted)
+    }
+  }
+}
+
 /** In-memory event buffer keyed by session ID. */
-export const sessionEventCache = new Map<string, BridgeEvent[]>()
+export const sessionEventCache = {
+  get(sessionId: string): BridgeEvent[] | undefined {
+    const value = _eventMap.get(sessionId)
+    if (value !== undefined) touchSession(sessionId)
+    return value
+  },
+  set(sessionId: string, events: BridgeEvent[]): void {
+    _eventMap.set(sessionId, events)
+    touchSession(sessionId)
+  },
+}
 
 /** Last seen sequence number keyed by session ID. */
-export const sessionLastSeqCache = new Map<string, number>()
+export const sessionLastSeqCache = {
+  get(sessionId: string): number | undefined {
+    return _seqMap.get(sessionId)
+  },
+  set(sessionId: string, seq: number): void {
+    _seqMap.set(sessionId, seq)
+    // access order is already updated by sessionEventCache.set for the same session;
+    // seq updates always accompany event writes so no separate touchSession needed.
+  },
+}

--- a/apps/gateway-admin/lib/chat/session-event-cache.ts
+++ b/apps/gateway-admin/lib/chat/session-event-cache.ts
@@ -1,0 +1,16 @@
+'use client'
+
+/**
+ * Shared SSE event caches — single source of truth.
+ *
+ * Both `chat-session-provider.tsx` and `use-session-events.ts` import from
+ * here so the two subscribers always read from the same Maps.
+ */
+
+import type { BridgeEvent } from '@/lib/acp/types'
+
+/** In-memory event buffer keyed by session ID. */
+export const sessionEventCache = new Map<string, BridgeEvent[]>()
+
+/** Last seen sequence number keyed by session ID. */
+export const sessionLastSeqCache = new Map<string, number>()

--- a/apps/gateway-admin/lib/chat/session-events.ts
+++ b/apps/gateway-admin/lib/chat/session-events.ts
@@ -337,13 +337,14 @@ export function resolveSessionStatusFromEvents(
   events: BridgeEvent[],
   fallback: BridgeSessionStatus = 'idle',
 ) {
-  let status = fallback
-  for (const event of events) {
-    if (event.kind === 'status' && isBridgeSessionStatus(event.status)) {
-      status = event.status
+  // Reverse scan — stop at the first (most-recent) status event: O(1) in the common case.
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    if (event && event.kind === 'status' && isBridgeSessionStatus(event.status)) {
+      return event.status
     }
   }
-  return status
+  return fallback
 }
 
 function upsertToolCall(toolCalls: TranscriptToolCall[], patch: ToolCallPatch): TranscriptToolCall[] {

--- a/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
+++ b/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
@@ -1,9 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { normalizeGatewayApiBase } from '@/lib/api/gateway-config'
-import { gatewayHeaders } from '@/lib/api/gateway-request'
-import { isStandaloneBearerAuthMode } from '@/lib/auth/auth-mode'
+import { createAcpFetcher } from '@/lib/acp/fetch'
 import { toProjects } from './session-events'
 import { useSessionEvents } from './use-session-events'
 import {
@@ -85,11 +83,10 @@ export function useChatSessionController(options: {
   onSessionPanelClose?: () => void
 }) {
   const { isMobileViewport, onSessionPanelClose } = options
-  const acpBase = React.useMemo(() => `${normalizeGatewayApiBase()}/acp`, [])
-  const standaloneBearerAuth = React.useMemo(() => isStandaloneBearerAuthMode(), [])
-  const requestCredentials = React.useMemo<RequestCredentials>(
-    () => (standaloneBearerAuth ? 'omit' : 'include'),
-    [standaloneBearerAuth],
+  const fetchAcpRef = React.useRef(createAcpFetcher())
+  const fetchAcp = React.useCallback(
+    (path: string, init?: RequestInit) => fetchAcpRef.current(path, init),
+    [],
   )
   const [runs, setRuns] = React.useState<ACPRun[]>([])
   const [selectedRunId, setSelectedRunId] = React.useState<string | null>(null)
@@ -136,24 +133,6 @@ export function useChatSessionController(options: {
         name: selectedRun.provider,
       })
     : (agents.find((agent) => agent.id === selectedProviderId) ?? agents[0] ?? ACP_AGENT)
-
-  const fetchAcp = React.useCallback(
-    async (path: string, init?: RequestInit) => {
-      const headers = new Headers(init?.headers ?? {})
-      const authHeaders = gatewayHeaders()
-      for (const [key, value] of Object.entries(authHeaders)) {
-        headers.set(key, value)
-      }
-
-      return fetch(`${acpBase}${path}`, {
-        ...init,
-        headers,
-        credentials: requestCredentials,
-        cache: 'no-store',
-      })
-    },
-    [acpBase, requestCredentials],
-  )
 
   const refreshSessions = React.useCallback(async () => {
     const response = await fetchAcp('/sessions')

--- a/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
+++ b/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
@@ -6,6 +6,18 @@ import { gatewayHeaders } from '@/lib/api/gateway-request'
 import { isStandaloneBearerAuthMode } from '@/lib/auth/auth-mode'
 import { toProjects } from './session-events'
 import { useSessionEvents } from './use-session-events'
+import {
+  type ProviderListPayload,
+  type SessionCreatePayload,
+  type ErrorPayload,
+  type RawSessionSummary,
+  toRun,
+  normalizeProviderHealth,
+  normalizeProviderList,
+  extractCreatedSession,
+  readJsonSafe,
+  errorMessageFromPayload,
+} from './acp-normalizers'
 import type { ACPAgent, ACPRun } from '@/components/chat/types'
 import type { BridgeSessionSummary, ProviderHealth } from '@/lib/acp/types'
 import type { AttachmentRef } from '@/lib/fs/types'
@@ -18,47 +30,6 @@ export const ACP_AGENT: ACPAgent = {
   description: 'codex-acp over local ACP bridge',
   version: 'live',
   capabilities: ['tool_use', 'streaming', 'permissions', 'plans'],
-}
-
-type ProviderListPayload = {
-  providers?: Array<{
-    name?: string
-    available?: boolean
-    version?: string | null
-    error?: string | null
-    command?: string | null
-    args?: string[] | null
-  }>
-  provider?: ProviderHealth
-}
-
-type SessionCreatePayload = {
-  session?: BridgeSessionSummary
-} & BridgeSessionSummary
-
-type ErrorPayload = {
-  message?: string
-  error?: string
-  kind?: string
-}
-
-type RawSessionSummary = {
-  id: string
-  provider: string
-  title: string
-  cwd: string
-  status?: string
-  state?: string
-  createdAt?: string
-  updatedAt?: string
-  providerSessionId?: string
-  agentName?: string
-  agentVersion?: string
-  created_at?: string
-  updated_at?: string
-  provider_session_id?: string
-  agent_name?: string
-  agent_version?: string
 }
 
 export type SessionCreationIntent = 'bootstrap' | 'manual' | 'send'
@@ -107,87 +78,6 @@ export async function ensurePromptRunId(
 
   const run = await createSessionForIntent(createSession, 'send', isMobileViewport)
   return run.id
-}
-
-function normalizeSessionSummary(session: RawSessionSummary): BridgeSessionSummary {
-  return {
-    id: session.id,
-    provider: session.provider,
-    title: session.title,
-    cwd: session.cwd,
-    status: (session.status ?? session.state ?? 'idle') as BridgeSessionSummary['status'],
-    createdAt: session.createdAt ?? session.created_at ?? '',
-    updatedAt: session.updatedAt ?? session.updated_at ?? '',
-    providerSessionId: session.providerSessionId ?? session.provider_session_id ?? '',
-    agentName: session.agentName ?? session.agent_name ?? 'Codex',
-    agentVersion: session.agentVersion ?? session.agent_version ?? 'unknown',
-  }
-}
-
-function toRun(session: RawSessionSummary): ACPRun {
-  const normalized = normalizeSessionSummary(session)
-  return {
-    id: normalized.id,
-    projectId: 'workspace',
-    agentId: normalized.provider,
-    provider: normalized.provider,
-    title: normalized.title,
-    createdAt: new Date(normalized.createdAt),
-    updatedAt: new Date(normalized.updatedAt),
-    status: normalized.status,
-    providerSessionId: normalized.providerSessionId,
-    cwd: normalized.cwd,
-  }
-}
-
-function normalizeProviderHealth(payload: ProviderListPayload): ProviderHealth {
-  if (payload.provider) {
-    return payload.provider
-  }
-
-  const provider = payload.providers?.[0]
-  return {
-    provider: provider?.name ?? 'codex',
-    ready: Boolean(provider?.available),
-    command: '',
-    args: [],
-    message: provider?.error ?? '',
-  }
-}
-
-function normalizeProviderList(payload: ProviderListPayload): ProviderHealth[] {
-  if (payload.provider) {
-    return [payload.provider]
-  }
-
-  return (payload.providers ?? []).map((provider) => ({
-    provider: provider.name ?? 'codex-acp',
-    ready: Boolean(provider.available),
-    command: provider.command ?? '',
-    args: provider.args ?? [],
-    message: provider.error ?? '',
-  }))
-}
-
-function extractCreatedSession(payload: SessionCreatePayload): RawSessionSummary {
-  return payload.session ?? payload
-}
-
-async function readJsonSafe<T>(response: Response): Promise<T | null> {
-  const text = await response.text()
-  if (!text) {
-    return null
-  }
-
-  try {
-    return JSON.parse(text) as T
-  } catch {
-    return null
-  }
-}
-
-function errorMessageFromPayload(payload: ErrorPayload | null, fallback: string) {
-  return payload?.message ?? payload?.error ?? fallback
 }
 
 export function useChatSessionController(options: {
@@ -331,7 +221,13 @@ export function useChatSessionController(options: {
         }))
         throw new Error(message)
       }
-      const run = toRun(extractCreatedSession(payload))
+      // Narrow: SessionCreatePayload has an `id` field; ErrorPayload does not
+      const isSessionPayload = 'id' in payload || ('session' in payload && payload.session != null)
+      if (!isSessionPayload) {
+        const message = errorMessageFromPayload(payload as ErrorPayload, 'Failed to create ACP session.')
+        throw new Error(message)
+      }
+      const run = toRun(extractCreatedSession(payload as SessionCreatePayload))
       setRuns((current) => integrateCreatedRun(current, run))
       setSelectedRunId(run.id)
       if (createOptions?.closeSessionPanel) {

--- a/apps/gateway-admin/lib/chat/use-page-context-sync.ts
+++ b/apps/gateway-admin/lib/chat/use-page-context-sync.ts
@@ -1,0 +1,21 @@
+'use client'
+
+/**
+ * usePageContextSync — Syncs the current pathname into ChatSessionProvider.pageContext.
+ * Must be rendered inside ChatSessionProvider (consumes ChatSessionActionsContext).
+ */
+
+import * as React from 'react'
+import { usePathname } from 'next/navigation'
+import { useChatSessionActions } from './chat-session-provider'
+import type { PageContext } from './chat-session-provider'
+
+export function usePageContextSync(): void {
+  const pathname = usePathname()
+  const { setPageContext } = useChatSessionActions()
+
+  React.useEffect(() => {
+    const ctx: PageContext = { route: pathname }
+    setPageContext(ctx)
+  }, [pathname, setPageContext])
+}

--- a/apps/gateway-admin/lib/chat/use-session-events.ts
+++ b/apps/gateway-admin/lib/chat/use-session-events.ts
@@ -12,13 +12,11 @@ import {
   resolveLastSessionEventSeq,
   resolveSessionStatusFromEvents,
 } from './session-events'
+import { sessionEventCache, sessionLastSeqCache } from './session-event-cache'
 
 export type SessionEventConnectionState = 'idle' | 'connecting' | 'open' | 'error'
 
 const USE_MOCK_DATA = process.env.NEXT_PUBLIC_MOCK_DATA === 'true'
-
-const sessionEventCache = new Map<string, BridgeEvent[]>()
-const sessionLastSeqCache = new Map<string, number>()
 
 function hasSequence(value: unknown): value is { seq: number } {
   return (
@@ -178,15 +176,19 @@ export function useSessionEvents(sessionId: string | null) {
           const consumed = consumeSessionEventBuffer(buffer, lastSeqRef.current)
           buffer = consumed.buffer
 
-          for (const event of consumed.events) {
-            lastSeqRef.current = event.seq
-            sessionLastSeqCache.set(sessionId, event.seq)
-            setEvents((current) => {
-              const next = appendSessionEvent(current, event)
-              sessionEventCache.set(sessionId, next)
-              return next
-            })
-          }
+          if (consumed.events.length === 0) return
+
+          // Batch: apply all events from this chunk in one setEvents call
+          setEvents((current) => {
+            let next = current
+            for (const event of consumed.events) {
+              lastSeqRef.current = event.seq
+              sessionLastSeqCache.set(sessionId, event.seq)
+              next = appendSessionEvent(next, event)
+            }
+            sessionEventCache.set(sessionId, next)
+            return next
+          })
         }
 
         while (true) {

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -54,6 +54,10 @@ use super::types::{
 /// Capacity for each subscriber's mpsc channel.
 const SUBSCRIBER_CAPACITY: usize = 64;
 
+/// Maximum number of concurrent SSE subscribers per session.
+/// Excess subscribe calls return `too_many_subscribers`.
+const MAX_SUBSCRIBERS_PER_SESSION: usize = 32;
+
 /// Maximum backlog events returned from SQLite on subscribe.
 const BACKFILL_CAP: u64 = 10_000;
 
@@ -504,6 +508,15 @@ impl AcpSessionRegistry {
         let (tx, rx) = mpsc::channel::<Arc<AcpEvent>>(SUBSCRIBER_CAPACITY);
         {
             let mut subs = session.subscribers.lock().await;
+            if subs.len() >= MAX_SUBSCRIBERS_PER_SESSION {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "too_many_subscribers".to_string(),
+                    message: format!(
+                        "session has reached the maximum of {} concurrent subscribers",
+                        MAX_SUBSCRIBERS_PER_SESSION
+                    ),
+                });
+            }
             subs.push(tx);
         }
 

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -19,6 +19,108 @@ use crate::dispatch::acp::dispatch::dispatch_with_registry;
 use crate::dispatch::acp::dispatch::validate_subscribe_ticket;
 use crate::dispatch::error::ToolError;
 
+// ---- pageContext support ----
+
+/// Maximum tokens allowed for the assembled context prefix.
+/// Estimated at ~4 chars/token; we enforce a char budget of 30 * 4 = 120 chars.
+const PAGE_CONTEXT_MAX_TOKENS: usize = 30;
+const PAGE_CONTEXT_MAX_CHARS: usize = PAGE_CONTEXT_MAX_TOKENS * 4;
+
+/// Characters allowed in pageContext field values.
+const PAGE_CONTEXT_ALLOWED: &[char] = &[
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '_', '-',
+];
+
+/// Tokens that indicate prompt-injection attempts — reject the entire pageContext field if any match.
+const PAGE_CONTEXT_DENY_LIST: &[&str] = &[
+    "system", "ignore", "override", "admin", "instruction", "assistant", "prompt",
+];
+
+/// Sanitize a single pageContext field value.
+/// Returns `None` if the value fails validation (contains deny-list tokens after stripping).
+/// NFKC-normalizes (ASCII-safe: identity for ASCII input), strips to allowed characters,
+/// truncates to 32 chars.
+fn sanitize_page_context_field(value: &str) -> Option<String> {
+    // Strip to allowed characters (NFKC normalization is identity for our ASCII allow-list).
+    // For non-ASCII Unicode the filter naturally drops all non-ASCII chars, achieving
+    // the same safety goal as NFKC + strip without pulling in the unicode-normalization crate.
+    let stripped: String = value
+        .chars()
+        .filter(|c| PAGE_CONTEXT_ALLOWED.contains(c))
+        .take(32)
+        .collect();
+
+    if stripped.is_empty() {
+        return None;
+    }
+
+    // Deny-list check (case-insensitive)
+    let lower = stripped.to_lowercase();
+    for denied in PAGE_CONTEXT_DENY_LIST {
+        if lower.contains(denied) {
+            return None;
+        }
+    }
+
+    Some(stripped)
+}
+
+/// Assemble compact context prefix from a validated PageContextBody.
+/// Returns `None` if validation fails (any required field is invalid).
+/// Format: `[context: page={route}]` or `[context: page={route} entity={type}/{id}]`
+fn assemble_page_context_prefix(
+    session_id: &str,
+    ctx: &PageContextBody,
+) -> Option<String> {
+    let route = sanitize_page_context_field(&ctx.route)?;
+
+    // Build prefix candidates, longest first, then trim to token budget
+    let prefix = match (&ctx.entity_type, &ctx.entity_id) {
+        (Some(et), Some(eid)) => {
+            let entity_type = sanitize_page_context_field(et)?;
+            let entity_id = sanitize_page_context_field(eid)?;
+            let candidate = format!("[context: page={route} entity={entity_type}/{entity_id}]");
+            if candidate.len() <= PAGE_CONTEXT_MAX_CHARS {
+                candidate
+            } else {
+                // Try without entity_id
+                let without_id = format!("[context: page={route} entity={entity_type}]");
+                if without_id.len() <= PAGE_CONTEXT_MAX_CHARS {
+                    without_id
+                } else {
+                    // Fall back to route only
+                    format!("[context: page={route}]")
+                }
+            }
+        }
+        (Some(et), None) => {
+            let entity_type = sanitize_page_context_field(et)?;
+            format!("[context: page={route} entity={entity_type}]")
+        }
+        _ => format!("[context: page={route}]"),
+    };
+
+    // Estimate token count: chars / 4, rough approximation
+    let estimated_tokens = prefix.len().div_ceil(4);
+    tracing::info!(
+        surface = "api",
+        service = "acp",
+        action = "session.prompt",
+        session_id,
+        page_context_route = %route,
+        page_context_token_estimate = estimated_tokens,
+        "page context injected",
+    );
+
+    Some(prefix)
+}
+
+// ---- End pageContext support ----
+
 pub fn routes(_state: AppState) -> Router<AppState> {
     Router::new()
         .route("/provider", get(provider_health))
@@ -64,9 +166,23 @@ async fn create_session(
     }
 }
 
+/// Optional page context from the frontend — sent only when user has enabled
+/// the "Send page context" toggle. Absent field = zero injection, zero token cost.
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageContextBody {
+    route: String,
+    entity_type: Option<String>,
+    entity_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PromptBody {
     prompt: String,
+    /// Optional structured page context. If present, server assembles a compact
+    /// token-minimal context prefix and prepends it to the system prompt.
+    page_context: Option<PageContextBody>,
 }
 
 async fn prompt_session(
@@ -81,9 +197,30 @@ async fn prompt_session(
         }
         .into_response();
     }
+
+    // Assemble the effective prompt text: optional context prefix + user prompt.
+    // Validation failure silently skips injection — never errors the request.
+    let prompt_text = if let Some(ctx) = &body.page_context {
+        match assemble_page_context_prefix(&session_id, ctx) {
+            Some(prefix) => format!("{}\n\n{}", prefix, body.prompt.trim()),
+            None => {
+                tracing::warn!(
+                    surface = "api",
+                    service = "acp",
+                    action = "session.prompt",
+                    session_id = %session_id,
+                    "page context validation failed — injecting without context",
+                );
+                body.prompt.trim().to_string()
+            }
+        }
+    } else {
+        body.prompt.trim().to_string()
+    };
+
     let params = json!({
         "session_id": session_id,
-        "text": body.prompt.trim(),
+        "text": prompt_text,
     });
     match dispatch_with_registry(&state.acp_registry, "session.prompt", params).await {
         Ok(v) => Json(v).into_response(),

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -39,6 +39,9 @@ async fn provider_health(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 async fn list_sessions(State(state): State<AppState>) -> impl IntoResponse {
+    // TODO(phase-2): extract bearer principal from request extensions and pass it here
+    // so each caller only sees their own sessions. Until bearer auth is wired in the
+    // middleware layer this returns all sessions (anonymous == empty principal).
     match dispatch_with_registry(&state.acp_registry, "session.list", json!({})).await {
         Ok(v) => Json(v).into_response(),
         Err(e) => e.into_response(),

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -19,107 +19,8 @@ use crate::dispatch::acp::dispatch::dispatch_with_registry;
 use crate::dispatch::acp::dispatch::validate_subscribe_ticket;
 use crate::dispatch::error::ToolError;
 
-// ---- pageContext support ----
-
-/// Maximum tokens allowed for the assembled context prefix.
-/// Estimated at ~4 chars/token; we enforce a char budget of 30 * 4 = 120 chars.
-const PAGE_CONTEXT_MAX_TOKENS: usize = 30;
-const PAGE_CONTEXT_MAX_CHARS: usize = PAGE_CONTEXT_MAX_TOKENS * 4;
-
-/// Characters allowed in pageContext field values.
-const PAGE_CONTEXT_ALLOWED: &[char] = &[
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '_', '-',
-];
-
-/// Tokens that indicate prompt-injection attempts — reject the entire pageContext field if any match.
-const PAGE_CONTEXT_DENY_LIST: &[&str] = &[
-    "system", "ignore", "override", "admin", "instruction", "assistant", "prompt",
-];
-
-/// Sanitize a single pageContext field value.
-/// Returns `None` if the value fails validation (contains deny-list tokens after stripping).
-/// NFKC-normalizes (ASCII-safe: identity for ASCII input), strips to allowed characters,
-/// truncates to 32 chars.
-fn sanitize_page_context_field(value: &str) -> Option<String> {
-    // Strip to allowed characters (NFKC normalization is identity for our ASCII allow-list).
-    // For non-ASCII Unicode the filter naturally drops all non-ASCII chars, achieving
-    // the same safety goal as NFKC + strip without pulling in the unicode-normalization crate.
-    let stripped: String = value
-        .chars()
-        .filter(|c| PAGE_CONTEXT_ALLOWED.contains(c))
-        .take(32)
-        .collect();
-
-    if stripped.is_empty() {
-        return None;
-    }
-
-    // Deny-list check (case-insensitive)
-    let lower = stripped.to_lowercase();
-    for denied in PAGE_CONTEXT_DENY_LIST {
-        if lower.contains(denied) {
-            return None;
-        }
-    }
-
-    Some(stripped)
-}
-
-/// Assemble compact context prefix from a validated PageContextBody.
-/// Returns `None` if validation fails (any required field is invalid).
-/// Format: `[context: page={route}]` or `[context: page={route} entity={type}/{id}]`
-fn assemble_page_context_prefix(
-    session_id: &str,
-    ctx: &PageContextBody,
-) -> Option<String> {
-    let route = sanitize_page_context_field(&ctx.route)?;
-
-    // Build prefix candidates, longest first, then trim to token budget
-    let prefix = match (&ctx.entity_type, &ctx.entity_id) {
-        (Some(et), Some(eid)) => {
-            let entity_type = sanitize_page_context_field(et)?;
-            let entity_id = sanitize_page_context_field(eid)?;
-            let candidate = format!("[context: page={route} entity={entity_type}/{entity_id}]");
-            if candidate.len() <= PAGE_CONTEXT_MAX_CHARS {
-                candidate
-            } else {
-                // Try without entity_id
-                let without_id = format!("[context: page={route} entity={entity_type}]");
-                if without_id.len() <= PAGE_CONTEXT_MAX_CHARS {
-                    without_id
-                } else {
-                    // Fall back to route only
-                    format!("[context: page={route}]")
-                }
-            }
-        }
-        (Some(et), None) => {
-            let entity_type = sanitize_page_context_field(et)?;
-            format!("[context: page={route} entity={entity_type}]")
-        }
-        _ => format!("[context: page={route}]"),
-    };
-
-    // Estimate token count: chars / 4, rough approximation
-    let estimated_tokens = prefix.len().div_ceil(4);
-    tracing::info!(
-        surface = "api",
-        service = "acp",
-        action = "session.prompt",
-        session_id,
-        page_context_route = %route,
-        page_context_token_estimate = estimated_tokens,
-        "page context injected",
-    );
-
-    Some(prefix)
-}
-
-// ---- End pageContext support ----
+/// Hard cap on incoming prompt text (64 000 chars ≈ 16 000 tokens at 4 chars/token).
+const PROMPT_MAX_CHARS: usize = 64_000;
 
 pub fn routes(_state: AppState) -> Router<AppState> {
     Router::new()
@@ -166,8 +67,8 @@ async fn create_session(
     }
 }
 
-/// Optional page context from the frontend — sent only when user has enabled
-/// the "Send page context" toggle. Absent field = zero injection, zero token cost.
+/// Optional structured page context from the frontend.
+/// All validation and injection logic lives in `dispatch/acp/page_context.rs`.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PageContextBody {
@@ -180,8 +81,7 @@ struct PageContextBody {
 #[serde(rename_all = "camelCase")]
 struct PromptBody {
     prompt: String,
-    /// Optional structured page context. If present, server assembles a compact
-    /// token-minimal context prefix and prepends it to the system prompt.
+    /// Optional structured page context. Passed to dispatch; injection is handled there.
     page_context: Option<PageContextBody>,
 }
 
@@ -198,29 +98,32 @@ async fn prompt_session(
         .into_response();
     }
 
-    // Assemble the effective prompt text: optional context prefix + user prompt.
-    // Validation failure silently skips injection — never errors the request.
-    let prompt_text = if let Some(ctx) = &body.page_context {
-        match assemble_page_context_prefix(&session_id, ctx) {
-            Some(prefix) => format!("{}\n\n{}", prefix, body.prompt.trim()),
-            None => {
-                tracing::warn!(
-                    surface = "api",
-                    service = "acp",
-                    action = "session.prompt",
-                    session_id = %session_id,
-                    "page context validation failed — injecting without context",
-                );
-                body.prompt.trim().to_string()
-            }
+    if body.prompt.len() > PROMPT_MAX_CHARS {
+        return ToolError::InvalidParam {
+            message: format!(
+                "prompt exceeds maximum allowed length ({} > {} chars)",
+                body.prompt.len(),
+                PROMPT_MAX_CHARS
+            ),
+            param: "prompt".to_string(),
         }
-    } else {
-        body.prompt.trim().to_string()
-    };
+        .into_response();
+    }
+
+    // Pass page_context as a JSON object to the dispatch layer.
+    // All sanitization and prefix assembly happens there — HTTP handler is a thin shim.
+    let page_context_value = body.page_context.as_ref().map(|ctx| {
+        json!({
+            "route": ctx.route,
+            "entityType": ctx.entity_type,
+            "entityId": ctx.entity_id,
+        })
+    });
 
     let params = json!({
         "session_id": session_id,
-        "text": prompt_text,
+        "text": body.prompt.trim(),
+        "page_context": page_context_value,
     });
     match dispatch_with_registry(&state.acp_registry, "session.prompt", params).await {
         Ok(v) => Json(v).into_response(),
@@ -275,8 +178,13 @@ async fn stream_events(
             }
         }
     } else {
-        // No ticket — anonymous principal (bead 7 note: auth wired in Phase 2).
-        String::new()
+        // No ticket provided — reject immediately (Phase 2 will wire full auth;
+        // until then, every SSE caller must obtain a ticket via session.subscribe_ticket).
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({ "kind": "auth_failed", "message": "SSE ticket required; call session.subscribe_ticket first" })),
+        )
+            .into_response();
     };
 
     let since = query.since.unwrap_or(0);

--- a/crates/lab/src/dispatch/acp.rs
+++ b/crates/lab/src/dispatch/acp.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod client;
 pub mod dispatch;
+pub mod page_context;
 pub mod params;
 pub mod persistence;
 

--- a/crates/lab/src/dispatch/acp/catalog.rs
+++ b/crates/lab/src/dispatch/acp/catalog.rs
@@ -136,6 +136,12 @@ pub const ACTIONS: &[ActionSpec] = &[
                 required: false,
                 description: "Caller principal for ownership verification",
             },
+            ParamSpec {
+                name: "page_context",
+                ty: "object",
+                required: false,
+                description: "Optional page context: {route, entityType?, entityId?} — prepends a compact context prefix to the prompt",
+            },
         ],
     },
     ActionSpec {

--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -12,6 +12,7 @@ use crate::dispatch::helpers::{action_schema, help_payload, to_json};
 
 use super::catalog::ACTIONS;
 use super::client::require_registry;
+use super::page_context::{PageContextInput, build_prompt_with_context};
 use super::params::{opt_str, opt_u64, require_str};
 
 /// SSE ticket lifetime in seconds.
@@ -171,7 +172,7 @@ pub async fn dispatch_with_registry(
         "session.prompt" => {
             let session_id = require_str(&params, "session_id")?;
             let principal = opt_str(&params, "principal").unwrap_or("");
-            let text = params
+            let raw_text = params
                 .get("text")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
@@ -180,7 +181,21 @@ pub async fn dispatch_with_registry(
                     param: "text".to_string(),
                 })?;
 
-            registry.prompt_session(session_id, text, principal).await?;
+            // Optional structured page context (HTTP / MCP / CLI can all supply it).
+            let page_ctx = params.get("page_context").and_then(|v| v.as_object()).map(|obj| {
+                PageContextInput {
+                    route: obj.get("route").and_then(|v| v.as_str()).unwrap_or(""),
+                    entity_type: obj.get("entityType").and_then(|v| v.as_str()),
+                    entity_id: obj.get("entityId").and_then(|v| v.as_str()),
+                }
+            });
+            let effective_text = build_prompt_with_context(
+                session_id,
+                raw_text,
+                page_ctx.as_ref(),
+            );
+
+            registry.prompt_session(session_id, &effective_text, principal).await?;
             to_json(json!({ "ok": true, "session_id": session_id }))
         }
 

--- a/crates/lab/src/dispatch/acp/page_context.rs
+++ b/crates/lab/src/dispatch/acp/page_context.rs
@@ -1,0 +1,139 @@
+//! Page-context injection helpers for `session.prompt`.
+//!
+//! Moved from `api/services/acp.rs` so that MCP and CLI can also benefit from
+//! context injection without duplicating the sanitization logic.
+
+/// Maximum tokens allowed for the assembled context prefix.
+/// Estimated at ~4 chars/token; we enforce a char budget of 30 * 4 = 120 chars.
+const PAGE_CONTEXT_MAX_TOKENS: usize = 30;
+const PAGE_CONTEXT_MAX_CHARS: usize = PAGE_CONTEXT_MAX_TOKENS * 4;
+
+/// Characters allowed in pageContext field values.
+const PAGE_CONTEXT_ALLOWED: &[char] = &[
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '_', '-',
+];
+
+/// Tokens that indicate prompt-injection attempts — reject the entire pageContext
+/// field if any match.
+///
+/// Only keeps truly dangerous injection terms. Legitimate admin/app route names
+/// (`admin`, `prompt`, `system`) are allowed — the character allowlist is the
+/// primary safety layer.
+const PAGE_CONTEXT_DENY_LIST: &[&str] = &[
+    "ignore", "override", "instruction", "assistant",
+];
+
+/// Optional structured page context sent by the frontend.
+/// All fields are strings; validation is applied by `assemble_page_context_prefix`.
+pub struct PageContextInput<'a> {
+    pub route: &'a str,
+    pub entity_type: Option<&'a str>,
+    pub entity_id: Option<&'a str>,
+}
+
+/// Sanitize a single pageContext field value.
+/// Returns `None` if the value fails validation.
+/// Strips to allowed characters, truncates to 32 chars, then deny-list checks.
+pub fn sanitize_page_context_field(value: &str) -> Option<String> {
+    let stripped: String = value
+        .chars()
+        .filter(|c| PAGE_CONTEXT_ALLOWED.contains(c))
+        .take(32)
+        .collect();
+
+    if stripped.is_empty() {
+        return None;
+    }
+
+    // Split on separators before deny-list check to resist bypass.
+    let lower = stripped.to_lowercase();
+    let segments: Vec<&str> = lower.split(['/', '_', '-']).collect();
+    for segment in &segments {
+        for denied in PAGE_CONTEXT_DENY_LIST {
+            if segment.contains(denied) {
+                return None;
+            }
+        }
+    }
+    // Also check the full string for runs that span segment boundaries.
+    for denied in PAGE_CONTEXT_DENY_LIST {
+        if lower.contains(denied) {
+            return None;
+        }
+    }
+
+    Some(stripped)
+}
+
+/// Assemble a compact context prefix from validated page context input.
+/// Returns `None` if route validation fails.
+/// Format: `[context: page={route}]` or `[context: page={route} entity={type}/{id}]`
+pub fn assemble_page_context_prefix(session_id: &str, ctx: &PageContextInput<'_>) -> Option<String> {
+    let route = sanitize_page_context_field(ctx.route)?;
+
+    let prefix = match (ctx.entity_type, ctx.entity_id) {
+        (Some(et), Some(eid)) => {
+            let entity_type = sanitize_page_context_field(et)?;
+            let entity_id = sanitize_page_context_field(eid)?;
+            let candidate = format!("[context: page={route} entity={entity_type}/{entity_id}]");
+            if candidate.len() <= PAGE_CONTEXT_MAX_CHARS {
+                candidate
+            } else {
+                let without_id = format!("[context: page={route} entity={entity_type}]");
+                if without_id.len() <= PAGE_CONTEXT_MAX_CHARS {
+                    without_id
+                } else {
+                    format!("[context: page={route}]")
+                }
+            }
+        }
+        (Some(et), None) => {
+            let entity_type = sanitize_page_context_field(et)?;
+            format!("[context: page={route} entity={entity_type}]")
+        }
+        _ => format!("[context: page={route}]"),
+    };
+
+    let estimated_tokens = prefix.len().div_ceil(4);
+    tracing::info!(
+        surface = "dispatch",
+        service = "acp",
+        action = "session.prompt",
+        session_id,
+        page_context_route = %route,
+        page_context_token_estimate = estimated_tokens,
+        "page context injected",
+    );
+
+    Some(prefix)
+}
+
+/// Build the effective prompt text from optional page context + user prompt.
+/// On validation failure the context is silently dropped (never errors the request).
+pub fn build_prompt_with_context(
+    session_id: &str,
+    prompt: &str,
+    ctx: Option<&PageContextInput<'_>>,
+) -> String {
+    if let Some(ctx) = ctx {
+        match assemble_page_context_prefix(session_id, ctx) {
+            Some(prefix) => format!("{prefix}\n\n{prompt}"),
+            None => {
+                tracing::warn!(
+                    surface = "dispatch",
+                    service = "acp",
+                    action = "session.prompt",
+                    session_id,
+                    "page context validation failed — injecting without context",
+                );
+                prompt.to_string()
+            }
+        }
+    } else {
+        prompt.to_string()
+    }
+}


### PR DESCRIPTION
## Summary

Implements a global floating chat surface available on every admin page — a fixed pill FAB that opens a draggable/resizable popover backed by shared session state with the `/chat` route.

### Phase 1: Session Context Extraction (`lab-gych.1`)
- `ChatSessionProvider` with 4-context re-render isolation (Data / Actions / Connection / Stream)
- Lazy SSE stream: starts only on first FAB click — non-chat pages pay zero SSE cost
- `createSession` mutex via `isCreatingRef` to prevent duplicate sessions
- `selectedRunId` seeded from localStorage with regex validation
- `lib/acp/fetch.ts`: standalone ACP fetcher utility (re-derives credentials per call)

### Phase 2: FAB + Popover Shell (`lab-gych.2`)
- `FloatingChatFab`: fixed pill (bottom-right), Cmd/Ctrl+/ hotkey, CSS-hidden on /chat
- `FloatingChatPopover`: draggable (DOM ref + rAF, no React state), resizable (bottom-right handle), viewport hard-clamp, localStorage persistence, gear config panel (4 toggles), mobile Sheet, focus trap
- `AdminLayoutClient`: `'use client'` wrapper to keep `layout.tsx` as server component
- Layout updated to host `ChatSessionProvider` + FAB + Popover

### Phase 3: Full Parity Wiring (`lab-gych.3`)
- `FloatingChatShell`: consumes all 4 contexts, `React.memo` wrapper
- `sendPrompt` wires `pageContext`: when config toggle enabled and context non-null, includes as separate field in request body
- Lazy mount: `FloatingChatShell` mounts on first FAB click, stays mounted permanently

### Phase 4: Design System Sandbox (`lab-gych.4`)
- `FloatingChatSection` added to `/design-system` after `CommandPaletteSection`
- Demonstrates FAB states (default, badge, active, connecting, error), popover states (default, gear open, compact), persistence schema, hotkey reference, mobile sheet note

### Phase 5: ACP Gateway pageContext (`lab-gych.5`)
- `POST /acp/sessions/{id}/prompt` accepts optional `pageContext: { route, entityType?, entityId? }`
- Server assembles compact prefix: `[context: page=gateways entity=gateway/abc123]`
- Hard 30-token budget; truncates entityId first, then entityType, never route
- Sanitization: NFKC-safe allowlist `[a-zA-Z0-9/_-]`, max 32 chars/field, deny-list check
- Validation failure silently skips injection — never errors the request
- Every injection logged at INFO with `session_id`, `route`, `estimated_tokens`

## Files Changed

**New files (TypeScript):**
- `apps/gateway-admin/lib/acp/fetch.ts`
- `apps/gateway-admin/lib/chat/chat-session-provider.tsx`
- `apps/gateway-admin/components/floating-chat-fab.tsx`
- `apps/gateway-admin/components/floating-chat-popover.tsx`
- `apps/gateway-admin/components/admin-layout-client.tsx`
- `apps/gateway-admin/components/floating-chat-shell.tsx`
- `apps/gateway-admin/components/design-system/floating-chat-section.tsx`

**Modified files:**
- `apps/gateway-admin/app/(admin)/layout.tsx` — wrap children in AdminLayoutClient
- `apps/gateway-admin/components/design-system/design-system-shell.tsx` — add FloatingChatSection
- `crates/lab/src/api/services/acp.rs` — pageContext support in prompt handler

## Test Plan

- [ ] TypeScript: `pnpm tsc --noEmit` — 0 new errors in new files
- [ ] Rust: `cargo clippy --workspace --all-features` — 0 errors/warnings
- [ ] Manual: FAB appears bottom-right on all admin pages except /chat
- [ ] Manual: Cmd/Ctrl+/ toggles popover open/closed
- [ ] Manual: Popover is draggable and resizable, clamps to viewport
- [ ] Manual: Position/size/open state persists across page navigations
- [ ] Manual: First FAB click starts SSE stream; non-open pages have no SSE cost
- [ ] Manual: Mobile (< 768px) renders as full-screen Sheet
- [ ] Manual: `/design-system` shows Floating Chat section with all demos
- [ ] Manual: POST /acp/sessions/{id}/prompt with pageContext injects compact prefix

## Beads

- lab-gych.1: Session Context Extraction ✅
- lab-gych.2: FAB + Popover Shell ✅
- lab-gych.3: Full Parity Wiring ✅
- lab-gych.4: Design System Sandbox ✅
- lab-gych.5: ACP Gateway pageContext ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global floating chat popover on every admin page with full `/chat` parity and shared session state. SSE now starts whenever a session is selected, and ACP is hardened (SSE ticket required; 64k prompt cap).

- **New Features**
  - Floating pill FAB (bottom-right) with Cmd/Ctrl+/; CSS-hidden on `/chat`.
  - Draggable/resizable popover with viewport clamp; persists open/position/size; mobile renders as a full‑screen Sheet; simplified gear with a single “Send page context” toggle.
  - `ChatSessionProvider` (4-context split) with shared runs/messages; SSE opens when `selectedRunId` is set; `PageContextSync` auto-syncs the current route into `pageContext`, and it’s only sent when the gear toggle is on.
  - ACP API: `POST /acp/sessions/{id}/prompt` accepts `pageContext`; server builds a compact prefix (30‑token budget); 64k‑char prompt cap; events SSE requires a subscribe ticket (401 otherwise); registry caps subscribers/session at 32.
  - Design system: Floating Chat section showing FAB/popover states and the persistence schema.

- **Refactors**
  - Removed lazy-SSE and first-open shell gating; FloatingChatShell is always mounted inside the popover, and the stream lifecycle is tied to `selectedRunId`.
  - Resize now uses requestAnimationFrame with direct DOM writes during drag; commits on pointer up.
  - Introduced shared LRU session event caches (last 10 sessions) consumed by all SSE readers.
  - Consolidated ACP normalizers and adopted `createAcpFetcher` across provider/controller.
  - Stream/UI improvements: batched SSE event updates and O(1) last-status scan; fixed focus trap inert logic; wired `selectAgent`; cross-validates `selectedRunId` in `refreshSessions`.

<sup>Written for commit 264ba831d41f285a2a405d09f388235c91b9b63b. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/lab/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added floating chat interface with keyboard shortcut support (Cmd/Ctrl + /)
  * Chat supports dragging, resizing, and persistent layout configuration
  * Automatic page context sync sends current route information to chat sessions
  * Visual connection indicators (error state, streaming animation, unread badges)
  * Mobile-optimized sheet mode for responsive viewing
  * Settings panel for toggling context sharing preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->