### PR TITLE
feat(lab-aid2.1): add application_log_batch envelope kind and wire th…

### DIFF
--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -182,20 +182,19 @@ pub async fn dispatch_with_registry(
                 })?;
 
             // Optional structured page context (HTTP / MCP / CLI can all supply it).
-            let page_ctx = params.get("page_context").and_then(|v| v.as_object()).map(|obj| {
-                PageContextInput {
+            let page_ctx = params
+                .get("page_context")
+                .and_then(|v| v.as_object())
+                .map(|obj| PageContextInput {
                     route: obj.get("route").and_then(|v| v.as_str()).unwrap_or(""),
                     entity_type: obj.get("entityType").and_then(|v| v.as_str()),
                     entity_id: obj.get("entityId").and_then(|v| v.as_str()),
-                }
-            });
-            let effective_text = build_prompt_with_context(
-                session_id,
-                raw_text,
-                page_ctx.as_ref(),
-            );
+                });
+            let effective_text = build_prompt_with_context(session_id, raw_text, page_ctx.as_ref());
 
-            registry.prompt_session(session_id, &effective_text, principal).await?;
+            registry
+                .prompt_session(session_id, &effective_text, principal)
+                .await?;
             to_json(json!({ "ok": true, "session_id": session_id }))
         }
 

--- a/crates/lab/src/dispatch/acp/page_context.rs
+++ b/crates/lab/src/dispatch/acp/page_context.rs
@@ -10,11 +10,10 @@ const PAGE_CONTEXT_MAX_CHARS: usize = PAGE_CONTEXT_MAX_TOKENS * 4;
 
 /// Characters allowed in pageContext field values.
 const PAGE_CONTEXT_ALLOWED: &[char] = &[
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '_', '-',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+    't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4',
+    '5', '6', '7', '8', '9', '/', '_', '-',
 ];
 
 /// Tokens that indicate prompt-injection attempts — reject the entire pageContext
@@ -23,9 +22,7 @@ const PAGE_CONTEXT_ALLOWED: &[char] = &[
 /// Only keeps truly dangerous injection terms. Legitimate admin/app route names
 /// (`admin`, `prompt`, `system`) are allowed — the character allowlist is the
 /// primary safety layer.
-const PAGE_CONTEXT_DENY_LIST: &[&str] = &[
-    "ignore", "override", "instruction", "assistant",
-];
+const PAGE_CONTEXT_DENY_LIST: &[&str] = &["ignore", "override", "instruction", "assistant"];
 
 /// Optional structured page context sent by the frontend.
 /// All fields are strings; validation is applied by `assemble_page_context_prefix`.
@@ -72,7 +69,10 @@ pub fn sanitize_page_context_field(value: &str) -> Option<String> {
 /// Assemble a compact context prefix from validated page context input.
 /// Returns `None` if route validation fails.
 /// Format: `[context: page={route}]` or `[context: page={route} entity={type}/{id}]`
-pub fn assemble_page_context_prefix(session_id: &str, ctx: &PageContextInput<'_>) -> Option<String> {
+pub fn assemble_page_context_prefix(
+    session_id: &str,
+    ctx: &PageContextInput<'_>,
+) -> Option<String> {
     let route = sanitize_page_context_field(ctx.route)?;
 
     let prefix = match (ctx.entity_type, ctx.entity_id) {

--- a/crates/lab/src/node/queue.rs
+++ b/crates/lab/src/node/queue.rs
@@ -43,6 +43,15 @@ impl QueuedEnvelope {
             payload,
         }
     }
+
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn application_log_batch(payload: serde_json::Value) -> Self {
+        Self {
+            kind: "application_log_batch".to_string(),
+            payload,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/lab/src/node/ws_client.rs
+++ b/crates/lab/src/node/ws_client.rs
@@ -1065,11 +1065,8 @@ mod tests {
             "node_id": "device-1",
             "events": [{"message": "hello", "source": "application"}]
         }));
-        let request = queue_envelope_to_request(
-            &envelope,
-            "44444444-4444-4444-8444-444444444444",
-        )
-        .expect("request");
+        let request = queue_envelope_to_request(&envelope, "44444444-4444-4444-8444-444444444444")
+            .expect("request");
         assert_eq!(request["method"], "nodes/log.event");
         assert_eq!(
             request["params"]["events"][0]["source"].as_str(),
@@ -1098,9 +1095,8 @@ mod tests {
         let envelope = &drained[0];
         assert_eq!(envelope.kind, "application_log_batch");
 
-        let request =
-            queue_envelope_to_request(envelope, "55555555-5555-4555-8555-555555555555")
-                .expect("request");
+        let request = queue_envelope_to_request(envelope, "55555555-5555-4555-8555-555555555555")
+            .expect("request");
         assert_eq!(request["method"], "nodes/log.event");
         assert_eq!(request["params"], payload);
     }

--- a/crates/lab/src/node/ws_client.rs
+++ b/crates/lab/src/node/ws_client.rs
@@ -941,7 +941,7 @@ pub fn build_initialize_request(
 
 pub fn queue_envelope_to_request(envelope: &QueuedEnvelope, id: &str) -> Result<Value> {
     let method = match envelope.kind.as_str() {
-        "syslog_batch" => "nodes/log.event",
+        "syslog_batch" | "application_log_batch" => "nodes/log.event",
         "status" => "nodes/status.push",
         "metadata" => "nodes/metadata.push",
         other => return Err(anyhow!("unsupported queued envelope kind `{other}`")),
@@ -1045,6 +1045,64 @@ mod tests {
         )
         .expect("metadata");
         assert_eq!(metadata["method"], "nodes/metadata.push");
+    }
+
+    #[test]
+    fn application_log_batch_envelope_serializes_with_application_source() {
+        let payload = serde_json::json!({
+            "node_id": "device-1",
+            "events": [{"message": "hello", "source": "application"}]
+        });
+        let envelope = QueuedEnvelope::application_log_batch(payload.clone());
+        let serialized = serde_json::to_value(&envelope).expect("serialize");
+        assert_eq!(serialized["kind"], "application_log_batch");
+        assert_eq!(serialized["payload"], payload);
+    }
+
+    #[test]
+    fn application_log_batch_maps_to_log_event_method() {
+        let envelope = QueuedEnvelope::application_log_batch(serde_json::json!({
+            "node_id": "device-1",
+            "events": [{"message": "hello", "source": "application"}]
+        }));
+        let request = queue_envelope_to_request(
+            &envelope,
+            "44444444-4444-4444-8444-444444444444",
+        )
+        .expect("request");
+        assert_eq!(request["method"], "nodes/log.event");
+        assert_eq!(
+            request["params"]["events"][0]["source"].as_str(),
+            Some("application")
+        );
+    }
+
+    #[tokio::test]
+    async fn application_log_batch_round_trip_through_queue() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let queue = NodeOutboundQueue::open(tempdir.path().join("node-runtime-queue.jsonl"))
+            .await
+            .expect("open queue");
+
+        let payload = serde_json::json!({
+            "node_id": "device-1",
+            "events": [{"message": "app event", "source": "application"}]
+        });
+        queue
+            .push(QueuedEnvelope::application_log_batch(payload.clone()))
+            .await
+            .expect("push");
+
+        let drained = queue.drain_batch(10).await.expect("drain");
+        assert_eq!(drained.len(), 1);
+        let envelope = &drained[0];
+        assert_eq!(envelope.kind, "application_log_batch");
+
+        let request =
+            queue_envelope_to_request(envelope, "55555555-5555-4555-8555-555555555555")
+                .expect("request");
+        assert_eq!(request["method"], "nodes/log.event");
+        assert_eq!(request["params"], payload);
     }
 
     #[tokio::test]

--- a/crates/lab/tests/auth_admin_api.rs
+++ b/crates/lab/tests/auth_admin_api.rs
@@ -14,7 +14,10 @@
 //! - No oauth_state (bearer-only mode) → 404
 //! - CSRF missing on mutations → 422 (enforced by /v1 middleware)
 
-use axum::{body::Body, http::{Request, StatusCode, header}};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
 use lab::api::{router::build_router, state::AppState};
 use lab_auth::{
     config::{AuthConfig, AuthMode, GoogleConfig},
@@ -105,7 +108,8 @@ impl Harness {
 
     /// Seed an admin session (email == admin_email).
     async fn seed_admin_session(&self) -> BrowserSessionRow {
-        self.seed_session(Some(&self.admin_email), "csrf-admin").await
+        self.seed_session(Some(&self.admin_email), "csrf-admin")
+            .await
     }
 
     /// Issue a JWT access token for the test issuer.
@@ -160,7 +164,10 @@ impl Harness {
                     session.session_id
                 ),
             )
-            .header(lab_auth::session::BROWSER_CSRF_HEADER_NAME, &session.csrf_token)
+            .header(
+                lab_auth::session::BROWSER_CSRF_HEADER_NAME,
+                &session.csrf_token,
+            )
             .body(Body::from(body.to_string()))
             .unwrap()
     }
@@ -178,7 +185,10 @@ impl Harness {
                     session.session_id
                 ),
             )
-            .header(lab_auth::session::BROWSER_CSRF_HEADER_NAME, &session.csrf_token)
+            .header(
+                lab_auth::session::BROWSER_CSRF_HEADER_NAME,
+                &session.csrf_token,
+            )
             .body(Body::empty())
             .unwrap()
     }
@@ -289,10 +299,15 @@ async fn post_jwt_bearer_returns_403() {
 #[tokio::test]
 async fn get_non_admin_session_returns_403() {
     let h = Harness::new().await;
-    let session = h.seed_session(Some("notadmin@example.com"), "csrf-na").await;
+    let session = h
+        .seed_session(Some("notadmin@example.com"), "csrf-na")
+        .await;
     let app = h.router();
     let response = app
-        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .oneshot(Harness::get_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+        ))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -308,7 +323,10 @@ async fn get_admin_session_returns_200_with_entries() {
     let session = h.seed_admin_session().await;
     let app = h.router();
     let response = app
-        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .oneshot(Harness::get_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+        ))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
@@ -593,7 +611,10 @@ async fn list_shows_added_emails() {
     let session = h.seed_admin_session().await;
     let app = h.router();
     let response = app
-        .oneshot(Harness::get_with_session("/v1/auth/allowed-emails", &session))
+        .oneshot(Harness::get_with_session(
+            "/v1/auth/allowed-emails",
+            &session,
+        ))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);


### PR DESCRIPTION
…rough ws_client

- Add `QueuedEnvelope::application_log_batch()` constructor in queue.rs with kind = "application_log_batch"; mirrors the syslog_batch pattern exactly
- Handle "application_log_batch" in `queue_envelope_to_request()` alongside "syslog_batch" — both map to `nodes/log.event`; source value comes from the payload (set by callers as "application")
- Add three unit tests:
  - `application_log_batch_envelope_serializes_with_application_source`
  - `application_log_batch_maps_to_log_event_method`
  - `application_log_batch_round_trip_through_queue`
- Add `#[allow(dead_code)]` on the constructor (caller in lab-aid2.2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `application_log_batch` envelope and wires it through the WS client, mapping to `nodes/log.event` so application logs can be queued and sent. Mirrors the existing `syslog_batch` behavior and includes format-only fixes to pass CI.

- **New Features**
  - Added `QueuedEnvelope::application_log_batch(...)` with kind `"application_log_batch"`.
  - Updated `queue_envelope_to_request()` to map `syslog_batch` and `application_log_batch` to `nodes/log.event`; `source` is read from the payload (callers set `"application"`).
  - Added tests for serialization, method mapping, and round‑trip through the queue; constructor is `#[allow(dead_code)]` until used by lab-aid2.2.

- **Refactors**
  - Applied `cargo fmt` across affected modules to fix Format CI; no logic changes.

<sup>Written for commit 5cc69145d97914fb3df990bea6c919b1c8b760f4. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/lab/pull/39?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

