### PR TITLE
Fix mobile chat sticky header

### DIFF
--- a/apps/gateway-admin/components/chat/chat-shell.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.tsx
@@ -77,7 +77,10 @@ export function ChatShell() {
 
   return (
     <div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-aurora-page-bg">
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-aurora-border-default bg-aurora-nav-bg px-2.5 sm:px-3">
+      <header
+        role="banner"
+        className="sticky top-0 z-20 flex h-[calc(3rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-2 border-b border-aurora-border-default bg-aurora-nav-bg px-2.5 pt-[env(safe-area-inset-top,0px)] sm:px-3 md:static md:z-auto md:h-12 md:pt-0"
+      >
         <SidebarTrigger
           aria-label="Toggle app sidebar"
           className="-ml-1 text-aurora-text-muted/60 hover:text-aurora-text-primary"

--- a/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
+++ b/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
@@ -167,6 +167,105 @@ test.after(async () => {
   }
 })
 
+test('chat page keeps the header visible while the mobile message thread scrolls', { concurrency: false }, async (t) => {
+  await startPreviewServer()
+
+  const browser = await chromium.launch({ headless: true })
+  t.after(async () => {
+    await browser.close()
+  })
+
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true })
+  const sessions: BrowserSession[] = [session('session-mobile', 'Mobile sticky header')]
+
+  await mockAuthenticatedSession(page)
+  await page.route('**/v1/acp/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+
+    if (url.pathname === '/v1/acp/provider') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          provider: {
+            provider: 'codex',
+            ready: true,
+            command: 'npx',
+            args: ['@zed-industries/codex-acp'],
+            message: 'ready',
+          },
+        }),
+      })
+      return
+    }
+
+    if (url.pathname === '/v1/acp/sessions' && request.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sessions }),
+      })
+      return
+    }
+
+    const ticketMatch = url.pathname.match(/^\/v1\/acp\/sessions\/([^/]+)\/subscribe_ticket$/)
+    if (ticketMatch && request.method() === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ticket: `ticket-${decodeURIComponent(ticketMatch[1]!)}` }),
+      })
+      return
+    }
+
+    const eventMatch = url.pathname.match(/^\/v1\/acp\/sessions\/([^/]+)\/events$/)
+    if (eventMatch && request.method() === 'GET') {
+      const sessionId = decodeURIComponent(eventMatch[1]!)
+      const body = Array.from({ length: 40 }, (_, index) =>
+        sseFrame(bridgeEvent(sessionId, index + 1, { text: `Mobile message ${index + 1}` })),
+      ).join('')
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body,
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: `Unhandled ACP request: ${url.pathname}` }),
+    })
+  })
+
+  await page.goto(`${BASE_URL}/chat/`, { waitUntil: 'networkidle' })
+  await page.getByText('Mobile sticky header').first().waitFor()
+  await page.getByText('Mobile message 40').waitFor()
+
+  const header = page.getByRole('banner').first()
+  const input = page.getByRole('textbox', { name: 'Message' })
+  const scrollViewport = page.locator('[data-slot="scroll-area-viewport"]').first()
+
+  const before = await header.boundingBox()
+  assert.ok(before, 'header should be measurable before scroll')
+
+  await scrollViewport.evaluate((node) => {
+    node.scrollTop = Math.max(0, node.scrollHeight / 2)
+    node.dispatchEvent(new Event('scroll', { bubbles: true }))
+  })
+
+  const after = await header.boundingBox()
+  const inputBox = await input.boundingBox()
+  assert.ok(after, 'header should be measurable after scroll')
+  assert.ok(inputBox, 'input should be measurable after scroll')
+  assert.ok(after.y >= 0, `header should stay within the viewport, got y=${after.y}`)
+  assert.ok(after.y < inputBox.y, 'header must not overlap the prompt input')
+  assert.equal(Math.round(after.height), Math.round(before.height))
+})
+
 test('chat shell sends prompts without bearer auth and resumes session streams from the last sequence on reselection', { concurrency: false }, async (t) => {
   await startPreviewServer()
 

--- a/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
+++ b/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
@@ -35,6 +35,7 @@ type BrowserEvent = {
   createdAt: string
   role?: 'user' | 'assistant' | 'thinking'
   text?: string
+  messageId?: string
 }
 
 function session(id: string, title: string, provider = 'codex'): BrowserSession {
@@ -223,7 +224,11 @@ test('chat page keeps the header visible while the mobile message thread scrolls
     if (eventMatch && request.method() === 'GET') {
       const sessionId = decodeURIComponent(eventMatch[1]!)
       const body = Array.from({ length: 40 }, (_, index) =>
-        sseFrame(bridgeEvent(sessionId, index + 1, { text: `Mobile message ${index + 1}` })),
+        sseFrame(bridgeEvent(sessionId, index + 1, {
+          messageId: `mobile-message-${index + 1}`,
+          role: index % 2 === 0 ? 'user' : 'assistant',
+          text: `Mobile message ${index + 1}`,
+        })),
       ).join('')
 
       await route.fulfill({
@@ -247,22 +252,41 @@ test('chat page keeps the header visible while the mobile message thread scrolls
 
   const header = page.getByRole('banner').first()
   const input = page.getByRole('textbox', { name: 'Message' })
-  const scrollViewport = page.locator('[data-slot="scroll-area-viewport"]').first()
+  const scrollViewport = page.locator('[data-slot="scroll-area-viewport"]').last()
 
   const before = await header.boundingBox()
   assert.ok(before, 'header should be measurable before scroll')
 
-  await scrollViewport.evaluate((node) => {
-    node.scrollTop = Math.max(0, node.scrollHeight / 2)
+  const scrollMetrics = await scrollViewport.evaluate((node) => {
+    node.scrollTop = 0
+    const before = node.scrollTop
+    node.scrollTop = Math.max(1, node.scrollHeight / 2)
     node.dispatchEvent(new Event('scroll', { bubbles: true }))
+    return {
+      before,
+      after: node.scrollTop,
+      scrollHeight: node.scrollHeight,
+      clientHeight: node.clientHeight,
+    }
   })
+  assert.ok(
+    scrollMetrics.scrollHeight > scrollMetrics.clientHeight,
+    'message viewport should have scrollable overflow for sticky-header coverage',
+  )
+  assert.ok(
+    scrollMetrics.after > scrollMetrics.before,
+    `message viewport should scroll before measuring sticky header, got ${scrollMetrics.before} -> ${scrollMetrics.after}`,
+  )
 
   const after = await header.boundingBox()
   const inputBox = await input.boundingBox()
   assert.ok(after, 'header should be measurable after scroll')
   assert.ok(inputBox, 'input should be measurable after scroll')
   assert.ok(after.y >= 0, `header should stay within the viewport, got y=${after.y}`)
-  assert.ok(after.y < inputBox.y, 'header must not overlap the prompt input')
+  assert.ok(
+    after.y + after.height <= inputBox.y,
+    `header must not overlap the prompt input, header bottom=${after.y + after.height}, input top=${inputBox.y}`,
+  )
   assert.equal(Math.round(after.height), Math.round(before.height))
 })
 


### PR DESCRIPTION
## Summary
- Keeps the chat page header sticky on mobile while preserving the desktop static header behavior.
- Adds safe-area top handling without shrinking the visible control row.
- Adds mobile browser coverage that scrolls the Radix message viewport and verifies the header remains visible above the prompt input.

## Tests
- pnpm exec node --test --experimental-strip-types lib/browser/chat-shell.browser.test.ts
- pnpm exec tsx --test components/chat/chat-shell.test.tsx components/chat/message-bubble.test.tsx components/chat/tool-call-presentation.test.ts
- pnpm test
- pnpm run build

## Browser Verification
- agent-browser 0.26.0 against local static preview at http://127.0.0.1:3123/chat/ with mocked auth/ACP endpoints.
- Set viewport to 390x844, opened /chat/, scrolled [data-slot="scroll-area-viewport"], and evaluated geometry.
- Evidence: scrollTop=389, scrollHeight=1061, clientHeight=672; header after scroll y=0 height=48; input y=730; headerVisible=true; headerAboveInput=true.
- Screenshot: /tmp/chat-mobile-sticky-header-agent-browser.png on the local machine.

## Known Limitations
- `pnpm run test:browser -- lib/browser/chat-shell.browser.test.ts` also executes unrelated browser test files because the package script expands `lib/browser/**/*.test.ts` before forwarded args. In that broad command, the chat tests passed, while unrelated gateway/marketplace preview servers timed out on ports 3101/3102. The isolated chat browser command above passed.
- Safe-area behavior is validated by CSS geometry and the mobile viewport check; this run did not use physical notch hardware.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the chat header sticky on mobile with safe-area support and correct stacking, while preserving the static header on desktop. Strengthens browser coverage to confirm the header stays visible and above the input as the message viewport scrolls.

- **Bug Fixes**
  - Mobile header is sticky with safe-area top padding, `role="banner"`, and higher z-index; desktop stays static.
  - Scopes scrolling to the message viewport so the header never overlaps the prompt input.
  - Strengthened mobile browser test: streams messages, verifies the viewport is scrollable, and asserts header visibility, constant height, and position above the input.

<sup>Written for commit 4f46ff1cb92c3a6b1fbeadb1b28954c2c6038a5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

