### PR TITLE
Add contextual chat message actions

### DIFF
--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -23,6 +23,7 @@ interface ChatInputProps {
   disabledReason?: string
   draftText?: string
   onDraftTextChange?: (value: string) => void
+  attachmentsResetToken?: number
   selectedAgent: ACPAgent | null
   agents: ACPAgent[]
   onSelectAgent: (agentId: string) => void
@@ -34,6 +35,7 @@ export function ChatInput({
   disabledReason,
   draftText,
   onDraftTextChange,
+  attachmentsResetToken,
   selectedAgent,
   agents,
   onSelectAgent,
@@ -126,6 +128,10 @@ export function ChatInput({
     textareaRef.current.style.height = 'auto'
     textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`
   }, [value])
+
+  React.useEffect(() => {
+    setAttachments([])
+  }, [attachmentsResetToken])
 
   React.useEffect(() => {
     if (!agentPickerOpen) return

--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -21,6 +21,8 @@ interface ChatInputProps {
   onSend: (payload: ChatInputPayload) => void | Promise<void>
   disabled?: boolean
   disabledReason?: string
+  draftText?: string
+  onDraftTextChange?: (value: string) => void
   selectedAgent: ACPAgent | null
   agents: ACPAgent[]
   onSelectAgent: (agentId: string) => void
@@ -30,11 +32,13 @@ export function ChatInput({
   onSend,
   disabled = false,
   disabledReason,
+  draftText,
+  onDraftTextChange,
   selectedAgent,
   agents,
   onSelectAgent,
 }: ChatInputProps) {
-  const [value, setValue] = React.useState('')
+  const [uncontrolledValue, setUncontrolledValue] = React.useState('')
   const [sending, setSending] = React.useState(false)
   const [agentPickerOpen, setAgentPickerOpen] = React.useState(false)
   const [attachments, setAttachments] = React.useState<AttachmentRef[]>([])
@@ -50,6 +54,17 @@ export function ChatInput({
   const optionRefs = React.useRef<Array<HTMLButtonElement | null>>([])
   const [activeAgentIndex, setActiveAgentIndex] = React.useState(0)
   const pickerId = React.useId()
+
+  const value = draftText ?? uncontrolledValue
+  const setValue = React.useCallback(
+    (nextValue: string) => {
+      if (draftText === undefined) {
+        setUncontrolledValue(nextValue)
+      }
+      onDraftTextChange?.(nextValue)
+    },
+    [draftText, onDraftTextChange],
+  )
 
   optionRefs.current.length = agents.length
 
@@ -105,6 +120,12 @@ export function ChatInput({
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }
+
+  React.useEffect(() => {
+    if (!textareaRef.current) return
+    textareaRef.current.style.height = 'auto'
+    textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`
+  }, [value])
 
   React.useEffect(() => {
     if (!agentPickerOpen) return

--- a/apps/gateway-admin/components/chat/chat-shell.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.test.tsx
@@ -249,16 +249,17 @@ test('sendPromptForSelectedProvider removes optimistic message and throws normal
   assert.deepEqual(optimisticIds, [])
 })
 
-test('retry payload uses selected message text without inventing attachments', async () => {
+test('retry payload preserves the original message text and attachments', async () => {
   const sent: unknown[] = []
   await retryMessageText(
     {
       text: 'retry this',
+      attachments: [{ kind: 'file', path: '/tmp/original.txt' }],
     },
     async (payload) => {
       sent.push(payload)
     },
   )
 
-  assert.deepEqual(sent, [{ text: 'retry this', attachments: [] }])
+  assert.deepEqual(sent, [{ text: 'retry this', attachments: [{ kind: 'file', path: '/tmp/original.txt' }] }])
 })

--- a/apps/gateway-admin/components/chat/chat-shell.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.test.tsx
@@ -6,6 +6,7 @@ import {
   ensurePromptRunIdForProvider,
   integrateCreatedRun,
   providerDisplayName,
+  retryMessageText,
   resolveSelectedAgent,
   sendPromptForSelectedProvider,
   sessionCreationOptionsForIntent,
@@ -246,4 +247,18 @@ test('sendPromptForSelectedProvider removes optimistic message and throws normal
   )
 
   assert.deepEqual(optimisticIds, [])
+})
+
+test('retry payload uses selected message text without inventing attachments', async () => {
+  const sent: unknown[] = []
+  await retryMessageText(
+    {
+      text: 'retry this',
+    },
+    async (payload) => {
+      sent.push(payload)
+    },
+  )
+
+  assert.deepEqual(sent, [{ text: 'retry this', attachments: [] }])
 })

--- a/apps/gateway-admin/components/chat/chat-shell.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.tsx
@@ -20,10 +20,10 @@ import {
 } from '@/lib/chat/chat-session-provider'
 
 export async function retryMessageText(
-  message: Pick<ACPMessage, 'text'>,
+  message: Pick<ACPMessage, 'text'> & { attachments?: ChatInputPayload['attachments'] },
   send: (payload: ChatInputPayload) => Promise<void>,
 ) {
-  await send({ text: message.text, attachments: [] })
+  await send({ text: message.text, attachments: message.attachments ?? [] })
 }
 
 export {
@@ -46,6 +46,7 @@ export function ChatShell() {
   const [temperature, setTemperature] = React.useState(0.7)
   const [maxTokens, setMaxTokens] = React.useState(8192)
   const [draftText, setDraftText] = React.useState('')
+  const [attachmentsResetToken, setAttachmentsResetToken] = React.useState(0)
   const { runs, selectedRun, selectedRunId, providerHealth, selectedAgent, agents, projects } =
     useChatSessionData()
   const { selectRun, createSession, sendPrompt, selectAgent } = useChatSessionActions()
@@ -63,9 +64,9 @@ export function ChatShell() {
   }, [createSession, isMobileViewport])
 
   const handleSendPrompt = React.useCallback(
-    async (payload: Parameters<typeof sendPrompt>[0]) => {
+    async (payload: Parameters<typeof sendPrompt>[0], options?: Parameters<typeof sendPrompt>[1]) => {
       try {
-        await sendPrompt(payload)
+        await sendPrompt(payload, options)
       } catch {
         // Provider health carries the failure detail.
       }
@@ -75,14 +76,23 @@ export function ChatShell() {
 
   const handleRetryMessage = React.useCallback(
     async (message: ACPMessage) => {
-      await retryMessageText(message, handleSendPrompt)
+      if (message.runId !== selectedRunId) return
+      await retryMessageText(message, (payload) =>
+        handleSendPrompt(payload, { providerId: selectedRun?.provider ?? selectedAgent.id }),
+      )
     },
-    [handleSendPrompt],
+    [handleSendPrompt, selectedAgent.id, selectedRun?.provider, selectedRunId],
   )
 
   const handleEditMessage = React.useCallback((message: ACPMessage) => {
     setDraftText(message.text)
+    setAttachmentsResetToken((token) => token + 1)
   }, [])
+
+  React.useEffect(() => {
+    setDraftText('')
+    setAttachmentsResetToken((token) => token + 1)
+  }, [selectedRunId])
 
   React.useEffect(() => {
     const media = window.matchMedia('(max-width: 767px)')
@@ -228,7 +238,7 @@ export function ChatShell() {
             connectionState={connectionState}
             canRetryMessages={providerReady}
             canEditMessages
-            onRetryMessage={(message) => void handleRetryMessage(message)}
+            onRetryMessage={handleRetryMessage}
             onEditMessage={handleEditMessage}
           />
           <ChatInput
@@ -237,6 +247,7 @@ export function ChatShell() {
             disabledReason={providerUnavailableMessage ?? undefined}
             draftText={draftText}
             onDraftTextChange={setDraftText}
+            attachmentsResetToken={attachmentsResetToken}
             selectedAgent={selectedAgent}
             agents={agents.length > 0 ? agents : [selectedAgent]}
             onSelectAgent={selectAgent}

--- a/apps/gateway-admin/components/chat/chat-shell.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.tsx
@@ -9,14 +9,22 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
 import { SessionSidebar } from './session-sidebar'
 import { MessageThread } from './message-thread'
-import { ChatInput } from './chat-input'
+import { ChatInput, type ChatInputPayload } from './chat-input'
 import { SettingsPanel } from './settings-panel'
+import type { ACPMessage } from './types'
 import {
   useChatSessionData,
   useChatSessionActions,
   useChatSessionConnection,
   useChatSessionStream,
 } from '@/lib/chat/chat-session-provider'
+
+export async function retryMessageText(
+  message: Pick<ACPMessage, 'text'>,
+  send: (payload: ChatInputPayload) => Promise<void>,
+) {
+  await send({ text: message.text, attachments: [] })
+}
 
 export {
   createSessionForIntent,
@@ -37,6 +45,7 @@ export function ChatShell() {
   const [systemPrompt, setSystemPrompt] = React.useState('')
   const [temperature, setTemperature] = React.useState(0.7)
   const [maxTokens, setMaxTokens] = React.useState(8192)
+  const [draftText, setDraftText] = React.useState('')
   const { runs, selectedRun, selectedRunId, providerHealth, selectedAgent, agents, projects } =
     useChatSessionData()
   const { selectRun, createSession, sendPrompt, selectAgent } = useChatSessionActions()
@@ -63,6 +72,17 @@ export function ChatShell() {
     },
     [sendPrompt],
   )
+
+  const handleRetryMessage = React.useCallback(
+    async (message: ACPMessage) => {
+      await retryMessageText(message, handleSendPrompt)
+    },
+    [handleSendPrompt],
+  )
+
+  const handleEditMessage = React.useCallback((message: ACPMessage) => {
+    setDraftText(message.text)
+  }, [])
 
   React.useEffect(() => {
     const media = window.matchMedia('(max-width: 767px)')
@@ -202,11 +222,21 @@ export function ChatShell() {
               <span className="text-aurora-text-muted">{providerUnavailableMessage}</span>
             </div>
           )}
-          <MessageThread run={selectedRun} messages={messages} connectionState={connectionState} />
+          <MessageThread
+            run={selectedRun}
+            messages={messages}
+            connectionState={connectionState}
+            canRetryMessages={providerReady}
+            canEditMessages
+            onRetryMessage={(message) => void handleRetryMessage(message)}
+            onEditMessage={handleEditMessage}
+          />
           <ChatInput
             onSend={handleSendPrompt}
             disabled={!providerReady}
             disabledReason={providerUnavailableMessage ?? undefined}
+            draftText={draftText}
+            onDraftTextChange={setDraftText}
             selectedAgent={selectedAgent}
             agents={agents.length > 0 ? agents : [selectedAgent]}
             onSelectAgent={selectAgent}

--- a/apps/gateway-admin/components/chat/message-bubble.test.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.test.tsx
@@ -2,37 +2,13 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import React from 'react'
 import { act } from 'react'
-import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { Window } from 'happy-dom'
 
 import { MessageBubble, getMessageActionAvailability, getMessageCopyText } from './message-bubble'
+import { installChatTestDom, renderClient } from './test-utils'
 import type { ACPMessage } from './types'
 
-const window = new Window()
-Object.defineProperty(globalThis, 'window', { value: window, configurable: true })
-Object.defineProperty(globalThis, 'document', { value: window.document, configurable: true })
-Object.defineProperty(globalThis, 'navigator', { value: window.navigator, configurable: true })
-Object.defineProperty(globalThis, 'DOMException', { value: window.DOMException, configurable: true })
-Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true })
-
-async function renderClient(element: React.ReactElement) {
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  const root = createRoot(container)
-
-  await act(async () => {
-    root.render(element)
-  })
-
-  return {
-    container,
-    unmount: async () => {
-      await act(async () => root.unmount())
-      container.remove()
-    },
-  }
-}
+installChatTestDom()
 
 function assistantMessage(overrides: Partial<ACPMessage> = {}): ACPMessage {
   return {
@@ -258,6 +234,7 @@ test('renders message actions under the bubble and right aligned', () => {
   )
 
   assert.match(markup, /aria-label="Message actions"/)
+  assert.match(markup, /role="group"/)
   assert.match(markup, /Copy message/)
   assert.match(markup, /Retry message/)
   assert.match(markup, /Edit message/)

--- a/apps/gateway-admin/components/chat/message-bubble.test.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.test.tsx
@@ -1,10 +1,38 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { Window } from 'happy-dom'
 
-import { MessageBubble, getMessageCopyText } from './message-bubble'
+import { MessageBubble, getMessageActionAvailability, getMessageCopyText } from './message-bubble'
 import type { ACPMessage } from './types'
+
+const window = new Window()
+Object.defineProperty(globalThis, 'window', { value: window, configurable: true })
+Object.defineProperty(globalThis, 'document', { value: window.document, configurable: true })
+Object.defineProperty(globalThis, 'navigator', { value: window.navigator, configurable: true })
+Object.defineProperty(globalThis, 'DOMException', { value: window.DOMException, configurable: true })
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true })
+
+async function renderClient(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(element)
+  })
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => root.unmount())
+      container.remove()
+    },
+  }
+}
 
 function assistantMessage(overrides: Partial<ACPMessage> = {}): ACPMessage {
   return {
@@ -193,6 +221,118 @@ test('copies raw message text rather than rendered markdown text', () => {
   })
 
   assert.equal(getMessageCopyText(message), message.text)
+})
+
+test('derives message actions from role, text, and callback availability', () => {
+  assert.deepEqual(
+    getMessageActionAvailability(userMessage({ text: 'Retry me.' }), {
+      canRetry: true,
+      canEdit: true,
+    }),
+    { copy: true, retry: true, edit: true },
+  )
+
+  assert.deepEqual(
+    getMessageActionAvailability(assistantMessage({ text: 'Assistant.' }), {
+      canRetry: true,
+      canEdit: true,
+    }),
+    { copy: true, retry: false, edit: false },
+  )
+
+  assert.deepEqual(
+    getMessageActionAvailability(userMessage({ text: '   ' }), {
+      canRetry: true,
+      canEdit: true,
+    }),
+    { copy: false, retry: false, edit: false },
+  )
+})
+
+test('renders message actions under the bubble and right aligned', () => {
+  const markup = renderToStaticMarkup(
+    <MessageBubble
+      message={userMessage({ text: 'Can you retry this?' })}
+      actionState={{ selected: false, canRetry: true, canEdit: true }}
+    />,
+  )
+
+  assert.match(markup, /aria-label="Message actions"/)
+  assert.match(markup, /Copy message/)
+  assert.match(markup, /Retry message/)
+  assert.match(markup, /Edit message/)
+  assert.match(markup, /justify-end/)
+  assert.ok(
+    markup.indexOf('Can you retry this?') < markup.indexOf('aria-label="Message actions"'),
+    'actions should render after the message content',
+  )
+})
+
+test('omits retry and edit for assistant messages', () => {
+  const markup = renderToStaticMarkup(
+    <MessageBubble
+      message={assistantMessage({ isStreaming: false, thoughts: [], toolCalls: [] })}
+      actionState={{ selected: false, canRetry: true, canEdit: true }}
+    />,
+  )
+
+  assert.match(markup, /Copy message/)
+  assert.doesNotMatch(markup, /Retry message/)
+  assert.doesNotMatch(markup, /Edit message/)
+})
+
+test('copy action writes raw message text and shows copied state', async () => {
+  const writes: string[] = []
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: async (value: string) => {
+        writes.push(value)
+      },
+    },
+    configurable: true,
+  })
+
+  const view = await renderClient(
+    <MessageBubble
+      message={assistantMessage({ text: '**raw** markdown', isStreaming: false, thoughts: [], toolCalls: [] })}
+      actionState={{ selected: true }}
+    />,
+  )
+
+  const button = view.container.querySelector('button[aria-label="Copy message"]') as HTMLButtonElement
+  await act(async () => {
+    button.click()
+  })
+
+  assert.deepEqual(writes, ['**raw** markdown'])
+  assert.match(view.container.textContent ?? '', /Copied/)
+  await view.unmount()
+})
+
+test('copy action exposes failure state when clipboard write is denied', async () => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: async () => {
+        throw new DOMException('Denied', 'NotAllowedError')
+      },
+    },
+    configurable: true,
+  })
+
+  const view = await renderClient(
+    <MessageBubble
+      message={assistantMessage({ text: 'copy me', isStreaming: false, thoughts: [], toolCalls: [] })}
+      actionState={{ selected: true }}
+    />,
+  )
+
+  const button = view.container.querySelector('button[aria-label="Copy message"]') as HTMLButtonElement
+  await act(async () => {
+    button.click()
+  })
+
+  assert.match(button.getAttribute('aria-label') ?? '', /Copy failed/)
+  await view.unmount()
 })
 
 test('keeps the streaming cursor adjacent to assistant markdown content', () => {

--- a/apps/gateway-admin/components/chat/message-bubble.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.tsx
@@ -97,7 +97,6 @@ export type MessageBubbleActionState = {
 
 export type MessageBubbleActionHandlers = {
   onSelect?: (messageId: string) => void
-  onDismiss?: () => void
   onRetry?: (message: ACPMessage) => void
   onEdit?: (message: ACPMessage) => void
 }
@@ -230,6 +229,7 @@ function MessageActionToolbar({
   return (
     <div
       aria-label="Message actions"
+      role="group"
       data-selected={selected ? 'true' : 'false'}
       className={cn(
         'flex w-full justify-end gap-1 pr-1 transition-opacity',
@@ -421,7 +421,10 @@ function areMessageBubblePropsEqual(
     prev.toolCalls.length === current.toolCalls.length &&
     previous.actionState?.selected === next.actionState?.selected &&
     previous.actionState?.canRetry === next.actionState?.canRetry &&
-    previous.actionState?.canEdit === next.actionState?.canEdit
+    previous.actionState?.canEdit === next.actionState?.canEdit &&
+    previous.actionHandlers?.onSelect === next.actionHandlers?.onSelect &&
+    previous.actionHandlers?.onRetry === next.actionHandlers?.onRetry &&
+    previous.actionHandlers?.onEdit === next.actionHandlers?.onEdit
   )
 }
 

--- a/apps/gateway-admin/components/chat/message-bubble.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Bot, Check, ChevronDown, Copy, ListChecks, UserRound } from 'lucide-react'
+import { Bot, Check, ChevronDown, Copy, ListChecks, Pencil, RotateCcw, UserRound } from 'lucide-react'
 import {
   Streamdown,
   defaultUrlTransform,
@@ -22,34 +22,84 @@ import { GroupedToolCallDisplay, groupConsecutiveToolCalls } from './grouped-too
 import { getToolCategory } from './tool-call-presentation'
 import type { ACPMessage } from './types'
 
+type CopyState = 'idle' | 'copied' | 'failed'
+
 function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = React.useState(false)
+  const [copyState, setCopyState] = React.useState<CopyState>('idle')
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(text)
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 2000)
+      setCopyState('copied')
+      window.setTimeout(() => setCopyState('idle'), 2000)
     } catch {
-      setCopied(false)
+      setCopyState('failed')
+      window.setTimeout(() => setCopyState('idle'), 2000)
     }
   }
+
+  const label =
+    copyState === 'copied'
+      ? 'Copied message'
+      : copyState === 'failed'
+        ? 'Copy failed'
+        : 'Copy message'
 
   return (
     <Button
       variant="ghost"
       size="icon"
       onClick={handleCopy}
-      aria-label="Copy message"
-      className="size-6 shrink-0 rounded text-aurora-text-muted/40 opacity-0 transition-opacity group-hover/bubble:opacity-100 hover:bg-aurora-hover-bg hover:text-aurora-text-muted"
+      aria-label={label}
+      className="size-7 shrink-0 rounded text-aurora-text-muted/70 hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
     >
-      {copied ? <Check className="size-3 text-aurora-success" /> : <Copy className="size-3" />}
+      {copyState === 'copied' ? <Check className="size-3.5 text-aurora-success" /> : <Copy className="size-3.5" />}
+      <span className="sr-only">{label}</span>
     </Button>
   )
 }
 
 export function getMessageCopyText(message: Pick<ACPMessage, 'text'>) {
   return message.text
+}
+
+export type MessageActionAvailabilityInput = {
+  canRetry?: boolean
+  canEdit?: boolean
+}
+
+export type MessageActionAvailability = {
+  copy: boolean
+  retry: boolean
+  edit: boolean
+}
+
+export function getMessageActionAvailability(
+  message: Pick<ACPMessage, 'role' | 'text' | 'isStreaming'>,
+  input: MessageActionAvailabilityInput = {},
+): MessageActionAvailability {
+  const hasText = message.text.trim().length > 0
+  const isUser = message.role === 'user'
+  const isStable = !message.isStreaming
+
+  return {
+    copy: hasText,
+    retry: hasText && isUser && isStable && Boolean(input.canRetry),
+    edit: hasText && isUser && isStable && Boolean(input.canEdit),
+  }
+}
+
+export type MessageBubbleActionState = {
+  selected?: boolean
+  canRetry?: boolean
+  canEdit?: boolean
+}
+
+export type MessageBubbleActionHandlers = {
+  onSelect?: (messageId: string) => void
+  onDismiss?: () => void
+  onRetry?: (message: ACPMessage) => void
+  onEdit?: (message: ACPMessage) => void
 }
 
 function StreamingCursor() {
@@ -160,7 +210,70 @@ function AgentActionsPanel({
   )
 }
 
-function MessageBubbleComponent({ message }: { message: ACPMessage }) {
+function MessageActionToolbar({
+  message,
+  availability,
+  selected,
+  onRetry,
+  onEdit,
+}: {
+  message: ACPMessage
+  availability: MessageActionAvailability
+  selected: boolean
+  onRetry?: (message: ACPMessage) => void
+  onEdit?: (message: ACPMessage) => void
+}) {
+  if (!availability.copy && !availability.retry && !availability.edit) {
+    return null
+  }
+
+  return (
+    <div
+      aria-label="Message actions"
+      data-selected={selected ? 'true' : 'false'}
+      className={cn(
+        'flex w-full justify-end gap-1 pr-1 transition-opacity',
+        selected
+          ? 'opacity-100'
+          : 'opacity-0 group-hover/bubble:opacity-100 group-focus-within/bubble:opacity-100',
+      )}
+    >
+      {availability.copy ? <CopyButton text={getMessageCopyText(message)} /> : null}
+      {availability.retry ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Retry message"
+          className="size-7 rounded text-aurora-text-muted/70 hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
+          onClick={() => onRetry?.(message)}
+        >
+          <RotateCcw className="size-3.5" />
+        </Button>
+      ) : null}
+      {availability.edit ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Edit message"
+          className="size-7 rounded text-aurora-text-muted/70 hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
+          onClick={() => onEdit?.(message)}
+        >
+          <Pencil className="size-3.5" />
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function MessageBubbleComponent({
+  message,
+  actionState = {},
+  actionHandlers = {},
+}: {
+  message: ACPMessage
+  actionState?: MessageBubbleActionState
+  actionHandlers?: MessageBubbleActionHandlers
+}) {
   const isUser = message.role === 'user'
   const [reasoningOpen, setReasoningOpen] = React.useState(Boolean(message.isStreaming))
   const [chainOpen, setChainOpen] = React.useState(Boolean(message.isStreaming))
@@ -177,7 +290,15 @@ function MessageBubbleComponent({ message }: { message: ACPMessage }) {
   const hasActions = !isUser && message.toolCalls.length > 0
 
   return (
-    <div className={cn('group/bubble flex min-w-0 gap-3', isUser && 'flex-row-reverse')}>
+    <div
+      data-message-id={message.id}
+      onPointerDown={(event) => {
+        if (event.pointerType === 'touch') {
+          actionHandlers.onSelect?.(message.id)
+        }
+      }}
+      className={cn('group/bubble flex min-w-0 gap-3', isUser && 'flex-row-reverse')}
+    >
       <div
         className={cn(
           'mt-1 flex size-6 shrink-0 items-center justify-center rounded-full border',
@@ -254,26 +375,38 @@ function MessageBubbleComponent({ message }: { message: ACPMessage }) {
               />
             )}
             {isUser ? (
-              <p className="min-w-0 whitespace-pre-wrap pr-8 text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
+              <p className="min-w-0 whitespace-pre-wrap text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
                 {message.text}
                 {message.isStreaming ? <StreamingCursor /> : null}
               </p>
             ) : (
               <AssistantMarkdown text={message.text} isStreaming={Boolean(message.isStreaming)} />
             )}
-            <div className="absolute right-2 top-2">
-              <CopyButton text={getMessageCopyText(message)} />
-            </div>
           </div>
         )}
+        <MessageActionToolbar
+          message={message}
+          availability={getMessageActionAvailability(message, actionState)}
+          selected={Boolean(actionState.selected)}
+          onRetry={actionHandlers.onRetry}
+          onEdit={actionHandlers.onEdit}
+        />
       </div>
     </div>
   )
 }
 
 function areMessageBubblePropsEqual(
-  previous: Readonly<{ message: ACPMessage }>,
-  next: Readonly<{ message: ACPMessage }>,
+  previous: Readonly<{
+    message: ACPMessage
+    actionState?: MessageBubbleActionState
+    actionHandlers?: MessageBubbleActionHandlers
+  }>,
+  next: Readonly<{
+    message: ACPMessage
+    actionState?: MessageBubbleActionState
+    actionHandlers?: MessageBubbleActionHandlers
+  }>,
 ) {
   const prev = previous.message
   const current = next.message
@@ -285,7 +418,10 @@ function areMessageBubblePropsEqual(
     prev.isStreaming === current.isStreaming &&
     prev.version === current.version &&
     prev.thoughts.length === current.thoughts.length &&
-    prev.toolCalls.length === current.toolCalls.length
+    prev.toolCalls.length === current.toolCalls.length &&
+    previous.actionState?.selected === next.actionState?.selected &&
+    previous.actionState?.canRetry === next.actionState?.canRetry &&
+    previous.actionState?.canEdit === next.actionState?.canEdit
   )
 }
 

--- a/apps/gateway-admin/components/chat/message-thread.test.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.test.tsx
@@ -2,20 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import React from 'react'
 import { act } from 'react'
-import { createRoot } from 'react-dom/client'
-import { Window } from 'happy-dom'
 
 import { MessageThread } from './message-thread'
+import { installChatTestDom, renderClient } from './test-utils'
 import type { ACPMessage, ACPRun } from './types'
 
-const window = new Window()
-Object.defineProperty(globalThis, 'window', { value: window, configurable: true })
-Object.defineProperty(globalThis, 'document', { value: window.document, configurable: true })
-Object.defineProperty(globalThis, 'navigator', { value: window.navigator, configurable: true })
-Object.defineProperty(globalThis, 'Node', { value: window.Node, configurable: true })
-Object.defineProperty(globalThis, 'PointerEvent', { value: window.PointerEvent, configurable: true })
-Object.defineProperty(globalThis, 'KeyboardEvent', { value: window.KeyboardEvent, configurable: true })
-Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true })
+installChatTestDom()
 
 function run(): ACPRun {
   return {
@@ -43,20 +35,6 @@ function message(id: string, text: string): ACPMessage {
     thoughts: [],
     toolCalls: [],
     version: 1,
-  }
-}
-
-async function renderClient(element: React.ReactElement) {
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  const root = createRoot(container)
-  await act(async () => root.render(element))
-  return {
-    container,
-    unmount: async () => {
-      await act(async () => root.unmount())
-      container.remove()
-    },
   }
 }
 

--- a/apps/gateway-admin/components/chat/message-thread.test.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.test.tsx
@@ -1,0 +1,133 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Window } from 'happy-dom'
+
+import { MessageThread } from './message-thread'
+import type { ACPMessage, ACPRun } from './types'
+
+const window = new Window()
+Object.defineProperty(globalThis, 'window', { value: window, configurable: true })
+Object.defineProperty(globalThis, 'document', { value: window.document, configurable: true })
+Object.defineProperty(globalThis, 'navigator', { value: window.navigator, configurable: true })
+Object.defineProperty(globalThis, 'Node', { value: window.Node, configurable: true })
+Object.defineProperty(globalThis, 'PointerEvent', { value: window.PointerEvent, configurable: true })
+Object.defineProperty(globalThis, 'KeyboardEvent', { value: window.KeyboardEvent, configurable: true })
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true })
+
+function run(): ACPRun {
+  return {
+    id: 'run-1',
+    projectId: 'workspace',
+    agentId: 'codex',
+    provider: 'codex-acp',
+    title: 'Run',
+    createdAt: new Date('2026-05-05T00:00:00Z'),
+    updatedAt: new Date('2026-05-05T00:00:00Z'),
+    status: 'idle',
+    providerSessionId: 'provider-run-1',
+    cwd: '/home/jmagar/workspace/lab',
+  }
+}
+
+function message(id: string, text: string): ACPMessage {
+  return {
+    id,
+    runId: 'run-1',
+    role: 'user',
+    text,
+    createdAt: new Date('2026-05-05T00:00:00Z'),
+    isStreaming: false,
+    thoughts: [],
+    toolCalls: [],
+    version: 1,
+  }
+}
+
+async function renderClient(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => root.render(element))
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+test('touch selection shows actions for one message and selecting another moves the row', async () => {
+  const view = await renderClient(
+    <MessageThread
+      run={run()}
+      messages={[message('m1', 'first'), message('m2', 'second')]}
+      canRetryMessages
+      canEditMessages
+    />,
+  )
+
+  const bubbles = view.container.querySelectorAll('[data-message-id]')
+  await act(async () => {
+    bubbles[0]!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }))
+  })
+  assert.equal(
+    view.container.querySelector('[data-message-id="m1"] [aria-label="Message actions"]')?.getAttribute('data-selected'),
+    'true',
+  )
+
+  await act(async () => {
+    bubbles[1]!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }))
+  })
+  assert.equal(
+    view.container.querySelector('[data-message-id="m1"] [aria-label="Message actions"]')?.getAttribute('data-selected'),
+    'false',
+  )
+  assert.equal(
+    view.container.querySelector('[data-message-id="m2"] [aria-label="Message actions"]')?.getAttribute('data-selected'),
+    'true',
+  )
+
+  await view.unmount()
+})
+
+test('escape dismisses selected mobile message actions', async () => {
+  const view = await renderClient(
+    <MessageThread run={run()} messages={[message('m1', 'first')]} canRetryMessages canEditMessages />,
+  )
+
+  const bubble = view.container.querySelector('[data-message-id="m1"]')!
+  await act(async () => {
+    bubble.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }))
+  })
+  assert.equal(view.container.querySelector('[aria-label="Message actions"]')?.getAttribute('data-selected'), 'true')
+
+  await act(async () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  })
+  assert.equal(view.container.querySelector('[aria-label="Message actions"]')?.getAttribute('data-selected'), 'false')
+
+  await view.unmount()
+})
+
+test('outside pointer dismisses selected mobile message actions', async () => {
+  const view = await renderClient(
+    <MessageThread run={run()} messages={[message('m1', 'first')]} canRetryMessages canEditMessages />,
+  )
+
+  const bubble = view.container.querySelector('[data-message-id="m1"]')!
+  await act(async () => {
+    bubble.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }))
+  })
+  assert.equal(view.container.querySelector('[aria-label="Message actions"]')?.getAttribute('data-selected'), 'true')
+
+  await act(async () => {
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }))
+  })
+  assert.equal(view.container.querySelector('[aria-label="Message actions"]')?.getAttribute('data-selected'), 'false')
+
+  await view.unmount()
+})

--- a/apps/gateway-admin/components/chat/message-thread.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.tsx
@@ -134,7 +134,6 @@ export function MessageThread({
             }}
             actionHandlers={{
               onSelect: setSelectedMessageId,
-              onDismiss: () => setSelectedMessageId(null),
               onRetry: onRetryMessage,
               onEdit: onEditMessage,
             }}

--- a/apps/gateway-admin/components/chat/message-thread.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.tsx
@@ -13,6 +13,10 @@ interface MessageThreadProps {
   run: ACPRun | null
   messages: ACPMessage[]
   connectionState?: SessionEventConnectionState
+  canRetryMessages?: boolean
+  canEditMessages?: boolean
+  onRetryMessage?: (message: ACPMessage) => void
+  onEditMessage?: (message: ACPMessage) => void
 }
 
 function EmptyState() {
@@ -69,12 +73,44 @@ function SessionStatusNotice({ run, connectionState }: { run: ACPRun; connection
   )
 }
 
-export function MessageThread({ run, messages, connectionState }: MessageThreadProps) {
+export function MessageThread({
+  run,
+  messages,
+  connectionState,
+  canRetryMessages = false,
+  canEditMessages = false,
+  onRetryMessage,
+  onEditMessage,
+}: MessageThreadProps) {
   const bottomRef = React.useRef<HTMLDivElement>(null)
+  const threadRef = React.useRef<HTMLDivElement>(null)
+  const [selectedMessageId, setSelectedMessageId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  React.useEffect(() => {
+    if (!selectedMessageId) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSelectedMessageId(null)
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Node && !threadRef.current?.contains(target)) {
+        setSelectedMessageId(null)
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [selectedMessageId])
 
   if (!run) {
     return <EmptyState />
@@ -82,10 +118,27 @@ export function MessageThread({ run, messages, connectionState }: MessageThreadP
 
   return (
     <ScrollArea className="min-h-0 min-w-0 flex-1 overflow-hidden">
-      <div className="mx-auto flex w-full max-w-[860px] min-w-0 flex-col gap-4 px-3 py-4 sm:gap-5 sm:px-6 sm:py-6">
+      <div
+        ref={threadRef}
+        className="mx-auto flex w-full max-w-[860px] min-w-0 flex-col gap-4 px-3 py-4 sm:gap-5 sm:px-6 sm:py-6"
+      >
         <SessionStatusNotice run={run} connectionState={connectionState} />
         {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
+          <MessageBubble
+            key={message.id}
+            message={message}
+            actionState={{
+              selected: selectedMessageId === message.id,
+              canRetry: canRetryMessages,
+              canEdit: canEditMessages,
+            }}
+            actionHandlers={{
+              onSelect: setSelectedMessageId,
+              onDismiss: () => setSelectedMessageId(null),
+              onRetry: onRetryMessage,
+              onEdit: onEditMessage,
+            }}
+          />
         ))}
         <div ref={bottomRef} />
       </div>

--- a/apps/gateway-admin/components/chat/test-utils.tsx
+++ b/apps/gateway-admin/components/chat/test-utils.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Window } from 'happy-dom'
+
+export function installChatTestDom() {
+  const window = new Window()
+  Object.defineProperty(globalThis, 'window', { value: window, configurable: true })
+  Object.defineProperty(globalThis, 'document', { value: window.document, configurable: true })
+  Object.defineProperty(globalThis, 'navigator', { value: window.navigator, configurable: true })
+  Object.defineProperty(globalThis, 'DOMException', { value: window.DOMException, configurable: true })
+  Object.defineProperty(globalThis, 'Node', { value: window.Node, configurable: true })
+  Object.defineProperty(globalThis, 'PointerEvent', { value: window.PointerEvent, configurable: true })
+  Object.defineProperty(globalThis, 'KeyboardEvent', { value: window.KeyboardEvent, configurable: true })
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true, configurable: true })
+  return window
+}
+
+export async function renderClient(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(element)
+  })
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => root.unmount())
+      container.remove()
+    },
+  }
+}

--- a/apps/gateway-admin/components/chat/types.ts
+++ b/apps/gateway-admin/components/chat/types.ts
@@ -78,6 +78,7 @@ export interface ACPMessage {
   runId: string
   role: 'user' | 'assistant' | 'system'
   text: string
+  attachments?: AttachmentRef[]
   createdAt: Date
   isStreaming?: boolean
   thoughts: string[]

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -91,7 +91,7 @@ export type ChatSessionActionsContextValue = {
   selectRun: (runId: string) => void
   sendPrompt: (
     payload: PromptPayload,
-    options?: { includePageContext?: boolean; pageContext?: unknown },
+    options?: { includePageContext?: boolean; pageContext?: unknown; providerId?: string | null },
   ) => Promise<void>
   refreshSessions: () => Promise<void>
   refreshProvider: () => Promise<void>
@@ -378,7 +378,7 @@ export function ChatSessionProvider({
         await sendPromptForSelectedProvider({
           payload,
           selectedRun,
-          selectedProviderId,
+          selectedProviderId: options?.providerId ?? selectedProviderId,
           createSession,
           isMobileViewport,
           fetchAcp,

--- a/apps/gateway-admin/package.json
+++ b/apps/gateway-admin/package.json
@@ -98,6 +98,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0",
+    "happy-dom": "^20.9.0",
     "playwright": "^1.59.1",
     "postcss": "^8.5",
     "sharp": "^0.34.5",

--- a/apps/gateway-admin/pnpm-lock.yaml
+++ b/apps/gateway-admin/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -715,105 +718,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -910,28 +897,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.0':
     resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.0':
     resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.0':
     resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.0':
     resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==}
@@ -1822,28 +1805,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -2030,6 +2009,12 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -2469,6 +2454,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -2639,6 +2628,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
@@ -2830,28 +2823,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -3629,6 +3618,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3637,6 +3630,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -5399,6 +5404,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.11
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.7.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5884,6 +5895,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -6079,6 +6092,18 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   hachure-fill@0.5.2: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 22.19.11
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   hast-util-from-parse5@8.0.3:
     dependencies:
@@ -7437,11 +7462,15 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.20.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- add under-bubble message action controls for copy, retry, and edit
- support touch selection/mobile dismissal plus desktop hover/focus reveal
- wire retry through the existing prompt send path and edit into the composer draft

## Tests
- `pnpm exec tsx --test components/chat/message-bubble.test.tsx components/chat/message-thread.test.tsx components/chat/chat-shell.test.tsx` (29/29 passing)
- `pnpm run build` (passing with `NEXT_PUBLIC_MOCK_DATA=true` for browser preview build)

## Agent-browser verification
- served the built app locally with `python3 -m http.server 3131 -d out`
- opened `http://127.0.0.1:3131/chat/` with `agent-browser 0.26.0`
- verified the real chat page loads under mock-data auth bypass and exposes the chat controls in the accessibility snapshot
- limitation: mock provider state leaves the composer/session disabled in this static preview, so live bubble action interaction is verified by the component interaction tests rather than by agent-browser on a populated transcript

## Notes
- `.env`, `config.toml`, ignored plan files, and generated output were not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add under-bubble chat message actions (copy, retry, edit) with mobile touch selection and desktop hover for quicker control. Retry resends the original text and attachments; Edit loads the text into the composer and clears attachments.

- **New Features**
  - Message actions: copy/retry/edit toolbar under each bubble; hover/focus reveal on desktop; tap to select on mobile; Escape/outside tap to dismiss.
  - Behavior: copy writes raw message text with success/fail states; retry resends original text and attachments; edit populates the composer draft and clears current attachments.
  - Availability: retry/edit only for stable user messages; assistant messages omit retry/edit; actions computed from role/text/streaming and `canRetryMessages`/`canEditMessages`.
  - Thread: manages per-message selection; props `canRetryMessages`, `canEditMessages`, `onRetryMessage`, `onEditMessage`.
  - Input: supports controlled drafts via `draftText`/`onDraftTextChange`; `attachmentsResetToken` clears attachments; textarea auto-resizes on draft changes.

- **Dependencies**
  - Added `happy-dom` for client-like DOM in interaction tests.

<sup>Written for commit 016acbd83620ef53115097a52ae5ba804949ad81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit and retry messages with draft preservation
  * Added message actions toolbar with copy, retry, and edit options
  * Messages can be interactively selected with keyboard and pointer support
  * Textarea auto-resizing improved with state-driven updates

* **Tests**
  * Added tests for message actions availability and interaction flows
  * Added tests for message selection, dismissal, and mobile interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->