### PR TITLE
Support local file attachments in chat

### DIFF
--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -7,14 +7,20 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ACPAgent } from './types'
-import type { AttachmentRef } from '@/lib/fs/types'
+import {
+  createLocalAttachmentDraft,
+  fileToSerializableAttachment,
+  revokeLocalAttachmentPreview,
+  validateLocalFiles,
+} from '@/lib/chat/local-attachments'
+import type { AttachmentRef, LocalAttachmentDraft, PromptAttachmentRef } from '@/lib/fs/types'
 import { isInlineImageMime, previewWorkspaceFile } from '@/lib/fs/client'
 import { WorkspacePicker } from './workspace-picker'
 
 /** Payload emitted by the chat input on submit. */
 export interface ChatInputPayload {
   text: string
-  attachments: AttachmentRef[]
+  attachments: PromptAttachmentRef[]
 }
 
 interface ChatInputProps {
@@ -38,6 +44,9 @@ export function ChatInput({
   const [sending, setSending] = React.useState(false)
   const [agentPickerOpen, setAgentPickerOpen] = React.useState(false)
   const [attachments, setAttachments] = React.useState<AttachmentRef[]>([])
+  const attachmentsRef = React.useRef<AttachmentRef[]>(attachments)
+  const localFileInputRef = React.useRef<HTMLInputElement>(null)
+  const [attachmentError, setAttachmentError] = React.useState<string | null>(null)
   const [workspacePickerOpen, setWorkspacePickerOpen] = React.useState(false)
   // Synchronous send-lock: state updates batch across a render tick, so a fast
   // Enter+Click can fire handleSend twice before `sending` flips. The ref
@@ -54,6 +63,9 @@ export function ChatInput({
   optionRefs.current.length = agents.length
 
   const hasContent = value.trim().length > 0 || attachments.length > 0
+  const localAttachments = attachments.filter(
+    (attachment): attachment is LocalAttachmentDraft => attachment.kind === 'local',
+  )
 
   const handleSend = async () => {
     const trimmed = value.trim()
@@ -65,7 +77,23 @@ export function ChatInput({
     sendingRef.current = true
     try {
       setSending(true)
-      await onSend({ text: trimmed, attachments })
+      let serializedAttachments: PromptAttachmentRef[]
+      try {
+        serializedAttachments = await Promise.all(
+          attachments.map((attachment) =>
+            attachment.kind === 'local' ? fileToSerializableAttachment(attachment) : attachment,
+          ),
+        )
+      } catch {
+        setAttachmentError('Could not read one or more attached files.')
+        return
+      }
+
+      await onSend({ text: trimmed, attachments: serializedAttachments })
+      attachments.forEach((attachment) => {
+        if (attachment.kind === 'local') revokeLocalAttachmentPreview(attachment)
+      })
+      setAttachmentError(null)
       setValue('')
       setAttachments([])
       if (textareaRef.current) {
@@ -77,18 +105,40 @@ export function ChatInput({
     }
   }
 
+  const handleLocalFiles = (fileList: FileList | null) => {
+    if (!fileList) return
+    const incoming = Array.from(fileList)
+    const { accepted, errors } = validateLocalFiles(
+      incoming,
+      localAttachments.map((attachment) => attachment.file),
+    )
+    setAttachmentError(errors[0] ?? null)
+    setAttachments((prev) => [...prev, ...accepted.map(createLocalAttachmentDraft)])
+    if (localFileInputRef.current) {
+      localFileInputRef.current.value = ''
+    }
+  }
+
   const handleAttach = (attachment: AttachmentRef) => {
     setAttachments((prev) => {
       // Dedupe by path so double-adding the same file is a no-op.
-      if (prev.some((a) => a.kind === attachment.kind && a.path === attachment.path)) return prev
+      if (
+        attachment.kind === 'file'
+        && prev.some((a) => a.kind === 'file' && a.path === attachment.path)
+      ) return prev
       return [...prev, attachment]
     })
   }
 
   const removeAttachment = (ref: AttachmentRef) => {
-    // Match on the compound (kind, path) key so a future Drive-kind variant
-    // with the same path as a file attachment is not removed by collision.
-    setAttachments((prev) => prev.filter((a) => a.kind !== ref.kind || a.path !== ref.path))
+    if (ref.kind === 'local') revokeLocalAttachmentPreview(ref)
+    setAttachments((prev) =>
+      prev.filter((attachment) => {
+        if (attachment.kind === 'local' && ref.kind === 'local') return attachment.id !== ref.id
+        if (attachment.kind === 'file' && ref.kind === 'file') return attachment.path !== ref.path
+        return true
+      }),
+    )
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -180,6 +230,18 @@ export function ChatInput({
     }
   }
 
+  React.useEffect(() => {
+    attachmentsRef.current = attachments
+  }, [attachments])
+
+  React.useEffect(() => {
+    return () => {
+      attachmentsRef.current.forEach((attachment) => {
+        if (attachment.kind === 'local') revokeLocalAttachmentPreview(attachment)
+      })
+    }
+  }, [])
+
   return (
     <div className="shrink-0 border-t border-aurora-border-default bg-aurora-nav-bg px-3 py-2 sm:px-4 sm:py-3">
       <div
@@ -192,11 +254,11 @@ export function ChatInput({
       >
         {attachments.length > 0 && (
           <ul
-            aria-label="Attached workspace files"
+            aria-label="Attached files"
             className="flex flex-wrap gap-1.5 border-b border-aurora-border-default px-3 pt-2 pb-1.5 sm:px-4"
           >
             {attachments.map((attachment) => (
-              <li key={attachment.path}>
+              <li key={attachment.kind === 'local' ? attachment.id : attachment.path}>
                 <AttachmentChip
                   attachment={attachment}
                   onRemove={() => removeAttachment(attachment)}
@@ -204,6 +266,12 @@ export function ChatInput({
               </li>
             ))}
           </ul>
+        )}
+
+        {attachmentError && (
+          <p role="alert" className="border-b border-aurora-error/30 px-3 py-1.5 text-[11px] text-aurora-error sm:px-4">
+            {attachmentError}
+          </p>
         )}
 
         <textarea
@@ -232,12 +300,28 @@ export function ChatInput({
                   <Button
                     variant="ghost"
                     size="icon"
+                    aria-label="Attach local file"
+                    onClick={() => localFileInputRef.current?.click()}
+                    disabled={disabled || sending}
+                    className="size-7 rounded text-aurora-text-muted hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
+                  >
+                    <Paperclip className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">Attach local file</TooltipContent>
+              </Tooltip>
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     aria-label="Attach workspace file"
                     onClick={() => setWorkspacePickerOpen(true)}
                     disabled={disabled || sending}
                     className="size-7 rounded text-aurora-text-muted hover:bg-aurora-hover-bg hover:text-aurora-text-primary"
                   >
-                    <Paperclip className="size-3.5" />
+                    <FileText className="size-3.5" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" className="text-xs">Attach workspace file</TooltipContent>
@@ -330,6 +414,15 @@ export function ChatInput({
             </Button>
           </div>
         </div>
+        <input
+          ref={localFileInputRef}
+          type="file"
+          multiple
+          accept="text/*,application/json,application/pdf,image/png,image/jpeg,image/gif,image/webp"
+          className="sr-only"
+          aria-label="Local file picker"
+          onChange={(event) => handleLocalFiles(event.currentTarget.files)}
+        />
       </div>
 
       <p className="mt-1.5 px-1 text-center text-[10px] text-aurora-text-muted/40 sm:text-[11px]">
@@ -360,12 +453,15 @@ function AttachmentChip({
   attachment: AttachmentRef
   onRemove: () => void
 }) {
+  const label = attachment.kind === 'local' ? attachment.file.name : attachment.path
   // Bundle the URL with the path it was fetched for. Rendering gates on
   // forPath === attachment.path, so a revoked-but-not-yet-replaced URL from
   // a prior path never lands in the DOM during a swap.
   const [thumb, setThumb] = React.useState<{ url: string; forPath: string } | null>(null)
 
   React.useEffect(() => {
+    if (attachment.kind === 'local') return undefined
+
     const controller = new AbortController()
     let objectUrl: string | null = null
     let disposed = false
@@ -389,7 +485,7 @@ function AttachmentChip({
       controller.abort()
       if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [attachment.path])
+  }, [attachment])
 
   return (
     <span
@@ -398,7 +494,16 @@ function AttachmentChip({
         'bg-aurora-panel-medium px-2 py-0.5 text-[11px] text-aurora-text-primary',
       )}
     >
-      {thumb && thumb.forPath === attachment.path ? (
+      {attachment.kind === 'local' && attachment.previewUrl ? (
+        <Image
+          src={attachment.previewUrl}
+          alt=""
+          className="size-4 rounded-[2px] object-cover"
+          height={16}
+          width={16}
+          unoptimized
+        />
+      ) : thumb && attachment.kind === 'file' && thumb.forPath === attachment.path ? (
         <Image
           src={thumb.url}
           alt=""
@@ -410,11 +515,11 @@ function AttachmentChip({
       ) : (
         <FileText className="size-3 text-aurora-text-muted" />
       )}
-      <span className="max-w-[18rem] truncate" title={attachment.path}>{attachment.path}</span>
+      <span className="max-w-[18rem] truncate" title={label}>{label}</span>
       <button
         type="button"
         onClick={onRemove}
-        aria-label={`Remove ${attachment.path}`}
+        aria-label={`Remove ${label}`}
         className="text-aurora-text-muted hover:text-aurora-text-primary"
       >
         <X className="size-3" />

--- a/apps/gateway-admin/components/chat/chat-shell.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.test.tsx
@@ -214,6 +214,61 @@ test('sendPromptForSelectedProvider creates provider-matched run and posts page 
   ])
 })
 
+test('sendPromptForSelectedProvider posts local attachment payloads without dropping prompt text', async () => {
+  const requests: Array<{ path: string; body: unknown }> = []
+
+  await sendPromptForSelectedProvider({
+    payload: {
+      text: 'summarize this file',
+      attachments: [
+        {
+          kind: 'local',
+          id: 'local-notes',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 11,
+          contentKind: 'text',
+          text: 'hello world',
+        },
+      ],
+    },
+    selectedRun: {
+      ...run('run-codex'),
+      provider: 'codex-acp',
+    },
+    selectedProviderId: 'codex-acp',
+    createSession: async () => run('unused'),
+    isMobileViewport: false,
+    fetchAcp: async (path, init) => {
+      requests.push({ path, body: JSON.parse(String(init?.body)) })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    },
+    refreshSessions: async () => {},
+    addOptimisticMessage: () => {},
+    removeOptimisticMessage: () => {},
+  })
+
+  assert.deepEqual(requests, [
+    {
+      path: '/sessions/run-codex/prompt',
+      body: {
+        prompt: 'summarize this file',
+        attachments: [
+          {
+            kind: 'local',
+            id: 'local-notes',
+            name: 'notes.txt',
+            mimeType: 'text/plain',
+            size: 11,
+            contentKind: 'text',
+            text: 'hello world',
+          },
+        ],
+      },
+    },
+  ])
+})
+
 test('sendPromptForSelectedProvider removes optimistic message and throws normalized backend errors', async () => {
   const optimisticIds: string[] = []
 

--- a/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
+++ b/apps/gateway-admin/lib/browser/chat-shell.browser.test.ts
@@ -582,3 +582,118 @@ test('chat shell agent picker switches provider and sends through a provider-mat
     },
   ])
 })
+
+test('chat shell attaches and removes local files before sending prompt', { concurrency: false }, async (t) => {
+  await startPreviewServer()
+
+  const browser = await chromium.launch({ headless: true })
+  t.after(async () => {
+    await browser.close()
+  })
+
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } })
+  const sessions: BrowserSession[] = []
+  const promptRequests: Array<{ prompt: string; attachments?: unknown[] }> = []
+
+  await mockAuthenticatedSession(page)
+  await page.route('**/v1/acp/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+
+    if (url.pathname === '/v1/acp/provider') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ provider: { provider: 'codex', ready: true, command: 'npx', args: [], message: 'ready' } }),
+      })
+      return
+    }
+
+    if (url.pathname === '/v1/acp/sessions' && request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sessions }) })
+      return
+    }
+
+    if (url.pathname === '/v1/acp/sessions' && request.method() === 'POST') {
+      const created = session('session-attach', 'Attachment session')
+      sessions.unshift(created)
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ session: created }) })
+      return
+    }
+
+    const promptMatch = url.pathname.match(/^\/v1\/acp\/sessions\/([^/]+)\/prompt$/)
+    if (promptMatch && request.method() === 'POST') {
+      const payload = JSON.parse(request.postData() ?? '{}') as { prompt?: string; attachments?: unknown[] }
+      promptRequests.push({ prompt: payload.prompt ?? '', attachments: payload.attachments })
+      await route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ accepted: true }) })
+      return
+    }
+
+    const ticketMatch = url.pathname.match(/^\/v1\/acp\/sessions\/([^/]+)\/subscribe_ticket$/)
+    if (ticketMatch && request.method() === 'POST') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ticket: 'ticket-attach' }) })
+      return
+    }
+
+    const eventMatch = url.pathname.match(/^\/v1\/acp\/sessions\/([^/]+)\/events$/)
+    if (eventMatch && request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+      return
+    }
+
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: `Unhandled ACP request: ${url.pathname}` }) })
+  })
+
+  await page.goto(`${BASE_URL}/chat/`, { waitUntil: 'networkidle' })
+  await page.getByRole('textbox', { name: 'Message' }).fill('Use these notes')
+
+  const chooserPromise = page.waitForEvent('filechooser')
+  await page.getByRole('button', { name: 'Attach local file' }).click()
+  const chooser = await chooserPromise
+  await chooser.setFiles([
+    {
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('local browser notes'),
+    },
+  ])
+
+  await assert.doesNotReject(() => page.getByText('notes.txt').waitFor())
+  await page.getByRole('button', { name: 'Remove notes.txt' }).click()
+  await assert.doesNotReject(() => page.getByRole('button', { name: 'Send message' }).waitFor())
+
+  const chooserPromise2 = page.waitForEvent('filechooser')
+  await page.getByRole('button', { name: 'Attach local file' }).click()
+  const chooser2 = await chooserPromise2
+  await chooser2.setFiles([
+    {
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('local browser notes'),
+    },
+  ])
+
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await waitForCondition(() => promptRequests.length === 1)
+
+  assert.equal(promptRequests[0]?.prompt, 'Use these notes')
+  const attachments = promptRequests[0]?.attachments as Array<Record<string, unknown>> | undefined
+  assert.equal(attachments?.length, 1)
+  assert.deepEqual(
+    {
+      ...attachments?.[0],
+      id: typeof attachments?.[0]?.id === 'string' && attachments[0].id.startsWith('local-notes.txt-19-')
+        ? 'local-notes.txt-19-*'
+        : attachments?.[0]?.id,
+    },
+    {
+      kind: 'local',
+      id: 'local-notes.txt-19-*',
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      size: 19,
+      contentKind: 'text',
+      text: 'local browser notes',
+    },
+  )
+})

--- a/apps/gateway-admin/lib/chat/local-attachments.test.ts
+++ b/apps/gateway-admin/lib/chat/local-attachments.test.ts
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  MAX_LOCAL_ATTACHMENTS,
+  MAX_LOCAL_ATTACHMENT_BYTES,
+  fileToSerializableAttachment,
+  validateLocalFiles,
+} from './local-attachments.ts'
+
+function file(name: string, type: string, body: string): File {
+  return new File([body], name, { type })
+}
+
+test('validateLocalFiles accepts supported files within count and size limits', () => {
+  const files = [
+    file('notes.txt', 'text/plain', 'hello'),
+    file('diagram.png', 'image/png', 'png-bytes'),
+  ]
+
+  const result = validateLocalFiles(files, [])
+
+  assert.deepEqual(result.errors, [])
+  assert.equal(result.accepted.length, 2)
+})
+
+test('validateLocalFiles rejects unsupported types, oversized files, and count overflow', () => {
+  const existing = Array.from({ length: MAX_LOCAL_ATTACHMENTS }, (_, index) =>
+    file(`existing-${index}.txt`, 'text/plain', 'x'),
+  )
+  const unsupported = file('archive.zip', 'application/zip', 'zip')
+  const oversized = new File([new Uint8Array(MAX_LOCAL_ATTACHMENT_BYTES + 1)], 'big.txt', {
+    type: 'text/plain',
+  })
+
+  const result = validateLocalFiles([unsupported, oversized], existing)
+
+  assert.equal(result.accepted.length, 0)
+  assert.ok(result.errors.some((message) => message.includes('You can attach up to 5 files')))
+  assert.ok(result.errors.some((message) => message.includes('archive.zip has unsupported type application/zip')))
+  assert.ok(result.errors.some((message) => message.includes('big.txt is larger than 2 MiB')))
+})
+
+test('fileToSerializableAttachment emits text resources for text files', async () => {
+  const result = await fileToSerializableAttachment(
+    {
+      id: 'local-1',
+      kind: 'local',
+      file: file('notes.txt', 'text/plain', 'hello world'),
+      previewUrl: null,
+    },
+  )
+
+  assert.deepEqual(result, {
+    kind: 'local',
+    id: 'local-1',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    size: 11,
+    contentKind: 'text',
+    text: 'hello world',
+  })
+})
+
+test('fileToSerializableAttachment emits base64 blob resources for binary files', async () => {
+  const result = await fileToSerializableAttachment(
+    {
+      id: 'local-2',
+      kind: 'local',
+      file: new File([new Uint8Array([1, 2, 3])], 'image.png', { type: 'image/png' }),
+      previewUrl: 'blob:http://localhost/image',
+    },
+  )
+
+  assert.deepEqual(result, {
+    kind: 'local',
+    id: 'local-2',
+    name: 'image.png',
+    mimeType: 'image/png',
+    size: 3,
+    contentKind: 'blob',
+    base64: 'AQID',
+  })
+})

--- a/apps/gateway-admin/lib/chat/local-attachments.test.ts
+++ b/apps/gateway-admin/lib/chat/local-attachments.test.ts
@@ -38,7 +38,7 @@ test('validateLocalFiles rejects unsupported types, oversized files, and count o
   assert.equal(result.accepted.length, 0)
   assert.ok(result.errors.some((message) => message.includes('You can attach up to 5 files')))
   assert.ok(result.errors.some((message) => message.includes('archive.zip has unsupported type application/zip')))
-  assert.ok(result.errors.some((message) => message.includes('big.txt is larger than 2 MiB')))
+  assert.ok(result.errors.some((message) => message.includes('big.txt is larger than 48 KiB')))
 })
 
 test('fileToSerializableAttachment emits text resources for text files', async () => {
@@ -81,4 +81,19 @@ test('fileToSerializableAttachment emits base64 blob resources for binary files'
     contentKind: 'blob',
     base64: 'AQID',
   })
+})
+
+test('fileToSerializableAttachment normalizes json MIME casing before content selection', async () => {
+  const result = await fileToSerializableAttachment(
+    {
+      id: 'local-json',
+      kind: 'local',
+      file: file('data.json', 'Application/JSON', '{"ok":true}'),
+      previewUrl: null,
+    },
+  )
+
+  assert.equal(result.mimeType, 'application/json')
+  assert.equal(result.contentKind, 'text')
+  assert.equal(result.text, '{"ok":true}')
 })

--- a/apps/gateway-admin/lib/chat/local-attachments.ts
+++ b/apps/gateway-admin/lib/chat/local-attachments.ts
@@ -1,7 +1,8 @@
 import type { LocalAttachmentDraft, SerializableLocalAttachment } from '@/lib/fs/types'
 
 export const MAX_LOCAL_ATTACHMENTS = 5
-export const MAX_LOCAL_ATTACHMENT_BYTES = 2 * 1024 * 1024
+export const MAX_LOCAL_ATTACHMENT_BYTES = 48 * 1024
+export const MAX_LOCAL_ATTACHMENT_LABEL = '48 KiB'
 
 const ALLOWED_EXACT_TYPES = new Set([
   'application/json',
@@ -58,7 +59,7 @@ export function validateLocalFiles(
     }
 
     if (candidate.size > MAX_LOCAL_ATTACHMENT_BYTES) {
-      errors.push(`${candidate.name} is larger than 2 MiB.`)
+      errors.push(`${candidate.name} is larger than ${MAX_LOCAL_ATTACHMENT_LABEL}.`)
       continue
     }
 
@@ -83,7 +84,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 export async function fileToSerializableAttachment(
   attachment: LocalAttachmentDraft,
 ): Promise<SerializableLocalAttachment> {
-  const mimeType = attachment.file.type || 'application/octet-stream'
+  const mimeType = (attachment.file.type || 'application/octet-stream').trim().toLowerCase()
   const base = {
     kind: 'local' as const,
     id: attachment.id,
@@ -92,7 +93,7 @@ export async function fileToSerializableAttachment(
     size: attachment.file.size,
   }
 
-  if (mimeType.trim().toLowerCase().startsWith('text/') || mimeType === 'application/json') {
+  if (mimeType.startsWith('text/') || mimeType === 'application/json') {
     return {
       ...base,
       contentKind: 'text',

--- a/apps/gateway-admin/lib/chat/local-attachments.ts
+++ b/apps/gateway-admin/lib/chat/local-attachments.ts
@@ -1,0 +1,108 @@
+import type { LocalAttachmentDraft, SerializableLocalAttachment } from '@/lib/fs/types'
+
+export const MAX_LOCAL_ATTACHMENTS = 5
+export const MAX_LOCAL_ATTACHMENT_BYTES = 2 * 1024 * 1024
+
+const ALLOWED_EXACT_TYPES = new Set([
+  'application/json',
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+])
+
+export function isSupportedLocalAttachmentType(mimeType: string): boolean {
+  const normalized = mimeType.trim().toLowerCase()
+  return normalized.startsWith('text/') || ALLOWED_EXACT_TYPES.has(normalized)
+}
+
+export function localAttachmentId(file: File): string {
+  return `local-${file.name}-${file.size}-${file.lastModified}`
+}
+
+export function createLocalAttachmentDraft(file: File): LocalAttachmentDraft {
+  const mimeType = file.type.trim().toLowerCase()
+  const previewUrl = mimeType.startsWith('image/') ? URL.createObjectURL(file) : null
+  return {
+    kind: 'local',
+    id: localAttachmentId(file),
+    file,
+    previewUrl,
+  }
+}
+
+export function revokeLocalAttachmentPreview(attachment: LocalAttachmentDraft): void {
+  if (attachment.previewUrl) {
+    URL.revokeObjectURL(attachment.previewUrl)
+  }
+}
+
+export function validateLocalFiles(
+  incoming: File[],
+  existingLocalAttachments: readonly File[],
+): { accepted: File[]; errors: string[] } {
+  const errors: string[] = []
+  const remainingSlots = Math.max(0, MAX_LOCAL_ATTACHMENTS - existingLocalAttachments.length)
+
+  if (incoming.length > remainingSlots) {
+    errors.push(`You can attach up to ${MAX_LOCAL_ATTACHMENTS} files.`)
+  }
+
+  const accepted: File[] = []
+  for (const candidate of incoming) {
+    const mimeType = candidate.type || 'application/octet-stream'
+    if (!isSupportedLocalAttachmentType(mimeType)) {
+      errors.push(`${candidate.name} has unsupported type ${mimeType}.`)
+      continue
+    }
+
+    if (candidate.size > MAX_LOCAL_ATTACHMENT_BYTES) {
+      errors.push(`${candidate.name} is larger than 2 MiB.`)
+      continue
+    }
+
+    if (accepted.length < remainingSlots) {
+      accepted.push(candidate)
+    }
+  }
+
+  return { accepted, errors }
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = ''
+  const bytes = new Uint8Array(buffer)
+  const chunkSize = 0x8000
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+  }
+  return btoa(binary)
+}
+
+export async function fileToSerializableAttachment(
+  attachment: LocalAttachmentDraft,
+): Promise<SerializableLocalAttachment> {
+  const mimeType = attachment.file.type || 'application/octet-stream'
+  const base = {
+    kind: 'local' as const,
+    id: attachment.id,
+    name: attachment.file.name,
+    mimeType,
+    size: attachment.file.size,
+  }
+
+  if (mimeType.trim().toLowerCase().startsWith('text/') || mimeType === 'application/json') {
+    return {
+      ...base,
+      contentKind: 'text',
+      text: await attachment.file.text(),
+    }
+  }
+
+  return {
+    ...base,
+    contentKind: 'blob',
+    base64: arrayBufferToBase64(await attachment.file.arrayBuffer()),
+  }
+}

--- a/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
+++ b/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
@@ -4,7 +4,7 @@ import {
   errorMessageFromPayload,
 } from './acp-normalizers'
 import type { ACPAgent, ACPMessage, ACPRun } from '@/components/chat/types'
-import type { AttachmentRef } from '@/lib/fs/types'
+import type { PromptAttachmentRef } from '@/lib/fs/types'
 
 export const ACP_AGENT: ACPAgent = {
   id: 'codex',
@@ -121,7 +121,7 @@ export function resolveSelectedAgent(
 
 export type PromptPayload = {
   text: string
-  attachments: AttachmentRef[]
+  attachments: PromptAttachmentRef[]
 }
 
 export type SendPromptForSelectedProviderOptions = {

--- a/apps/gateway-admin/lib/fs/types.ts
+++ b/apps/gateway-admin/lib/fs/types.ts
@@ -29,11 +29,34 @@ export interface FsListResponse {
   truncated: boolean
 }
 
-/**
- * Attachment reference emitted by the chat input on submit.
- *
- * Intentionally narrow: only a filesystem path is carried. Google Drive
- * support is a future `{ kind: 'drive'; fileId; mimeType? }` variant
- * (deferred — see lab-f1t2 locked decisions).
- */
-export type AttachmentRef = { kind: 'file'; path: string }
+export type WorkspaceAttachmentRef = { kind: 'file'; path: string }
+
+export type LocalAttachmentDraft = {
+  kind: 'local'
+  id: string
+  file: File
+  previewUrl: string | null
+}
+
+export type SerializableLocalAttachment =
+  | {
+      kind: 'local'
+      id: string
+      name: string
+      mimeType: string
+      size: number
+      contentKind: 'text'
+      text: string
+    }
+  | {
+      kind: 'local'
+      id: string
+      name: string
+      mimeType: string
+      size: number
+      contentKind: 'blob'
+      base64: string
+    }
+
+export type PromptAttachmentRef = WorkspaceAttachmentRef | SerializableLocalAttachment
+export type AttachmentRef = WorkspaceAttachmentRef | LocalAttachmentDraft

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -25,7 +25,8 @@ use crate::dispatch::acp::persistence::SqliteAcpPersistence;
 use crate::dispatch::error::ToolError;
 
 use super::runtime::{
-    RuntimeHandle, launch_codex_runtime, normalize_provider_id, provider_healths,
+    PromptAttachment, PromptAttachmentContent, PromptInput, RuntimeHandle, launch_codex_runtime,
+    normalize_provider_id, provider_healths,
 };
 use super::types::{
     StartSessionInput, event_created_at, session_title_from_event, stamp_event_sequence,
@@ -407,6 +408,62 @@ impl AcpSessionRegistry {
         prompt: &str,
         principal: &str,
     ) -> Result<(), ToolError> {
+        self.prompt_session_input(
+            session_id,
+            PromptInput {
+                text: prompt.to_string(),
+                attachments: Vec::new(),
+            },
+            principal,
+        )
+        .await
+    }
+
+    pub async fn prompt_session_with_attachments(
+        &self,
+        session_id: &str,
+        prompt: &str,
+        attachments: Vec<crate::dispatch::acp::params::LocalPromptAttachment>,
+        principal: &str,
+    ) -> Result<(), ToolError> {
+        let runtime_attachments = attachments
+            .into_iter()
+            .map(|attachment| {
+                let content = match attachment.content {
+                    crate::dispatch::acp::params::LocalAttachmentContent::Text { text } => {
+                        PromptAttachmentContent::Text(text)
+                    }
+                    crate::dispatch::acp::params::LocalAttachmentContent::Blob { base64 } => {
+                        PromptAttachmentContent::Blob(base64)
+                    }
+                };
+                PromptAttachment {
+                    id: attachment.id,
+                    name: attachment.name,
+                    mime_type: attachment.mime_type,
+                    size: attachment.size,
+                    content,
+                }
+            })
+            .collect();
+
+        self.prompt_session_input(
+            session_id,
+            PromptInput {
+                text: prompt.to_string(),
+                attachments: runtime_attachments,
+            },
+            principal,
+        )
+        .await
+    }
+
+    async fn prompt_session_input(
+        &self,
+        session_id: &str,
+        prompt: PromptInput,
+        principal: &str,
+    ) -> Result<(), ToolError> {
         let session = self.get_session_arc(session_id).await?;
         Self::check_principal(&session, principal)?;
 
@@ -426,7 +483,7 @@ impl AcpSessionRegistry {
         {
             let mut summary = session.summary.write().await;
             if should_replace_prompt_title(&summary.title)
-                && let Some(title) = title_from_prompt(prompt)
+                && let Some(title) = title_from_prompt(&prompt.text)
             {
                 summary.title = title;
             }
@@ -441,7 +498,9 @@ impl AcpSessionRegistry {
 
         tracing::debug!(
             surface = "acp", service = "registry", action = "session.prompt",
-            session_id = %session_id, prompt_len = prompt.len(),
+            session_id = %session_id,
+            prompt_len = prompt.text.len(),
+            attachment_count = prompt.attachments.len(),
             "ACP session prompt dispatched",
         );
 
@@ -464,7 +523,7 @@ impl AcpSessionRegistry {
                 .ok_or_else(|| internal("ACP runtime unavailable"))?
         };
         runtime
-            .prompt(prompt.to_string())
+            .prompt_input(prompt)
             .await
             .map_err(session_command_error)?;
 

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 use std::{collections::HashMap, fmt};
 
 use agent_client_protocol::schema::{
-    BlobResourceContents, CancelNotification, ClientCapabilities, ConfigOptionUpdate,
-    ContentBlock, ContentChunk, CreateTerminalRequest, CurrentModeUpdate, EmbeddedResource,
+    BlobResourceContents, CancelNotification, ClientCapabilities, ConfigOptionUpdate, ContentBlock,
+    ContentChunk, CreateTerminalRequest, CurrentModeUpdate, EmbeddedResource,
     EmbeddedResourceResource, FileSystemCapabilities, Implementation, InitializeRequest,
     KillTerminalRequest, PermissionOption, PermissionOptionKind, PromptRequest, PromptResponse,
     ProtocolVersion, ReadTextFileRequest, ReleaseTerminalRequest, RequestPermissionOutcome,
@@ -185,10 +185,14 @@ fn prompt_input_to_content_blocks(input: &PromptInput) -> Vec<ContentBlock> {
     blocks.push(ContentBlock::Text(TextContent::new(input.text.clone())));
 
     for attachment in &input.attachments {
-        let uri = format!("file://local-attachment/{}", attachment.name);
+        let uri = format!(
+            "file://local-attachment/{}",
+            percent_encode_path_segment(&attachment.name)
+        );
         let resource = match &attachment.content {
             PromptAttachmentContent::Text(text) => EmbeddedResourceResource::TextResourceContents(
-                TextResourceContents::new(text.clone(), uri).mime_type(attachment.mime_type.clone()),
+                TextResourceContents::new(text.clone(), uri)
+                    .mime_type(attachment.mime_type.clone()),
             ),
             PromptAttachmentContent::Blob(base64) => {
                 EmbeddedResourceResource::BlobResourceContents(
@@ -201,6 +205,21 @@ fn prompt_input_to_content_blocks(input: &PromptInput) -> Vec<ContentBlock> {
     }
 
     blocks
+}
+
+fn percent_encode_path_segment(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => {
+                encoded.push(char::from(byte));
+            }
+            _ => {
+                encoded.push_str(&format!("%{byte:02X}"));
+            }
+        }
+    }
+    encoded
 }
 
 #[derive(Default)]
@@ -2296,6 +2315,14 @@ mod tests {
         AvailableCommandsUpdate, PermissionOptionId, TextContent, ToolCall, ToolCallUpdate,
         ToolCallUpdateFields,
     };
+
+    #[test]
+    fn percent_encode_path_segment_escapes_local_attachment_names() {
+        assert_eq!(
+            percent_encode_path_segment("../my notes#1.txt"),
+            "..%2Fmy%20notes%231.txt"
+        );
+    }
 
     #[test]
     fn launch_uses_structured_args_when_present() {

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -5,13 +5,14 @@ use std::time::{Duration, Instant};
 use std::{collections::HashMap, fmt};
 
 use agent_client_protocol::schema::{
-    CancelNotification, ClientCapabilities, ConfigOptionUpdate, ContentBlock, ContentChunk,
-    CreateTerminalRequest, CurrentModeUpdate, FileSystemCapabilities, Implementation,
-    InitializeRequest, KillTerminalRequest, PermissionOption, PermissionOptionKind,
+    BlobResourceContents, CancelNotification, ClientCapabilities, ConfigOptionUpdate,
+    ContentBlock, ContentChunk, CreateTerminalRequest, CurrentModeUpdate, EmbeddedResource,
+    EmbeddedResourceResource, FileSystemCapabilities, Implementation, InitializeRequest,
+    KillTerminalRequest, PermissionOption, PermissionOptionKind, PromptRequest, PromptResponse,
     ProtocolVersion, ReadTextFileRequest, ReleaseTerminalRequest, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
     SessionInfoUpdate, SessionNotification, SessionUpdate, StopReason, TerminalOutputRequest,
-    WaitForTerminalExitRequest, WriteTextFileRequest,
+    TextContent, TextResourceContents, WaitForTerminalExitRequest, WriteTextFileRequest,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, Dispatch, JsonRpcMessage, on_receive_request,
@@ -113,8 +114,16 @@ pub struct RuntimeHandle {
 
 impl RuntimeHandle {
     pub async fn prompt(&self, prompt: String) -> Result<(), String> {
+        self.prompt_input(PromptInput {
+            text: prompt,
+            attachments: Vec::new(),
+        })
+        .await
+    }
+
+    pub async fn prompt_input(&self, input: PromptInput) -> Result<(), String> {
         self.command_tx
-            .try_send(SessionCommand::Prompt(prompt))
+            .try_send(SessionCommand::Prompt(input))
             .map_err(session_command_send_error)
     }
 
@@ -138,8 +147,29 @@ impl RuntimeHandle {
     }
 }
 
+#[derive(Clone)]
+pub struct PromptAttachment {
+    pub id: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+    pub content: PromptAttachmentContent,
+}
+
+#[derive(Clone)]
+pub enum PromptAttachmentContent {
+    Text(String),
+    Blob(String),
+}
+
+#[derive(Clone)]
+pub struct PromptInput {
+    pub text: String,
+    pub attachments: Vec<PromptAttachment>,
+}
+
 enum SessionCommand {
-    Prompt(String),
+    Prompt(PromptInput),
     Cancel,
 }
 
@@ -148,6 +178,29 @@ fn session_command_send_error(error: mpsc::error::TrySendError<SessionCommand>) 
         mpsc::error::TrySendError::Full(_) => "ACP session command queue saturated".to_string(),
         mpsc::error::TrySendError::Closed(_) => "ACP session command channel closed".to_string(),
     }
+}
+
+fn prompt_input_to_content_blocks(input: &PromptInput) -> Vec<ContentBlock> {
+    let mut blocks = Vec::with_capacity(1 + input.attachments.len());
+    blocks.push(ContentBlock::Text(TextContent::new(input.text.clone())));
+
+    for attachment in &input.attachments {
+        let uri = format!("file://local-attachment/{}", attachment.name);
+        let resource = match &attachment.content {
+            PromptAttachmentContent::Text(text) => EmbeddedResourceResource::TextResourceContents(
+                TextResourceContents::new(text.clone(), uri).mime_type(attachment.mime_type.clone()),
+            ),
+            PromptAttachmentContent::Blob(base64) => {
+                EmbeddedResourceResource::BlobResourceContents(
+                    BlobResourceContents::new(base64.clone(), uri)
+                        .mime_type(attachment.mime_type.clone()),
+                )
+            }
+        };
+        blocks.push(ContentBlock::Resource(EmbeddedResource::new(resource)));
+    }
+
+    blocks
 }
 
 #[derive(Default)]
@@ -862,6 +915,20 @@ fn acp_permission_option_from_protocol(option: &PermissionOption) -> AcpPermissi
 fn resolve_provider_launch(provider: Option<&str>) -> Result<ProviderLaunch, String> {
     let provider_id = normalize_provider_id(provider);
     if provider_id == "codex-acp" {
+        if codex_launch_override()
+            .lock()
+            .expect("codex launch override poisoned")
+            .is_some()
+        {
+            let (command, args) = resolve_codex_launch();
+            return Ok(ProviderLaunch {
+                id: provider_id,
+                command,
+                args,
+                cwd: None,
+                env: std::collections::BTreeMap::new(),
+            });
+        }
         if let Some(entry) = read_providers()
             .map_err(|error| error.to_string())?
             .into_iter()
@@ -1388,14 +1455,30 @@ async fn run_codex_session(
                                             json!({
                                                 "type": "prompt_started",
                                                 "title": "Prompt started",
-                                                "text": prompt.clone(),
+                                                "text": prompt.text.clone(),
+                                                "attachment_count": prompt.attachments.len(),
                                             }),
                                         ))
                                         .await,
                                 );
 
+                                let (prompt_response_tx, prompt_response_rx) =
+                                    oneshot::channel::<Result<StopReason, String>>();
+                                let mut prompt_response_rx = Box::pin(prompt_response_rx);
+                                let blocks = prompt_input_to_content_blocks(&prompt);
                                 session
-                                    .send_prompt(prompt)
+                                    .connection()
+                                    .send_request_to(
+                                        Agent,
+                                        PromptRequest::new(session.session_id().clone(), blocks),
+                                    )
+                                    .on_receiving_result(async move |result| {
+                                        let stop_reason = result
+                                            .map(|PromptResponse { stop_reason, .. }| stop_reason)
+                                            .map_err(|error| error.to_string());
+                                        drop(prompt_response_tx.send(stop_reason));
+                                        Ok(())
+                                    })
                                     .map_err(|error| acp_internal_error(error.to_string()))?;
 
                                 let mut saw_assistant_output = false;
@@ -1404,6 +1487,12 @@ async fn run_codex_session(
                                 // before the next turn's prompt is dispatched.
                                 let mut ended_via_idle = false;
                                 loop {
+                                    enum PromptTurnMessage {
+                                        Provider(Result<agent_client_protocol::SessionMessage, agent_client_protocol::Error>),
+                                        Stop(Result<StopReason, String>),
+                                        Idle,
+                                    }
+
                                     let update = tokio::select! {
                                         // Prefer consuming a real update over the idle timeout.
                                         // Without `biased`, when both arms are ready simultaneously
@@ -1411,12 +1500,78 @@ async fn run_codex_session(
                                         // tokio picks randomly. A timeout win leaves StopReason
                                         // in the channel where it poisons the next turn's read loop.
                                         biased;
-                                        update = session.read_update() => Some(update),
-                                        () = tokio::time::sleep(acp_prompt_idle_timeout()), if saw_assistant_output => None,
+                                        stop_reason = &mut prompt_response_rx => {
+                                            PromptTurnMessage::Stop(
+                                                stop_reason.unwrap_or_else(|_| Err("prompt response channel closed".to_string())),
+                                            )
+                                        },
+                                        update = session.read_update() => PromptTurnMessage::Provider(update),
+                                        () = tokio::time::sleep(acp_prompt_idle_timeout()), if saw_assistant_output => PromptTurnMessage::Idle,
                                     };
                                     let update = match update {
-                                        Some(update) => update,
-                                        None => {
+                                        PromptTurnMessage::Provider(update) => update,
+                                        PromptTurnMessage::Stop(Ok(stop_reason)) => {
+                                            let stop_reason =
+                                                map_stop_reason(&stop_reason).to_string();
+                                            let state = if stop_reason == "cancelled" {
+                                                lab_apis::acp::types::AcpSessionState::Cancelled
+                                            } else {
+                                                lab_apis::acp::types::AcpSessionState::Completed
+                                            };
+                                            drop(
+                                                event_tx
+                                                    .send(session_state_event(
+                                                        session_id.clone(),
+                                                        state.clone(),
+                                                    ))
+                                                    .await,
+                                            );
+                                            drop(
+                                                event_tx
+                                                    .send(provider_info_event(
+                                                        session_id.clone(),
+                                                        &provider_id,
+                                                        json!({
+                                                            "type": "stop_reason",
+                                                            "title": "Prompt completed",
+                                                            "status": match state {
+                                                                lab_apis::acp::types::AcpSessionState::Cancelled => "cancelled",
+                                                                _ => "completed",
+                                                            },
+                                                            "stop_reason": stop_reason,
+                                                        }),
+                                                    ))
+                                                    .await,
+                                            );
+                                            prompt_lifecycle.finish();
+                                            break;
+                                        }
+                                        PromptTurnMessage::Stop(Err(error)) => {
+                                            drop(
+                                                event_tx
+                                                    .send(session_state_event(
+                                                        session_id.clone(),
+                                                        lab_apis::acp::types::AcpSessionState::Failed,
+                                                    ))
+                                                    .await,
+                                            );
+                                            drop(
+                                                event_tx
+                                                    .send(provider_info_event(
+                                                        session_id.clone(),
+                                                        &provider_id,
+                                                        json!({
+                                                            "type": "provider_error",
+                                                            "title": "Provider error",
+                                                            "text": error,
+                                                        }),
+                                                    ))
+                                                    .await,
+                                            );
+                                            prompt_lifecycle.finish();
+                                            break;
+                                        }
+                                        PromptTurnMessage::Idle => {
                                             drop(
                                                 event_tx
                                                     .send(session_state_event(
@@ -2934,7 +3089,10 @@ pub fn fake_handle_for_tests() -> (RuntimeHandle, mpsc::Receiver<AcpEvent>) {
 pub fn saturated_fake_handle_for_tests() -> (RuntimeHandle, mpsc::Receiver<AcpEvent>) {
     let (command_tx, command_rx) = mpsc::channel::<SessionCommand>(1);
     command_tx
-        .try_send(SessionCommand::Prompt("already queued".to_string()))
+        .try_send(SessionCommand::Prompt(PromptInput {
+            text: "already queued".to_string(),
+            attachments: Vec::new(),
+        }))
         .expect("prefill command queue");
     tokio::spawn(async move {
         let _command_rx = command_rx;

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -21,6 +21,9 @@ use crate::api::state::AppState;
 use crate::dispatch::acp::catalog::ACTIONS;
 use crate::dispatch::acp::dispatch::dispatch_with_registry;
 use crate::dispatch::acp::dispatch::validate_subscribe_ticket;
+use crate::dispatch::acp::params::{
+    PromptAttachmentParam, local_prompt_attachments, validate_prompt_attachments,
+};
 use crate::dispatch::error::ToolError;
 
 /// Hard cap on incoming prompt text (64 000 chars ≈ 16 000 tokens at 4 chars/token).
@@ -178,6 +181,7 @@ struct PromptBody {
     prompt: String,
     /// Optional structured page context. Passed to dispatch; injection is handled there.
     page_context: Option<PageContextBody>,
+    attachments: Option<Vec<PromptAttachmentParam>>,
 }
 
 async fn prompt_session(
@@ -210,6 +214,12 @@ async fn prompt_session(
         .into_response();
     }
 
+    let attachments = body.attachments.unwrap_or_default();
+    if let Err(error) = validate_prompt_attachments(&attachments) {
+        return error.into_response();
+    }
+    let local_attachments = local_prompt_attachments(&attachments);
+
     // Pass page_context as a JSON object to the dispatch layer.
     // All sanitization and prefix assembly happens there — HTTP handler is a thin shim.
     let page_context_value = body.page_context.as_ref().map(|ctx| {
@@ -224,6 +234,7 @@ async fn prompt_session(
         "session_id": session_id,
         "text": body.prompt.trim(),
         "page_context": page_context_value,
+        "attachments": local_attachments,
         "principal": principal,
     });
     match dispatch_with_registry(&state.acp_registry, "session.prompt", params).await {

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -22,7 +22,7 @@ use crate::dispatch::acp::catalog::ACTIONS;
 use crate::dispatch::acp::dispatch::dispatch_with_registry;
 use crate::dispatch::acp::dispatch::validate_subscribe_ticket;
 use crate::dispatch::acp::params::{
-    PromptAttachmentParam, local_prompt_attachments, validate_prompt_attachments,
+    PromptAttachmentParam, into_local_prompt_attachments, validate_prompt_attachments,
 };
 use crate::dispatch::error::ToolError;
 
@@ -218,7 +218,7 @@ async fn prompt_session(
     if let Err(error) = validate_prompt_attachments(&attachments) {
         return error.into_response();
     }
-    let local_attachments = local_prompt_attachments(&attachments);
+    let local_attachments = into_local_prompt_attachments(attachments);
 
     // Pass page_context as a JSON object to the dispatch layer.
     // All sanitization and prefix assembly happens there — HTTP handler is a thin shim.

--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -20,6 +20,7 @@ use super::params::{
 /// SSE ticket lifetime in seconds.
 const TICKET_TTL_SECS: u64 = 30;
 const MAX_ACP_PARAMS_BYTES: usize = 64 * 1024;
+const MAX_ACP_PROMPT_PARAMS_BYTES: usize = 384 * 1024;
 const MAX_ACP_PROMPT_BYTES: usize = 32 * 1024;
 
 fn require_confirm(params: &Value, action: &str) -> Result<(), ToolError> {
@@ -36,16 +37,14 @@ fn require_confirm(params: &Value, action: &str) -> Result<(), ToolError> {
     }
 }
 
-fn ensure_params_size(params: &Value) -> Result<(), ToolError> {
+fn ensure_params_size(params: &Value, max_bytes: usize) -> Result<(), ToolError> {
     let size = serde_json::to_vec(params)
         .map(|bytes| bytes.len())
         .unwrap_or(usize::MAX);
-    if size > MAX_ACP_PARAMS_BYTES {
+    if size > max_bytes {
         return Err(ToolError::Sdk {
             sdk_kind: "content_too_large".to_string(),
-            message: format!(
-                "ACP params exceed {MAX_ACP_PARAMS_BYTES} bytes (received {size} bytes)"
-            ),
+            message: format!("ACP params exceed {max_bytes} bytes (received {size} bytes)"),
         });
     }
     Ok(())
@@ -115,9 +114,12 @@ pub async fn dispatch_with_registry(
     action: &str,
     params: Value,
 ) -> Result<Value, ToolError> {
-    if action != "session.prompt" {
-        ensure_params_size(&params)?;
-    }
+    let max_params_bytes = if action == "session.prompt" {
+        MAX_ACP_PROMPT_PARAMS_BYTES
+    } else {
+        MAX_ACP_PARAMS_BYTES
+    };
+    ensure_params_size(&params, max_params_bytes)?;
 
     match action {
         "help" => Ok(help_payload("acp", ACTIONS)),
@@ -514,6 +516,27 @@ mod tests {
         )
         .await
         .expect_err("oversized params must be rejected");
+
+        assert_eq!(err.kind(), "content_too_large");
+    }
+
+    #[tokio::test]
+    async fn session_prompt_rejects_oversized_prompt_params() {
+        let registry = AcpSessionRegistry::new_for_tests(Duration::from_millis(100));
+        let oversized = "x".repeat(MAX_ACP_PROMPT_PARAMS_BYTES + 1);
+
+        let err = dispatch_with_registry(
+            &registry,
+            "session.prompt",
+            json!({
+                "session_id": "sess-over-limit",
+                "principal": "alice",
+                "text": "hello",
+                "padding": oversized,
+            }),
+        )
+        .await
+        .expect_err("oversized session.prompt params must be rejected");
 
         assert_eq!(err.kind(), "content_too_large");
     }

--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -13,7 +13,9 @@ use crate::dispatch::helpers::{action_schema, help_payload, to_json};
 use super::catalog::ACTIONS;
 use super::client::require_registry;
 use super::page_context::{PageContextInput, build_prompt_with_context};
-use super::params::{opt_str, opt_u64, require_str};
+use super::params::{
+    LocalPromptAttachment, opt_str, opt_u64, require_str, validate_local_attachments,
+};
 
 /// SSE ticket lifetime in seconds.
 const TICKET_TTL_SECS: u64 = 30;
@@ -113,7 +115,9 @@ pub async fn dispatch_with_registry(
     action: &str,
     params: Value,
 ) -> Result<Value, ToolError> {
-    ensure_params_size(&params)?;
+    if action != "session.prompt" {
+        ensure_params_size(&params)?;
+    }
 
     match action {
         "help" => Ok(help_payload("acp", ACTIONS)),
@@ -251,8 +255,25 @@ pub async fn dispatch_with_registry(
             let effective_text = build_prompt_with_context(session_id, raw_text, page_ctx.as_ref());
             ensure_prompt_size(&effective_text)?;
 
+            let attachments: Vec<LocalPromptAttachment> = params
+                .get("attachments")
+                .cloned()
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(|error| ToolError::InvalidParam {
+                    message: format!("invalid attachments payload: {error}"),
+                    param: "attachments".into(),
+                })?
+                .unwrap_or_default();
+            validate_local_attachments(&attachments)?;
+
             registry
-                .prompt_session(session_id, &effective_text, principal)
+                .prompt_session_with_attachments(
+                    session_id,
+                    &effective_text,
+                    attachments,
+                    principal,
+                )
                 .await?;
             to_json(json!({ "ok": true, "session_id": session_id }))
         }

--- a/crates/lab/src/dispatch/acp/params.rs
+++ b/crates/lab/src/dispatch/acp/params.rs
@@ -6,10 +6,127 @@
 //! ACP's contract. These wrappers preserve the empty-as-missing behavior on
 //! top of the shared helpers.
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::dispatch::error::ToolError;
 use crate::dispatch::helpers;
+
+pub const MAX_LOCAL_ATTACHMENTS: usize = 5;
+pub const MAX_LOCAL_ATTACHMENT_BYTES: u64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "contentKind")]
+pub enum LocalAttachmentContent {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "blob")]
+    Blob { base64: String },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalPromptAttachment {
+    pub id: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+    #[serde(flatten)]
+    pub content: LocalAttachmentContent,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum PromptAttachmentParam {
+    #[serde(rename = "local")]
+    Local {
+        id: String,
+        name: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+        size: u64,
+        #[serde(flatten)]
+        content: LocalAttachmentContent,
+    },
+    #[serde(rename = "file")]
+    File { path: String },
+}
+
+pub fn local_prompt_attachments(
+    attachments: &[PromptAttachmentParam],
+) -> Vec<LocalPromptAttachment> {
+    attachments
+        .iter()
+        .filter_map(|attachment| match attachment {
+            PromptAttachmentParam::Local {
+                id,
+                name,
+                mime_type,
+                size,
+                content,
+            } => Some(LocalPromptAttachment {
+                id: id.clone(),
+                name: name.clone(),
+                mime_type: mime_type.clone(),
+                size: *size,
+                content: content.clone(),
+            }),
+            PromptAttachmentParam::File { .. } => None,
+        })
+        .collect()
+}
+
+pub fn validate_prompt_attachments(
+    attachments: &[PromptAttachmentParam],
+) -> Result<(), ToolError> {
+    let local = local_prompt_attachments(attachments);
+    validate_local_attachments(&local)
+}
+
+pub fn validate_local_attachments(
+    attachments: &[LocalPromptAttachment],
+) -> Result<(), ToolError> {
+    if attachments.len() > MAX_LOCAL_ATTACHMENTS {
+        return Err(ToolError::InvalidParam {
+            message: format!("at most {MAX_LOCAL_ATTACHMENTS} attachments are allowed"),
+            param: "attachments".into(),
+        });
+    }
+
+    for attachment in attachments {
+        if attachment.size > MAX_LOCAL_ATTACHMENT_BYTES {
+            return Err(ToolError::InvalidParam {
+                message: format!("attachment `{}` exceeds the 2 MiB limit", attachment.name),
+                param: "attachments".into(),
+            });
+        }
+        if !is_supported_attachment_mime(&attachment.mime_type) {
+            return Err(ToolError::InvalidParam {
+                message: format!(
+                    "attachment `{}` has unsupported type `{}`",
+                    attachment.name, attachment.mime_type
+                ),
+                param: "attachments".into(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub fn is_supported_attachment_mime(mime_type: &str) -> bool {
+    let normalized = mime_type.trim().to_ascii_lowercase();
+    normalized.starts_with("text/")
+        || matches!(
+            normalized.as_str(),
+            "application/json"
+                | "application/pdf"
+                | "image/png"
+                | "image/jpeg"
+                | "image/gif"
+                | "image/webp"
+        )
+}
 
 /// Extract a required string param. Returns `MissingParam` if absent, null, or empty.
 pub fn require_str<'a>(params: &'a Value, name: &str) -> Result<&'a str, ToolError> {

--- a/crates/lab/src/dispatch/acp/params.rs
+++ b/crates/lab/src/dispatch/acp/params.rs
@@ -11,9 +11,11 @@ use serde_json::Value;
 
 use crate::dispatch::error::ToolError;
 use crate::dispatch::helpers;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
 
 pub const MAX_LOCAL_ATTACHMENTS: usize = 5;
-pub const MAX_LOCAL_ATTACHMENT_BYTES: u64 = 2 * 1024 * 1024;
+pub const MAX_LOCAL_ATTACHMENT_BYTES: u64 = 48 * 1024;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", tag = "contentKind")]
@@ -76,16 +78,36 @@ pub fn local_prompt_attachments(
         .collect()
 }
 
-pub fn validate_prompt_attachments(
-    attachments: &[PromptAttachmentParam],
-) -> Result<(), ToolError> {
+pub fn into_local_prompt_attachments(
+    attachments: Vec<PromptAttachmentParam>,
+) -> Vec<LocalPromptAttachment> {
+    attachments
+        .into_iter()
+        .filter_map(|attachment| match attachment {
+            PromptAttachmentParam::Local {
+                id,
+                name,
+                mime_type,
+                size,
+                content,
+            } => Some(LocalPromptAttachment {
+                id,
+                name,
+                mime_type,
+                size,
+                content,
+            }),
+            PromptAttachmentParam::File { .. } => None,
+        })
+        .collect()
+}
+
+pub fn validate_prompt_attachments(attachments: &[PromptAttachmentParam]) -> Result<(), ToolError> {
     let local = local_prompt_attachments(attachments);
     validate_local_attachments(&local)
 }
 
-pub fn validate_local_attachments(
-    attachments: &[LocalPromptAttachment],
-) -> Result<(), ToolError> {
+pub fn validate_local_attachments(attachments: &[LocalPromptAttachment]) -> Result<(), ToolError> {
     if attachments.len() > MAX_LOCAL_ATTACHMENTS {
         return Err(ToolError::InvalidParam {
             message: format!("at most {MAX_LOCAL_ATTACHMENTS} attachments are allowed"),
@@ -94,9 +116,34 @@ pub fn validate_local_attachments(
     }
 
     for attachment in attachments {
+        let actual_size = attachment_content_size(attachment)?;
         if attachment.size > MAX_LOCAL_ATTACHMENT_BYTES {
             return Err(ToolError::InvalidParam {
-                message: format!("attachment `{}` exceeds the 2 MiB limit", attachment.name),
+                message: format!("attachment `{}` exceeds the 48 KiB limit", attachment.name),
+                param: "attachments".into(),
+            });
+        }
+        if actual_size > MAX_LOCAL_ATTACHMENT_BYTES {
+            return Err(ToolError::InvalidParam {
+                message: format!(
+                    "attachment `{}` content exceeds the 48 KiB limit",
+                    attachment.name
+                ),
+                param: "attachments".into(),
+            });
+        }
+        if attachment.size != actual_size {
+            return Err(ToolError::InvalidParam {
+                message: format!(
+                    "attachment `{}` declared size {} does not match content size {}",
+                    attachment.name, attachment.size, actual_size
+                ),
+                param: "attachments".into(),
+            });
+        }
+        if !is_safe_attachment_name(&attachment.name) {
+            return Err(ToolError::InvalidParam {
+                message: format!("attachment `{}` has an unsafe name", attachment.name),
                 param: "attachments".into(),
             });
         }
@@ -112,6 +159,41 @@ pub fn validate_local_attachments(
     }
 
     Ok(())
+}
+
+fn attachment_content_size(attachment: &LocalPromptAttachment) -> Result<u64, ToolError> {
+    match &attachment.content {
+        LocalAttachmentContent::Text { text } => Ok(text.len() as u64),
+        LocalAttachmentContent::Blob { base64 } => {
+            let encoded_limit = MAX_LOCAL_ATTACHMENT_BYTES.div_ceil(3) * 4;
+            if base64.len() as u64 > encoded_limit {
+                return Err(ToolError::InvalidParam {
+                    message: format!(
+                        "attachment `{}` base64 content exceeds the 48 KiB limit",
+                        attachment.name
+                    ),
+                    param: "attachments".into(),
+                });
+            }
+            B64.decode(base64)
+                .map(|bytes| bytes.len() as u64)
+                .map_err(|error| ToolError::InvalidParam {
+                    message: format!(
+                        "attachment `{}` has invalid base64 content: {error}",
+                        attachment.name
+                    ),
+                    param: "attachments".into(),
+                })
+        }
+    }
+}
+
+fn is_safe_attachment_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains("..")
+        && !name.chars().any(char::is_control)
 }
 
 pub fn is_supported_attachment_mime(mime_type: &str) -> bool {
@@ -156,5 +238,65 @@ pub fn opt_u64(params: &Value, name: &str) -> Result<Option<u64>, ToolError> {
             message: format!("`{name}` must be a non-negative integer"),
             param: name.to_string(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_attachment(size: u64, text: &str) -> LocalPromptAttachment {
+        LocalPromptAttachment {
+            id: "local-1".to_string(),
+            name: "notes.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            size,
+            content: LocalAttachmentContent::Text {
+                text: text.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_local_attachments_rejects_declared_size_mismatch() {
+        let err = validate_local_attachments(&[text_attachment(1, "hello")])
+            .expect_err("size mismatch should be rejected");
+
+        assert_eq!(err.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn validate_local_attachments_rejects_oversized_actual_text() {
+        let text = "x".repeat(MAX_LOCAL_ATTACHMENT_BYTES as usize + 1);
+        let err = validate_local_attachments(&[text_attachment(text.len() as u64, &text)])
+            .expect_err("oversized content should be rejected");
+
+        assert_eq!(err.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn validate_local_attachments_rejects_unsafe_names() {
+        let mut attachment = text_attachment(5, "hello");
+        attachment.name = "../notes.txt".to_string();
+
+        let err = validate_local_attachments(&[attachment])
+            .expect_err("unsafe attachment name should be rejected");
+
+        assert_eq!(err.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn validate_local_attachments_checks_decoded_blob_size() {
+        let attachment = LocalPromptAttachment {
+            id: "local-1".to_string(),
+            name: "image.png".to_string(),
+            mime_type: "image/png".to_string(),
+            size: 3,
+            content: LocalAttachmentContent::Blob {
+                base64: "AQID".to_string(),
+            },
+        };
+
+        validate_local_attachments(&[attachment]).expect("valid decoded blob");
     }
 }

--- a/crates/lab/tests/acp_backend_contract.rs
+++ b/crates/lab/tests/acp_backend_contract.rs
@@ -62,6 +62,9 @@ import os
 import sys
 
 session_id = f"stub-session-{os.getpid()}"
+capture_path = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("LAB_ACP_FAKE_PROMPT_CAPTURE")
+if capture_path:
+    open(capture_path, "a", encoding="utf-8").close()
 
 for raw in sys.stdin:
     raw = raw.strip()
@@ -89,6 +92,9 @@ for raw in sys.stdin:
         result = {"sessionId": session_id, "configOptions": []}
         print(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}), flush=True)
     elif method == "session/prompt":
+        if capture_path:
+            with open(capture_path, "a", encoding="utf-8") as out:
+                out.write(json.dumps(params.get("prompt", [])) + "\n")
         print(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": {}}), flush=True)
     elif req_id is not None:
         error = {"code": -32601, "message": "method not found"}
@@ -108,6 +114,31 @@ fn install_fake_provider() -> LaunchGuard {
         vec!["-u".to_string(), script_path.display().to_string()],
     );
     LaunchGuard
+}
+
+fn install_fake_provider_with_prompt_capture(capture: &std::path::Path) -> LaunchGuard {
+    let script_path = write_fake_provider_script();
+    let python = choose_python_command();
+    set_codex_launch_override_for_tests(
+        Some(python),
+        vec![
+            "-u".to_string(),
+            script_path.display().to_string(),
+            capture.display().to_string(),
+        ],
+    );
+    LaunchGuard
+}
+
+fn prompt_capture_path(name: &str) -> PathBuf {
+    let root = std::env::current_dir().expect("workspace cwd");
+    let dir = root.join("target/test-artifacts");
+    std::fs::create_dir_all(&dir).expect("create test artifact dir");
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    dir.join(format!("{name}-{unique}.jsonl"))
 }
 
 async fn create_owned_session(registry: &AcpSessionRegistry, principal: &str) -> String {
@@ -132,6 +163,27 @@ async fn json_body(response: axum::response::Response) -> Value {
         .await
         .expect("response bytes");
     serde_json::from_slice(&bytes).expect("json body")
+}
+
+async fn response_body_text(response: axum::response::Response) -> (StatusCode, String) {
+    let status = response.status();
+    let bytes = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response bytes");
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn read_prompt_capture(path: &std::path::Path) -> Vec<Value> {
+    for _ in 0..100 {
+        if path.metadata().map(|meta| meta.len() > 0).unwrap_or(false) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let raw = std::fs::read_to_string(path).expect("read prompt capture");
+    raw.lines()
+        .map(|line| serde_json::from_str(line).expect("captured prompt json"))
+        .collect()
 }
 
 fn acp_test_app() -> (Router, Arc<AcpSessionRegistry>) {
@@ -528,6 +580,137 @@ async fn http_acp_action_route_returns_shared_error_envelopes() {
     );
     let missing_confirmation_json = json_body(missing_confirmation).await;
     assert_eq!(missing_confirmation_json["kind"], "confirmation_required");
+}
+
+#[tokio::test]
+async fn acp_prompt_accepts_local_text_attachment_as_embedded_resource() {
+    let _guard = test_lock().lock().await;
+    let capture = prompt_capture_path("acp-local-text-attachment");
+    let _launch = install_fake_provider_with_prompt_capture(&capture);
+    let (app, registry) = acp_test_app();
+    let session_id = create_owned_session(&registry, "static-bearer").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/acp/sessions/{session_id}/prompt"))
+                .header(header::AUTHORIZATION, "Bearer secret-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "prompt": "Summarize",
+                        "attachments": [{
+                            "kind": "local",
+                            "id": "local-notes",
+                            "name": "notes.txt",
+                            "mimeType": "text/plain",
+                            "size": 11,
+                            "contentKind": "text",
+                            "text": "hello world"
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = json_body(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["ok"], true);
+
+    let captured = read_prompt_capture(&capture);
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0][0]["type"], "text");
+    assert_eq!(captured[0][0]["text"], "Summarize");
+    assert_eq!(captured[0][1]["type"], "resource");
+    assert_eq!(
+        captured[0][1]["resource"]["uri"],
+        "file://local-attachment/notes.txt"
+    );
+    assert_eq!(captured[0][1]["resource"]["mimeType"], "text/plain");
+    assert_eq!(captured[0][1]["resource"]["text"], "hello world");
+}
+
+#[tokio::test]
+async fn acp_prompt_preserves_workspace_attachment_noop_behavior() {
+    let _guard = test_lock().lock().await;
+    let capture = prompt_capture_path("acp-workspace-attachment");
+    let _launch = install_fake_provider_with_prompt_capture(&capture);
+    let (app, registry) = acp_test_app();
+    let session_id = create_owned_session(&registry, "static-bearer").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/acp/sessions/{session_id}/prompt"))
+                .header(header::AUTHORIZATION, "Bearer secret-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "prompt": "Summarize",
+                        "attachments": [{
+                            "kind": "file",
+                            "path": "/tmp/a.txt"
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let (status, body) = response_body_text(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let captured = read_prompt_capture(&capture);
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].as_array().expect("prompt blocks").len(), 1);
+    assert_eq!(captured[0][0]["text"], "Summarize");
+}
+
+#[tokio::test]
+async fn acp_prompt_rejects_oversized_local_attachment_metadata() {
+    let _guard = test_lock().lock().await;
+    let _launch = install_fake_provider();
+    let (app, registry) = acp_test_app();
+    let session_id = create_owned_session(&registry, "alice").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/acp/sessions/{session_id}/prompt"))
+                .header(header::AUTHORIZATION, "Bearer secret-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "prompt": "Summarize",
+                        "attachments": [{
+                            "kind": "local",
+                            "id": "local-big",
+                            "name": "big.txt",
+                            "mimeType": "text/plain",
+                            "size": 2_097_153,
+                            "contentKind": "text",
+                            "text": "too big"
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = json_body(response).await;
+    assert_eq!(body["kind"], "invalid_param");
+    assert_eq!(body["param"], "attachments");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add local attachment validation, preview/removal UI, and serialization in the chat input
- send local attachments through the gateway-admin ACP prompt request without dropping prompt text
- map local text/blob attachments into ACP embedded resource blocks on the Rust backend

## Tests
- `pnpm exec tsx --test components/chat/chat-shell.test.tsx lib/chat/local-attachments.test.ts` (16/16 passing)
- `pnpm exec node --test --experimental-strip-types lib/browser/chat-shell.browser.test.ts` (4/4 passing, includes attach/remove/send browser coverage with mocked ACP endpoints)
- `cargo test --manifest-path crates/lab/Cargo.toml --test acp_backend_contract` (10/10 passing)
- `cargo test --manifest-path crates/lab/Cargo.toml acp --lib` (85/85 passing)
- `NEXT_PUBLIC_MOCK_DATA=true pnpm run build` (passing)

## Agent-browser verification
- served the built app locally with `python3 -m http.server 3132 -d out`
- opened `http://127.0.0.1:3132/chat/` using `agent-browser 0.26.0`
- verified the real chat page exposes `Attach local file`, `Local file picker`, message input, and send controls in the accessibility snapshot
- limitation: static mock preview leaves the provider/session disabled, so live attach/remove/send behavior is verified by the Playwright browser test with mocked ACP routes rather than direct agent-browser file selection

## Notes
- `.env`, `config.toml`, ignored plan files, generated `out/`, and node modules were not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add local file attachments to chat. Users can pick files, preview/remove them, and send them with their message; the backend embeds them in ACP prompts as resources and strictly validates payloads.

- New Features
  - Chat input: local file picker with image previews, removal, and error UI. Object URLs are revoked on remove/unmount.
  - Validation: max 5 files, max 48 KiB each. Allowed types: text/*, `application/json`, `application/pdf`, `image/png|jpeg|gif|webp`. Shows the first error.
  - Serialization: local files are sent with the prompt as either text or base64 blob. Workspace file attachments continue to work unchanged.
  - Backend (`crates/lab`): prompt API accepts `attachments`, validates count/size/MIME, safe names, and actual vs declared size (including base64 decode). Caps `session.prompt` param size. Maps local files to ACP embedded resources (text/blob) without dropping prompt text; resource URIs are percent-encoded. Contract and browser tests cover acceptance, rejection, and attach/remove/send flows.

<sup>Written for commit 4fdb40c1f433d139f09ddd2b0ac6194cc3ae6bbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

