### PR TITLE
Support adapter-specific chat model selection

### DIFF
--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -6,7 +6,7 @@ import { Send, Paperclip, Wrench, ChevronDown, X, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { ACPAgent } from './types'
+import type { ACPAgent, ACPModelOption } from './types'
 import type { AttachmentRef } from '@/lib/fs/types'
 import { isInlineImageMime, previewWorkspaceFile } from '@/lib/fs/client'
 import { WorkspacePicker } from './workspace-picker'
@@ -24,6 +24,9 @@ interface ChatInputProps {
   selectedAgent: ACPAgent | null
   agents: ACPAgent[]
   onSelectAgent: (agentId: string) => void
+  selectedModel: ACPModelOption | null
+  modelOptions: ACPModelOption[]
+  onSelectModel: (modelId: string) => void
 }
 
 export function ChatInput({
@@ -33,10 +36,14 @@ export function ChatInput({
   selectedAgent,
   agents,
   onSelectAgent,
+  selectedModel,
+  modelOptions,
+  onSelectModel,
 }: ChatInputProps) {
   const [value, setValue] = React.useState('')
   const [sending, setSending] = React.useState(false)
   const [agentPickerOpen, setAgentPickerOpen] = React.useState(false)
+  const [modelPickerOpen, setModelPickerOpen] = React.useState(false)
   const [attachments, setAttachments] = React.useState<AttachmentRef[]>([])
   const [workspacePickerOpen, setWorkspacePickerOpen] = React.useState(false)
   // Synchronous send-lock: state updates batch across a render tick, so a fast
@@ -48,10 +55,16 @@ export function ChatInput({
   const pickerRef = React.useRef<HTMLDivElement>(null)
   const triggerRef = React.useRef<HTMLButtonElement>(null)
   const optionRefs = React.useRef<Array<HTMLButtonElement | null>>([])
+  const modelPickerRef = React.useRef<HTMLDivElement>(null)
+  const modelTriggerRef = React.useRef<HTMLButtonElement>(null)
+  const modelOptionRefs = React.useRef<Array<HTMLButtonElement | null>>([])
   const [activeAgentIndex, setActiveAgentIndex] = React.useState(0)
+  const [activeModelIndex, setActiveModelIndex] = React.useState(0)
   const pickerId = React.useId()
+  const modelPickerId = React.useId()
 
   optionRefs.current.length = agents.length
+  modelOptionRefs.current.length = modelOptions.length
 
   const hasContent = value.trim().length > 0 || attachments.length > 0
 
@@ -129,6 +142,29 @@ export function ChatInput({
     }
   }, [agentPickerOpen, agents, selectedAgent?.id])
 
+  React.useEffect(() => {
+    if (!modelPickerOpen) return
+
+    const selectedIndex = Math.max(modelOptions.findIndex((model) => model.id === selectedModel?.id), 0)
+    setActiveModelIndex(selectedIndex)
+    const frame = window.requestAnimationFrame(() => {
+      modelOptionRefs.current[selectedIndex]?.focus()
+    })
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!modelPickerRef.current?.contains(event.target as Node)) {
+        setModelPickerOpen(false)
+        modelTriggerRef.current?.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    return () => {
+      window.cancelAnimationFrame(frame)
+      document.removeEventListener('mousedown', handlePointerDown)
+    }
+  }, [modelPickerOpen, modelOptions, selectedModel?.id])
+
   const selectAgent = (agentId: string) => {
     onSelectAgent(agentId)
     setAgentPickerOpen(false)
@@ -177,6 +213,57 @@ export function ChatInput({
     } else if ((event.key === 'Enter' || event.key === ' ') && agents[activeAgentIndex]) {
       event.preventDefault()
       selectAgent(agents[activeAgentIndex].id)
+    }
+  }
+
+  const selectModel = (modelId: string) => {
+    onSelectModel(modelId)
+    setModelPickerOpen(false)
+    modelTriggerRef.current?.focus()
+  }
+
+  const handleModelTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      if (modelOptions.length > 1) setModelPickerOpen(true)
+    }
+  }
+
+  const handleModelListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setModelPickerOpen(false)
+      modelTriggerRef.current?.focus()
+      return
+    }
+
+    if (event.key === 'Tab') {
+      setModelPickerOpen(false)
+      return
+    }
+
+    if (modelOptions.length === 0) return
+
+    const moveTo = (nextIndex: number) => {
+      setActiveModelIndex(nextIndex)
+      modelOptionRefs.current[nextIndex]?.focus()
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      moveTo((activeModelIndex + 1) % modelOptions.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      moveTo((activeModelIndex - 1 + modelOptions.length) % modelOptions.length)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      moveTo(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      moveTo(modelOptions.length - 1)
+    } else if ((event.key === 'Enter' || event.key === ' ') && modelOptions[activeModelIndex]) {
+      event.preventDefault()
+      selectModel(modelOptions[activeModelIndex].id)
     }
   }
 
@@ -255,6 +342,69 @@ export function ChatInput({
           </TooltipProvider>
 
           <div className="ml-auto flex min-w-0 items-center gap-1.5">
+            {modelOptions.length > 0 && (
+              <div ref={modelPickerRef} className="relative min-w-0">
+                <button
+                  ref={modelTriggerRef}
+                  type="button"
+                  onClick={() => modelOptions.length > 1 && setModelPickerOpen((open) => !open)}
+                  onKeyDown={handleModelTriggerKeyDown}
+                  aria-label={selectedModel ? `Selected model: ${selectedModel.name}` : 'Select model'}
+                  aria-haspopup="listbox"
+                  aria-expanded={modelPickerOpen}
+                  aria-controls={modelPickerId}
+                  disabled={disabled || sending || modelOptions.length <= 1}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-full border border-aurora-border-default',
+                    'max-w-[8.5rem] bg-aurora-panel-medium px-2.5 py-1 text-[11px] font-medium text-aurora-text-muted sm:max-w-[12rem]',
+                    'transition-colors hover:border-aurora-border-strong hover:text-aurora-text-primary',
+                    (disabled || sending || modelOptions.length <= 1) && 'opacity-80 hover:border-aurora-border-default',
+                  )}
+                >
+                  <span className="truncate">{selectedModel?.name ?? modelOptions[0]?.name ?? 'Model'}</span>
+                  {modelOptions.length > 1 && <ChevronDown className="size-3 shrink-0" />}
+                </button>
+
+                {modelPickerOpen && (
+                  <div
+                    id={modelPickerId}
+                    role="listbox"
+                    aria-label="Model picker"
+                    aria-activedescendant={modelOptions[activeModelIndex] ? `${modelPickerId}-${modelOptions[activeModelIndex].id}` : undefined}
+                    onKeyDown={handleModelListKeyDown}
+                    className={cn(
+                      'absolute bottom-full right-0 z-50 mb-1.5 min-w-[180px] overflow-hidden',
+                      'rounded-aurora-2 border border-aurora-border-strong bg-aurora-panel-strong',
+                      'shadow-[var(--aurora-shadow-strong),var(--aurora-highlight-strong)]',
+                    )}
+                  >
+                    {modelOptions.map((model, index) => (
+                      <button
+                        key={model.id}
+                        id={`${modelPickerId}-${model.id}`}
+                        ref={(node) => {
+                          modelOptionRefs.current[index] = node
+                        }}
+                        type="button"
+                        role="option"
+                        aria-selected={selectedModel?.id === model.id}
+                        tabIndex={index === activeModelIndex ? 0 : -1}
+                        onFocus={() => setActiveModelIndex(index)}
+                        onClick={() => selectModel(model.id)}
+                        className={cn(
+                          'flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-colors hover:bg-aurora-hover-bg',
+                          selectedModel?.id === model.id && 'bg-aurora-panel-medium',
+                        )}
+                      >
+                        <span className="text-[13px] font-medium text-aurora-text-primary">{model.name}</span>
+                        {model.description && <span className="text-[11px] text-aurora-text-muted">{model.description}</span>}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
             <div ref={pickerRef} className="relative min-w-0">
             <button
               ref={triggerRef}

--- a/apps/gateway-admin/components/chat/chat-shell.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.test.tsx
@@ -7,6 +7,7 @@ import {
   integrateCreatedRun,
   providerDisplayName,
   resolveSelectedAgent,
+  resolveSelectedModel,
   sendPromptForSelectedProvider,
   sessionCreationOptionsForIntent,
   shouldAutoCreateInitialRun,
@@ -114,6 +115,59 @@ test('resolveSelectedAgent prefers the selected provider over the selected run',
   assert.equal(selected.name, 'claude-acp')
 })
 
+test('normalizes adapter-scoped model options and selected run model', () => {
+  const agentsWithModels: ACPAgent[] = [
+    {
+      id: 'codex-acp',
+      name: 'Codex ACP',
+      description: 'codex-acp over local ACP bridge',
+      version: 'live',
+      capabilities: [],
+      models: [
+        { id: 'gpt-5', name: 'GPT-5' },
+        { id: 'gpt-5-mini', name: 'GPT-5 Mini' },
+      ],
+      defaultModelId: 'gpt-5',
+      currentModelId: 'gpt-5-mini',
+    },
+  ]
+
+  const selected = resolveSelectedAgent(agentsWithModels, 'codex-acp', {
+    ...run('run-codex'),
+    provider: 'codex-acp',
+    modelId: 'gpt-5-mini',
+    modelName: 'GPT-5 Mini',
+  })
+
+  assert.equal(selected.id, 'codex-acp')
+  assert.equal(selected.models?.length, 2)
+  assert.equal(selected.currentModelId, 'gpt-5-mini')
+})
+
+test('resolveSelectedModel clears invalid model when adapter changes', () => {
+  const codex: ACPAgent = {
+    id: 'codex-acp',
+    name: 'Codex ACP',
+    description: '',
+    version: 'live',
+    capabilities: [],
+    models: [{ id: 'gpt-5', name: 'GPT-5' }],
+    defaultModelId: 'gpt-5',
+  }
+  const claude: ACPAgent = {
+    id: 'claude-acp',
+    name: 'Claude ACP',
+    description: '',
+    version: 'live',
+    capabilities: [],
+    models: [{ id: 'sonnet-4.5', name: 'Sonnet 4.5' }],
+    defaultModelId: 'sonnet-4.5',
+  }
+
+  assert.equal(resolveSelectedModel(codex, 'sonnet-4.5', null)?.id, 'gpt-5')
+  assert.equal(resolveSelectedModel(claude, 'gpt-5', null)?.id, 'sonnet-4.5')
+})
+
 test('ensurePromptRunIdForProvider creates a run when selected provider differs from selected run', async () => {
   let createCalls = 0
   let receivedOptions: { closeSessionPanel?: boolean } | undefined
@@ -212,6 +266,28 @@ test('sendPromptForSelectedProvider creates provider-matched run and posts page 
       },
     },
   ])
+})
+
+test('sendPromptForSelectedProvider includes selected model', async () => {
+  const requests: Array<{ body: unknown }> = []
+
+  await sendPromptForSelectedProvider({
+    payload: { text: 'hello', attachments: [] },
+    selectedRun: { ...run('run-codex'), provider: 'codex-acp' },
+    selectedProviderId: 'codex-acp',
+    selectedModelId: 'gpt-5-mini',
+    createSession: async () => run('unused'),
+    isMobileViewport: false,
+    fetchAcp: async (_path, init) => {
+      requests.push({ body: JSON.parse(String(init?.body)) })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    },
+    refreshSessions: async () => {},
+    addOptimisticMessage: () => {},
+    removeOptimisticMessage: () => {},
+  })
+
+  assert.deepEqual(requests[0]?.body, { prompt: 'hello', model: 'gpt-5-mini' })
 })
 
 test('sendPromptForSelectedProvider removes optimistic message and throws normalized backend errors', async () => {

--- a/apps/gateway-admin/components/chat/chat-shell.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.test.tsx
@@ -151,7 +151,10 @@ test('resolveSelectedModel clears invalid model when adapter changes', () => {
     description: '',
     version: 'live',
     capabilities: [],
-    models: [{ id: 'gpt-5', name: 'GPT-5' }],
+    models: [
+      { id: 'gpt-5-mini', name: 'GPT-5 Mini' },
+      { id: 'gpt-5', name: 'GPT-5' },
+    ],
     defaultModelId: 'gpt-5',
   }
   const claude: ACPAgent = {
@@ -166,6 +169,33 @@ test('resolveSelectedModel clears invalid model when adapter changes', () => {
 
   assert.equal(resolveSelectedModel(codex, 'sonnet-4.5', null)?.id, 'gpt-5')
   assert.equal(resolveSelectedModel(claude, 'gpt-5', null)?.id, 'sonnet-4.5')
+})
+
+test('resolveSelectedModel falls through invalid requested ids before using list order', () => {
+  const codex: ACPAgent = {
+    id: 'codex-acp',
+    name: 'Codex ACP',
+    description: '',
+    version: 'live',
+    capabilities: [],
+    models: [
+      { id: 'gpt-5-mini', name: 'GPT-5 Mini' },
+      { id: 'gpt-5', name: 'GPT-5' },
+      { id: 'gpt-5-pro', name: 'GPT-5 Pro' },
+    ],
+    defaultModelId: 'gpt-5',
+    currentModelId: 'gpt-5-pro',
+  }
+
+  assert.equal(resolveSelectedModel(codex, 'stale-model', null)?.id, 'gpt-5-pro')
+  assert.equal(
+    resolveSelectedModel(codex, 'stale-model', {
+      ...run('run-codex'),
+      provider: 'codex-acp',
+      modelId: 'gpt-5',
+    })?.id,
+    'gpt-5',
+  )
 })
 
 test('ensurePromptRunIdForProvider creates a run when selected provider differs from selected run', async () => {

--- a/apps/gateway-admin/components/chat/chat-shell.tsx
+++ b/apps/gateway-admin/components/chat/chat-shell.tsx
@@ -25,6 +25,7 @@ export {
   integrateCreatedRun,
   providerDisplayName,
   resolveSelectedAgent,
+  resolveSelectedModel,
   sendPromptForSelectedProvider,
   sessionCreationOptionsForIntent,
   shouldAutoCreateInitialRun,
@@ -37,9 +38,9 @@ export function ChatShell() {
   const [systemPrompt, setSystemPrompt] = React.useState('')
   const [temperature, setTemperature] = React.useState(0.7)
   const [maxTokens, setMaxTokens] = React.useState(8192)
-  const { runs, selectedRun, selectedRunId, providerHealth, selectedAgent, agents, projects } =
+  const { runs, selectedRun, selectedRunId, providerHealth, selectedAgent, selectedModel, agents, projects } =
     useChatSessionData()
-  const { selectRun, createSession, sendPrompt, selectAgent } = useChatSessionActions()
+  const { selectRun, createSession, sendPrompt, selectAgent, selectModel } = useChatSessionActions()
   const { messages } = useChatSessionStream()
   const { connectionState } = useChatSessionConnection()
   const providerReady = Boolean(providerHealth?.ready)
@@ -109,6 +110,14 @@ export function ChatShell() {
             <span className="hidden text-aurora-text-muted/50 sm:block">{projects[0]?.name}</span>
             <span className="hidden text-aurora-text-muted/30 sm:block">/</span>
             <span className="max-w-[180px] truncate text-aurora-text-primary sm:max-w-[300px]">{selectedRun.title}</span>
+            {selectedRun.modelName && (
+              <>
+                <span className="hidden text-aurora-text-muted/30 sm:block">/</span>
+                <span className="max-w-[120px] truncate text-aurora-text-muted sm:max-w-[180px]">
+                  {selectedRun.modelName}
+                </span>
+              </>
+            )}
           </div>
         )}
 
@@ -210,6 +219,9 @@ export function ChatShell() {
             selectedAgent={selectedAgent}
             agents={agents.length > 0 ? agents : [selectedAgent]}
             onSelectAgent={selectAgent}
+            selectedModel={selectedModel}
+            modelOptions={selectedAgent.models ?? []}
+            onSelectModel={(modelId) => selectModel(selectedAgent.id, modelId)}
           />
         </div>
 

--- a/apps/gateway-admin/components/chat/session-sidebar.tsx
+++ b/apps/gateway-admin/components/chat/session-sidebar.tsx
@@ -71,7 +71,14 @@ function RunRow({
         />
       )}
       <RunIcon status={run.status} agentId={run.agentId} />
-      <span className="min-w-0 flex-1 truncate text-[13px] leading-[1.2]">{run.title}</span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13px] leading-[1.2]">{run.title}</span>
+        {run.modelName && (
+          <span className="block truncate text-[11px] leading-[1.2] text-aurora-text-muted/70">
+            {run.modelName}
+          </span>
+        )}
+      </span>
       <span className={cn(AURORA_DENSE_META, 'shrink-0 tabular-nums text-aurora-text-muted')}>
         {formatTimeAgo(run.updatedAt)}
       </span>

--- a/apps/gateway-admin/components/chat/types.ts
+++ b/apps/gateway-admin/components/chat/types.ts
@@ -3,12 +3,22 @@ import type { AttachmentRef } from '@/lib/fs/types'
 
 export type { AttachmentRef }
 
+export interface ACPModelOption {
+  id: string
+  name: string
+  description?: string | null
+  fixed?: boolean
+}
+
 export interface ACPAgent {
   id: string
   name: string
   description: string
   version: string
   capabilities: string[]
+  models?: ACPModelOption[]
+  defaultModelId?: string | null
+  currentModelId?: string | null
 }
 
 export interface ACPProject {
@@ -31,6 +41,8 @@ export interface ACPRun {
   status: ACPRunStatus
   providerSessionId: string
   cwd: string
+  modelId?: string | null
+  modelName?: string | null
 }
 
 /**

--- a/apps/gateway-admin/lib/acp/types.ts
+++ b/apps/gateway-admin/lib/acp/types.ts
@@ -16,6 +16,13 @@ import type {
 } from '@agentclientprotocol/sdk'
 
 export type AcpProviderKind = string
+export type ACPModelOption = {
+  id: string
+  name: string
+  description?: string | null
+  fixed?: boolean
+}
+
 export type BridgeSessionStatus =
   | 'idle'
   | 'running'
@@ -31,6 +38,9 @@ export type ProviderHealth = {
   command: string
   args: string[]
   message: string
+  models?: ACPModelOption[]
+  defaultModelId?: string | null
+  currentModelId?: string | null
 }
 
 export type BridgeSessionSummary = {
@@ -45,6 +55,8 @@ export type BridgeSessionSummary = {
   agentName: string
   agentVersion: string
   resumable?: boolean
+  modelId?: string | null
+  modelName?: string | null
 }
 
 export type BridgePermissionOption = {

--- a/apps/gateway-admin/lib/chat/acp-normalizers.test.ts
+++ b/apps/gateway-admin/lib/chat/acp-normalizers.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sameProviderList } from './acp-normalizers'
+import type { ProviderHealth } from '@/lib/acp/types'
+
+function provider(modelName: string): ProviderHealth {
+  return {
+    provider: 'codex-acp',
+    ready: true,
+    command: 'codex-acp',
+    args: [],
+    message: '',
+    models: [
+      {
+        id: 'gpt-5.4',
+        name: modelName,
+        description: 'balanced model',
+        fixed: false,
+      },
+    ],
+    defaultModelId: 'gpt-5.4',
+    currentModelId: 'gpt-5.4',
+  }
+}
+
+test('sameProviderList detects model metadata changes for stable model ids', () => {
+  assert.equal(sameProviderList([provider('GPT 5.4')], [provider('GPT 5.4')]), true)
+  assert.equal(sameProviderList([provider('GPT 5.4')], [provider('GPT 5.4 refreshed')]), false)
+})

--- a/apps/gateway-admin/lib/chat/acp-normalizers.ts
+++ b/apps/gateway-admin/lib/chat/acp-normalizers.ts
@@ -20,6 +20,11 @@ export type ProviderListPayload = {
     error?: string | null
     command?: string | null
     args?: string[] | null
+    models?: Array<{ id: string; name: string; description?: string | null; fixed?: boolean }>
+    defaultModelId?: string | null
+    currentModelId?: string | null
+    default_model_id?: string | null
+    current_model_id?: string | null
   }>
   provider?: ProviderHealth
 }
@@ -51,6 +56,10 @@ export type RawSessionSummary = {
   provider_session_id?: string
   agent_name?: string
   agent_version?: string
+  modelId?: string | null
+  modelName?: string | null
+  model_id?: string | null
+  model_name?: string | null
 }
 
 // ---- Normalization helpers ----
@@ -67,6 +76,8 @@ export function normalizeSessionSummary(session: RawSessionSummary): BridgeSessi
     providerSessionId: session.providerSessionId ?? session.provider_session_id ?? '',
     agentName: session.agentName ?? session.agent_name ?? 'Codex',
     agentVersion: session.agentVersion ?? session.agent_version ?? 'unknown',
+    modelId: session.modelId ?? session.model_id ?? null,
+    modelName: session.modelName ?? session.model_name ?? null,
   }
 }
 
@@ -83,6 +94,8 @@ export function toRun(session: RawSessionSummary): ACPRun {
     status: normalized.status,
     providerSessionId: normalized.providerSessionId,
     cwd: normalized.cwd,
+    modelId: normalized.modelId ?? null,
+    modelName: normalized.modelName ?? null,
   }
 }
 
@@ -98,6 +111,9 @@ export function normalizeProviderHealth(payload: ProviderListPayload): ProviderH
     command: '',
     args: [],
     message: provider?.error ?? '',
+    models: provider?.models ?? [],
+    defaultModelId: provider?.defaultModelId ?? provider?.default_model_id ?? null,
+    currentModelId: provider?.currentModelId ?? provider?.current_model_id ?? null,
   }
 }
 
@@ -112,6 +128,9 @@ export function normalizeProviderList(payload: ProviderListPayload): ProviderHea
     command: provider.command ?? '',
     args: provider.args ?? [],
     message: provider.error ?? '',
+    models: provider.models ?? [],
+    defaultModelId: provider.defaultModelId ?? provider.default_model_id ?? null,
+    currentModelId: provider.currentModelId ?? provider.current_model_id ?? null,
   }))
 }
 
@@ -138,5 +157,18 @@ export function errorMessageFromPayload(payload: ErrorPayload | null, fallback: 
 
 export function sameProviderList(a: ProviderHealth[], b: ProviderHealth[]): boolean {
   if (a.length !== b.length) return false
-  return a.every((item, i) => item.provider === b[i]?.provider && item.ready === b[i]?.ready)
+  return a.every((item, i) => {
+    const other = b[i]
+    if (!other) return false
+    const models = item.models ?? []
+    const otherModels = other.models ?? []
+    return (
+      item.provider === other.provider &&
+      item.ready === other.ready &&
+      item.defaultModelId === other.defaultModelId &&
+      item.currentModelId === other.currentModelId &&
+      models.length === otherModels.length &&
+      models.every((model, index) => model.id === otherModels[index]?.id)
+    )
+  })
 }

--- a/apps/gateway-admin/lib/chat/acp-normalizers.ts
+++ b/apps/gateway-admin/lib/chat/acp-normalizers.ts
@@ -168,7 +168,15 @@ export function sameProviderList(a: ProviderHealth[], b: ProviderHealth[]): bool
       item.defaultModelId === other.defaultModelId &&
       item.currentModelId === other.currentModelId &&
       models.length === otherModels.length &&
-      models.every((model, index) => model.id === otherModels[index]?.id)
+      models.every((model, index) => {
+        const otherModel = otherModels[index]
+        return (
+          model.id === otherModel?.id &&
+          model.name === otherModel.name &&
+          model.description === otherModel.description &&
+          model.fixed === otherModel.fixed
+        )
+      })
     )
   })
 }

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -44,7 +44,7 @@ import {
   errorMessageFromPayload,
   sameProviderList,
 } from './acp-normalizers'
-import type { ACPAgent, ACPRun, ACPProject, ACPMessage } from '@/components/chat/types'
+import type { ACPAgent, ACPRun, ACPProject, ACPMessage, ACPModelOption } from '@/components/chat/types'
 import type { BridgeSessionSummary, ProviderHealth, BridgeEvent } from '@/lib/acp/types'
 import type { SessionEventConnectionState } from './use-session-events'
 import {
@@ -52,6 +52,7 @@ import {
   integrateCreatedRun,
   providerDisplayName,
   resolveSelectedAgent,
+  resolveSelectedModel,
   sendPromptForSelectedProvider,
   shouldAutoCreateInitialRun,
   type PromptPayload,
@@ -80,6 +81,7 @@ export type ChatSessionDataContextValue = {
   providers: ProviderHealth[]
   selectedProviderId: string | null
   selectedAgent: ACPAgent
+  selectedModel: ACPModelOption | null
   agents: ACPAgent[]
   projects: ACPProject[]
   sessionsLoaded: boolean
@@ -96,6 +98,7 @@ export type ChatSessionActionsContextValue = {
   refreshSessions: () => Promise<void>
   refreshProvider: () => Promise<void>
   selectAgent: (providerId: string) => void
+  selectModel: (providerId: string, modelId: string) => void
   setPageContext: (ctx: PageContext) => void
 }
 
@@ -182,6 +185,7 @@ export function ChatSessionProvider({
   const [providerHealth, setProviderHealth] = React.useState<ProviderHealth | null>(null)
   const [providers, setProviders] = React.useState<ProviderHealth[]>([])
   const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
+  const [selectedModelByProvider, setSelectedModelByProvider] = React.useState<Record<string, string>>({})
   const [optimisticMessages, setOptimisticMessages] = React.useState<ACPMessage[]>([])
   const [pageContext, setPageContext] = React.useState<PageContext>(null)
 
@@ -233,6 +237,9 @@ export function ChatSessionProvider({
         id: provider.provider,
         name: providerDisplayName(provider.provider),
         version: ACP_AGENT.version,
+        models: provider.models,
+        defaultModelId: provider.defaultModelId,
+        currentModelId: provider.currentModelId,
       })),
     [providers],
   )
@@ -240,6 +247,16 @@ export function ChatSessionProvider({
   const selectedAgent = React.useMemo(
     () => resolveSelectedAgent(agents, selectedProviderId, selectedRun),
     [agents, selectedProviderId, selectedRun],
+  )
+
+  const selectedModel = React.useMemo(
+    () =>
+      resolveSelectedModel(
+        selectedAgent,
+        selectedAgent ? selectedModelByProvider[selectedAgent.id] ?? null : null,
+        selectedRun,
+      ),
+    [selectedAgent, selectedModelByProvider, selectedRun],
   )
 
   const sessionStatus = React.useMemo(
@@ -312,7 +329,10 @@ export function ChatSessionProvider({
       try {
         const response = await fetchAcp('/sessions', {
           method: 'POST',
-          body: JSON.stringify({ provider: selectedProviderId ?? providerHealth?.provider ?? 'codex-acp' }),
+          body: JSON.stringify({
+            provider: selectedProviderId ?? providerHealth?.provider ?? 'codex-acp',
+            ...(selectedModel?.id && { model: selectedModel.id }),
+          }),
         })
         const payload = await readJsonSafe<SessionCreatePayload | ErrorPayload>(response)
         if (!response.ok || !payload) {
@@ -346,7 +366,7 @@ export function ChatSessionProvider({
         isCreatingRef.current = false
       }
     },
-    [fetchAcp, onSessionPanelClose, providerHealth?.provider, selectedProviderId],
+    [fetchAcp, onSessionPanelClose, providerHealth?.provider, selectedModel?.id, selectedProviderId],
   )
 
   const selectRun = React.useCallback(
@@ -372,6 +392,12 @@ export function ChatSessionProvider({
     setSelectedProviderId(providerId)
   }, [])
 
+  const selectModel = React.useCallback((providerId: string, modelId: string) => {
+    const provider = providers.find((candidate) => candidate.provider === providerId)
+    if (!provider?.models?.some((model) => model.id === modelId)) return
+    setSelectedModelByProvider((current) => ({ ...current, [providerId]: modelId }))
+  }, [providers])
+
   const sendPrompt = React.useCallback<ChatSessionActionsContextValue['sendPrompt']>(
     async (payload, options) => {
       try {
@@ -379,6 +405,7 @@ export function ChatSessionProvider({
           payload,
           selectedRun,
           selectedProviderId,
+          selectedModelId: selectedModel?.id ?? null,
           createSession,
           isMobileViewport,
           fetchAcp,
@@ -407,6 +434,7 @@ export function ChatSessionProvider({
       isMobileViewport,
       refreshSessions,
       selectedProviderId,
+      selectedModel?.id,
       selectedRun,
     ],
   )
@@ -589,12 +617,13 @@ export function ChatSessionProvider({
       providers,
       selectedProviderId,
       selectedAgent,
+      selectedModel,
       agents,
       projects,
       sessionsLoaded,
       pageContext,
     }),
-    [runs, selectedRunId, selectedRun, providerHealth, providers, selectedProviderId, selectedAgent, agents, projects, sessionsLoaded, pageContext],
+    [runs, selectedRunId, selectedRun, providerHealth, providers, selectedProviderId, selectedAgent, selectedModel, agents, projects, sessionsLoaded, pageContext],
   )
 
   const actionsValue = React.useMemo<ChatSessionActionsContextValue>(
@@ -605,9 +634,10 @@ export function ChatSessionProvider({
       refreshSessions,
       refreshProvider,
       selectAgent,
+      selectModel,
       setPageContext: setPageContextStable,
     }),
-    [createSession, selectRun, sendPrompt, refreshSessions, refreshProvider, selectAgent, setPageContextStable],
+    [createSession, selectRun, sendPrompt, refreshSessions, refreshProvider, selectAgent, selectModel, setPageContextStable],
   )
 
   const connectionValue = React.useMemo<ChatSessionConnectionContextValue>(

--- a/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
+++ b/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
@@ -119,6 +119,18 @@ export function resolveSelectedAgent(
   return agents[0] ?? ACP_AGENT
 }
 
+export function resolveSelectedModel(
+  agent: ACPAgent | null,
+  requestedModelId: string | null,
+  selectedRun: ACPRun | null,
+) {
+  const models = agent?.models ?? []
+  if (models.length === 0) return null
+  const runModel = selectedRun?.provider === agent?.id ? selectedRun.modelId : null
+  const candidate = requestedModelId ?? runModel ?? agent?.currentModelId ?? agent?.defaultModelId ?? null
+  return models.find((model) => model.id === candidate) ?? models[0] ?? null
+}
+
 export type PromptPayload = {
   text: string
   attachments: AttachmentRef[]
@@ -128,6 +140,7 @@ export type SendPromptForSelectedProviderOptions = {
   payload: PromptPayload
   selectedRun: ACPRun | null
   selectedProviderId: string | null
+  selectedModelId?: string | null
   createSession: CreateSessionFn
   isMobileViewport: boolean
   fetchAcp: (path: string, init?: RequestInit) => Promise<Response>
@@ -142,6 +155,7 @@ export async function sendPromptForSelectedProvider({
   payload,
   selectedRun,
   selectedProviderId,
+  selectedModelId,
   createSession,
   isMobileViewport,
   fetchAcp,
@@ -172,6 +186,7 @@ export async function sendPromptForSelectedProvider({
 
   const body = {
     prompt: payload.text,
+    ...(selectedModelId && { model: selectedModelId }),
     ...(payload.attachments.length > 0 && { attachments: payload.attachments }),
     ...(includePageContext && pageContext !== null && pageContext !== undefined && { pageContext }),
   }

--- a/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
+++ b/apps/gateway-admin/lib/chat/use-chat-session-controller.ts
@@ -127,8 +127,11 @@ export function resolveSelectedModel(
   const models = agent?.models ?? []
   if (models.length === 0) return null
   const runModel = selectedRun?.provider === agent?.id ? selectedRun.modelId : null
-  const candidate = requestedModelId ?? runModel ?? agent?.currentModelId ?? agent?.defaultModelId ?? null
-  return models.find((model) => model.id === candidate) ?? models[0] ?? null
+  for (const candidate of [requestedModelId, runModel, agent?.currentModelId, agent?.defaultModelId]) {
+    const model = candidate ? models.find((option) => option.id === candidate) : null
+    if (model) return model
+  }
+  return models[0] ?? null
 }
 
 export type PromptPayload = {

--- a/crates/lab-apis/src/acp/types.rs
+++ b/crates/lab-apis/src/acp/types.rs
@@ -70,6 +70,36 @@ pub struct AcpSessionSummary {
     pub agent_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config_options: Vec<AcpSessionConfigOptionView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct AcpModelOption {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fixed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct AcpSessionConfigOptionView {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_value: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<AcpModelOption>,
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +127,12 @@ pub struct AcpProviderHealth {
     pub available: bool,
     pub version: Option<String>,
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<AcpModelOption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_model_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -19,7 +19,9 @@ use futures::{Stream, StreamExt, stream};
 use tokio::sync::{Mutex, OnceCell, RwLock, mpsc};
 
 use lab_apis::acp::persistence::AcpPersistence;
-use lab_apis::acp::types::{AcpEvent, AcpProviderHealth, AcpSessionState, AcpSessionSummary};
+use lab_apis::acp::types::{
+    AcpEvent, AcpModelOption, AcpProviderHealth, AcpSessionState, AcpSessionSummary,
+};
 
 use crate::dispatch::acp::persistence::SqliteAcpPersistence;
 use crate::dispatch::error::ToolError;
@@ -132,6 +134,7 @@ pub struct AcpSessionRegistry {
     shutting_down: Arc<AtomicBool>,
     /// Idle timeout — configurable for tests.
     idle_timeout: Duration,
+    provider_models: Arc<RwLock<HashMap<String, Vec<AcpModelOption>>>>,
 }
 
 impl AcpSessionRegistry {
@@ -150,6 +153,7 @@ impl AcpSessionRegistry {
             recent_creations: Arc::new(Mutex::new(VecDeque::new())),
             shutting_down: Arc::new(AtomicBool::new(false)),
             idle_timeout: Duration::from_secs(SESSION_IDLE_TIMEOUT_MINS * 60),
+            provider_models: Arc::new(RwLock::new(HashMap::new())),
         };
         Self::spawn_health_reporter(Arc::clone(&registry.sessions));
         Self::spawn_idle_reaper(registry.clone(), IDLE_REAPER_INTERVAL_SECS);
@@ -178,6 +182,15 @@ impl AcpSessionRegistry {
             .ok_or_else(|| not_found("unknown ACP session"))
     }
 
+    async fn provider_model_options(&self, provider: &str) -> Vec<AcpModelOption> {
+        self.provider_models
+            .read()
+            .await
+            .get(provider)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     fn check_principal(session: &Session, principal: &str) -> Result<(), ToolError> {
         if principal.trim().is_empty() || session.principal.trim().is_empty() {
             return Err(ToolError::Sdk {
@@ -198,7 +211,17 @@ impl AcpSessionRegistry {
 
     #[must_use]
     pub fn provider_healths(&self) -> Vec<AcpProviderHealth> {
-        provider_healths()
+        let mut healths = provider_healths();
+        if let Ok(models) = self.provider_models.try_read() {
+            for health in &mut healths {
+                if let Some(provider_models) = models.get(&health.provider) {
+                    health.models = provider_models.clone();
+                    health.default_model_id = provider_models.first().map(|model| model.id.clone());
+                    health.current_model_id = health.default_model_id.clone();
+                }
+            }
+        }
+        healths
     }
 
     pub async fn list_sessions(&self, principal: &str) -> Vec<AcpSessionSummary> {
@@ -334,6 +357,7 @@ impl AcpSessionRegistry {
                 cwd: cwd.clone(),
                 title: input.title.clone(),
                 principal: input.principal.clone(),
+                model_id: input.model_id.clone(),
             },
             event_tx.clone(),
         )
@@ -351,6 +375,9 @@ impl AcpSessionRegistry {
         })?;
 
         let provider = normalize_provider_id(input.provider.as_deref());
+        let options = self.provider_model_options(&provider).await;
+        let (model_id, model_name) =
+            resolve_model_selection(&provider, input.model_id.as_deref(), &options, started.model_id.as_deref())?;
         let summary = AcpSessionSummary {
             id: session_id.clone(),
             provider,
@@ -367,6 +394,9 @@ impl AcpSessionRegistry {
             provider_session_id: Some(started.provider_session_id),
             agent_name: Some(started.agent_name),
             agent_version: Some(started.agent_version),
+            model_id,
+            model_name: model_name.or(started.model_name),
+            config_options: started.config_options,
         };
 
         let session = Session::new(session_id.clone(), principal.to_string(), summary.clone());
@@ -406,9 +436,28 @@ impl AcpSessionRegistry {
         session_id: &str,
         prompt: &str,
         principal: &str,
+        model_id: Option<&str>,
     ) -> Result<(), ToolError> {
         let session = self.get_session_arc(session_id).await?;
         Self::check_principal(&session, principal)?;
+        let (selected_model_id, selected_model_name) = {
+            let summary = session.summary.read().await;
+            let options = if summary.config_options.is_empty() {
+                self.provider_model_options(&summary.provider).await
+            } else {
+                summary
+                    .config_options
+                    .iter()
+                    .flat_map(|option| option.options.clone())
+                    .collect()
+            };
+            resolve_model_selection(
+                &summary.provider,
+                model_id,
+                &options,
+                summary.model_id.as_deref(),
+            )?
+        };
 
         {
             let state = session.state.read().await;
@@ -432,6 +481,10 @@ impl AcpSessionRegistry {
             }
             summary.state = AcpSessionState::Running;
             summary.updated_at = jiff::Timestamp::now().to_string();
+            if model_id.is_some() {
+                summary.model_id = selected_model_id.clone();
+                summary.model_name = selected_model_name.clone();
+            }
         }
         // Touch activity timestamp so idle reaper leaves this session alone.
         {
@@ -464,7 +517,7 @@ impl AcpSessionRegistry {
                 .ok_or_else(|| internal("ACP runtime unavailable"))?
         };
         runtime
-            .prompt(prompt.to_string())
+            .prompt(prompt.to_string(), selected_model_id)
             .await
             .map_err(session_command_error)?;
 
@@ -988,6 +1041,7 @@ impl AcpSessionRegistry {
                 cwd,
                 title: Some(title),
                 principal: None,
+                model_id: None,
             },
             event_tx.clone(),
         )
@@ -1175,6 +1229,26 @@ impl AcpSessionRegistry {
             recent_creations: Arc::new(Mutex::new(VecDeque::new())),
             shutting_down: Arc::new(AtomicBool::new(false)),
             idle_timeout,
+            provider_models: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test_with_provider_models(
+        provider_models: Vec<(String, Vec<AcpModelOption>)>,
+    ) -> Self {
+        let models = provider_models
+            .into_iter()
+            .map(|(provider, models)| (normalize_provider_id(Some(&provider)), models))
+            .collect();
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            persistence: Arc::new(OnceCell::new()),
+            default_cwd: ".".to_string(),
+            recent_creations: Arc::new(Mutex::new(VecDeque::new())),
+            shutting_down: Arc::new(AtomicBool::new(false)),
+            idle_timeout: Duration::from_millis(100),
+            provider_models: Arc::new(RwLock::new(models)),
         }
     }
 
@@ -1204,6 +1278,9 @@ impl AcpSessionRegistry {
             provider_session_id: Some("fake-provider-session".to_string()),
             agent_name: Some("test-agent".to_string()),
             agent_version: Some("0.0.1".to_string()),
+            model_id: None,
+            model_name: None,
+            config_options: Vec::new(),
         };
         let session = Session::new(
             session_id.to_string(),
@@ -1262,6 +1339,9 @@ impl AcpSessionRegistry {
             provider_session_id: Some("fake-provider-session".to_string()),
             agent_name: Some("test-agent".to_string()),
             agent_version: Some("0.0.1".to_string()),
+            model_id: None,
+            model_name: None,
+            config_options: Vec::new(),
         };
         let session = Session::new(
             session_id.to_string(),
@@ -1475,6 +1555,38 @@ fn not_found(message: &str) -> ToolError {
     }
 }
 
+fn resolve_model_selection(
+    provider: &str,
+    requested: Option<&str>,
+    options: &[AcpModelOption],
+    current: Option<&str>,
+) -> Result<(Option<String>, Option<String>), ToolError> {
+    let selected = requested.or(current);
+    let Some(selected) = selected
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok((None, None));
+    };
+    if options.is_empty() {
+        return if requested.is_some() {
+            Err(ToolError::InvalidParam {
+                message: format!("provider `{provider}` does not expose switchable models"),
+                param: "model".to_string(),
+            })
+        } else {
+            Ok((Some(selected.to_string()), None))
+        };
+    }
+    let Some(option) = options.iter().find(|option| option.id == selected) else {
+        return Err(ToolError::InvalidParam {
+            message: format!("model `{selected}` is not valid for provider `{provider}`"),
+            param: "model".to_string(),
+        });
+    };
+    Ok((Some(option.id.clone()), Some(option.name.clone())))
+}
+
 fn should_replace_prompt_title(title: &str) -> bool {
     title.trim().is_empty() || title.trim() == "New session"
 }
@@ -1666,7 +1778,7 @@ mod tests {
             .await;
 
         let err = registry
-            .prompt_session("saturated-sess", "hello", "alice")
+            .prompt_session("saturated-sess", "hello", "alice", None)
             .await
             .expect_err("full command queue must be rejected");
 
@@ -1686,6 +1798,7 @@ mod tests {
                 "title-sess",
                 "Context: route=/chat\n\nInvestigate empty ACP sessions",
                 "alice",
+                None,
             )
             .await
             .expect("prompt dispatch");

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -216,8 +216,6 @@ impl AcpSessionRegistry {
             for health in &mut healths {
                 if let Some(provider_models) = models.get(&health.provider) {
                     health.models = provider_models.clone();
-                    health.default_model_id = provider_models.first().map(|model| model.id.clone());
-                    health.current_model_id = health.default_model_id.clone();
                 }
             }
         }
@@ -1868,5 +1866,28 @@ mod tests {
 
         assert_eq!(model_id.as_deref(), Some("gpt-5.4"));
         assert_eq!(model_name.as_deref(), Some("GPT 5.4"));
+    }
+
+    #[test]
+    fn provider_healths_does_not_synthesize_current_or_default_model_from_order() {
+        let registry = AcpSessionRegistry::new_for_test_with_provider_models(vec![(
+            "codex-acp".to_string(),
+            vec![AcpModelOption {
+                id: "gpt-5-mini".to_string(),
+                name: "GPT-5 Mini".to_string(),
+                description: None,
+                fixed: false,
+            }],
+        )]);
+
+        let codex = registry
+            .provider_healths()
+            .into_iter()
+            .find(|health| health.provider == "codex-acp")
+            .expect("codex provider health should be present");
+
+        assert_eq!(codex.models.len(), 1);
+        assert_eq!(codex.default_model_id, None);
+        assert_eq!(codex.current_model_id, None);
     }
 }

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -375,9 +375,19 @@ impl AcpSessionRegistry {
         })?;
 
         let provider = normalize_provider_id(input.provider.as_deref());
+        if !started.models.is_empty() {
+            self.provider_models
+                .write()
+                .await
+                .insert(provider.clone(), started.models.clone());
+        }
         let options = self.provider_model_options(&provider).await;
-        let (model_id, model_name) =
-            resolve_model_selection(&provider, input.model_id.as_deref(), &options, started.model_id.as_deref())?;
+        let (model_id, model_name) = resolve_model_selection(
+            &provider,
+            input.model_id.as_deref(),
+            &options,
+            started.model_id.as_deref(),
+        )?;
         let summary = AcpSessionSummary {
             id: session_id.clone(),
             provider,
@@ -1562,21 +1572,11 @@ fn resolve_model_selection(
     current: Option<&str>,
 ) -> Result<(Option<String>, Option<String>), ToolError> {
     let selected = requested.or(current);
-    let Some(selected) = selected
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
+    let Some(selected) = selected.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok((None, None));
     };
     if options.is_empty() {
-        return if requested.is_some() {
-            Err(ToolError::InvalidParam {
-                message: format!("provider `{provider}` does not expose switchable models"),
-                param: "model".to_string(),
-            })
-        } else {
-            Ok((Some(selected.to_string()), None))
-        };
+        return Ok((Some(selected.to_string()), None));
     }
     let Some(option) = options.iter().find(|option| option.id == selected) else {
         return Err(ToolError::InvalidParam {
@@ -1841,5 +1841,32 @@ mod tests {
             title_from_prompt(prompt).as_deref(),
             Some("Summarize the Docker ACP session creation behavior and identi...")
         );
+    }
+
+    #[test]
+    fn resolve_model_selection_accepts_requested_model_without_cached_options() {
+        let (model_id, model_name) =
+            resolve_model_selection("codex-acp", Some("gpt-5.4"), &[], None)
+                .expect("requested model should pass through when provider model cache is empty");
+
+        assert_eq!(model_id.as_deref(), Some("gpt-5.4"));
+        assert_eq!(model_name, None);
+    }
+
+    #[test]
+    fn resolve_model_selection_uses_cached_model_metadata() {
+        let options = vec![AcpModelOption {
+            id: "gpt-5.4".to_string(),
+            name: "GPT 5.4".to_string(),
+            description: Some("fast".to_string()),
+            fixed: false,
+        }];
+
+        let (model_id, model_name) =
+            resolve_model_selection("codex-acp", Some("gpt-5.4"), &options, None)
+                .expect("cached model should validate");
+
+        assert_eq!(model_id.as_deref(), Some("gpt-5.4"));
+        assert_eq!(model_name.as_deref(), Some("GPT 5.4"));
     }
 }

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -112,9 +112,9 @@ pub struct RuntimeHandle {
 }
 
 impl RuntimeHandle {
-    pub async fn prompt(&self, prompt: String) -> Result<(), String> {
+    pub async fn prompt(&self, prompt: String, model_id: Option<String>) -> Result<(), String> {
         self.command_tx
-            .try_send(SessionCommand::Prompt(prompt))
+            .try_send(SessionCommand::Prompt(PromptCommand { prompt, model_id }))
             .map_err(session_command_send_error)
     }
 
@@ -139,8 +139,13 @@ impl RuntimeHandle {
 }
 
 enum SessionCommand {
-    Prompt(String),
+    Prompt(PromptCommand),
     Cancel,
+}
+
+struct PromptCommand {
+    prompt: String,
+    model_id: Option<String>,
 }
 
 fn session_command_send_error(error: mpsc::error::TrySendError<SessionCommand>) -> String {
@@ -440,6 +445,9 @@ pub async fn launch_codex_runtime(
             provider_session_id: started.provider_session_id,
             agent_name: started.agent_name,
             agent_version: started.agent_version,
+            model_id: None,
+            model_name: None,
+            config_options: Vec::new(),
         },
     ))
 }
@@ -492,6 +500,9 @@ pub fn codex_provider_health() -> AcpProviderHealth {
                     .to_string(),
             )
         },
+        models: Vec::new(),
+        default_model_id: None,
+        current_model_id: None,
     }
 }
 
@@ -514,6 +525,9 @@ fn health_for_provider_entry(provider: &AcpProviderEntry) -> AcpProviderHealth {
                 launch.command
             ))
         },
+        models: Vec::new(),
+        default_model_id: None,
+        current_model_id: None,
     }
 }
 
@@ -1290,7 +1304,8 @@ async fn run_codex_session(
 
                     while let Some(command) = command_rx.recv().await {
                         match command {
-                            SessionCommand::Prompt(prompt) => {
+                            SessionCommand::Prompt(command) => {
+                                let PromptCommand { prompt, model_id } = command;
                                 prompt_lifecycle.start();
 
                                 if previous_turn_idle {
@@ -1388,6 +1403,7 @@ async fn run_codex_session(
                                             json!({
                                                 "type": "prompt_started",
                                                 "title": "Prompt started",
+                                                "model_id": model_id,
                                                 "text": prompt.clone(),
                                             }),
                                         ))
@@ -2934,7 +2950,10 @@ pub fn fake_handle_for_tests() -> (RuntimeHandle, mpsc::Receiver<AcpEvent>) {
 pub fn saturated_fake_handle_for_tests() -> (RuntimeHandle, mpsc::Receiver<AcpEvent>) {
     let (command_tx, command_rx) = mpsc::channel::<SessionCommand>(1);
     command_tx
-        .try_send(SessionCommand::Prompt("already queued".to_string()))
+        .try_send(SessionCommand::Prompt(PromptCommand {
+            prompt: "already queued".to_string(),
+            model_id: None,
+        }))
         .expect("prefill command queue");
     tokio::spawn(async move {
         let _command_rx = command_rx;

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -10,8 +10,8 @@ use agent_client_protocol::schema::{
     InitializeRequest, KillTerminalRequest, PermissionOption, PermissionOptionKind,
     ProtocolVersion, ReadTextFileRequest, ReleaseTerminalRequest, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionInfoUpdate, SessionNotification, SessionUpdate, StopReason, TerminalOutputRequest,
-    WaitForTerminalExitRequest, WriteTextFileRequest,
+    SessionInfoUpdate, SessionNotification, SessionUpdate, SetSessionModelRequest, StopReason,
+    TerminalOutputRequest, WaitForTerminalExitRequest, WriteTextFileRequest,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, Dispatch, JsonRpcMessage, on_receive_request,
@@ -179,6 +179,29 @@ struct RuntimeStarted {
     provider_session_id: String,
     agent_name: String,
     agent_version: String,
+    model_id: Option<String>,
+    model_name: Option<String>,
+    models: Vec<lab_apis::acp::types::AcpModelOption>,
+}
+
+fn session_model_options(
+    response: &agent_client_protocol::schema::NewSessionResponse,
+) -> (Option<String>, Vec<lab_apis::acp::types::AcpModelOption>) {
+    let Some(models) = response.models.as_ref() else {
+        return (None, Vec::new());
+    };
+    let current = Some(models.current_model_id.to_string());
+    let options = models
+        .available_models
+        .iter()
+        .map(|model| lab_apis::acp::types::AcpModelOption {
+            id: model.model_id.to_string(),
+            name: model.name.clone(),
+            description: model.description.clone(),
+            fixed: false,
+        })
+        .collect();
+    (current, options)
 }
 
 #[derive(Default)]
@@ -445,8 +468,9 @@ pub async fn launch_codex_runtime(
             provider_session_id: started.provider_session_id,
             agent_name: started.agent_name,
             agent_version: started.agent_version,
-            model_id: None,
-            model_name: None,
+            model_id: started.model_id,
+            model_name: started.model_name,
+            models: started.models,
             config_options: Vec::new(),
         },
     ))
@@ -1270,6 +1294,12 @@ async fn run_codex_session(
                         .start_session()
                         .await
                         .map_err(|error| acp_internal_error(error.to_string()))?;
+                    let session_response = session.response();
+                    let (model_id, models) = session_model_options(&session_response);
+                    let model_name = model_id
+                        .as_ref()
+                        .and_then(|id| models.iter().find(|model| &model.id == id))
+                        .map(|model| model.name.clone());
 
                     let started = RuntimeStarted {
                         provider_session_id: session.session_id().to_string(),
@@ -1289,6 +1319,9 @@ async fn run_codex_session(
                             .as_ref()
                             .map(|info| info.version.clone())
                             .unwrap_or_else(|| "unknown".to_string()),
+                        model_id,
+                        model_name,
+                        models,
                     };
                     if let Some(sender) = started_tx.lock().ok().and_then(|mut guard| guard.take()) {
                         drop(sender.send(Ok(started)));
@@ -1395,6 +1428,20 @@ async fn run_codex_session(
                                         ))
                                         .await,
                                 );
+                                if let Some(model_id) = model_id.as_deref() {
+                                    session
+                                        .connection()
+                                        .send_request_to(
+                                            Agent,
+                                            SetSessionModelRequest::new(
+                                                session.session_id().clone(),
+                                                model_id.to_string(),
+                                            ),
+                                        )
+                                        .block_task()
+                                        .await
+                                        .map_err(|error| acp_internal_error(error.to_string()))?;
+                                }
                                 drop(
                                     event_tx
                                         .send(provider_info_event(

--- a/crates/lab/src/acp/types.rs
+++ b/crates/lab/src/acp/types.rs
@@ -26,6 +26,9 @@ pub struct ProviderHealth {
     pub command: String,
     pub args: Vec<String>,
     pub message: String,
+    pub models: Vec<lab_apis::acp::types::AcpModelOption>,
+    pub default_model_id: Option<String>,
+    pub current_model_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +46,10 @@ pub struct BridgeSessionSummary {
     pub agent_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resumable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -322,6 +329,7 @@ pub struct StartSessionInput {
     pub cwd: String,
     pub title: Option<String>,
     pub principal: Option<String>,
+    pub model_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -329,4 +337,7 @@ pub struct StartSessionResult {
     pub provider_session_id: String,
     pub agent_name: String,
     pub agent_version: String,
+    pub model_id: Option<String>,
+    pub model_name: Option<String>,
+    pub config_options: Vec<lab_apis::acp::types::AcpSessionConfigOptionView>,
 }

--- a/crates/lab/src/acp/types.rs
+++ b/crates/lab/src/acp/types.rs
@@ -339,5 +339,6 @@ pub struct StartSessionResult {
     pub agent_version: String,
     pub model_id: Option<String>,
     pub model_name: Option<String>,
+    pub models: Vec<lab_apis::acp::types::AcpModelOption>,
     pub config_options: Vec<lab_apis::acp::types::AcpSessionConfigOptionView>,
 }

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -135,10 +135,13 @@ async fn list_sessions(
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateSessionBody {
     provider: Option<String>,
     cwd: Option<String>,
     title: Option<String>,
+    model: Option<String>,
+    model_id: Option<String>,
 }
 
 async fn create_session(
@@ -154,6 +157,7 @@ async fn create_session(
         "provider": body.provider,
         "cwd": body.cwd,
         "title": body.title,
+        "model": body.model.or(body.model_id),
         "principal": principal,
     });
     match dispatch_with_registry(&state.acp_registry, "session.start", params).await {
@@ -178,6 +182,8 @@ struct PromptBody {
     prompt: String,
     /// Optional structured page context. Passed to dispatch; injection is handled there.
     page_context: Option<PageContextBody>,
+    model: Option<String>,
+    model_id: Option<String>,
 }
 
 async fn prompt_session(
@@ -224,6 +230,7 @@ async fn prompt_session(
         "session_id": session_id,
         "text": body.prompt.trim(),
         "page_context": page_context_value,
+        "model": body.model.or(body.model_id),
         "principal": principal,
     });
     match dispatch_with_registry(&state.acp_registry, "session.prompt", params).await {

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -145,6 +145,20 @@ struct CreateSessionBody {
     model_id: Option<String>,
 }
 
+fn preferred_model_param(model: Option<String>, model_id: Option<String>) -> Option<String> {
+    model
+        .and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .or_else(|| {
+            model_id.and_then(|value| {
+                let trimmed = value.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            })
+        })
+}
+
 async fn create_session(
     State(state): State<AppState>,
     auth: Option<Extension<AuthContext>>,
@@ -158,7 +172,7 @@ async fn create_session(
         "provider": body.provider,
         "cwd": body.cwd,
         "title": body.title,
-        "model": body.model.or(body.model_id),
+        "model": preferred_model_param(body.model, body.model_id),
         "principal": principal,
     });
     match dispatch_with_registry(&state.acp_registry, "session.start", params).await {
@@ -232,12 +246,33 @@ async fn prompt_session(
         "session_id": session_id,
         "text": body.prompt.trim(),
         "page_context": page_context_value,
-        "model": body.model.or(body.model_id),
+        "model": preferred_model_param(body.model, body.model_id),
         "principal": principal,
     });
     match dispatch_with_registry(&state.acp_registry, "session.prompt", params).await {
         Ok(v) => Json(v).into_response(),
         Err(e) => e.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preferred_model_param;
+
+    #[test]
+    fn preferred_model_param_treats_blank_model_as_absent() {
+        assert_eq!(
+            preferred_model_param(Some("  ".to_string()), Some("gpt-5".to_string())),
+            Some("gpt-5".to_string())
+        );
+        assert_eq!(
+            preferred_model_param(Some(" claude ".to_string()), Some("gpt-5".to_string())),
+            Some("claude".to_string())
+        );
+        assert_eq!(
+            preferred_model_param(Some("".to_string()), Some(" ".to_string())),
+            None
+        );
     }
 }
 

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -141,6 +141,7 @@ struct CreateSessionBody {
     cwd: Option<String>,
     title: Option<String>,
     model: Option<String>,
+    #[serde(alias = "model_id")]
     model_id: Option<String>,
 }
 
@@ -183,6 +184,7 @@ struct PromptBody {
     /// Optional structured page context. Passed to dispatch; injection is handled there.
     page_context: Option<PageContextBody>,
     model: Option<String>,
+    #[serde(alias = "model_id")]
     model_id: Option<String>,
 }
 

--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -133,6 +133,9 @@ pub async fn dispatch_with_registry(
                         "available": health.available,
                         "version": health.version,
                         "error": health.message,
+                        "models": health.models,
+                        "defaultModelId": health.default_model_id,
+                        "currentModelId": health.current_model_id,
                     })
                 })
                 .collect();
@@ -157,6 +160,9 @@ pub async fn dispatch_with_registry(
                 "available": health.available,
                 "version": health.version,
                 "error": health.message,
+                "models": health.models,
+                "defaultModelId": health.default_model_id,
+                "currentModelId": health.current_model_id,
             }))
         }
 
@@ -211,6 +217,9 @@ pub async fn dispatch_with_registry(
             let provider = opt_str(&params, "provider").map(|s| s.to_string());
             let title = opt_str(&params, "title").map(|s| s.to_string());
             let cwd = opt_str(&params, "cwd").unwrap_or("").to_string();
+            let model_id = opt_str(&params, "model")
+                .or_else(|| opt_str(&params, "model_id"))
+                .map(str::to_string);
 
             let input = StartSessionInput {
                 provider,
@@ -221,6 +230,7 @@ pub async fn dispatch_with_registry(
                 } else {
                     Some(principal.to_string())
                 },
+                model_id,
             };
             let summary = registry.create_session(input, principal).await?;
             to_json(summary)
@@ -250,9 +260,10 @@ pub async fn dispatch_with_registry(
                 });
             let effective_text = build_prompt_with_context(session_id, raw_text, page_ctx.as_ref());
             ensure_prompt_size(&effective_text)?;
+            let model_id = opt_str(&params, "model").or_else(|| opt_str(&params, "model_id"));
 
             registry
-                .prompt_session(session_id, &effective_text, principal)
+                .prompt_session(session_id, &effective_text, principal, model_id)
                 .await?;
             to_json(json!({ "ok": true, "session_id": session_id }))
         }

--- a/crates/lab/src/dispatch/acp/persistence.rs
+++ b/crates/lab/src/dispatch/acp/persistence.rs
@@ -438,7 +438,34 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         conn.execute_batch(SCHEMA_SQL)?;
         conn.pragma_update(None, "user_version", 1)?;
     }
+    if version < 2 {
+        add_column_if_missing(conn, "acp_sessions", "model_id", "TEXT")?;
+        add_column_if_missing(conn, "acp_sessions", "model_name", "TEXT")?;
+        add_column_if_missing(
+            conn,
+            "acp_sessions",
+            "config_options_json",
+            "TEXT NOT NULL DEFAULT '[]'",
+        )?;
+        conn.pragma_update(None, "user_version", 2)?;
+    }
     Ok(())
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for existing in columns {
+        if existing? == column {
+            return Ok(());
+        }
+    }
+    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {definition};"))
 }
 
 const SCHEMA_SQL: &str = "
@@ -453,7 +480,10 @@ CREATE TABLE IF NOT EXISTS acp_sessions (
     principal          TEXT NOT NULL DEFAULT '',
     agent_name         TEXT,
     agent_version      TEXT,
-    provider_session_id TEXT
+    provider_session_id TEXT,
+    model_id           TEXT,
+    model_name         TEXT,
+    config_options_json TEXT NOT NULL DEFAULT '[]'
 );
 
 CREATE TABLE IF NOT EXISTS acp_session_events (
@@ -485,7 +515,8 @@ CREATE INDEX IF NOT EXISTS idx_perm_session
 fn db_load_sessions(conn: &Connection) -> rusqlite::Result<Vec<AcpSessionSummary>> {
     let mut stmt = conn.prepare(
         "SELECT id, provider, title, cwd, state, created_at, updated_at,
-                principal, agent_name, agent_version, provider_session_id
+                principal, agent_name, agent_version, provider_session_id,
+                model_id, model_name, config_options_json
          FROM acp_sessions
          ORDER BY updated_at DESC",
     )?;
@@ -493,6 +524,20 @@ fn db_load_sessions(conn: &Connection) -> rusqlite::Result<Vec<AcpSessionSummary
         let state_str: String = row.get("state")?;
         let state = parse_session_state(&state_str);
         let principal: String = row.get("principal")?;
+        let config_options_json: String = row
+            .get("config_options_json")
+            .unwrap_or_else(|_| "[]".to_string());
+        let config_options = serde_json::from_str(&config_options_json).unwrap_or_else(|error| {
+            tracing::warn!(
+                surface = "acp",
+                service = "persistence",
+                action = "session.config_options.decode",
+                kind = "decode_error",
+                error = %error,
+                "failed to decode ACP session config options; returning empty config option list",
+            );
+            Vec::new()
+        });
         Ok(AcpSessionSummary {
             id: row.get("id")?,
             provider: row.get("provider")?,
@@ -509,17 +554,24 @@ fn db_load_sessions(conn: &Connection) -> rusqlite::Result<Vec<AcpSessionSummary
             agent_name: row.get("agent_name")?,
             agent_version: row.get("agent_version")?,
             provider_session_id: row.get("provider_session_id")?,
+            model_id: row.get("model_id")?,
+            model_name: row.get("model_name")?,
+            config_options,
         })
     })?;
     rows.collect()
 }
 
 fn db_save_session(conn: &Connection, s: &AcpSessionSummary) -> rusqlite::Result<()> {
+    let config_options_json = serde_json::to_string(&s.config_options).map_err(|error| {
+        rusqlite::Error::ToSqlConversionFailure(Box::new(error))
+    })?;
     conn.execute(
         "INSERT INTO acp_sessions
              (id, provider, title, cwd, state, created_at, updated_at,
-              principal, agent_name, agent_version, provider_session_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+              principal, agent_name, agent_version, provider_session_id,
+              model_id, model_name, config_options_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
          ON CONFLICT(id) DO UPDATE SET
              provider           = excluded.provider,
              title              = excluded.title,
@@ -529,7 +581,10 @@ fn db_save_session(conn: &Connection, s: &AcpSessionSummary) -> rusqlite::Result
              principal          = excluded.principal,
              agent_name         = excluded.agent_name,
              agent_version      = excluded.agent_version,
-             provider_session_id = excluded.provider_session_id",
+             provider_session_id = excluded.provider_session_id,
+             model_id           = excluded.model_id,
+             model_name         = excluded.model_name,
+             config_options_json = excluded.config_options_json",
         params![
             s.id,
             s.provider,
@@ -542,6 +597,9 @@ fn db_save_session(conn: &Connection, s: &AcpSessionSummary) -> rusqlite::Result
             s.agent_name,
             s.agent_version,
             s.provider_session_id,
+            s.model_id,
+            s.model_name,
+            config_options_json,
         ],
     )?;
     Ok(())


### PR DESCRIPTION
## Summary
- add adapter-scoped model options and selected model state through chat UI/session data
- send selected model with prompts and persist/normalize model metadata across ACP session surfaces
- clear invalid model selections when switching adapters

## Tests
- `pnpm exec tsx --test components/chat/chat-shell.test.tsx lib/chat/*.test.ts lib/acp/*.test.ts` (38/38 passing)
- `cargo test --manifest-path crates/lab/Cargo.toml acp --lib` (85/85 passing before the lab-apis rerun)
- `RUSTC_WRAPPER= cargo test --manifest-path crates/lab-apis/Cargo.toml acp --lib` (0 tests after filter, compile passed)
- `pnpm run build` (passing)
- `NEXT_PUBLIC_MOCK_DATA=true pnpm run build` fails in unrelated `/settings/services` mock-data prerender path; normal build passes

## Agent-browser verification
- ran `NEXT_PUBLIC_MOCK_DATA=true pnpm exec next dev -H 127.0.0.1 -p 3133`
- opened `http://127.0.0.1:3133/chat/` with `agent-browser 0.26.0`
- verified chat UI loads and exposes agent/model-adjacent controls in the accessibility snapshot
- limitation: mock provider state keeps prompt controls disabled, so actual model payload behavior is covered by unit tests rather than direct browser send

## Notes
- `.env`, `config.toml`, ignored plan files, generated Next files, and node modules were not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adapter-scoped chat model selection and applies the chosen model to new prompts and sessions. Selection is validated per provider, persisted, and reflected in the chat header, session list, and prompt events.

- New Features
  - Model picker in chat input; keyboard accessible and disabled when only one option exists. Current model is shown in the chat header and session sidebar.
  - Provider health/list now exposes `models`, `defaultModelId`, and `currentModelId`. Selection is stored per provider, cleared if invalid when switching adapters, and falls back to run model → provider current/default → first option.
  - Selected `model` is sent on session create and prompt; server accepts `model` or `model_id` (trims blanks), validates against provider options (or passes through when none cached), applies the model in the runtime, and returns `modelId`/`modelName` in session summaries and prompt events.

- Migration
  - SQLite schema v2 adds `model_id`, `model_name`, and `config_options_json`; auto-migrates on startup. Existing sessions continue to work.

<sup>Written for commit 27e7f099b173d68a30dc06a3f40a88b2dfca5c90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Users can now select a chat model alongside agent selection in the chat interface
* Selected model is displayed in the session header and sidebar
* Model selection is persisted and sent with chat prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->