### PR TITLE
Support ACP provider handoff in chat sessions

### DIFF
--- a/crates/lab-apis/src/acp/types.rs
+++ b/crates/lab-apis/src/acp/types.rs
@@ -152,6 +152,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         role: String,
         text: String,
         message_id: String,
@@ -161,6 +163,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         text: String,
     },
     ToolCallStart {
@@ -168,6 +172,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         tool_call_id: String,
         name: String,
         input: Value,
@@ -177,6 +183,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         tool_call_id: String,
         output: Value,
         status: String,
@@ -186,6 +194,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         request_id: String,
         action_summary: String,
         options: Vec<AcpPermissionOption>,
@@ -195,6 +205,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         request_id: String,
         granted: bool,
     },
@@ -203,6 +215,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         raw: Value,
     },
     ContentBlocks {
@@ -210,6 +224,8 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         blocks: Vec<AcpContentBlock>,
     },
     SessionUpdate {
@@ -217,7 +233,19 @@ pub enum AcpEvent {
         created_at: String,
         session_id: String,
         seq: u64,
+        #[serde(default)]
+        provider: String,
         state: AcpSessionState,
+    },
+    ProviderSwitch {
+        id: String,
+        created_at: String,
+        session_id: String,
+        seq: u64,
+        from_provider: String,
+        to_provider: String,
+        continuity_mode: String,
+        message: String,
     },
     ProviderInfo {
         id: String,
@@ -253,6 +281,7 @@ impl AcpEvent {
             | Self::UsageUpdate { seq, .. }
             | Self::ContentBlocks { seq, .. }
             | Self::SessionUpdate { seq, .. }
+            | Self::ProviderSwitch { seq, .. }
             | Self::ProviderInfo { seq, .. }
             | Self::Unknown { seq, .. } => *seq,
         }
@@ -270,8 +299,34 @@ impl AcpEvent {
             | Self::UsageUpdate { session_id, .. }
             | Self::ContentBlocks { session_id, .. }
             | Self::SessionUpdate { session_id, .. }
+            | Self::ProviderSwitch { session_id, .. }
             | Self::ProviderInfo { session_id, .. }
             | Self::Unknown { session_id, .. } => session_id,
+        }
+    }
+
+    /// Returns the provider that owns this event, when the event represents
+    /// provider-owned turn output or a provider switch target.
+    pub fn provider_id(&self) -> Option<&str> {
+        match self {
+            Self::MessageChunk { provider, .. }
+            | Self::ReasoningChunk { provider, .. }
+            | Self::ToolCallStart { provider, .. }
+            | Self::ToolCallUpdate { provider, .. }
+            | Self::PermissionRequest { provider, .. }
+            | Self::PermissionOutcome { provider, .. }
+            | Self::UsageUpdate { provider, .. }
+            | Self::ContentBlocks { provider, .. }
+            | Self::SessionUpdate { provider, .. }
+            | Self::ProviderInfo { provider, .. } => {
+                if provider.is_empty() {
+                    None
+                } else {
+                    Some(provider)
+                }
+            }
+            Self::ProviderSwitch { to_provider, .. } => Some(to_provider),
+            Self::Unknown { .. } => None,
         }
     }
 }

--- a/crates/lab-apis/tests/acp_types.rs
+++ b/crates/lab-apis/tests/acp_types.rs
@@ -1,0 +1,40 @@
+use lab_apis::acp::AcpEvent;
+
+#[test]
+fn acp_message_chunk_round_trips_provider_owner() {
+    let event = AcpEvent::MessageChunk {
+        id: "evt-1".into(),
+        created_at: "2026-05-05T00:00:00Z".into(),
+        session_id: "session-1".into(),
+        seq: 1,
+        provider: "claude-acp".into(),
+        role: "assistant".into(),
+        text: "I can continue from the handoff.".into(),
+        message_id: "msg-1".into(),
+    };
+
+    let value = serde_json::to_value(&event).unwrap();
+    assert_eq!(value["provider"], "claude-acp");
+    let decoded: AcpEvent = serde_json::from_value(value).unwrap();
+    assert_eq!(decoded.provider_id(), Some("claude-acp"));
+}
+
+#[test]
+fn acp_provider_switch_event_round_trips_visible_continuity() {
+    let event = AcpEvent::ProviderSwitch {
+        id: "evt-switch".into(),
+        created_at: "2026-05-05T00:00:00Z".into(),
+        session_id: "session-1".into(),
+        seq: 2,
+        from_provider: "codex-acp".into(),
+        to_provider: "claude-acp".into(),
+        continuity_mode: "handoff".into(),
+        message: "Continuing with Claude ACP using a bounded transcript handoff.".into(),
+    };
+
+    let value = serde_json::to_value(&event).unwrap();
+    assert_eq!(value["kind"], "provider_switch");
+    assert_eq!(value["to_provider"], "claude-acp");
+    let decoded: AcpEvent = serde_json::from_value(value).unwrap();
+    assert_eq!(decoded.seq(), 2);
+}

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -75,6 +75,9 @@ const HEALTH_REPORT_INTERVAL_SECS: u64 = 60;
 /// Idle reaper check interval (seconds, production).
 const IDLE_REAPER_INTERVAL_SECS: u64 = 5 * 60;
 
+const HANDOFF_MAX_MESSAGES: usize = 10;
+const HANDOFF_MAX_BYTES: usize = 12 * 1024;
+
 // ---------------------------------------------------------------------------
 // Session struct
 // ---------------------------------------------------------------------------
@@ -132,6 +135,12 @@ pub struct AcpSessionRegistry {
     shutting_down: Arc<AtomicBool>,
     /// Idle timeout — configurable for tests.
     idle_timeout: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PromptSessionOptions {
+    pub provider: Option<String>,
+    pub continuity_mode: Option<String>,
 }
 
 impl AcpSessionRegistry {
@@ -379,7 +388,11 @@ impl AcpSessionRegistry {
             map_guard.insert(session_id.clone(), Arc::clone(&session));
         }
 
-        self.spawn_event_forwarder(Arc::clone(&session), event_rx);
+        self.spawn_event_forwarder(
+            Arc::clone(&session),
+            event_rx,
+            summary.provider_session_id.clone(),
+        );
 
         tracing::info!(
             surface = "acp", service = "registry", action = "session.create",
@@ -406,6 +419,22 @@ impl AcpSessionRegistry {
         session_id: &str,
         prompt: &str,
         principal: &str,
+    ) -> Result<(), ToolError> {
+        self.prompt_session_with_options(
+            session_id,
+            prompt,
+            principal,
+            PromptSessionOptions::default(),
+        )
+        .await
+    }
+
+    pub async fn prompt_session_with_options(
+        &self,
+        session_id: &str,
+        prompt: &str,
+        principal: &str,
+        options: PromptSessionOptions,
     ) -> Result<(), ToolError> {
         let session = self.get_session_arc(session_id).await?;
         Self::check_principal(&session, principal)?;
@@ -445,6 +474,10 @@ impl AcpSessionRegistry {
             "ACP session prompt dispatched",
         );
 
+        let prompt = self
+            .switch_runtime_if_requested(&session, prompt, options)
+            .await?;
+
         let needs_reattach = { session.handle.lock().await.is_none() };
         if needs_reattach {
             tracing::warn!(
@@ -480,6 +513,154 @@ impl AcpSessionRegistry {
         }
 
         Ok(())
+    }
+
+    async fn switch_runtime_if_requested(
+        &self,
+        session: &Arc<Session>,
+        prompt: &str,
+        options: PromptSessionOptions,
+    ) -> Result<String, ToolError> {
+        let Some(requested_provider) = options
+            .provider
+            .as_deref()
+            .map(|provider| normalize_provider_id(Some(provider)))
+            .filter(|provider| !provider.trim().is_empty())
+        else {
+            return Ok(prompt.to_string());
+        };
+
+        let (current_provider, cwd, title) = {
+            let summary = session.summary.read().await;
+            (
+                summary.provider.clone(),
+                summary.cwd.clone(),
+                summary.title.clone(),
+            )
+        };
+        if requested_provider == current_provider {
+            return Ok(prompt.to_string());
+        }
+
+        {
+            let state = session.state.read().await;
+            if !matches!(
+                *state,
+                AcpSessionState::Idle | AcpSessionState::Completed | AcpSessionState::Running
+            ) {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "invalid_state".to_string(),
+                    message: format!("session is in state {state:?}, cannot switch provider"),
+                });
+            }
+        }
+
+        let Some(health) = self
+            .provider_healths()
+            .into_iter()
+            .find(|health| health.provider == requested_provider)
+        else {
+            return Err(ToolError::InvalidParam {
+                message: format!("unknown provider `{requested_provider}`"),
+                param: "provider".to_string(),
+            });
+        };
+        if !health.available {
+            return Err(ToolError::Sdk {
+                sdk_kind: "service_unavailable".to_string(),
+                message: health
+                    .message
+                    .unwrap_or_else(|| format!("provider `{requested_provider}` is unavailable")),
+            });
+        }
+
+        let continuity_mode = match options.continuity_mode.as_deref() {
+            Some("reset") => "reset",
+            Some("handoff") | None | Some("") => "handoff",
+            Some(other) => {
+                return Err(ToolError::InvalidParam {
+                    message: format!("unsupported continuity_mode `{other}`"),
+                    param: "continuity_mode".to_string(),
+                });
+            }
+        };
+
+        let prompt_for_provider = if continuity_mode == "reset" {
+            format!(
+                "You are continuing a Lab conversation that was previously handled by {current_provider}.\n\
+                 Continuity mode: reset.\n\
+                 No prior transcript was provided to this provider.\n\n\
+                 New user prompt:\n{prompt}"
+            )
+        } else {
+            build_handoff_prompt(session, &current_provider, prompt).await
+        };
+
+        let (event_tx, event_rx) = mpsc::channel::<AcpEvent>(ACP_EVENT_CHANNEL_CAPACITY);
+        let (new_runtime, started) = launch_codex_runtime(
+            session.id.clone(),
+            StartSessionInput {
+                provider: Some(requested_provider.clone()),
+                cwd,
+                title: Some(title),
+                principal: Some(session.principal.clone()),
+            },
+            event_tx,
+        )
+        .await
+        .map_err(internal_message)?;
+
+        let switch_message = if continuity_mode == "reset" {
+            format!(
+                "Switched from {current_provider} to {requested_provider}. Context was reset for this provider."
+            )
+        } else {
+            format!(
+                "Switched from {current_provider} to {requested_provider}. Continuing with a bounded transcript handoff."
+            )
+        };
+        let switch_event = next_session_event(
+            session,
+            AcpEvent::ProviderSwitch {
+                id: uuid::Uuid::new_v4().to_string(),
+                created_at: jiff::Timestamp::now().to_string(),
+                session_id: session.id.clone(),
+                seq: 0,
+                from_provider: current_provider,
+                to_provider: requested_provider.clone(),
+                continuity_mode: continuity_mode.to_string(),
+                message: switch_message,
+            },
+        )
+        .await;
+
+        persist_session_event(self, &switch_event).await;
+        apply_session_event(session, &switch_event).await;
+        let _ = fanout_event(session, Arc::new(switch_event)).await;
+
+        let old_runtime = {
+            let mut handle = session.handle.lock().await;
+            handle.replace(new_runtime)
+        };
+        self.spawn_event_forwarder(
+            Arc::clone(session),
+            event_rx,
+            Some(started.provider_session_id.clone()),
+        );
+        if let Some(old_runtime) = old_runtime {
+            drop(old_runtime.cancel().await);
+        }
+
+        {
+            let mut summary = session.summary.write().await;
+            summary.provider = requested_provider;
+            summary.provider_session_id = Some(started.provider_session_id);
+            summary.agent_name = Some(started.agent_name);
+            summary.agent_version = Some(started.agent_version);
+            summary.updated_at = jiff::Timestamp::now().to_string();
+        }
+
+        Ok(prompt_for_provider)
     }
 
     pub async fn cancel_session(&self, session_id: &str, principal: &str) -> Result<(), ToolError> {
@@ -857,7 +1038,12 @@ impl AcpSessionRegistry {
         }
     }
 
-    fn spawn_event_forwarder(&self, session: Arc<Session>, mut rx: mpsc::Receiver<AcpEvent>) {
+    fn spawn_event_forwarder(
+        &self,
+        session: Arc<Session>,
+        mut rx: mpsc::Receiver<AcpEvent>,
+        provider_session_id: Option<String>,
+    ) {
         let registry = self.clone();
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
@@ -898,6 +1084,24 @@ impl AcpSessionRegistry {
             // Runtime thread exited (event_tx dropped). Keep the session and
             // transcript available for replay; the idle reaper or explicit
             // close path owns eventual removal.
+            let current_handle_matches = {
+                let handle = session.handle.lock().await;
+                match (handle.as_ref(), provider_session_id.as_deref()) {
+                    (Some(handle), Some(provider_session_id)) => {
+                        handle.provider_session_id == provider_session_id
+                    }
+                    (None, _) => true,
+                    _ => false,
+                }
+            };
+            if !current_handle_matches {
+                tracing::debug!(
+                    surface = "acp", service = "registry", action = "runtime.exit",
+                    session_id = %session.id,
+                    "superseded ACP runtime exited after provider switch",
+                );
+                return;
+            }
             let current_state = session.state.read().await.clone();
             if matches!(
                 current_state,
@@ -910,6 +1114,7 @@ impl AcpSessionRegistry {
                         created_at: jiff::Timestamp::now().to_string(),
                         session_id: session.id.clone(),
                         seq: 0,
+                        provider: session.summary.read().await.provider.clone(),
                         state: AcpSessionState::Failed,
                     },
                 )
@@ -994,7 +1199,11 @@ impl AcpSessionRegistry {
         .await
         .map_err(internal_message)?;
 
-        self.spawn_event_forwarder(Arc::clone(session), event_rx);
+        self.spawn_event_forwarder(
+            Arc::clone(session),
+            event_rx,
+            Some(started.provider_session_id.clone()),
+        );
         {
             *session.handle.lock().await = Some(runtime);
         }
@@ -1116,6 +1325,7 @@ impl AcpSessionRegistry {
                         created_at: now.clone(),
                         session_id: summary.id.clone(),
                         seq: 0,
+                        provider: summary.provider.clone(),
                         state: AcpSessionState::Failed,
                     },
                 )
@@ -1366,6 +1576,9 @@ async fn apply_session_event(session: &Arc<Session>, event: &AcpEvent) {
         if let Some(title) = session_title_from_event(event) {
             summary.title = title;
         }
+        if let AcpEvent::ProviderSwitch { to_provider, .. } = event {
+            summary.provider = to_provider.clone();
+        }
     }
     if let Some(new_state) = maybe_new_state {
         *session.state.write().await = new_state;
@@ -1501,6 +1714,71 @@ fn title_from_prompt(prompt: &str) -> Option<String> {
         return Some(title);
     }
     Some(normalized)
+}
+
+async fn build_handoff_prompt(session: &Arc<Session>, from_provider: &str, prompt: &str) -> String {
+    let events = session.events.read().await;
+    let mut lines = Vec::new();
+    for event in events.iter().rev() {
+        if lines.len() >= HANDOFF_MAX_MESSAGES {
+            break;
+        }
+        if let AcpEvent::MessageChunk {
+            role,
+            text,
+            provider,
+            ..
+        } = event
+        {
+            if text.trim().is_empty() {
+                continue;
+            }
+            let label = match role.as_str() {
+                "user" => "User".to_string(),
+                "assistant" => {
+                    let owner = if provider.is_empty() {
+                        from_provider
+                    } else {
+                        provider.as_str()
+                    };
+                    format!("Assistant ({owner})")
+                }
+                other => other.to_string(),
+            };
+            lines.push(format!(
+                "{label}: {}",
+                crate::dispatch::redact::redact_stdio_value(text)
+            ));
+        }
+    }
+    lines.reverse();
+    let transcript = if lines.is_empty() {
+        "(No prior text transcript available.)".to_string()
+    } else {
+        lines.join("\n")
+    };
+    let mut handoff = format!(
+        "You are continuing a Lab conversation that was previously handled by {from_provider}.\n\
+         Continuity mode: handoff.\n\
+         Recent transcript:\n{transcript}\n\n\
+         New user prompt:\n{prompt}"
+    );
+    if handoff.len() > HANDOFF_MAX_BYTES {
+        let tail = handoff
+            .chars()
+            .rev()
+            .take(HANDOFF_MAX_BYTES)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<String>();
+        handoff = format!(
+            "You are continuing a Lab conversation that was previously handled by {from_provider}.\n\
+             Continuity mode: handoff.\n\
+             Recent transcript was truncated to fit the handoff budget.\n{tail}\n",
+        );
+    }
+    handoff
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/lab/src/acp/registry.rs
+++ b/crates/lab/src/acp/registry.rs
@@ -439,7 +439,7 @@ impl AcpSessionRegistry {
         let session = self.get_session_arc(session_id).await?;
         Self::check_principal(&session, principal)?;
 
-        {
+        let previous_state = {
             let state = session.state.read().await;
             if !state.can_transition_to(&AcpSessionState::Running) {
                 return Err(ToolError::Sdk {
@@ -447,7 +447,8 @@ impl AcpSessionRegistry {
                     message: format!("session is in state {state:?}, cannot send prompt"),
                 });
             }
-        }
+            state.clone()
+        };
         {
             let mut state = session.state.write().await;
             *state = AcpSessionState::Running;
@@ -474,9 +475,24 @@ impl AcpSessionRegistry {
             "ACP session prompt dispatched",
         );
 
-        let prompt = self
+        let prompt = match self
             .switch_runtime_if_requested(&session, prompt, options)
-            .await?;
+            .await
+        {
+            Ok(prompt) => prompt,
+            Err(error) => {
+                {
+                    let mut state = session.state.write().await;
+                    *state = previous_state.clone();
+                }
+                {
+                    let mut summary = session.summary.write().await;
+                    summary.state = previous_state;
+                    summary.updated_at = jiff::Timestamp::now().to_string();
+                }
+                return Err(error);
+            }
+        };
 
         let needs_reattach = { session.handle.lock().await.is_none() };
         if needs_reattach {
@@ -1757,28 +1773,36 @@ async fn build_handoff_prompt(session: &Arc<Session>, from_provider: &str, promp
     } else {
         lines.join("\n")
     };
-    let mut handoff = format!(
+    let prompt_section = format!("\n\nNew user prompt:\n{prompt}");
+    let mut transcript_header = "Recent transcript:\n";
+    let mut transcript_body = transcript.as_str();
+    let prefix = format!(
         "You are continuing a Lab conversation that was previously handled by {from_provider}.\n\
-         Continuity mode: handoff.\n\
-         Recent transcript:\n{transcript}\n\n\
-         New user prompt:\n{prompt}"
+         Continuity mode: handoff.\n"
     );
-    if handoff.len() > HANDOFF_MAX_BYTES {
-        let tail = handoff
-            .chars()
-            .rev()
-            .take(HANDOFF_MAX_BYTES)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<String>();
-        handoff = format!(
-            "You are continuing a Lab conversation that was previously handled by {from_provider}.\n\
-             Continuity mode: handoff.\n\
-             Recent transcript was truncated to fit the handoff budget.\n{tail}\n",
-        );
+    let full_len =
+        prefix.len() + transcript_header.len() + transcript_body.len() + prompt_section.len();
+    if full_len > HANDOFF_MAX_BYTES {
+        transcript_header = "Recent transcript was truncated to fit the handoff budget.\n";
+        let fixed_len = prefix.len() + transcript_header.len() + prompt_section.len();
+        let transcript_budget = HANDOFF_MAX_BYTES.saturating_sub(fixed_len);
+        transcript_body = utf8_tail_by_bytes(&transcript, transcript_budget);
     }
-    handoff
+    format!("{prefix}{transcript_header}{transcript_body}{prompt_section}")
+}
+
+fn utf8_tail_by_bytes(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    if max_bytes == 0 {
+        return "";
+    }
+    let mut start = value.len().saturating_sub(max_bytes);
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
+    }
+    &value[start..]
 }
 
 // ---------------------------------------------------------------------------
@@ -1976,6 +2000,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_session_rolls_back_state_when_provider_switch_fails() {
+        let registry = test_registry();
+        registry
+            .inject_fake_session("switch-fail-sess", "alice")
+            .await;
+
+        let err = registry
+            .prompt_session_with_options(
+                "switch-fail-sess",
+                "continue this on another provider",
+                "alice",
+                PromptSessionOptions {
+                    provider: Some("missing-provider".to_string()),
+                    continuity_mode: Some("handoff".to_string()),
+                },
+            )
+            .await
+            .expect_err("unknown provider switch should fail");
+
+        assert_eq!(err.kind(), "invalid_param");
+        let summary = registry
+            .get_session("switch-fail-sess")
+            .await
+            .expect("session summary");
+        assert_eq!(summary.state, AcpSessionState::Idle);
+    }
+
+    #[tokio::test]
+    async fn handoff_truncation_preserves_full_prompt_and_utf8_boundaries() {
+        let registry = test_registry();
+        registry.inject_fake_session("handoff-sess", "alice").await;
+        let session = registry
+            .get_session_arc("handoff-sess")
+            .await
+            .expect("session");
+        {
+            let mut events = session.events.write().await;
+            events.push(AcpEvent::MessageChunk {
+                id: "evt-1".to_string(),
+                created_at: "2026-05-05T00:00:00Z".to_string(),
+                session_id: "handoff-sess".to_string(),
+                seq: 1,
+                provider: "codex-acp".to_string(),
+                role: "assistant".to_string(),
+                text: "🙂".repeat(HANDOFF_MAX_BYTES),
+                message_id: "msg-1".to_string(),
+            });
+        }
+        let prompt = format!("Preserve this exact prompt: {}", "ü".repeat(256));
+
+        let handoff = build_handoff_prompt(&session, "codex-acp", &prompt).await;
+
+        assert!(
+            handoff.ends_with(&format!("New user prompt:\n{prompt}")),
+            "handoff should preserve the full new prompt"
+        );
+        assert!(
+            handoff.len() <= HANDOFF_MAX_BYTES + "\n\nNew user prompt:\n".len() + prompt.len(),
+            "transcript truncation should stay byte-bounded apart from the preserved prompt"
+        );
+        assert!(std::str::from_utf8(handoff.as_bytes()).is_ok());
+    }
+
+    #[tokio::test]
     async fn test_session_limit_resets_after_removal() {
         let registry = test_registry();
         for i in 0..MAX_CONCURRENT_SESSIONS {
@@ -2006,5 +2094,11 @@ mod tests {
             title_from_prompt(prompt).as_deref(),
             Some("Summarize the Docker ACP session creation behavior and identi...")
         );
+    }
+
+    #[test]
+    fn utf8_tail_by_bytes_never_splits_multibyte_characters() {
+        assert_eq!(utf8_tail_by_bytes("a🙂b", 2), "b");
+        assert_eq!(utf8_tail_by_bytes("a🙂b", 5), "🙂b");
     }
 }

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -663,6 +663,7 @@ fn launch_from_provider_entry(provider: &AcpProviderEntry) -> ProviderLaunch {
 
 async fn handle_permission_request(
     runtime_session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     permissions: &PendingPermissions,
     args: RequestPermissionRequest,
@@ -699,7 +700,14 @@ async fn handle_permission_request(
         Err(_) => true,
     };
     if lock_poisoned {
-        emit_permission_outcome(event_tx, runtime_session_id, &request_id, false).await;
+        emit_permission_outcome(
+            event_tx,
+            runtime_session_id,
+            provider_id,
+            &request_id,
+            false,
+        )
+        .await;
         return RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled);
     }
 
@@ -710,6 +718,7 @@ async fn handle_permission_request(
                 created_at: jiff::Timestamp::now().to_string(),
                 session_id: runtime_session_id.to_string(),
                 seq: 0,
+                provider: provider_id.to_string(),
                 request_id: request_id.clone(),
                 action_summary,
                 options: public_options,
@@ -755,6 +764,7 @@ async fn handle_permission_request(
     emit_permission_outcome(
         event_tx,
         runtime_session_id,
+        provider_id,
         &request_id,
         matches!(response.outcome, RequestPermissionOutcome::Selected(_))
             && selected_option_is_allow(&options, &response),
@@ -827,6 +837,7 @@ fn find_permission_option<'a>(
 async fn emit_permission_outcome(
     event_tx: &mpsc::Sender<AcpEvent>,
     session_id: &str,
+    provider_id: &str,
     request_id: &str,
     granted: bool,
 ) {
@@ -837,6 +848,7 @@ async fn emit_permission_outcome(
                 created_at: jiff::Timestamp::now().to_string(),
                 session_id: session_id.to_string(),
                 seq: 0,
+                provider: provider_id.to_string(),
                 request_id: request_id.to_string(),
                 granted,
             })
@@ -1163,9 +1175,10 @@ async fn run_codex_session(
                 let session_id = session_id.clone();
                 let event_tx = event_tx.clone();
                 let permissions = Arc::clone(&permissions);
+                let provider_id = provider_id.clone();
                 async move |args: RequestPermissionRequest, responder, _cx| {
                     let response =
-                        handle_permission_request(&session_id, &event_tx, &permissions, args)
+                        handle_permission_request(&session_id, &provider_id, &event_tx, &permissions, args)
                             .await;
                     responder.respond(response)
                 }
@@ -1376,6 +1389,7 @@ async fn run_codex_session(
                                     event_tx
                                         .send(session_state_event(
                                             session_id.clone(),
+                                            &provider_id,
                                             lab_apis::acp::types::AcpSessionState::Running,
                                         ))
                                         .await,
@@ -1421,6 +1435,7 @@ async fn run_codex_session(
                                                 event_tx
                                                     .send(session_state_event(
                                                         session_id.clone(),
+                                                        &provider_id,
                                                         lab_apis::acp::types::AcpSessionState::Completed,
                                                     ))
                                                     .await,
@@ -1451,6 +1466,7 @@ async fn run_codex_session(
                                         )) => {
                                             let progress = handle_session_dispatch(
                                                 &session_id,
+                                                &provider_id,
                                                 &event_tx,
                                                 dispatch,
                                                 &stream_message_ids,
@@ -1476,6 +1492,7 @@ async fn run_codex_session(
                                                 event_tx
                                                     .send(session_state_event(
                                                         session_id.clone(),
+                                                        &provider_id,
                                                         state.clone(),
                                                     ))
                                                     .await,
@@ -1519,6 +1536,7 @@ async fn run_codex_session(
                                                 event_tx
                                                     .send(session_state_event(
                                                         session_id.clone(),
+                                                        &provider_id,
                                                         lab_apis::acp::types::AcpSessionState::Failed,
                                                     ))
                                                     .await,
@@ -1584,7 +1602,7 @@ async fn run_codex_session(
         );
         drop(
             event_tx
-                .send(session_state_event(session_id.clone(), state))
+                .send(session_state_event(session_id.clone(), &provider_id, state))
                 .await,
         );
         drop(event_tx.send(event).await);
@@ -1659,6 +1677,7 @@ async fn terminate_codex_child(
 
 async fn push_session_update(
     session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     update: SessionUpdate,
     stream_message_ids: &Arc<Mutex<StreamMessageIds>>,
@@ -1679,6 +1698,7 @@ async fn push_session_update(
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
+                    provider: provider_id.to_string(),
                     role: "user".to_string(),
                     text: content_to_text(content),
                     message_id,
@@ -1699,6 +1719,7 @@ async fn push_session_update(
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
+                    provider: provider_id.to_string(),
                     role: "assistant".to_string(),
                     text: content_to_text(content),
                     message_id,
@@ -1713,6 +1734,7 @@ async fn push_session_update(
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
+                    provider: provider_id.to_string(),
                     text: content_to_text(content),
                 })
                 .await
@@ -1725,6 +1747,7 @@ async fn push_session_update(
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
+                    provider: provider_id.to_string(),
                     tool_call_id: tool_call.tool_call_id.to_string(),
                     name: tool_call.title.clone(),
                     input: tool_call.raw_input.unwrap_or(Value::Null),
@@ -1755,7 +1778,7 @@ async fn push_session_update(
                 event_tx
                     .send(provider_info_event(
                         session_id.to_string(),
-                        "codex",
+                        provider_id,
                         payload,
                     ))
                     .await
@@ -1776,6 +1799,7 @@ async fn push_session_update(
                     created_at: jiff::Timestamp::now().to_string(),
                     session_id: session_id.to_string(),
                     seq: 0,
+                    provider: provider_id.to_string(),
                     tool_call_id,
                     output: tool_call_update_output(update),
                     status,
@@ -1787,7 +1811,7 @@ async fn push_session_update(
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "plan",
                         "title": "Execution plan updated",
@@ -1804,7 +1828,7 @@ async fn push_session_update(
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "commands",
                         "title": "Available commands updated",
@@ -1818,19 +1842,19 @@ async fn push_session_update(
                 .map_err(|_| event_channel_closed())?;
         }
         SessionUpdate::CurrentModeUpdate(update) => {
-            emit_current_mode(session_id, event_tx, update).await?;
+            emit_current_mode(session_id, provider_id, event_tx, update).await?;
         }
         SessionUpdate::ConfigOptionUpdate(update) => {
-            emit_config_update(session_id, event_tx, update).await?;
+            emit_config_update(session_id, provider_id, event_tx, update).await?;
         }
         SessionUpdate::SessionInfoUpdate(update) => {
-            emit_session_info(session_id, event_tx, update).await?;
+            emit_session_info(session_id, provider_id, event_tx, update).await?;
         }
         other => {
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "debug",
                         "title": "Unhandled session update",
@@ -1847,6 +1871,7 @@ async fn push_session_update(
 
 async fn handle_session_dispatch(
     session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     dispatch: Dispatch,
     stream_message_ids: &Arc<Mutex<StreamMessageIds>>,
@@ -1864,6 +1889,7 @@ async fn handle_session_dispatch(
             let is_prompt_progress = is_prompt_progress_update(&notification.update);
             push_session_update(
                 session_id,
+                provider_id,
                 event_tx,
                 notification.update,
                 stream_message_ids,
@@ -1878,7 +1904,7 @@ async fn handle_session_dispatch(
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "unhandled_provider_notification",
                         "title": "Unhandled provider notification",
@@ -1897,7 +1923,7 @@ async fn handle_session_dispatch(
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "unhandled_provider_request",
                         "title": "Unhandled provider request",
@@ -1915,7 +1941,7 @@ async fn handle_session_dispatch(
             event_tx
                 .send(provider_info_event(
                     session_id.to_string(),
-                    "codex",
+                    provider_id,
                     json!({
                         "type": "unhandled_provider_response",
                         "title": "Unhandled provider response",
@@ -1945,13 +1971,14 @@ fn is_prompt_progress_update(update: &SessionUpdate) -> bool {
 
 async fn emit_current_mode(
     session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     update: CurrentModeUpdate,
 ) -> Result<(), String> {
     event_tx
         .send(provider_info_event(
             session_id.to_string(),
-            "codex",
+            provider_id,
             json!({
                 "type": "current_mode",
                 "title": "Agent mode updated",
@@ -1964,13 +1991,14 @@ async fn emit_current_mode(
 
 async fn emit_config_update(
     session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     update: ConfigOptionUpdate,
 ) -> Result<(), String> {
     event_tx
         .send(provider_info_event(
             session_id.to_string(),
-            "codex",
+            provider_id,
             json!({
                 "type": "config_update",
                 "title": "Configuration options updated",
@@ -1983,13 +2011,14 @@ async fn emit_config_update(
 
 async fn emit_session_info(
     session_id: &str,
+    provider_id: &str,
     event_tx: &mpsc::Sender<AcpEvent>,
     update: SessionInfoUpdate,
 ) -> Result<(), String> {
     event_tx
         .send(provider_info_event(
             session_id.to_string(),
-            "codex",
+            provider_id,
             json!({
                 "type": "session_info",
                 "title": "Session info updated",
@@ -2002,6 +2031,7 @@ async fn emit_session_info(
 
 fn session_state_event(
     session_id: String,
+    provider: &str,
     state: lab_apis::acp::types::AcpSessionState,
 ) -> AcpEvent {
     AcpEvent::SessionUpdate {
@@ -2009,6 +2039,7 @@ fn session_state_event(
         created_at: jiff::Timestamp::now().to_string(),
         session_id,
         seq: 0,
+        provider: provider.to_string(),
         state,
     }
 }
@@ -2283,6 +2314,7 @@ mod tests {
 
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::UserMessageChunk(text_chunk("hello ")),
             &message_ids,
@@ -2291,6 +2323,7 @@ mod tests {
         .expect("first user chunk");
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::UserMessageChunk(text_chunk("world")),
             &message_ids,
@@ -2299,6 +2332,7 @@ mod tests {
         .expect("second user chunk");
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::AgentMessageChunk(text_chunk("reply ")),
             &message_ids,
@@ -2307,6 +2341,7 @@ mod tests {
         .expect("first assistant chunk");
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::AgentMessageChunk(text_chunk("done")),
             &message_ids,
@@ -2387,6 +2422,7 @@ mod tests {
             .meta(meta.clone());
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::ToolCall(tool_call),
             &message_ids,
@@ -2433,6 +2469,7 @@ mod tests {
         let update = ToolCallUpdate::new("tc-2", fields).meta(update_meta.clone());
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::ToolCallUpdate(update),
             &message_ids,
@@ -2517,6 +2554,7 @@ mod tests {
             .status(agent_client_protocol::schema::ToolCallStatus::Completed);
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::ToolCall(tool_call),
             &message_ids,
@@ -2541,6 +2579,7 @@ mod tests {
         let update = ToolCallUpdate::new("tc-no-meta-update", fields);
         push_session_update(
             "session-1",
+            "codex-acp",
             &tx,
             SessionUpdate::ToolCallUpdate(update),
             &message_ids,
@@ -2676,9 +2715,14 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(crate::acp::registry::ACP_EVENT_CHANNEL_CAPACITY);
         let permissions = PendingPermissions::new(Duration::from_millis(25));
 
-        let response =
-            handle_permission_request("session-1", &tx, &permissions, permission_request("tool-1"))
-                .await;
+        let response = handle_permission_request(
+            "session-1",
+            "codex-acp",
+            &tx,
+            &permissions,
+            permission_request("tool-1"),
+        )
+        .await;
 
         assert!(matches!(
             response.outcome,
@@ -2700,6 +2744,7 @@ mod tests {
         let pending = tokio::spawn(async move {
             handle_permission_request(
                 "session-1",
+                "codex-acp",
                 &tx,
                 &permissions,
                 permission_request("tool-reject"),
@@ -2734,6 +2779,7 @@ mod tests {
         let pending = tokio::spawn(async move {
             handle_permission_request(
                 "session-1",
+                "codex-acp",
                 &tx,
                 &permissions,
                 permission_request("tool-allow"),
@@ -2778,6 +2824,7 @@ mod tests {
         let pending = tokio::spawn(async move {
             handle_permission_request(
                 "session-1",
+                "codex-acp",
                 &tx,
                 &permissions,
                 permission_request("tool-cancel"),

--- a/crates/lab/src/acp/types.rs
+++ b/crates/lab/src/acp/types.rs
@@ -113,6 +113,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             role,
             text,
             message_id,
@@ -122,6 +123,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             role,
             text,
             message_id,
@@ -130,6 +132,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             text,
             ..
         } => AcpEvent::ReasoningChunk {
@@ -137,12 +140,14 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             text,
         },
         AcpEvent::ToolCallStart {
             id,
             created_at,
             session_id,
+            provider,
             tool_call_id,
             name,
             input,
@@ -152,6 +157,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             tool_call_id,
             name,
             input,
@@ -160,6 +166,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             tool_call_id,
             output,
             status,
@@ -169,6 +176,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             tool_call_id,
             output,
             status,
@@ -177,6 +185,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             request_id,
             action_summary,
             options,
@@ -186,6 +195,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             request_id,
             action_summary,
             options,
@@ -194,6 +204,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             request_id,
             granted,
             ..
@@ -202,6 +213,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             request_id,
             granted,
         },
@@ -209,6 +221,7 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             id,
             created_at,
             session_id,
+            provider,
             raw,
             ..
         } => AcpEvent::UsageUpdate {
@@ -216,12 +229,14 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             raw,
         },
         AcpEvent::ContentBlocks {
             id,
             created_at,
             session_id,
+            provider,
             blocks,
             ..
         } => AcpEvent::ContentBlocks {
@@ -229,12 +244,14 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             blocks,
         },
         AcpEvent::SessionUpdate {
             id,
             created_at,
             session_id,
+            provider,
             state,
             ..
         } => AcpEvent::SessionUpdate {
@@ -242,7 +259,27 @@ pub(crate) fn stamp_event_sequence(event: AcpEvent, seq: u64) -> AcpEvent {
             created_at,
             session_id,
             seq,
+            provider,
             state,
+        },
+        AcpEvent::ProviderSwitch {
+            id,
+            created_at,
+            session_id,
+            from_provider,
+            to_provider,
+            continuity_mode,
+            message,
+            ..
+        } => AcpEvent::ProviderSwitch {
+            id,
+            created_at,
+            session_id,
+            seq,
+            from_provider,
+            to_provider,
+            continuity_mode,
+            message,
         },
         AcpEvent::ProviderInfo {
             id,
@@ -289,6 +326,7 @@ pub(crate) fn event_created_at(event: &AcpEvent) -> &str {
         | AcpEvent::UsageUpdate { created_at, .. }
         | AcpEvent::ContentBlocks { created_at, .. }
         | AcpEvent::SessionUpdate { created_at, .. }
+        | AcpEvent::ProviderSwitch { created_at, .. }
         | AcpEvent::ProviderInfo { created_at, .. }
         | AcpEvent::Unknown { created_at, .. } => created_at,
     }

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -176,6 +176,8 @@ struct PageContextBody {
 #[serde(rename_all = "camelCase")]
 struct PromptBody {
     prompt: String,
+    provider: Option<String>,
+    continuity_mode: Option<String>,
     /// Optional structured page context. Passed to dispatch; injection is handled there.
     page_context: Option<PageContextBody>,
 }
@@ -223,6 +225,8 @@ async fn prompt_session(
     let params = json!({
         "session_id": session_id,
         "text": body.prompt.trim(),
+        "provider": body.provider,
+        "continuity_mode": body.continuity_mode,
         "page_context": page_context_value,
         "principal": principal,
     });

--- a/crates/lab/src/dispatch/acp/catalog.rs
+++ b/crates/lab/src/dispatch/acp/catalog.rs
@@ -114,7 +114,7 @@ pub const ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "session.prompt",
-        description: "Send a prompt to a running session",
+        description: "Send a prompt to a session. Optional provider switches the active runtime inside the same Lab session before dispatch.",
         destructive: false,
         returns: "Value",
         params: &[
@@ -135,6 +135,18 @@ pub const ACTIONS: &[ActionSpec] = &[
                 ty: "string",
                 required: true,
                 description: "Caller principal for ownership verification",
+            },
+            ParamSpec {
+                name: "provider",
+                ty: "string",
+                required: false,
+                description: "Provider to use for this prompt; if different from the current session provider, Lab switches runtime before dispatch",
+            },
+            ParamSpec {
+                name: "continuity_mode",
+                ty: "string",
+                required: false,
+                description: "Provider switch continuity mode: 'handoff' (bounded transcript) or 'reset'",
             },
             ParamSpec {
                 name: "page_context",

--- a/crates/lab/src/dispatch/acp/dispatch.rs
+++ b/crates/lab/src/dispatch/acp/dispatch.rs
@@ -6,6 +6,7 @@ use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{Value, json};
 use sha2::Sha256;
 
+use crate::acp::registry::PromptSessionOptions;
 use crate::acp::types::StartSessionInput;
 use crate::dispatch::error::ToolError;
 use crate::dispatch::helpers::{action_schema, help_payload, to_json};
@@ -252,7 +253,15 @@ pub async fn dispatch_with_registry(
             ensure_prompt_size(&effective_text)?;
 
             registry
-                .prompt_session(session_id, &effective_text, principal)
+                .prompt_session_with_options(
+                    session_id,
+                    &effective_text,
+                    principal,
+                    PromptSessionOptions {
+                        provider: opt_str(&params, "provider").map(ToOwned::to_owned),
+                        continuity_mode: opt_str(&params, "continuity_mode").map(ToOwned::to_owned),
+                    },
+                )
                 .await?;
             to_json(json!({ "ok": true, "session_id": session_id }))
         }

--- a/crates/lab/src/dispatch/acp/persistence.rs
+++ b/crates/lab/src/dispatch/acp/persistence.rs
@@ -765,6 +765,7 @@ fn event_id(event: &AcpEvent) -> &str {
         | AcpEvent::UsageUpdate { id, .. }
         | AcpEvent::ContentBlocks { id, .. }
         | AcpEvent::SessionUpdate { id, .. }
+        | AcpEvent::ProviderSwitch { id, .. }
         | AcpEvent::ProviderInfo { id, .. }
         | AcpEvent::Unknown { id, .. } => id,
     }
@@ -781,6 +782,7 @@ fn event_kind_str(event: &AcpEvent) -> &'static str {
         AcpEvent::UsageUpdate { .. } => "usage_update",
         AcpEvent::ContentBlocks { .. } => "content_blocks",
         AcpEvent::SessionUpdate { .. } => "session_update",
+        AcpEvent::ProviderSwitch { .. } => "provider_switch",
         AcpEvent::ProviderInfo { .. } => "provider_info",
         AcpEvent::Unknown { .. } => "unknown",
     }
@@ -797,6 +799,7 @@ fn event_created_at(event: &AcpEvent) -> &str {
         | AcpEvent::UsageUpdate { created_at, .. }
         | AcpEvent::ContentBlocks { created_at, .. }
         | AcpEvent::SessionUpdate { created_at, .. }
+        | AcpEvent::ProviderSwitch { created_at, .. }
         | AcpEvent::ProviderInfo { created_at, .. }
         | AcpEvent::Unknown { created_at, .. } => created_at,
     }
@@ -938,6 +941,7 @@ mod db_load_events_tests {
                 session_id: session_id.to_string(),
                 seq: n,
                 created_at: "2026-04-30T00:00:00Z".to_string(),
+                provider: "codex-acp".to_string(),
                 role: "assistant".to_string(),
                 text: format!("chunk-{n}"),
                 message_id: "msg-1".to_string(),
@@ -1048,6 +1052,7 @@ mod hmac_tests {
             session_id: "sess-1".to_string(),
             seq: 7,
             created_at: "2026-04-30T00:00:00Z".to_string(),
+            provider: "codex-acp".to_string(),
             request_id: "perm-1".to_string(),
             granted: true,
         };


### PR DESCRIPTION
## Summary
- add provider switch events/metadata for ACP sessions
- allow `session.prompt` to request a provider switch with continuity mode before dispatch
- persist provider switch information and expose it through ACP API/types

## Tests
- `RUSTC_WRAPPER= cargo test --manifest-path crates/lab-apis/Cargo.toml --test acp_types` (2/2 passing)
- `RUSTC_WRAPPER= cargo test --manifest-path crates/lab/Cargo.toml acp --lib` (85/85 passing)

## Agent-browser verification
- Not directly browser-verifiable in this branch because the committed surface is backend/API/provider handoff plumbing without a new visible UI control in this worktree. Browser-level switching is covered by the adapter/model UI PR and should be rechecked after branches are integrated.

## Notes
- Created `apps/gateway-admin/out/` only as ignored build scaffolding for Rust `include_dir!`; it was not committed.
- `.env`, `config.toml`, and ignored plan files were not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-session provider switching for ACP chat with optional continuity, and attributes events to the active provider. Improves handoff robustness with availability checks, UTF-8-safe transcript bounds, stale-runtime guarding, and rollback on switch failure.

- **New Features**
  - Switch provider within a session via `session.prompt` options: `provider` and `continuity_mode` (`handoff` bounded transcript or `reset`).
  - Handoff builds a compact transcript (max 10 messages, ~12KB), truncates on UTF-8 boundaries, and validates provider availability before switching.
  - Event stream includes `provider` on turn, permission, tool, usage, content, session, and provider info events, plus a new `provider_switch` event; added `provider_id()` accessor.
  - Registry replaces runtimes safely, updates session summary/provider, ignores stale runtime exits using a provider_session_id guard, and rolls back session state if a switch fails.
  - HTTP/API: prompt endpoint accepts `provider` and `continuity_mode` (both optional).

- **Migration**
  - Handle the new `provider_switch` event kind in clients.
  - Accept the optional `provider` field on events; treat empty as unknown.
  - No changes needed for existing callers; new options are optional.

<sup>Written for commit 9fbdc0aedc8452ef88d8c44300dfa3bd326bc1e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

