### PR TITLE
Make chat prompt input scroll internally

### DIFF
--- a/apps/gateway-admin/components/chat/chat-input.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.test.tsx
@@ -55,7 +55,7 @@ test('chat input textarea renders with max height and without whole-composer ove
   )
 
   assert.match(markup, /aria-label="Message"/)
-  assert.match(markup, /max-height:200px/)
-  assert.match(markup, /overflow-y:hidden/)
+  assert.match(markup, new RegExp(`max-height:${CHAT_INPUT_MAX_HEIGHT_PX}px`))
+  assert.doesNotMatch(markup, /overflow-y:hidden/)
   assert.doesNotMatch(markup, /overflow-hidden bg-transparent/)
 })

--- a/apps/gateway-admin/components/chat/chat-input.test.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.test.tsx
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import {
+  CHAT_INPUT_MAX_HEIGHT_PX,
+  ChatInput,
+  resizeChatPromptTextarea,
+} from './chat-input'
+
+function textarea(scrollHeight: number) {
+  const style: Record<string, string> = {}
+  return {
+    scrollHeight,
+    scrollTop: 12,
+    style,
+  } as unknown as HTMLTextAreaElement
+}
+
+const selectedAgent = {
+  id: 'codex-acp',
+  name: 'Codex ACP',
+  description: 'codex-acp over local ACP bridge',
+  version: 'live',
+  capabilities: [],
+}
+
+test('resizeChatPromptTextarea grows until max height then enables internal scroll', () => {
+  const el = textarea(CHAT_INPUT_MAX_HEIGHT_PX + 80)
+
+  resizeChatPromptTextarea(el)
+
+  assert.equal(el.style.height, `${CHAT_INPUT_MAX_HEIGHT_PX}px`)
+  assert.equal(el.style.overflowY, 'auto')
+})
+
+test('resizeChatPromptTextarea hides vertical overflow while content fits', () => {
+  const el = textarea(88)
+
+  resizeChatPromptTextarea(el)
+
+  assert.equal(el.style.height, '88px')
+  assert.equal(el.style.overflowY, 'hidden')
+})
+
+test('chat input textarea renders with max height and without whole-composer overflow behavior', () => {
+  const markup = renderToStaticMarkup(
+    <ChatInput
+      onSend={() => {}}
+      selectedAgent={selectedAgent}
+      agents={[selectedAgent]}
+      onSelectAgent={() => {}}
+    />,
+  )
+
+  assert.match(markup, /aria-label="Message"/)
+  assert.match(markup, /max-height:200px/)
+  assert.match(markup, /overflow-y:hidden/)
+  assert.doesNotMatch(markup, /overflow-hidden bg-transparent/)
+})

--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -26,6 +26,15 @@ interface ChatInputProps {
   onSelectAgent: (agentId: string) => void
 }
 
+export const CHAT_INPUT_MAX_HEIGHT_PX = 200
+
+export function resizeChatPromptTextarea(el: HTMLTextAreaElement) {
+  el.style.height = 'auto'
+  const nextHeight = Math.min(el.scrollHeight, CHAT_INPUT_MAX_HEIGHT_PX)
+  el.style.height = `${nextHeight}px`
+  el.style.overflowY = el.scrollHeight > CHAT_INPUT_MAX_HEIGHT_PX ? 'auto' : 'hidden'
+}
+
 export function ChatInput({
   onSend,
   disabled = false,
@@ -70,6 +79,8 @@ export function ChatInput({
       setAttachments([])
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto'
+        textareaRef.current.style.overflowY = 'hidden'
+        textareaRef.current.scrollTop = 0
       }
     } finally {
       sendingRef.current = false
@@ -101,9 +112,7 @@ export function ChatInput({
 
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value)
-    const el = e.target
-    el.style.height = 'auto'
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`
+    resizeChatPromptTextarea(e.target)
   }
 
   React.useEffect(() => {
@@ -217,11 +226,15 @@ export function ChatInput({
           placeholder={disabled ? (disabledReason ?? 'ACP provider unavailable…') : 'Message the assistant… (Shift+Enter for newline)'}
           rows={1}
           className={cn(
-            'w-full resize-none overflow-hidden bg-transparent px-3 pt-2.5 pb-1.5 text-[13px] leading-[1.55] sm:px-4 sm:pt-3 sm:pb-2',
+            'w-full resize-none bg-transparent px-3 pt-2.5 pb-1.5 text-[13px] leading-[1.55] sm:px-4 sm:pt-3 sm:pb-2',
             'text-aurora-text-primary placeholder:text-aurora-text-muted/50',
             'outline-none disabled:opacity-50',
           )}
-          style={{ minHeight: '44px', maxHeight: '200px' }}
+          style={{
+            minHeight: '44px',
+            maxHeight: `${CHAT_INPUT_MAX_HEIGHT_PX}px`,
+            overflowY: 'hidden',
+          }}
         />
 
         <div className="flex items-center gap-2 px-2.5 pb-2 sm:gap-2.5 sm:px-3">

--- a/apps/gateway-admin/components/chat/chat-input.tsx
+++ b/apps/gateway-admin/components/chat/chat-input.tsx
@@ -27,6 +27,7 @@ interface ChatInputProps {
 }
 
 export const CHAT_INPUT_MAX_HEIGHT_PX = 200
+const CHAT_INPUT_MIN_HEIGHT_PX = 44
 
 export function resizeChatPromptTextarea(el: HTMLTextAreaElement) {
   el.style.height = 'auto'
@@ -230,11 +231,7 @@ export function ChatInput({
             'text-aurora-text-primary placeholder:text-aurora-text-muted/50',
             'outline-none disabled:opacity-50',
           )}
-          style={{
-            minHeight: '44px',
-            maxHeight: `${CHAT_INPUT_MAX_HEIGHT_PX}px`,
-            overflowY: 'hidden',
-          }}
+          style={{ minHeight: `${CHAT_INPUT_MIN_HEIGHT_PX}px`, maxHeight: `${CHAT_INPUT_MAX_HEIGHT_PX}px` }}
         />
 
         <div className="flex items-center gap-2 px-2.5 pb-2 sm:gap-2.5 sm:px-3">


### PR DESCRIPTION
## Summary
- Adds a chat prompt textarea resize helper and keeps the 200px composer cap explicit.
- Switches long prompt overflow to internal textarea scrolling after the cap.
- Resets height, overflow, and scroll position after successful send.

## Verification
- `pnpm --dir apps/gateway-admin exec tsx --test components/chat/chat-input.test.tsx` -> 3/3 pass
- `pnpm --dir apps/gateway-admin run build` -> pass
- `agent-browser` opened `NEXT_PUBLIC_MOCK_DATA=true` dev preview at `http://127.0.0.1:3140/chat/`; preview rendered the chat surface but mock provider disabled the composer, so internal scroll behavior is covered by focused resize tests.

## Notes
- `.env`, `config.toml`, `node_modules`, and `.next` were local ignored worktree support files only and are not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches long chat prompts to scroll inside the textarea after the 200px cap. Resets size and scroll on send for a smoother compose experience.

- **Bug Fixes**
  - Enable internal textarea scroll after the 200px cap (removes whole-composer overflow).
  - Reset height, overflowY, and scrollTop after a successful send.

- **Refactors**
  - Add `resizeChatPromptTextarea` and constants `CHAT_INPUT_MAX_HEIGHT_PX` (200) and `CHAT_INPUT_MIN_HEIGHT_PX` (44); replace inline resize logic with the helper.
  - Remove textarea `overflow-hidden` class and use constants in styles; add tests for cap behavior and overflow.

<sup>Written for commit 0654d68722da5636c8a8b366aa0818084efc4632. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

