### PR TITLE
Show chat message timestamps on interaction

### DIFF
--- a/apps/gateway-admin/components/chat/message-bubble.test.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.test.tsx
@@ -244,6 +244,30 @@ test('renders timestamp row after message content without overlapping copy actio
   )
 })
 
+test('renders timestamp for assistant messages with only tool activity', () => {
+  const markup = renderToStaticMarkup(
+    <MessageBubble
+      message={assistantMessage({
+        text: '',
+        isStreaming: false,
+        thoughts: [],
+        toolCalls: [
+          {
+            id: 'tool-only',
+            title: 'Read file',
+            status: 'completed',
+            locations: ['README.md'],
+          },
+        ],
+        createdAt: new Date('2026-05-04T12:45:00Z'),
+      })}
+    />,
+  )
+
+  assert.match(markup, /data-message-timestamp/)
+  assert.match(markup, /12:45 PM UTC/)
+})
+
 test('selected message renders timestamp as visible for touch interaction', () => {
   const markup = renderToStaticMarkup(<MessageBubble message={userMessage()} selected />)
 
@@ -262,6 +286,16 @@ test('message bubble memo comparison includes timestamp and selected state', () 
   assert.equal(
     areMessageBubblePropsEqual({ message: base, selected: false }, { message: base, selected: true }),
     false,
+  )
+})
+
+test('message bubble memo comparison treats invalid timestamps as stable', () => {
+  const invalid = userMessage({ createdAt: new Date(Number.NaN) })
+  const nextInvalid = { ...invalid, createdAt: new Date(Number.NaN) }
+
+  assert.equal(
+    areMessageBubblePropsEqual({ message: invalid, selected: false }, { message: nextInvalid, selected: false }),
+    true,
   )
 })
 

--- a/apps/gateway-admin/components/chat/message-bubble.test.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.test.tsx
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { MessageBubble, WorkingAssistantBubble, getMessageCopyText } from './message-bubble'
+import {
+  MessageBubble,
+  WorkingAssistantBubble,
+  areMessageBubblePropsEqual,
+  getMessageCopyText,
+  getMessageTimestampLabels,
+  shouldRenderMessageTimestamp,
+} from './message-bubble'
 import type { ACPMessage } from './types'
 
 const MESSAGE_TIMESTAMP = new Date('2026-05-04T12:00:00Z')
@@ -200,6 +207,62 @@ test('copies raw message text rather than rendered markdown text', () => {
   })
 
   assert.equal(getMessageCopyText(message), message.text)
+})
+
+test('formats message timestamp labels from createdAt metadata', () => {
+  const labels = getMessageTimestampLabels(userMessage({
+    createdAt: new Date('2026-05-04T12:34:00Z'),
+  }))
+
+  assert.equal(labels.visible, '12:34 PM UTC')
+  assert.equal(labels.detail, 'May 4, 2026, 12:34 PM UTC')
+})
+
+test('omits timestamp presentation when createdAt is invalid', () => {
+  const message = userMessage({ createdAt: new Date(Number.NaN) })
+
+  assert.equal(shouldRenderMessageTimestamp(message), false)
+})
+
+test('renders timestamp row after message content without overlapping copy action', () => {
+  const markup = renderToStaticMarkup(
+    <MessageBubble message={userMessage({ createdAt: new Date('2026-05-04T12:34:00Z') })} />,
+  )
+
+  assert.match(markup, /aria-label="Message sent at May 4, 2026, 12:34 PM UTC"/)
+  assert.match(markup, /12:34 PM UTC/)
+  assert.match(markup, /data-message-timestamp/)
+  assert.match(markup, /group-hover\/bubble:opacity-100/)
+  assert.match(markup, /group-focus-within\/bubble:opacity-100/)
+  assert.ok(
+    markup.indexOf('Hello.') < markup.indexOf('data-message-timestamp'),
+    'timestamp should render after the message text',
+  )
+  assert.ok(
+    markup.indexOf('Copy message') < markup.indexOf('data-message-timestamp'),
+    'timestamp row should not share the absolute copy-button slot',
+  )
+})
+
+test('selected message renders timestamp as visible for touch interaction', () => {
+  const markup = renderToStaticMarkup(<MessageBubble message={userMessage()} selected />)
+
+  assert.match(markup, /data-message-id="message-user-1"/)
+  assert.match(markup, /opacity-100/)
+})
+
+test('message bubble memo comparison includes timestamp and selected state', () => {
+  const base = userMessage({ createdAt: new Date('2026-05-04T12:00:00Z') })
+  const changedTimestamp = { ...base, createdAt: new Date('2026-05-04T12:01:00Z') }
+
+  assert.equal(
+    areMessageBubblePropsEqual({ message: base, selected: false }, { message: changedTimestamp, selected: false }),
+    false,
+  )
+  assert.equal(
+    areMessageBubblePropsEqual({ message: base, selected: false }, { message: base, selected: true }),
+    false,
+  )
 })
 
 test('keeps the streaming cursor adjacent to assistant markdown content', () => {

--- a/apps/gateway-admin/components/chat/message-bubble.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.tsx
@@ -288,7 +288,7 @@ function MessageBubbleComponent({
     <div
       data-message-id={message.id}
       className={cn('group/bubble flex min-w-0 gap-3', isUser && 'flex-row-reverse')}
-      onPointerDown={(event) => {
+      onClick={(event) => {
         const target = event.target as HTMLElement
         if (target.closest('button,a,input,textarea,select,[role="button"]')) return
         onSelect?.(message.id)
@@ -355,29 +355,27 @@ function MessageBubbleComponent({
         )}
 
         {message.text && (
-          <>
-            <div className={messageContentClass}>
-              {!isUser && (
-                <span
-                  aria-hidden="true"
-                  className="absolute inset-y-0 left-0 w-[2px] rounded-l-aurora-2 bg-aurora-accent-primary/40"
-                />
-              )}
-              {isUser ? (
-                <p className="min-w-0 whitespace-pre-wrap pr-8 text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
-                  {message.text}
-                  {message.isStreaming ? <StreamingCursor /> : null}
-                </p>
-              ) : (
-                <AssistantMarkdown text={message.text} isStreaming={isStreaming} />
-              )}
-              <div className="absolute right-2 top-2">
-                <CopyButton text={getMessageCopyText(message)} />
-              </div>
+          <div className={messageContentClass}>
+            {!isUser && (
+              <span
+                aria-hidden="true"
+                className="absolute inset-y-0 left-0 w-[2px] rounded-l-aurora-2 bg-aurora-accent-primary/40"
+              />
+            )}
+            {isUser ? (
+              <p className="min-w-0 whitespace-pre-wrap pr-8 text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
+                {message.text}
+                {message.isStreaming ? <StreamingCursor /> : null}
+              </p>
+            ) : (
+              <AssistantMarkdown text={message.text} isStreaming={isStreaming} />
+            )}
+            <div className="absolute right-2 top-2">
+              <CopyButton text={getMessageCopyText(message)} />
             </div>
-            <MessageTimestamp message={message} selected={selected} />
-          </>
+          </div>
         )}
+        <MessageTimestamp message={message} selected={selected} />
       </div>
     </div>
   )
@@ -395,7 +393,7 @@ export function areMessageBubblePropsEqual(
     previous.selected === next.selected &&
     prev.role === current.role &&
     prev.text === current.text &&
-    prev.createdAt.getTime() === current.createdAt.getTime() &&
+    Object.is(prev.createdAt.getTime(), current.createdAt.getTime()) &&
     prev.isStreaming === current.isStreaming &&
     prev.version === current.version &&
     prev.thoughts.length === current.thoughts.length &&

--- a/apps/gateway-admin/components/chat/message-bubble.tsx
+++ b/apps/gateway-admin/components/chat/message-bubble.tsx
@@ -17,6 +17,7 @@ import {
   ChainOfThoughtHeader,
 } from '@/components/ai/chain-of-thought'
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '@/components/ai/reasoning'
+import { formatUiDateTime, formatUiTime } from '@/lib/format-ui-time'
 import { ToolCallDisplay } from './tool-call-display'
 import { GroupedToolCallDisplay, groupConsecutiveToolCalls } from './grouped-tool-call-display'
 import { getToolCategory } from './tool-call-presentation'
@@ -50,6 +51,28 @@ function CopyButton({ text }: { text: string }) {
 
 export function getMessageCopyText(message: Pick<ACPMessage, 'text'>) {
   return message.text
+}
+
+export type MessageTimestampLabels = {
+  visible: string
+  detail: string
+}
+
+function hasValidDate(value: Date) {
+  return !Number.isNaN(value.getTime())
+}
+
+export function shouldRenderMessageTimestamp(message: Pick<ACPMessage, 'createdAt'>) {
+  return hasValidDate(message.createdAt)
+}
+
+export function getMessageTimestampLabels(
+  message: Pick<ACPMessage, 'createdAt'>,
+): MessageTimestampLabels {
+  return {
+    visible: formatUiTime(message.createdAt),
+    detail: formatUiDateTime(message.createdAt),
+  }
 }
 
 function StreamingCursor() {
@@ -166,6 +189,33 @@ function AgentActionsPanel({
   )
 }
 
+function MessageTimestamp({
+  message,
+  selected,
+}: {
+  message: ACPMessage
+  selected?: boolean
+}) {
+  if (!shouldRenderMessageTimestamp(message)) return null
+
+  const labels = getMessageTimestampLabels(message)
+
+  return (
+    <div
+      data-message-timestamp
+      aria-label={`Message sent at ${labels.detail}`}
+      title={labels.detail}
+      className={cn(
+        'min-h-4 text-[11px] leading-4 text-aurora-text-muted/60 transition-opacity duration-150',
+        'opacity-0 group-hover/bubble:opacity-100 group-focus-within/bubble:opacity-100',
+        selected && 'opacity-100',
+      )}
+    >
+      {labels.visible}
+    </div>
+  )
+}
+
 export function WorkingAssistantBubble({ label = 'Codex is working' }: { label?: string }) {
   return (
     <div className="group/bubble flex min-w-0 gap-3">
@@ -204,7 +254,17 @@ export function WorkingAssistantBubble({ label = 'Codex is working' }: { label?:
   )
 }
 
-function MessageBubbleComponent({ message }: { message: ACPMessage }) {
+export type MessageBubbleProps = {
+  message: ACPMessage
+  selected?: boolean
+  onSelect?: (messageId: string) => void
+}
+
+function MessageBubbleComponent({
+  message,
+  selected = false,
+  onSelect,
+}: MessageBubbleProps) {
   const isUser = message.role === 'user'
   const isStreaming = Boolean(message.isStreaming)
   const [reasoningOpen, setReasoningOpen] = React.useState(isStreaming)
@@ -225,7 +285,15 @@ function MessageBubbleComponent({ message }: { message: ACPMessage }) {
   )
 
   return (
-    <div className={cn('group/bubble flex min-w-0 gap-3', isUser && 'flex-row-reverse')}>
+    <div
+      data-message-id={message.id}
+      className={cn('group/bubble flex min-w-0 gap-3', isUser && 'flex-row-reverse')}
+      onPointerDown={(event) => {
+        const target = event.target as HTMLElement
+        if (target.closest('button,a,input,textarea,select,[role="button"]')) return
+        onSelect?.(message.id)
+      }}
+    >
       <div
         className={cn(
           'mt-1 flex size-6 shrink-0 items-center justify-center rounded-full border',
@@ -287,42 +355,47 @@ function MessageBubbleComponent({ message }: { message: ACPMessage }) {
         )}
 
         {message.text && (
-          <div className={messageContentClass}>
-            {!isUser && (
-              <span
-                aria-hidden="true"
-                className="absolute inset-y-0 left-0 w-[2px] rounded-l-aurora-2 bg-aurora-accent-primary/40"
-              />
-            )}
-            {isUser ? (
-              <p className="min-w-0 whitespace-pre-wrap pr-8 text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
-                {message.text}
-                {message.isStreaming ? <StreamingCursor /> : null}
-              </p>
-            ) : (
-              <AssistantMarkdown text={message.text} isStreaming={isStreaming} />
-            )}
-            <div className="absolute right-2 top-2">
-              <CopyButton text={getMessageCopyText(message)} />
+          <>
+            <div className={messageContentClass}>
+              {!isUser && (
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-y-0 left-0 w-[2px] rounded-l-aurora-2 bg-aurora-accent-primary/40"
+                />
+              )}
+              {isUser ? (
+                <p className="min-w-0 whitespace-pre-wrap pr-8 text-[13px] leading-[1.55] text-aurora-text-primary [overflow-wrap:anywhere]">
+                  {message.text}
+                  {message.isStreaming ? <StreamingCursor /> : null}
+                </p>
+              ) : (
+                <AssistantMarkdown text={message.text} isStreaming={isStreaming} />
+              )}
+              <div className="absolute right-2 top-2">
+                <CopyButton text={getMessageCopyText(message)} />
+              </div>
             </div>
-          </div>
+            <MessageTimestamp message={message} selected={selected} />
+          </>
         )}
       </div>
     </div>
   )
 }
 
-function areMessageBubblePropsEqual(
-  previous: Readonly<{ message: ACPMessage }>,
-  next: Readonly<{ message: ACPMessage }>,
+export function areMessageBubblePropsEqual(
+  previous: Readonly<MessageBubbleProps>,
+  next: Readonly<MessageBubbleProps>,
 ) {
   const prev = previous.message
   const current = next.message
 
   return (
     prev.id === current.id &&
+    previous.selected === next.selected &&
     prev.role === current.role &&
     prev.text === current.text &&
+    prev.createdAt.getTime() === current.createdAt.getTime() &&
     prev.isStreaming === current.isStreaming &&
     prev.version === current.version &&
     prev.thoughts.length === current.thoughts.length &&

--- a/apps/gateway-admin/components/chat/message-thread.test.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.test.tsx
@@ -1,89 +1,63 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
-import { shouldShowWorkingAssistantBubble } from './message-thread'
+import { MessageThread, shouldShowWorkingAssistantBubble } from './message-thread'
 import type { ACPMessage, ACPRun } from './types'
 
-const RUN_TIMESTAMP = new Date('2026-05-05T00:00:00Z')
-const MESSAGE_TIMESTAMP = new Date('2026-05-05T00:00:01Z')
-
-function run(status: ACPRun['status'] = 'running'): ACPRun {
+function run(): ACPRun {
   return {
     id: 'run-1',
-    projectId: 'workspace',
-    agentId: 'codex',
+    projectId: 'project-1',
+    agentId: 'agent-1',
     provider: 'codex',
-    title: 'Optimize mobile chat',
-    createdAt: RUN_TIMESTAMP,
-    updatedAt: RUN_TIMESTAMP,
-    status,
+    title: 'Run',
+    createdAt: new Date('2026-05-04T12:00:00Z'),
+    updatedAt: new Date('2026-05-04T12:00:00Z'),
+    status: 'idle',
     providerSessionId: 'provider-run-1',
     cwd: '/home/jmagar/workspace/lab',
   }
 }
 
-function message(overrides: Partial<ACPMessage> = {}): ACPMessage {
+function message(id: string, text: string, minute: string): ACPMessage {
   return {
-    id: 'message-1',
+    id,
     runId: 'run-1',
     role: 'user',
-    text: 'Please continue.',
-    createdAt: MESSAGE_TIMESTAMP,
+    text,
+    createdAt: new Date(`2026-05-04T12:${minute}:00Z`),
     isStreaming: false,
     thoughts: [],
     toolCalls: [],
     version: 1,
-    ...overrides,
   }
 }
 
-test('shows working assistant bubble while run is running and no assistant stream exists', () => {
-  assert.equal(
-    shouldShowWorkingAssistantBubble(run('running'), [message()], 'open'),
-    true,
+test('message thread renders timestamp-ready bubbles with stable message ids', () => {
+  const markup = renderToStaticMarkup(
+    <MessageThread
+      run={run()}
+      messages={[message('m1', 'First', '10'), message('m2', 'Second', '20')]}
+    />,
   )
+
+  assert.match(markup, /data-message-id="m1"/)
+  assert.match(markup, /data-message-id="m2"/)
+  assert.match(markup, /12:10 PM UTC/)
+  assert.match(markup, /12:20 PM UTC/)
+  assert.match(markup, /opacity-0 group-hover\/bubble:opacity-100 group-focus-within\/bubble:opacity-100/)
 })
 
-test('shows working assistant bubble during initial connecting state for a running run', () => {
-  assert.equal(
-    shouldShowWorkingAssistantBubble(run('running'), [message()], 'connecting'),
-    true,
-  )
-})
-
-test('does not show working assistant bubble when an assistant stream already exists', () => {
+test('working assistant bubble logic remains unchanged for running sessions', () => {
+  assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'running' }, [], 'open'), true)
   assert.equal(
     shouldShowWorkingAssistantBubble(
-      run('running'),
-      [
-        message(),
-        message({
-          id: 'assistant-stream',
-          role: 'assistant',
-          text: 'Working on it',
-          isStreaming: true,
-        }),
-      ],
+      { ...run(), status: 'running' },
+      [{ ...message('assistant-1', 'Streaming', '30'), role: 'assistant', isStreaming: true }],
       'open',
     ),
-    false,
-  )
-})
-
-test('does not show working assistant bubble for waiting-for-permission', () => {
-  assert.equal(
-    shouldShowWorkingAssistantBubble(run('waiting_for_permission'), [message()], 'open'),
-    false,
-  )
-})
-
-test('does not show working assistant bubble for idle runs or errored streams', () => {
-  assert.equal(
-    shouldShowWorkingAssistantBubble(run('idle'), [message()], 'open'),
-    false,
-  )
-  assert.equal(
-    shouldShowWorkingAssistantBubble(run('running'), [message()], 'error'),
     false,
   )
 })

--- a/apps/gateway-admin/components/chat/message-thread.test.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.test.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { MessageThread, shouldShowWorkingAssistantBubble } from './message-thread'
+import { MessageThread, reduceSelectedMessageId, shouldShowWorkingAssistantBubble } from './message-thread'
 import type { ACPMessage, ACPRun } from './types'
 
 function run(): ACPRun {
@@ -21,7 +21,15 @@ function run(): ACPRun {
   }
 }
 
-function message(id: string, text: string, minute: string): ACPMessage {
+function runWithId(id: string): ACPRun {
+  return {
+    ...run(),
+    id,
+    providerSessionId: `provider-${id}`,
+  }
+}
+
+function message(id: string, text: string, minute: string, overrides: Partial<ACPMessage> = {}): ACPMessage {
   return {
     id,
     runId: 'run-1',
@@ -32,6 +40,7 @@ function message(id: string, text: string, minute: string): ACPMessage {
     thoughts: [],
     toolCalls: [],
     version: 1,
+    ...overrides,
   }
 }
 
@@ -51,7 +60,12 @@ test('message thread renders timestamp-ready bubbles with stable message ids', (
 })
 
 test('working assistant bubble logic remains unchanged for running sessions', () => {
+  assert.equal(shouldShowWorkingAssistantBubble(null, [], 'open'), false)
+  assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'idle' }, [], 'open'), false)
+  assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'waiting_for_permission' }, [], 'open'), false)
+  assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'running' }, [], 'connecting'), true)
   assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'running' }, [], 'open'), true)
+  assert.equal(shouldShowWorkingAssistantBubble({ ...run(), status: 'running' }, [], 'error'), false)
   assert.equal(
     shouldShowWorkingAssistantBubble(
       { ...run(), status: 'running' },
@@ -60,4 +74,20 @@ test('working assistant bubble logic remains unchanged for running sessions', ()
     ),
     false,
   )
+})
+
+test('timestamp selection state handles tap selection and dismiss paths', () => {
+  assert.equal(reduceSelectedMessageId(null, { type: 'select', messageId: 'm1' }), 'm1')
+  assert.equal(reduceSelectedMessageId('m1', { type: 'select', messageId: 'm2' }), 'm2')
+  assert.equal(reduceSelectedMessageId('m1', { type: 'dismiss' }), null)
+  assert.equal(reduceSelectedMessageId('m1', { type: 'run-change', runId: runWithId('run-2').id }), null)
+
+  const selectedMarkup = renderToStaticMarkup(
+    <MessageThread
+      run={runWithId('run-2')}
+      messages={[message('shared-id', 'Second run', '20', { runId: 'run-2' })]}
+      connectionState="open"
+    />,
+  )
+  assert.doesNotMatch(selectedMarkup, /\sopacity-100"/)
 })

--- a/apps/gateway-admin/components/chat/message-thread.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.tsx
@@ -76,6 +76,26 @@ export function shouldShowWorkingAssistantBubble(
   return !hasStreamingAssistantMessage
 }
 
+export type MessageTimestampSelectionAction =
+  | { type: 'select'; messageId: string }
+  | { type: 'dismiss' }
+  | { type: 'run-change'; runId: string | null }
+
+export function reduceSelectedMessageId(
+  selectedMessageId: string | null,
+  action: MessageTimestampSelectionAction,
+): string | null {
+  switch (action.type) {
+    case 'select':
+      return action.messageId
+    case 'dismiss':
+    case 'run-change':
+      return null
+    default:
+      return selectedMessageId
+  }
+}
+
 export function MessageThread({ run, messages, connectionState }: MessageThreadProps) {
   const bottomRef = React.useRef<HTMLDivElement>(null)
   const threadRef = React.useRef<HTMLDivElement>(null)
@@ -86,12 +106,18 @@ export function MessageThread({ run, messages, connectionState }: MessageThreadP
   }, [messages])
 
   React.useEffect(() => {
+    setSelectedMessageId((current) => reduceSelectedMessageId(current, { type: 'run-change', runId: run?.id ?? null }))
+  }, [run?.id])
+
+  React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setSelectedMessageId(null)
+      if (event.key === 'Escape') {
+        setSelectedMessageId((current) => reduceSelectedMessageId(current, { type: 'dismiss' }))
+      }
     }
     const handlePointerDown = (event: PointerEvent) => {
       if (!threadRef.current?.contains(event.target as Node)) {
-        setSelectedMessageId(null)
+        setSelectedMessageId((current) => reduceSelectedMessageId(current, { type: 'dismiss' }))
       }
     }
 
@@ -119,7 +145,9 @@ export function MessageThread({ run, messages, connectionState }: MessageThreadP
             key={message.id}
             message={message}
             selected={selectedMessageId === message.id}
-            onSelect={setSelectedMessageId}
+            onSelect={(messageId) =>
+              setSelectedMessageId((current) => reduceSelectedMessageId(current, { type: 'select', messageId }))
+            }
           />
         ))}
         {shouldShowWorkingAssistantBubble(run, messages, connectionState) ? (

--- a/apps/gateway-admin/components/chat/message-thread.tsx
+++ b/apps/gateway-admin/components/chat/message-thread.tsx
@@ -78,10 +78,30 @@ export function shouldShowWorkingAssistantBubble(
 
 export function MessageThread({ run, messages, connectionState }: MessageThreadProps) {
   const bottomRef = React.useRef<HTMLDivElement>(null)
+  const threadRef = React.useRef<HTMLDivElement>(null)
+  const [selectedMessageId, setSelectedMessageId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSelectedMessageId(null)
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!threadRef.current?.contains(event.target as Node)) {
+        setSelectedMessageId(null)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [])
 
   if (!run) {
     return <EmptyState />
@@ -89,10 +109,18 @@ export function MessageThread({ run, messages, connectionState }: MessageThreadP
 
   return (
     <ScrollArea className="min-h-0 min-w-0 flex-1 overflow-hidden">
-      <div className="mx-auto flex w-full max-w-[860px] min-w-0 flex-col gap-4 px-3 py-4 sm:gap-5 sm:px-6 sm:py-6">
+      <div
+        ref={threadRef}
+        className="mx-auto flex w-full max-w-[860px] min-w-0 flex-col gap-4 px-3 py-4 sm:gap-5 sm:px-6 sm:py-6"
+      >
         <SessionStatusNotice run={run} connectionState={connectionState} />
         {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
+          <MessageBubble
+            key={message.id}
+            message={message}
+            selected={selectedMessageId === message.id}
+            onSelect={setSelectedMessageId}
+          />
         ))}
         {shouldShowWorkingAssistantBubble(run, messages, connectionState) ? (
           <WorkingAssistantBubble />


### PR DESCRIPTION
## Summary
- Adds timestamp formatting helpers for chat messages using existing UI time formatters.
- Renders a reserved under-bubble timestamp row that reveals on desktop hover/focus and selected touch/click state.
- Wires MessageThread selected-message state with Escape and outside-pointer dismissal.

## Verification
- `pnpm --dir apps/gateway-admin exec tsx --test components/chat/message-bubble.test.tsx components/chat/message-thread.test.tsx` -> 17/17 pass
- `pnpm --dir apps/gateway-admin run build` -> pass
- `agent-browser` opened `NEXT_PUBLIC_MOCK_DATA=true` dev preview at `http://127.0.0.1:3141/chat/`; preview rendered the chat surface but mock provider disabled live transcript interaction, so timestamp behavior is covered by focused component tests.

## Notes
- `.env`, `config.toml`, `node_modules`, and `.next` were local ignored worktree support files only and are not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show timestamps on chat messages on hover/focus and keep them visible when selected. Improves selection/dismiss behavior and accessibility.

- New Features
  - Render a timestamp row under each bubble using `formatUiTime`/`formatUiDateTime`; adds accessible aria-label/title; omitted if `createdAt` is invalid.
  - Tap/click the bubble (non-interactive areas) to select; clear with Escape, outside click/tap, and when the run changes; bubbles expose `data-message-id`.

- Refactors
  - Update `areMessageBubblePropsEqual` to include `createdAt` and `selected` and treat invalid dates as stable; `MessageThread` manages selection via `reduceSelectedMessageId` and passes `selected`/`onSelect` to `MessageBubble`.

<sup>Written for commit 13b27d02f7512c9e7e4d2d49e2a7bbcb36a1ddcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

