### PR TITLE
feat: extract lab-auth into parameterizable shared crate (OAuth epic syslog-mcp-brt0)

### DIFF
--- a/crates/lab-auth/Cargo.toml
+++ b/crates/lab-auth/Cargo.toml
@@ -1,38 +1,43 @@
 [package]
-name                   = "lab-auth"
-description            = "Pure axum/auth/storage crate for lab."
-version.workspace      = true
-edition.workspace      = true
+name = "lab-auth"
+description = "Parameterizable OAuth 2.0 + JWT auth crate (axum) for lab and other consumers."
+version.workspace = true
+edition.workspace = true
 rust-version.workspace = true
-license.workspace      = true
-repository.workspace   = true
-authors.workspace      = true
-readme                 = "../../README.md"
-keywords               = ["oauth", "auth", "axum", "jwt", "mcp"]
-categories             = ["authentication", "web-programming::http-server"]
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
+keywords = ["oauth", "auth", "axum", "jwt", "mcp"]
+categories = ["authentication", "web-programming::http-server"]
+publish = false
+
+[features]
+# Explicit empty default to keep Cargo feature unification a no-op for downstream consumers.
+default = []
 
 [dependencies]
-axum.workspace         = true
-base64.workspace       = true
-getrandom             = "0.4"
-httpdate              = "1"
+axum.workspace = true
+base64.workspace = true
+getrandom = "0.4"
+httpdate = "1"
 jsonwebtoken.workspace = true
-reqwest.workspace      = true
-rsa.workspace          = true
-rusqlite.workspace     = true
-serde.workspace        = true
-serde_json.workspace   = true
-sha2.workspace         = true
-subtle                 = "2"
-thiserror.workspace    = true
-tokio.workspace        = true
-tower.workspace        = true
-tracing.workspace      = true
-url.workspace          = true
+reqwest.workspace = true
+rsa.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+subtle = "2"
+thiserror.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-tempfile       = "3.27"
+tempfile = "3.27"
 tracing-subscriber.workspace = true
 wiremock.workspace = true
 

--- a/crates/lab-auth/src/auth_context.rs
+++ b/crates/lab-auth/src/auth_context.rs
@@ -1,0 +1,67 @@
+//! Auth context injected into request extensions by [`crate::middleware::AuthLayer`].
+//!
+//! Downstream handlers can read this when they need caller identity or scope
+//! checks, but not every route consumes it yet.
+
+use axum::http::request::Parts;
+use std::sync::Arc;
+
+/// Stored in request extensions by the HTTP auth middleware (see
+/// [`crate::middleware::AuthLayer`]).
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    /// JWT `sub` claim (or `"static-bearer"` for static-token requests).
+    pub sub: String,
+    /// Optional opaque actor key (lab-specific observability hook); produced
+    /// by the [`crate::middleware::ActorKeyDeriver`] closure when one is
+    /// installed on the layer. Consumers without an actor-key concept
+    /// (syslog-mcp etc.) leave this `None`.
+    pub actor_key: Option<Arc<str>>,
+    /// Effective scopes for this request.
+    pub scopes: Vec<String>,
+    /// JWT `iss` claim (or `"local"` / `"browser-session"` sentinel).
+    pub issuer: String,
+    /// `true` when the request was authenticated via the browser session
+    /// cookie rather than a bearer token.
+    pub via_session: bool,
+    /// Browser-session CSRF token, when the request was authenticated via
+    /// session cookie. Echoed back to handlers that need to mint a fresh
+    /// `x-csrf-token` for follow-up state-changing requests.
+    pub csrf_token: Option<String>,
+    /// Verified Google email tied to the browser session, when known.
+    pub email: Option<String>,
+}
+
+/// Build the value of an `WWW-Authenticate: Bearer ...` response header
+/// pointing browsers/agents at the protected-resource metadata document.
+#[must_use]
+pub fn www_authenticate_value(resource_url: &str) -> String {
+    format!(
+        "Bearer resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+        resource_url.trim_end_matches('/')
+    )
+}
+
+/// Convenience accessor for handlers that have already split a request into
+/// [`Parts`].
+#[must_use]
+pub fn auth_context(parts: &Parts) -> Option<&AuthContext> {
+    parts.extensions.get::<AuthContext>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::www_authenticate_value;
+
+    #[test]
+    fn www_authenticate_value_appends_metadata_path_and_strips_trailing_slash() {
+        assert_eq!(
+            www_authenticate_value("https://lab.example.com/"),
+            "Bearer resource_metadata=\"https://lab.example.com/.well-known/oauth-protected-resource\""
+        );
+        assert_eq!(
+            www_authenticate_value("https://lab.example.com"),
+            "Bearer resource_metadata=\"https://lab.example.com/.well-known/oauth-protected-resource\""
+        );
+    }
+}

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -155,7 +155,11 @@ pub async fn authorize(
     state.ensure_pending_oauth_state_capacity().await?;
     validate_response_type(&query.response_type)?;
     validate_resource(&state, query.resource.as_deref())?;
-    let scope = validate_scope(&query.scope, &state.config.default_scope)?;
+    let scope = validate_scope(
+        &query.scope,
+        &state.config.default_scope,
+        &state.config.scopes_supported,
+    )?;
     let client_state_id = fingerprint(&query.state);
     info!(
         client_id = %query.client_id,
@@ -428,17 +432,31 @@ fn validate_response_type(response_type: &str) -> Result<(), AuthError> {
     }
 }
 
-fn validate_scope(scope: &str, default_scope: &str) -> Result<String, AuthError> {
+fn validate_scope(
+    scope: &str,
+    default_scope: &str,
+    scopes_supported: &[String],
+) -> Result<String, AuthError> {
     let normalized = scope.trim();
     if normalized.is_empty() {
         return Ok(default_scope.to_string());
     }
-    if normalized == default_scope {
+    // Accept any space-separated combination where every token is in scopes_supported.
+    // Falls back to exact-match against default_scope when scopes_supported is empty.
+    if !scopes_supported.is_empty() {
+        let all_valid = normalized
+            .split_whitespace()
+            .all(|s| scopes_supported.iter().any(|sup| sup == s));
+        if all_valid {
+            return Ok(normalized.to_string());
+        }
+    } else if normalized == default_scope {
         return Ok(normalized.to_string());
     }
     warn!(scope = %normalized, "oauth authorize rejected: unsupported scope");
     Err(AuthError::Validation(format!(
-        "scope must be `{default_scope}`"
+        "scope must be one of: {}",
+        scopes_supported.join(", ")
     )))
 }
 

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -599,7 +599,9 @@ pub mod tests {
 
     #[tokio::test]
     async fn register_accepts_public_dcr_and_enforces_loopback_redirects() {
-        let app = router(test_auth_state().await);
+        let mut config = test_auth_config();
+        config.enable_dynamic_registration = true;
+        let app = router(test_auth_state_with_config(config).await);
         let response = app
             .clone()
             .oneshot(
@@ -641,6 +643,7 @@ pub mod tests {
     #[tokio::test]
     async fn register_accepts_allowed_non_loopback_redirect_patterns() {
         let mut config = test_auth_config();
+        config.enable_dynamic_registration = true;
         config.allowed_client_redirect_uris =
             vec!["https://callback.tootie.tv/callback/*".to_string()];
         let app = router(test_auth_state_with_config(config).await);
@@ -666,6 +669,7 @@ pub mod tests {
     #[tokio::test]
     async fn register_is_rate_limited_after_configured_burst() {
         let mut config = test_auth_config();
+        config.enable_dynamic_registration = true;
         config.register_requests_per_minute = 1;
         let app = router(test_auth_state_with_config(config).await);
 
@@ -1237,7 +1241,7 @@ pub mod tests {
         AuthState::new(config).await.unwrap()
     }
 
-    fn test_auth_config() -> AuthConfig {
+    pub fn test_auth_config() -> AuthConfig {
         let dir = Box::leak(Box::new(tempfile::tempdir().unwrap()));
         AuthConfig {
             mode: AuthMode::OAuth,

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -1177,15 +1177,15 @@ pub mod tests {
     #[test]
     fn validate_scope_accepts_configured_default_and_rejects_others() {
         // Empty scope falls back to configured default.
-        assert_eq!(super::validate_scope("", "syslog:read").unwrap(), "syslog:read");
+        assert_eq!(super::validate_scope("", "syslog:read", &["syslog:read".to_string(), "syslog:admin".to_string()]).unwrap(), "syslog:read");
         // Matching scope passes through.
         assert_eq!(
-            super::validate_scope("syslog:read", "syslog:read").unwrap(),
+            super::validate_scope("syslog:read", "syslog:read", &["syslog:read".to_string(), "syslog:admin".to_string()]).unwrap(),
             "syslog:read"
         );
         // Anything else is rejected — and the error mentions the configured
         // default (proving the LAB_SCOPE constant is gone).
-        let err = super::validate_scope("lab", "syslog:read").unwrap_err();
+        let err = super::validate_scope("lab", "syslog:read", &["syslog:read".to_string(), "syslog:admin".to_string()]).unwrap_err();
         assert!(err.to_string().contains("syslog:read"), "got: {err}");
     }
 

--- a/crates/lab-auth/src/authorize.rs
+++ b/crates/lab-auth/src/authorize.rs
@@ -19,7 +19,6 @@ use crate::types::{
 use crate::util::{expires_at, fingerprint, now_unix, random_token};
 
 const AUTH_REQUEST_TTL_SECS: i64 = 300;
-const LAB_SCOPE: &str = "lab";
 
 /// Enforces the configured email allowlist.
 ///
@@ -88,7 +87,7 @@ pub async fn browser_login(
 
     let location = state.google.authorize_url(&AuthorizeUrlRequest {
         state: request_state,
-        scope: LAB_SCOPE.to_string(),
+        scope: state.config.default_scope.clone(),
         code_challenge: provider_code_challenge,
         code_challenge_method: "S256".to_string(),
     })?;
@@ -156,7 +155,7 @@ pub async fn authorize(
     state.ensure_pending_oauth_state_capacity().await?;
     validate_response_type(&query.response_type)?;
     validate_resource(&state, query.resource.as_deref())?;
-    let scope = validate_scope(&query.scope)?;
+    let scope = validate_scope(&query.scope, &state.config.default_scope)?;
     let client_state_id = fingerprint(&query.state);
     info!(
         client_id = %query.client_id,
@@ -429,17 +428,17 @@ fn validate_response_type(response_type: &str) -> Result<(), AuthError> {
     }
 }
 
-fn validate_scope(scope: &str) -> Result<String, AuthError> {
+fn validate_scope(scope: &str, default_scope: &str) -> Result<String, AuthError> {
     let normalized = scope.trim();
     if normalized.is_empty() {
-        return Ok(LAB_SCOPE.to_string());
+        return Ok(default_scope.to_string());
     }
-    if normalized == LAB_SCOPE {
+    if normalized == default_scope {
         return Ok(normalized.to_string());
     }
     warn!(scope = %normalized, "oauth authorize rejected: unsupported scope");
     Err(AuthError::Validation(format!(
-        "scope must be `{LAB_SCOPE}`"
+        "scope must be `{default_scope}`"
     )))
 }
 
@@ -1151,6 +1150,21 @@ pub mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
         }
+    }
+
+    #[test]
+    fn validate_scope_accepts_configured_default_and_rejects_others() {
+        // Empty scope falls back to configured default.
+        assert_eq!(super::validate_scope("", "syslog:read").unwrap(), "syslog:read");
+        // Matching scope passes through.
+        assert_eq!(
+            super::validate_scope("syslog:read", "syslog:read").unwrap(),
+            "syslog:read"
+        );
+        // Anything else is rejected — and the error mentions the configured
+        // default (proving the LAB_SCOPE constant is gone).
+        let err = super::validate_scope("lab", "syslog:read").unwrap_err();
+        assert!(err.to_string().contains("syslog:read"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -521,38 +521,35 @@ fn read_url(vars: &HashMap<String, String>, key: &str) -> Result<Option<Url>, Au
 fn read_u64(vars: &HashMap<String, String>, key: &str) -> Result<Option<u64>, AuthError> {
     read_string(vars, key)
         .map(|value| {
-            value.parse::<u64>().map(Some).map_err(|error| {
+            value.parse::<u64>().map_err(|error| {
                 AuthError::Config(format!(
                     "{key} must be an integer number of seconds: {error}"
                 ))
             })
         })
         .transpose()
-        .map(Option::flatten)
 }
 
 fn read_u32(vars: &HashMap<String, String>, key: &str) -> Result<Option<u32>, AuthError> {
     read_string(vars, key)
         .map(|value| {
-            value.parse::<u32>().map(Some).map_err(|error| {
+            value.parse::<u32>().map_err(|error| {
                 AuthError::Config(format!(
                     "{key} must be an integer number of requests per minute: {error}"
                 ))
             })
         })
         .transpose()
-        .map(|value| value.flatten())
 }
 
 fn read_usize(vars: &HashMap<String, String>, key: &str) -> Result<Option<usize>, AuthError> {
     read_string(vars, key)
         .map(|value| {
-            value.parse::<usize>().map(Some).map_err(|error| {
+            value.parse::<usize>().map_err(|error| {
                 AuthError::Config(format!("{key} must be a positive integer: {error}"))
             })
         })
         .transpose()
-        .map(|value| value.flatten())
 }
 
 #[cfg(test)]

--- a/crates/lab-auth/src/config.rs
+++ b/crates/lab-auth/src/config.rs
@@ -17,6 +17,18 @@ const DEFAULT_REGISTER_REQUESTS_PER_MINUTE: u32 = 20;
 const DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE: u32 = 60;
 const DEFAULT_MAX_PENDING_OAUTH_STATES: usize = 1024;
 
+/// Default env-var prefix used when consumers do not specify one.
+/// Backward-compatible with the original `LAB_*` env scheme.
+pub const DEFAULT_ENV_PREFIX: &str = "LAB";
+/// Default browser session cookie name (preserved for the lab consumer).
+pub const DEFAULT_SESSION_COOKIE_NAME: &str = "lab_session";
+/// Default OAuth scope label applied when callers do not request one.
+pub const DEFAULT_SCOPE: &str = "lab";
+/// Default protected resource path (canonical MCP endpoint).
+pub const DEFAULT_RESOURCE_PATH: &str = "/mcp";
+/// Default browser login path mounted by the auth router.
+pub const DEFAULT_LOGIN_PATH: &str = "/auth/login";
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthMode {
@@ -26,7 +38,7 @@ pub enum AuthMode {
 }
 
 impl AuthMode {
-    fn parse(value: Option<&str>) -> Result<Self, AuthError> {
+    fn parse(value: Option<&str>, env_key_for_diagnostics: &str) -> Result<Self, AuthError> {
         match value
             .unwrap_or("bearer")
             .trim()
@@ -36,7 +48,7 @@ impl AuthMode {
             "bearer" => Ok(Self::Bearer),
             "oauth" => Ok(Self::OAuth),
             other => Err(AuthError::Config(format!(
-                "LAB_AUTH_MODE must be `bearer` or `oauth`, got `{other}`"
+                "{env_key_for_diagnostics} must be `bearer` or `oauth`, got `{other}`"
             ))),
         }
     }
@@ -51,9 +63,17 @@ impl AuthModeConfig {
     pub fn from_sources(
         vars: impl IntoIterator<Item = (String, String)>,
     ) -> Result<Self, AuthError> {
+        Self::from_sources_with_prefix(vars, DEFAULT_ENV_PREFIX)
+    }
+
+    pub fn from_sources_with_prefix(
+        vars: impl IntoIterator<Item = (String, String)>,
+        env_prefix: &str,
+    ) -> Result<Self, AuthError> {
         let vars = normalize(vars);
+        let key = env_key(env_prefix, "AUTH_MODE");
         Ok(Self {
-            mode: AuthMode::parse(vars.get("LAB_AUTH_MODE").map(String::as_str))?,
+            mode: AuthMode::parse(vars.get(&key).map(String::as_str), &key)?,
         })
     }
 }
@@ -90,6 +110,40 @@ pub struct AuthConfig {
     pub register_requests_per_minute: u32,
     pub authorize_requests_per_minute: u32,
     pub max_pending_oauth_states: usize,
+
+    // ---- Brand / consumer-specific parameterization (see L1 bead) ----
+    /// Env var prefix used for diagnostics (e.g. `"LAB"`, `"SYSLOG_MCP"`).
+    /// Set via [`AuthConfigBuilder::env_prefix`] BEFORE any env reads.
+    pub env_prefix: String,
+    /// Default base directory for `auth.db` and `auth-jwt.pem` when the
+    /// corresponding env vars are unset.
+    pub default_data_dir: PathBuf,
+    /// Browser session cookie name. Lab consumer leaves this at the default
+    /// (`"lab_session"`); other consumers override with their own brand.
+    pub session_cookie_name: String,
+    /// Scopes advertised on `/.well-known/oauth-authorization-server` and
+    /// `/.well-known/oauth-protected-resource`.
+    pub scopes_supported: Vec<String>,
+    /// Path appended to `public_url` to form the canonical resource URL
+    /// returned in the protected-resource metadata document.
+    pub resource_path: String,
+    /// Default scope applied when `/authorize` requests omit one and the
+    /// only scope accepted by the legacy single-scope validator.
+    pub default_scope: String,
+    /// Scopes minted into the static-bearer-derived AuthContext so legacy
+    /// admin tools keep functioning when the dual-mode middleware (L2) is
+    /// deployed. Lab keeps the legacy `["lab:read","lab:admin"]` defaults;
+    /// syslog-mcp will override with `["syslog:read","syslog:admin"]`.
+    pub static_token_scopes: Vec<String>,
+    /// Path of the browser login route (typically `/auth/login`).
+    pub login_path: String,
+    /// Whether `POST /register` (RFC 7591 dynamic client registration) is
+    /// mounted. Defaults to `false` (closed) — opt-in per consumer.
+    pub enable_dynamic_registration: bool,
+    /// When `true`, dual-mode middleware MUST reject the static bearer
+    /// token whenever OAuth is active. Defaults to `false` (lab keeps the
+    /// historical break-glass behavior); syslog-mcp overrides to `true`.
+    pub disable_static_token_with_oauth: bool,
 }
 
 impl Default for AuthConfig {
@@ -110,98 +164,294 @@ impl Default for AuthConfig {
             register_requests_per_minute: DEFAULT_REGISTER_REQUESTS_PER_MINUTE,
             authorize_requests_per_minute: DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE,
             max_pending_oauth_states: DEFAULT_MAX_PENDING_OAUTH_STATES,
+            env_prefix: DEFAULT_ENV_PREFIX.to_string(),
+            default_data_dir: base_dir,
+            session_cookie_name: DEFAULT_SESSION_COOKIE_NAME.to_string(),
+            scopes_supported: vec![DEFAULT_SCOPE.to_string()],
+            resource_path: DEFAULT_RESOURCE_PATH.to_string(),
+            default_scope: DEFAULT_SCOPE.to_string(),
+            static_token_scopes: vec!["lab:read".to_string(), "lab:admin".to_string()],
+            login_path: DEFAULT_LOGIN_PATH.to_string(),
+            enable_dynamic_registration: false,
+            disable_static_token_with_oauth: false,
         }
     }
 }
 
 impl AuthConfig {
+    /// Backward-compatible convenience: read env vars using the default
+    /// `LAB` prefix. Equivalent to `AuthConfigBuilder::new().build_from_sources(vars)`.
     pub fn from_sources(
         vars: impl IntoIterator<Item = (String, String)>,
     ) -> Result<Self, AuthError> {
+        AuthConfigBuilder::new().build_from_sources(vars)
+    }
+
+    fn validate(&self) -> Result<(), AuthError> {
+        let prefix = &self.env_prefix;
+        if !self.google.callback_path.starts_with('/') {
+            return Err(AuthError::Config(format!(
+                "{prefix}_GOOGLE_CALLBACK_PATH must start with `/`, got `{}`",
+                self.google.callback_path
+            )));
+        }
+
+        if !self.resource_path.starts_with('/') {
+            return Err(AuthError::Config(format!(
+                "resource_path must start with `/`, got `{}`",
+                self.resource_path
+            )));
+        }
+        if !self.login_path.starts_with('/') {
+            return Err(AuthError::Config(format!(
+                "login_path must start with `/`, got `{}`",
+                self.login_path
+            )));
+        }
+        if self.session_cookie_name.is_empty() {
+            return Err(AuthError::Config(
+                "session_cookie_name must not be empty".to_string(),
+            ));
+        }
+        if self.default_scope.is_empty() {
+            return Err(AuthError::Config(
+                "default_scope must not be empty".to_string(),
+            ));
+        }
+        if self.scopes_supported.is_empty() {
+            return Err(AuthError::Config(
+                "scopes_supported must contain at least one scope".to_string(),
+            ));
+        }
+
+        if matches!(self.mode, AuthMode::OAuth) {
+            if self.public_url.is_none() {
+                return Err(AuthError::Config(format!(
+                    "{prefix}_PUBLIC_URL is required when {prefix}_AUTH_MODE=oauth"
+                )));
+            }
+            if self.google.client_id.is_empty() {
+                return Err(AuthError::Config(format!(
+                    "{prefix}_GOOGLE_CLIENT_ID is required when {prefix}_AUTH_MODE=oauth"
+                )));
+            }
+            if self.google.client_secret.is_empty() {
+                return Err(AuthError::Config(format!(
+                    "{prefix}_GOOGLE_CLIENT_SECRET is required when {prefix}_AUTH_MODE=oauth"
+                )));
+            }
+            if self.admin_email.is_empty() {
+                return Err(AuthError::Config(format!(
+                    "{prefix}_AUTH_ADMIN_EMAIL is required when {prefix}_AUTH_MODE=oauth — \
+                     set the Google email of the bootstrap admin so no account \
+                     can log in unless explicitly permitted"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Consuming builder for [`AuthConfig`]. The `env_prefix` MUST be set BEFORE
+/// any env-driven `build_*` call; builder methods themselves do not read env.
+///
+/// ```ignore
+/// let cfg = AuthConfigBuilder::new()
+///     .env_prefix("SYSLOG_MCP")
+///     .session_cookie_name("syslog_session")
+///     .scopes_supported(vec!["syslog:read".to_string(), "syslog:admin".to_string()])
+///     .resource_path("/mcp")
+///     .default_scope("syslog:read")
+///     .static_token_scopes(vec!["syslog:read".to_string(), "syslog:admin".to_string()])
+///     .disable_static_token_with_oauth(true)
+///     .build_from_sources(std::env::vars())?;
+/// ```
+#[derive(Clone, Debug)]
+pub struct AuthConfigBuilder {
+    env_prefix: String,
+    default_data_dir: Option<PathBuf>,
+    session_cookie_name: String,
+    scopes_supported: Vec<String>,
+    resource_path: String,
+    default_scope: String,
+    static_token_scopes: Vec<String>,
+    login_path: String,
+    enable_dynamic_registration: bool,
+    disable_static_token_with_oauth: bool,
+}
+
+impl Default for AuthConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            env_prefix: DEFAULT_ENV_PREFIX.to_string(),
+            default_data_dir: None,
+            session_cookie_name: DEFAULT_SESSION_COOKIE_NAME.to_string(),
+            scopes_supported: vec![DEFAULT_SCOPE.to_string()],
+            resource_path: DEFAULT_RESOURCE_PATH.to_string(),
+            default_scope: DEFAULT_SCOPE.to_string(),
+            static_token_scopes: vec!["lab:read".to_string(), "lab:admin".to_string()],
+            login_path: DEFAULT_LOGIN_PATH.to_string(),
+            enable_dynamic_registration: false,
+            disable_static_token_with_oauth: false,
+        }
+    }
+
+    #[must_use]
+    pub fn env_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.env_prefix = prefix.into();
+        self
+    }
+
+    #[must_use]
+    pub fn default_data_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.default_data_dir = Some(dir.into());
+        self
+    }
+
+    #[must_use]
+    pub fn session_cookie_name(mut self, name: impl Into<String>) -> Self {
+        self.session_cookie_name = name.into();
+        self
+    }
+
+    #[must_use]
+    pub fn scopes_supported(mut self, scopes: Vec<String>) -> Self {
+        self.scopes_supported = scopes;
+        self
+    }
+
+    #[must_use]
+    pub fn resource_path(mut self, path: impl Into<String>) -> Self {
+        self.resource_path = path.into();
+        self
+    }
+
+    #[must_use]
+    pub fn default_scope(mut self, scope: impl Into<String>) -> Self {
+        self.default_scope = scope.into();
+        self
+    }
+
+    #[must_use]
+    pub fn static_token_scopes(mut self, scopes: Vec<String>) -> Self {
+        self.static_token_scopes = scopes;
+        self
+    }
+
+    #[must_use]
+    pub fn login_path(mut self, path: impl Into<String>) -> Self {
+        self.login_path = path.into();
+        self
+    }
+
+    #[must_use]
+    pub const fn enable_dynamic_registration(mut self, enabled: bool) -> Self {
+        self.enable_dynamic_registration = enabled;
+        self
+    }
+
+    #[must_use]
+    pub const fn disable_static_token_with_oauth(mut self, disabled: bool) -> Self {
+        self.disable_static_token_with_oauth = disabled;
+        self
+    }
+
+    /// Read configuration from the supplied env-style key/value pairs using
+    /// the configured `env_prefix`, then validate and return [`AuthConfig`].
+    pub fn build_from_sources(
+        self,
+        vars: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<AuthConfig, AuthError> {
         let vars = normalize(vars);
-        let mode = AuthMode::parse(vars.get("LAB_AUTH_MODE").map(String::as_str))?;
-        let admin_email = read_string(&vars, "LAB_AUTH_ADMIN_EMAIL")
+        let prefix = self.env_prefix.clone();
+        let key_mode = env_key(&prefix, "AUTH_MODE");
+        let key_admin = env_key(&prefix, "AUTH_ADMIN_EMAIL");
+        let key_public_url = env_key(&prefix, "PUBLIC_URL");
+        let key_db = env_key(&prefix, "AUTH_SQLITE_PATH");
+        let key_keypath = env_key(&prefix, "AUTH_KEY_PATH");
+        let key_secret = env_key(&prefix, "AUTH_BOOTSTRAP_SECRET");
+        let key_redirects = env_key(&prefix, "AUTH_ALLOWED_REDIRECT_URIS");
+        let key_g_id = env_key(&prefix, "GOOGLE_CLIENT_ID");
+        let key_g_secret = env_key(&prefix, "GOOGLE_CLIENT_SECRET");
+        let key_g_callback = env_key(&prefix, "GOOGLE_CALLBACK_PATH");
+        let key_g_scopes = env_key(&prefix, "GOOGLE_SCOPES");
+        let key_at_ttl = env_key(&prefix, "AUTH_ACCESS_TOKEN_TTL_SECS");
+        let key_rt_ttl = env_key(&prefix, "AUTH_REFRESH_TOKEN_TTL_SECS");
+        let key_code_ttl = env_key(&prefix, "AUTH_CODE_TTL_SECS");
+        let key_reg_rpm = env_key(&prefix, "AUTH_REGISTER_REQUESTS_PER_MINUTE");
+        let key_az_rpm = env_key(&prefix, "AUTH_AUTHORIZE_REQUESTS_PER_MINUTE");
+        let key_max_pending = env_key(&prefix, "AUTH_MAX_PENDING_OAUTH_STATES");
+
+        let mode = AuthMode::parse(vars.get(&key_mode).map(String::as_str), &key_mode)?;
+        let admin_email = read_string(&vars, &key_admin)
             .map(|raw| raw.trim().to_ascii_lowercase())
             .unwrap_or_default();
-        let config = Self {
+        let base_dir = self
+            .default_data_dir
+            .clone()
+            .unwrap_or_else(default_auth_dir);
+        let config = AuthConfig {
             mode,
-            public_url: read_url(&vars, "LAB_PUBLIC_URL")?,
-            sqlite_path: read_path(&vars, "LAB_AUTH_SQLITE_PATH")
-                .unwrap_or_else(|| default_auth_dir().join(DEFAULT_AUTH_DB_NAME)),
-            key_path: read_path(&vars, "LAB_AUTH_KEY_PATH")
-                .unwrap_or_else(|| default_auth_dir().join(DEFAULT_KEY_NAME)),
-            bootstrap_secret: read_string(&vars, "LAB_AUTH_BOOTSTRAP_SECRET"),
-            allowed_client_redirect_uris: read_csv(&vars, "LAB_AUTH_ALLOWED_REDIRECT_URIS")
-                .unwrap_or_default(),
+            public_url: read_url(&vars, &key_public_url)?,
+            sqlite_path: read_path(&vars, &key_db)
+                .unwrap_or_else(|| base_dir.join(DEFAULT_AUTH_DB_NAME)),
+            key_path: read_path(&vars, &key_keypath)
+                .unwrap_or_else(|| base_dir.join(DEFAULT_KEY_NAME)),
+            bootstrap_secret: read_string(&vars, &key_secret),
+            allowed_client_redirect_uris: read_csv(&vars, &key_redirects).unwrap_or_default(),
             admin_email,
             google: GoogleConfig {
-                client_id: read_string(&vars, "LAB_GOOGLE_CLIENT_ID").unwrap_or_default(),
-                client_secret: read_string(&vars, "LAB_GOOGLE_CLIENT_SECRET").unwrap_or_default(),
-                callback_path: read_string(&vars, "LAB_GOOGLE_CALLBACK_PATH")
+                client_id: read_string(&vars, &key_g_id).unwrap_or_default(),
+                client_secret: read_string(&vars, &key_g_secret).unwrap_or_default(),
+                callback_path: read_string(&vars, &key_g_callback)
                     .unwrap_or_else(|| DEFAULT_CALLBACK_PATH.to_string()),
-                scopes: read_csv(&vars, "LAB_GOOGLE_SCOPES").unwrap_or_else(default_google_scopes),
+                scopes: read_csv(&vars, &key_g_scopes).unwrap_or_else(default_google_scopes),
             },
             access_token_ttl: Duration::from_secs(
-                read_u64(&vars, "LAB_AUTH_ACCESS_TOKEN_TTL_SECS")?
-                    .unwrap_or(DEFAULT_ACCESS_TOKEN_TTL_SECS),
+                read_u64(&vars, &key_at_ttl)?.unwrap_or(DEFAULT_ACCESS_TOKEN_TTL_SECS),
             ),
             refresh_token_ttl: Duration::from_secs(
-                read_u64(&vars, "LAB_AUTH_REFRESH_TOKEN_TTL_SECS")?
-                    .unwrap_or(DEFAULT_REFRESH_TOKEN_TTL_SECS),
+                read_u64(&vars, &key_rt_ttl)?.unwrap_or(DEFAULT_REFRESH_TOKEN_TTL_SECS),
             ),
             auth_code_ttl: Duration::from_secs(
-                read_u64(&vars, "LAB_AUTH_CODE_TTL_SECS")?.unwrap_or(DEFAULT_AUTH_CODE_TTL_SECS),
+                read_u64(&vars, &key_code_ttl)?.unwrap_or(DEFAULT_AUTH_CODE_TTL_SECS),
             ),
-            register_requests_per_minute: read_u32(&vars, "LAB_AUTH_REGISTER_REQUESTS_PER_MINUTE")?
+            register_requests_per_minute: read_u32(&vars, &key_reg_rpm)?
                 .unwrap_or(DEFAULT_REGISTER_REQUESTS_PER_MINUTE),
-            authorize_requests_per_minute: read_u32(
-                &vars,
-                "LAB_AUTH_AUTHORIZE_REQUESTS_PER_MINUTE",
-            )?
-            .unwrap_or(DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE),
-            max_pending_oauth_states: read_usize(&vars, "LAB_AUTH_MAX_PENDING_OAUTH_STATES")?
+            authorize_requests_per_minute: read_u32(&vars, &key_az_rpm)?
+                .unwrap_or(DEFAULT_AUTHORIZE_REQUESTS_PER_MINUTE),
+            max_pending_oauth_states: read_usize(&vars, &key_max_pending)?
                 .unwrap_or(DEFAULT_MAX_PENDING_OAUTH_STATES),
+            env_prefix: prefix,
+            default_data_dir: base_dir,
+            session_cookie_name: self.session_cookie_name,
+            scopes_supported: self.scopes_supported,
+            resource_path: self.resource_path,
+            default_scope: self.default_scope,
+            static_token_scopes: self.static_token_scopes,
+            login_path: self.login_path,
+            enable_dynamic_registration: self.enable_dynamic_registration,
+            disable_static_token_with_oauth: self.disable_static_token_with_oauth,
         };
 
         config.validate()?;
         Ok(config)
     }
+}
 
-    fn validate(&self) -> Result<(), AuthError> {
-        if !self.google.callback_path.starts_with('/') {
-            return Err(AuthError::Config(format!(
-                "LAB_GOOGLE_CALLBACK_PATH must start with `/`, got `{}`",
-                self.google.callback_path
-            )));
-        }
-
-        if matches!(self.mode, AuthMode::OAuth) {
-            if self.public_url.is_none() {
-                return Err(AuthError::Config(
-                    "LAB_PUBLIC_URL is required when LAB_AUTH_MODE=oauth".to_string(),
-                ));
-            }
-            if self.google.client_id.is_empty() {
-                return Err(AuthError::Config(
-                    "LAB_GOOGLE_CLIENT_ID is required when LAB_AUTH_MODE=oauth".to_string(),
-                ));
-            }
-            if self.google.client_secret.is_empty() {
-                return Err(AuthError::Config(
-                    "LAB_GOOGLE_CLIENT_SECRET is required when LAB_AUTH_MODE=oauth".to_string(),
-                ));
-            }
-            if self.admin_email.is_empty() {
-                return Err(AuthError::Config(
-                    "LAB_AUTH_ADMIN_EMAIL is required when LAB_AUTH_MODE=oauth — \
-                     set the Google email of the bootstrap admin so no account \
-                     can log in unless explicitly permitted"
-                        .to_string(),
-                ));
-            }
-        }
-
-        Ok(())
+fn env_key(prefix: &str, suffix: &str) -> String {
+    let trimmed = prefix.trim_end_matches('_');
+    if trimmed.is_empty() {
+        suffix.to_string()
+    } else {
+        format!("{trimmed}_{suffix}")
     }
 }
 
@@ -307,7 +557,7 @@ fn read_usize(vars: &HashMap<String, String>, key: &str) -> Result<Option<usize>
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthConfig, AuthMode, AuthModeConfig};
+    use super::{AuthConfig, AuthConfigBuilder, AuthMode, AuthModeConfig};
 
     #[test]
     fn bearer_mode_preserves_existing_http_token_behavior() {
@@ -386,6 +636,87 @@ mod tests {
                 "https://claude.ai/api/mcp/auth_callback".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn default_config_preserves_lab_brand_for_backward_compat() {
+        let cfg = AuthConfig::default();
+        assert_eq!(cfg.env_prefix, "LAB");
+        assert_eq!(cfg.session_cookie_name, "lab_session");
+        assert_eq!(cfg.scopes_supported, vec!["lab".to_string()]);
+        assert_eq!(cfg.resource_path, "/mcp");
+        assert_eq!(cfg.default_scope, "lab");
+        assert_eq!(
+            cfg.static_token_scopes,
+            vec!["lab:read".to_string(), "lab:admin".to_string()]
+        );
+        assert_eq!(cfg.login_path, "/auth/login");
+        assert!(!cfg.enable_dynamic_registration);
+        assert!(!cfg.disable_static_token_with_oauth);
+    }
+
+    #[test]
+    fn builder_env_prefix_resolves_consumer_env_vars() {
+        let cfg = AuthConfigBuilder::new()
+            .env_prefix("SYSLOG_MCP")
+            .session_cookie_name("syslog_session")
+            .scopes_supported(vec!["syslog:read".to_string(), "syslog:admin".to_string()])
+            .default_scope("syslog:read")
+            .static_token_scopes(vec!["syslog:read".to_string(), "syslog:admin".to_string()])
+            .disable_static_token_with_oauth(true)
+            .build_from_sources(fake_env_with_many([
+                ("SYSLOG_MCP_AUTH_MODE", "oauth"),
+                ("SYSLOG_MCP_PUBLIC_URL", "https://syslog.example.com"),
+                ("SYSLOG_MCP_GOOGLE_CLIENT_ID", "id"),
+                ("SYSLOG_MCP_GOOGLE_CLIENT_SECRET", "secret"),
+                ("SYSLOG_MCP_AUTH_ADMIN_EMAIL", "admin@example.com"),
+            ]))
+            .unwrap();
+        assert!(matches!(cfg.mode, AuthMode::OAuth));
+        assert_eq!(cfg.env_prefix, "SYSLOG_MCP");
+        assert_eq!(cfg.session_cookie_name, "syslog_session");
+        assert_eq!(cfg.default_scope, "syslog:read");
+        assert!(cfg.disable_static_token_with_oauth);
+        assert_eq!(
+            cfg.scopes_supported,
+            vec!["syslog:read".to_string(), "syslog:admin".to_string()]
+        );
+    }
+
+    #[test]
+    fn builder_lab_env_vars_ignored_when_prefix_is_overridden() {
+        // Vars use LAB_*; builder is set to SYSLOG_MCP — so AUTH_MODE goes
+        // unread, defaults to bearer, and PUBLIC_URL stays None.
+        let cfg = AuthConfigBuilder::new()
+            .env_prefix("SYSLOG_MCP")
+            .build_from_sources(fake_env_with_many([
+                ("LAB_AUTH_MODE", "oauth"),
+                ("LAB_PUBLIC_URL", "https://lab.example.com"),
+                ("LAB_GOOGLE_CLIENT_ID", "id"),
+                ("LAB_GOOGLE_CLIENT_SECRET", "secret"),
+                ("LAB_AUTH_ADMIN_EMAIL", "admin@example.com"),
+            ]))
+            .unwrap();
+        assert!(matches!(cfg.mode, AuthMode::Bearer));
+        assert!(cfg.public_url.is_none());
+    }
+
+    #[test]
+    fn builder_validates_resource_path_starts_with_slash() {
+        let err = AuthConfigBuilder::new()
+            .resource_path("mcp")
+            .build_from_sources(Vec::<(String, String)>::new())
+            .unwrap_err();
+        assert!(err.to_string().contains("resource_path"));
+    }
+
+    #[test]
+    fn builder_validates_login_path_starts_with_slash() {
+        let err = AuthConfigBuilder::new()
+            .login_path("auth/login")
+            .build_from_sources(Vec::<(String, String)>::new())
+            .unwrap_err();
+        assert!(err.to_string().contains("login_path"));
     }
 
     fn fake_env_with(key: &'static str, value: &'static str) -> Vec<(String, String)> {

--- a/crates/lab-auth/src/google.rs
+++ b/crates/lab-auth/src/google.rs
@@ -17,6 +17,11 @@ const GOOGLE_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 const GOOGLE_JWKS_ENDPOINT: &str = "https://www.googleapis.com/oauth2/v3/certs";
 const GOOGLE_ISSUER: &str = "https://accounts.google.com";
 const GOOGLE_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+/// Per-request timeout on the JWKS GET. Bound aggressively (5s) so a slow
+/// google.com call cannot starve a tokio worker holding the JWKS write
+/// lock. Token exchange / refresh keep the looser 30s bound because they
+/// can legitimately take longer.
+const GOOGLE_JWKS_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const GOOGLE_DEFAULT_JWKS_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -505,6 +510,7 @@ impl GoogleProvider {
         let trace = GoogleRequestTrace::start("fetch_jwks", "GET", jwks_endpoint);
         let response = http
             .get(jwks_endpoint.clone())
+            .timeout(GOOGLE_JWKS_FETCH_TIMEOUT)
             .send()
             .await
             .map_err(|error| {

--- a/crates/lab-auth/src/jwt.rs
+++ b/crates/lab-auth/src/jwt.rs
@@ -114,6 +114,7 @@ impl SigningKeys {
     /// point is preserved for the lab consumer, which performs its own
     /// post-decode `iss` check. New consumers (syslog-mcp et al.) should
     /// always use the issuer-enforcing variant.
+    #[deprecated(note = "Use `validate_access_token_with_issuer` for RFC 7519 §4.1.1 compliance")]
     pub fn validate_access_token(
         &self,
         token: &str,
@@ -251,6 +252,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn minted_access_token_round_trips_and_contains_kid() {
         let signer = test_signer();
         let claims = sample_claims();
@@ -264,6 +266,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn wrong_audience_is_rejected() {
         let signer = test_signer();
         let claims = sample_claims();

--- a/crates/lab-auth/src/jwt.rs
+++ b/crates/lab-auth/src/jwt.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 use std::path::Path;
 
-use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use base64::Engine;
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
 use rsa::rand_core::{TryCryptoRng, TryRng, UnwrapErr};
 use rsa::traits::PublicKeyParts;
@@ -106,6 +106,14 @@ impl SigningKeys {
             .map_err(|error| AuthError::Storage(format!("encode access token: {error}")))
     }
 
+    /// Validate access token signature, algorithm, and audience.
+    ///
+    /// NOTE: this method does NOT enforce the `iss` claim. Callers that
+    /// need RFC 7519 issuer validation MUST use
+    /// [`Self::validate_access_token_with_issuer`] instead. This entry
+    /// point is preserved for the lab consumer, which performs its own
+    /// post-decode `iss` check. New consumers (syslog-mcp et al.) should
+    /// always use the issuer-enforcing variant.
     pub fn validate_access_token(
         &self,
         token: &str,
@@ -113,6 +121,24 @@ impl SigningKeys {
     ) -> Result<AccessClaims, AuthError> {
         let mut validation = Validation::new(Algorithm::RS256);
         validation.set_audience(&[expected_audience]);
+        decode::<AccessClaims>(token, &self.decoding_key, &validation)
+            .map(|data| data.claims)
+            .map_err(|_| AuthError::InvalidAccessToken)
+    }
+
+    /// Validate signature, algorithm, audience, AND issuer in a single
+    /// pass — the issuer is enforced via `Validation::set_issuer` BEFORE
+    /// decode (RFC 7519 §4.1.1 compliant) rather than via a manual
+    /// `claims.iss != expected` check after decode.
+    pub fn validate_access_token_with_issuer(
+        &self,
+        token: &str,
+        expected_audience: &str,
+        expected_issuer: &str,
+    ) -> Result<AccessClaims, AuthError> {
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[expected_audience]);
+        validation.set_issuer(&[expected_issuer]);
         decode::<AccessClaims>(token, &self.decoding_key, &validation)
             .map(|data| data.claims)
             .map_err(|_| AuthError::InvalidAccessToken)
@@ -246,6 +272,40 @@ mod tests {
         assert!(
             result.is_err(),
             "token with wrong audience must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_with_issuer_accepts_matching_issuer() {
+        let signer = test_signer();
+        let claims = sample_claims();
+        let token = signer.issue_access_token(&claims).unwrap();
+        let decoded = signer
+            .validate_access_token_with_issuer(
+                &token,
+                "https://lab.example.com",
+                "https://lab.example.com",
+            )
+            .expect("token with matching issuer must validate");
+        assert_eq!(decoded.iss, "https://lab.example.com");
+    }
+
+    #[test]
+    fn validate_with_issuer_rejects_wrong_issuer_via_validation_struct() {
+        // Locked decision: issuer enforcement uses Validation::set_issuer
+        // BEFORE decode (so jsonwebtoken rejects up-front), not a manual
+        // post-decode `claims.iss != expected` comparison.
+        let signer = test_signer();
+        let claims = sample_claims();
+        let token = signer.issue_access_token(&claims).unwrap();
+        let result = signer.validate_access_token_with_issuer(
+            &token,
+            "https://lab.example.com",
+            "https://attacker.example.com",
+        );
+        assert!(
+            result.is_err(),
+            "token signed by us but with wrong expected issuer must be rejected"
         );
     }
 

--- a/crates/lab-auth/src/lib.rs
+++ b/crates/lab-auth/src/lib.rs
@@ -1,9 +1,11 @@
+pub mod auth_context;
 pub mod authorize;
 pub mod config;
 pub mod error;
 pub mod google;
 pub mod jwt;
 pub mod metadata;
+pub mod middleware;
 pub mod routes;
 pub mod session;
 pub mod sqlite;
@@ -11,6 +13,9 @@ pub mod state;
 pub mod token;
 pub mod types;
 pub mod util;
+
+pub use auth_context::{AuthContext, auth_context, www_authenticate_value};
+pub use middleware::{ActorKeyDeriver, AuthLayer, AuthService, parse_bearer_token, tokens_equal};
 
 #[cfg(test)]
 pub mod test_support;

--- a/crates/lab-auth/src/metadata.rs
+++ b/crates/lab-auth/src/metadata.rs
@@ -1,4 +1,4 @@
-use axum::{Json, extract::State};
+use axum::{extract::State, Json};
 
 use crate::state::AuthState;
 use crate::types::{AuthorizationServerMetadata, ProtectedResourceMetadata};
@@ -30,7 +30,7 @@ pub async fn protected_resource_metadata(
     Json(ProtectedResourceMetadata {
         resource: canonical_resource_url(&state),
         authorization_servers: vec![base],
-        scopes_supported: vec!["lab".to_string()],
+        scopes_supported: state.config.scopes_supported.clone(),
         bearer_methods_supported: vec!["header".to_string()],
     })
 }
@@ -54,7 +54,13 @@ pub(crate) fn public_base_url(state: &AuthState) -> String {
 }
 
 pub fn canonical_resource_url(state: &AuthState) -> String {
-    format!("{}/mcp", public_base_url(state))
+    let base = public_base_url(state);
+    let suffix = state.config.resource_path.trim_start_matches('/');
+    if suffix.is_empty() {
+        base
+    } else {
+        format!("{base}/{suffix}")
+    }
 }
 
 #[cfg(test)]
@@ -105,5 +111,52 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["resource"], "https://lab.example.com/mcp");
+    }
+
+    #[tokio::test]
+    async fn protected_resource_metadata_advertises_configured_scopes_and_resource_path() {
+        use crate::authorize::tests::test_auth_state_with_config;
+        use crate::config::AuthConfig;
+
+        // Synthesize a config that overrides scopes_supported and resource_path,
+        // matching how syslog-mcp will eventually configure lab-auth.
+        let dir = tempfile::tempdir().unwrap();
+        let config = AuthConfig {
+            mode: crate::config::AuthMode::OAuth,
+            public_url: Some(url::Url::parse("https://syslog.example.com").unwrap()),
+            sqlite_path: dir.path().join("auth.db"),
+            key_path: dir.path().join("auth.pem"),
+            admin_email: "admin@example.com".into(),
+            google: crate::config::GoogleConfig {
+                client_id: "id".into(),
+                client_secret: "secret".into(),
+                callback_path: "/auth/google/callback".into(),
+                scopes: vec!["openid".into(), "email".into()],
+            },
+            scopes_supported: vec!["syslog:read".to_string(), "syslog:admin".to_string()],
+            resource_path: "/syslog/mcp".to_string(),
+            ..AuthConfig::default()
+        };
+        let state = test_auth_state_with_config(config).await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/oauth-protected-resource")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["resource"], "https://syslog.example.com/syslog/mcp");
+        assert_eq!(
+            json["scopes_supported"],
+            serde_json::json!(["syslog:read", "syslog:admin"])
+        );
     }
 }

--- a/crates/lab-auth/src/middleware.rs
+++ b/crates/lab-auth/src/middleware.rs
@@ -271,8 +271,14 @@ async fn authenticate(
         .and_then(parse_bearer_token);
 
     if let Some(token) = auth_header {
-        // 1. Static bearer match.
-        if let Some(ref expected) = layer.static_token
+        // 1. Static bearer match — skipped when the consumer has set
+        //    `disable_static_token_with_oauth=true` and OAuth mode is active.
+        let static_token_blocked = layer.auth_state.as_ref().is_some_and(|s| {
+            s.config.disable_static_token_with_oauth
+                && matches!(s.config.mode, crate::config::AuthMode::OAuth)
+        });
+        if !static_token_blocked
+            && let Some(ref expected) = layer.static_token
             && tokens_equal(&token, expected.as_ref())
         {
             let sub = "static-bearer".to_string();
@@ -485,7 +491,7 @@ mod tests {
     use axum::routing::get;
     use tower::ServiceExt;
 
-    use crate::authorize::tests::test_auth_state;
+    use crate::authorize::tests::{test_auth_config, test_auth_state, test_auth_state_with_config};
 
     fn echo_app(layer: AuthLayer) -> Router {
         Router::new()
@@ -767,5 +773,32 @@ mod tests {
             location.starts_with("/syslog/auth/login?return_to="),
             "unexpected redirect Location: `{location}`"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn static_bearer_blocked_when_disable_static_token_with_oauth_is_set() {
+        // When disable_static_token_with_oauth=true and mode=OAuth, the static
+        // token must be rejected even though the token value matches.
+        let mut config = test_auth_config();
+        config.disable_static_token_with_oauth = true;
+        let state = Arc::new(test_auth_state_with_config(config).await);
+
+        let token: Arc<str> = Arc::from("super-secret");
+        let layer = AuthLayer::from_state(state)
+            .with_static_token(Some(token.clone()));
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, "Bearer super-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Must be 401 — static token blocked because OAuth is active.
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/lab-auth/src/middleware.rs
+++ b/crates/lab-auth/src/middleware.rs
@@ -1,0 +1,771 @@
+//! Dual-mode bearer/JWT/cookie auth middleware shipped as a [`tower::Layer`].
+//!
+//! Consumers integrate with `.layer(AuthLayer::new(...))` rather than wrapping
+//! a free `authenticate_request` function in a closure-of-7-args. The
+//! middleware writes an [`AuthContext`] into request extensions on success,
+//! returns an [`AuthError`]-shaped 401 response on failure, and (for cookie
+//! mode + browser GETs) optionally redirects to a configured login path so the
+//! Google OAuth flow can establish a session.
+//!
+//! Precedence (matches the legacy lab middleware):
+//!
+//! 1. `Authorization: Bearer <token>` matches the static bearer (constant-time
+//!    compare) -> grants `static_token_scopes`.
+//! 2. `Authorization: Bearer <token>` validates as a JWT issued by the local
+//!    auth state (audience + issuer enforced inside
+//!    [`crate::jwt::SigningKeys::validate_access_token_with_issuer`]) ->
+//!    grants the JWT-claim scopes.
+//! 3. (Optional, when [`AuthLayer`] was constructed with
+//!    `allow_session_cookie = true`.) Browser session cookie matches a row in
+//!    the auth store, with CSRF enforced for non-GET/HEAD/OPTIONS.
+//! 4. Otherwise, browser GET requests with `Accept: text/html` are redirected
+//!    to the configured login path; everything else returns 401 with
+//!    `WWW-Authenticate: Bearer resource_metadata=...`.
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Method, Request, header};
+use axum::response::{IntoResponse, Redirect, Response};
+use subtle::ConstantTimeEq;
+use tower::{Layer, Service};
+
+use crate::auth_context::{AuthContext, www_authenticate_value};
+use crate::error::AuthError;
+use crate::metadata::canonical_resource_url;
+use crate::session;
+use crate::state::AuthState;
+
+/// Closure-erased actor-key derivation hook.
+///
+/// Consumers that have a notion of an opaque actor identifier (lab uses an
+/// HMAC over the JWT subject for non-PII observability) build one and pass
+/// it through [`AuthLayer::with_actor_key_deriver`]. Consumers without this
+/// concept (e.g. syslog-mcp) leave it unset.
+///
+/// The closure receives the JWT `sub` (or `"static-bearer"` /
+/// browser-session subject) and returns a per-request [`Arc<str>`] key.
+pub type ActorKeyDeriver = dyn Fn(&str) -> Option<Arc<str>> + Send + Sync;
+
+/// Tower layer that authenticates inbound requests and writes
+/// [`AuthContext`] into request extensions.
+///
+/// Construct via [`AuthLayer::new`] and customize with the chained
+/// `with_*` helpers.
+#[derive(Clone)]
+pub struct AuthLayer {
+    inner: Arc<AuthLayerInner>,
+}
+
+#[derive(Clone)]
+struct AuthLayerInner {
+    static_token: Option<Arc<str>>,
+    auth_state: Option<Arc<AuthState>>,
+    actor_key_deriver: Option<Arc<ActorKeyDeriver>>,
+    resource_url: Option<Arc<str>>,
+    allow_session_cookie: bool,
+    /// Scopes minted into the [`AuthContext`] when the static bearer or
+    /// session-cookie path matches. For the static path this is the legacy
+    /// `static_token_scopes` config; for the cookie path lab keeps the same
+    /// list (browser-session subjects are admin-equivalent today).
+    static_token_scopes: Vec<String>,
+    /// Browser login path used for the GET+text/html unauthenticated
+    /// redirect (when `allow_session_cookie` is `true`). Defaults to
+    /// `/auth/login` per [`crate::config::DEFAULT_LOGIN_PATH`].
+    login_path: String,
+    /// Browser session cookie name. Read from
+    /// [`crate::config::AuthConfig::session_cookie_name`] when an
+    /// `auth_state` is supplied; otherwise this is unused.
+    session_cookie_name: String,
+}
+
+impl AuthLayer {
+    /// Build a bearer-only layer with neither a static token nor an auth
+    /// state. Such a layer always rejects requests with 401 — useful only
+    /// as a placeholder; real consumers immediately chain at least one of
+    /// [`Self::with_static_token`] / [`Self::with_auth_state`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(AuthLayerInner {
+                static_token: None,
+                auth_state: None,
+                actor_key_deriver: None,
+                resource_url: None,
+                allow_session_cookie: false,
+                static_token_scopes: Vec::new(),
+                login_path: crate::config::DEFAULT_LOGIN_PATH.to_string(),
+                session_cookie_name: crate::config::DEFAULT_SESSION_COOKIE_NAME.to_string(),
+            }),
+        }
+    }
+
+    /// Convenience constructor that pulls
+    /// `static_token_scopes`, `login_path`, and `session_cookie_name`
+    /// directly from the supplied [`AuthState`]'s config — typically the
+    /// only call sites consumers need.
+    #[must_use]
+    pub fn from_state(auth_state: Arc<AuthState>) -> Self {
+        let cfg = &auth_state.config;
+        let static_token_scopes = cfg.static_token_scopes.clone();
+        let login_path = cfg.login_path.clone();
+        let session_cookie_name = cfg.session_cookie_name.clone();
+        Self {
+            inner: Arc::new(AuthLayerInner {
+                static_token: None,
+                auth_state: Some(auth_state),
+                actor_key_deriver: None,
+                resource_url: None,
+                allow_session_cookie: false,
+                static_token_scopes,
+                login_path,
+                session_cookie_name,
+            }),
+        }
+    }
+
+    fn with(mut self, mutate: impl FnOnce(&mut AuthLayerInner)) -> Self {
+        let inner = Arc::make_mut(&mut self.inner);
+        mutate(inner);
+        self
+    }
+
+    #[must_use]
+    pub fn with_static_token(self, token: Option<Arc<str>>) -> Self {
+        self.with(|inner| inner.static_token = token)
+    }
+
+    #[must_use]
+    pub fn with_auth_state(self, state: Option<Arc<AuthState>>) -> Self {
+        self.with(|inner| {
+            if let Some(state) = state.as_ref() {
+                let cfg = &state.config;
+                inner.static_token_scopes = cfg.static_token_scopes.clone();
+                inner.login_path = cfg.login_path.clone();
+                inner.session_cookie_name = cfg.session_cookie_name.clone();
+            }
+            inner.auth_state = state;
+        })
+    }
+
+    #[must_use]
+    pub fn with_actor_key_deriver(self, deriver: Option<Arc<ActorKeyDeriver>>) -> Self {
+        self.with(|inner| inner.actor_key_deriver = deriver)
+    }
+
+    #[must_use]
+    pub fn with_resource_url(self, resource_url: Option<Arc<str>>) -> Self {
+        self.with(|inner| inner.resource_url = resource_url)
+    }
+
+    #[must_use]
+    pub fn with_allow_session_cookie(self, allow: bool) -> Self {
+        self.with(|inner| inner.allow_session_cookie = allow)
+    }
+
+    /// Override the static-token scope list (defaults to the value pulled
+    /// from `AuthConfig::static_token_scopes` via [`Self::from_state`] /
+    /// [`Self::with_auth_state`]).
+    #[must_use]
+    pub fn with_static_token_scopes(self, scopes: Vec<String>) -> Self {
+        self.with(|inner| inner.static_token_scopes = scopes)
+    }
+
+    /// Override the browser login path used for the GET+text/html
+    /// unauthenticated redirect.
+    #[must_use]
+    pub fn with_login_path(self, path: impl Into<String>) -> Self {
+        self.with(|inner| inner.login_path = path.into())
+    }
+
+    /// Override the session cookie name read from inbound requests.
+    #[must_use]
+    pub fn with_session_cookie_name(self, name: impl Into<String>) -> Self {
+        self.with(|inner| inner.session_cookie_name = name.into())
+    }
+}
+
+impl Default for AuthLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            layer: self.inner.clone(),
+        }
+    }
+}
+
+/// Service half of [`AuthLayer`]. Forwards to `inner` after a successful
+/// authentication; otherwise short-circuits with a 401 / redirect response.
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    layer: Arc<AuthLayerInner>,
+}
+
+impl<S> Service<Request<Body>> for AuthService<S>
+where
+    S: Service<Request<Body>, Response = Response, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Response, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // Per tower::Service contract, `call` may take a stale `self.inner`
+        // because Service callers clone the service before calling. We follow
+        // the standard tower middleware idiom: clone, then swap so the
+        // freshly-readied service is the one we call.
+        let clone = self.inner.clone();
+        let inner = std::mem::replace(&mut self.inner, clone);
+        let layer = self.layer.clone();
+        Box::pin(authenticate_and_forward(layer, inner, request))
+    }
+}
+
+async fn authenticate_and_forward<S>(
+    layer: Arc<AuthLayerInner>,
+    mut inner: S,
+    request: Request<Body>,
+) -> Result<Response, Infallible>
+where
+    S: Service<Request<Body>, Response = Response, Error = Infallible> + Send,
+    S::Future: Send,
+{
+    match authenticate(&layer, request).await {
+        Ok(request) => inner.call(request).await,
+        Err(response) => Ok(response),
+    }
+}
+
+/// Core authentication routine. Returns the (possibly mutated) request on
+/// success so the wrapping Service can forward it; returns a finished
+/// [`Response`] on failure (401, redirect, etc.).
+async fn authenticate(
+    layer: &AuthLayerInner,
+    mut request: Request<Body>,
+) -> Result<Request<Body>, Response> {
+    let auth_header = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_bearer_token);
+
+    if let Some(token) = auth_header {
+        // 1. Static bearer match.
+        if let Some(ref expected) = layer.static_token
+            && tokens_equal(&token, expected.as_ref())
+        {
+            let sub = "static-bearer".to_string();
+            let actor_key = derive_actor_key(layer.actor_key_deriver.as_deref(), &sub);
+            request.extensions_mut().insert(AuthContext {
+                sub,
+                actor_key,
+                scopes: layer.static_token_scopes.clone(),
+                issuer: "local".to_string(),
+                via_session: false,
+                csrf_token: None,
+                email: None,
+            });
+            return Ok(request);
+        }
+
+        // 2. JWT validation.
+        if let Some(ref auth_state) = layer.auth_state {
+            let Some(expected_issuer) = auth_state
+                .config
+                .public_url
+                .as_ref()
+                .map(|url| url.as_str().trim_end_matches('/').to_string())
+            else {
+                return Err(auth_error_response(
+                    "server misconfigured: PUBLIC_URL required for JWT validation",
+                    layer.resource_url.as_deref(),
+                ));
+            };
+            let expected_aud = canonical_resource_url(auth_state);
+            match auth_state.signing_keys.validate_access_token_with_issuer(
+                &token,
+                &expected_aud,
+                &expected_issuer,
+            ) {
+                Ok(claims) => {
+                    let actor_key =
+                        derive_actor_key(layer.actor_key_deriver.as_deref(), &claims.sub);
+                    request.extensions_mut().insert(AuthContext {
+                        actor_key,
+                        sub: claims.sub,
+                        scopes: claims
+                            .scope
+                            .split_whitespace()
+                            .filter(|scope| !scope.is_empty())
+                            .map(ToOwned::to_owned)
+                            .collect(),
+                        issuer: claims.iss,
+                        via_session: false,
+                        csrf_token: None,
+                        email: None,
+                    });
+                    return Ok(request);
+                }
+                Err(error) => {
+                    tracing::debug!(error = %error, "lab-auth JWT validation failed");
+                }
+            }
+        }
+
+        return Err(auth_error_response(
+            "invalid bearer token",
+            layer.resource_url.as_deref(),
+        ));
+    }
+
+    // 3. Browser session cookie path.
+    if layer.allow_session_cookie
+        && let Some(auth_state) = layer.auth_state.as_ref()
+        && let Some(session_id) =
+            session::read_cookie(request.headers(), &layer.session_cookie_name)
+    {
+        match auth_state.store.find_browser_session(&session_id).await {
+            Ok(Some(session)) => {
+                if !matches!(
+                    *request.method(),
+                    Method::GET | Method::HEAD | Method::OPTIONS
+                ) {
+                    let csrf = request
+                        .headers()
+                        .get(session::BROWSER_CSRF_HEADER_NAME)
+                        .and_then(|value| value.to_str().ok());
+                    if csrf != Some(session.csrf_token.as_str()) {
+                        return Err(csrf_error_response("missing or invalid csrf token"));
+                    }
+                }
+
+                let actor_key = derive_actor_key(
+                    layer.actor_key_deriver.as_deref(),
+                    &session.subject,
+                );
+                request.extensions_mut().insert(AuthContext {
+                    actor_key,
+                    sub: session.subject,
+                    scopes: layer.static_token_scopes.clone(),
+                    issuer: "browser-session".to_string(),
+                    via_session: true,
+                    csrf_token: Some(session.csrf_token),
+                    email: session.email,
+                });
+                return Ok(request);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(error = %error, "browser session lookup failed");
+            }
+        }
+    }
+
+    // 4. Browser GET → redirect to login_path.
+    if layer.allow_session_cookie
+        && layer.auth_state.is_some()
+        && *request.method() == Method::GET
+        && request
+            .headers()
+            .get(header::ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|accept| accept.contains("text/html"))
+    {
+        let return_to = request
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        let encoded = percent_encode_path(return_to);
+        let login_url = format!("{}?return_to={encoded}", layer.login_path);
+        return Err(Redirect::to(&login_url).into_response());
+    }
+
+    Err(auth_error_response(
+        if layer.allow_session_cookie {
+            "missing bearer token or session cookie"
+        } else {
+            "missing bearer token"
+        },
+        layer.resource_url.as_deref(),
+    ))
+}
+
+/// Constant-time byte comparison for static-bearer matching (prevents
+/// timing-based prefix leakage).
+#[must_use]
+pub fn tokens_equal(a: &str, b: &str) -> bool {
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
+
+/// Parse a single `Authorization: Bearer <token>` header value, returning
+/// `None` for malformed or non-Bearer schemes.
+#[must_use]
+pub fn parse_bearer_token(header_value: &str) -> Option<String> {
+    let mut parts = header_value.split_whitespace();
+    let scheme = parts.next()?;
+    let token = parts.next()?;
+    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn derive_actor_key(deriver: Option<&ActorKeyDeriver>, subject: &str) -> Option<Arc<str>> {
+    deriver.and_then(|deriver| deriver(subject))
+}
+
+/// Build a 401 response wrapping [`AuthError::AuthFailed`] and decorate it
+/// with `WWW-Authenticate` when a `resource_url` was supplied.
+fn auth_error_response(message: &str, resource_url: Option<&str>) -> Response {
+    let mut response = AuthError::AuthFailed(message.to_string()).into_response();
+    if let Some(url) = resource_url {
+        let www_auth = www_authenticate_value(url);
+        if let Ok(value) = HeaderValue::from_str(&www_auth) {
+            response
+                .headers_mut()
+                .insert(header::WWW_AUTHENTICATE, value);
+        }
+    }
+    response
+}
+
+fn csrf_error_response(message: &str) -> Response {
+    AuthError::Validation(message.to_string()).into_response()
+}
+
+fn percent_encode_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~' | b'/' | b'?') {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(
+                char::from_digit(u32::from(b >> 4), 16)
+                    .unwrap()
+                    .to_ascii_uppercase(),
+            );
+            out.push(
+                char::from_digit(u32::from(b & 0xf), 16)
+                    .unwrap()
+                    .to_ascii_uppercase(),
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::http::{Request as HttpRequest, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    use crate::authorize::tests::test_auth_state;
+
+    fn echo_app(layer: AuthLayer) -> Router {
+        Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .route_layer(layer)
+    }
+
+    #[test]
+    fn parse_bearer_token_accepts_valid_header() {
+        assert_eq!(
+            parse_bearer_token("Bearer abc.def").as_deref(),
+            Some("abc.def")
+        );
+        assert_eq!(
+            parse_bearer_token("bearer abc.def").as_deref(),
+            Some("abc.def")
+        );
+    }
+
+    #[test]
+    fn parse_bearer_token_rejects_malformed() {
+        assert_eq!(parse_bearer_token("Basic abc.def"), None);
+        assert_eq!(parse_bearer_token("Bearer"), None);
+        assert_eq!(parse_bearer_token("Bearer one two"), None);
+        assert_eq!(parse_bearer_token(""), None);
+    }
+
+    #[test]
+    fn tokens_equal_distinguishes_unequal_strings() {
+        assert!(tokens_equal("abc", "abc"));
+        assert!(!tokens_equal("abc", "abd"));
+        assert!(!tokens_equal("abc", "abcd"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn missing_bearer_token_returns_401_with_www_authenticate() {
+        let layer = AuthLayer::new()
+            .with_resource_url(Some(Arc::<str>::from("https://lab.example.com")));
+        let app = echo_app(layer);
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let www = response
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            www.contains("resource_metadata="),
+            "missing resource_metadata in WWW-Authenticate: `{www}`"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn static_bearer_match_grants_configured_scopes() {
+        let token: Arc<str> = Arc::<str>::from("super-secret");
+        let layer = AuthLayer::new()
+            .with_static_token(Some(token.clone()))
+            .with_static_token_scopes(vec!["syslog:read".to_string(), "syslog:admin".to_string()]);
+        let app = Router::new()
+            .route(
+                "/probe",
+                get(|axum::Extension(ctx): axum::Extension<AuthContext>| async move {
+                    ctx.scopes.join(",")
+                }),
+            )
+            .route_layer(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, "Bearer super-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"syslog:read,syslog:admin");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wrong_static_bearer_rejected() {
+        let layer = AuthLayer::new()
+            .with_static_token(Some(Arc::<str>::from("super-secret")));
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, "Bearer wrong")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn jwt_validation_path_accepts_signed_token_and_writes_context() {
+        let state = Arc::new(test_auth_state().await);
+        let aud = canonical_resource_url(&state);
+        let iss = state
+            .config
+            .public_url
+            .as_ref()
+            .map(|url| url.as_str().trim_end_matches('/').to_string())
+            .unwrap();
+        let claims = crate::jwt::AccessClaims {
+            iss: iss.clone(),
+            sub: "user@example.com".to_string(),
+            aud: aud.clone(),
+            exp: (crate::util::now_unix() + 60) as usize,
+            iat: crate::util::now_unix() as usize,
+            jti: "j-1".to_string(),
+            scope: "syslog:read syslog:admin".to_string(),
+            azp: String::new(),
+        };
+        let token = state.signing_keys.issue_access_token(&claims).unwrap();
+        let layer = AuthLayer::from_state(state);
+        let app = Router::new()
+            .route(
+                "/probe",
+                get(|axum::Extension(ctx): axum::Extension<AuthContext>| async move {
+                    format!("{}|{}", ctx.sub, ctx.scopes.join(","))
+                }),
+            )
+            .route_layer(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"user@example.com|syslog:read,syslog:admin");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn jwt_with_wrong_issuer_rejected() {
+        let state = Arc::new(test_auth_state().await);
+        let aud = canonical_resource_url(&state);
+        let claims = crate::jwt::AccessClaims {
+            iss: "https://attacker.example.com".to_string(),
+            sub: "user@example.com".to_string(),
+            aud,
+            exp: (crate::util::now_unix() + 60) as usize,
+            iat: crate::util::now_unix() as usize,
+            jti: "j-1".to_string(),
+            scope: "syslog:read".to_string(),
+            azp: String::new(),
+        };
+        let token = state.signing_keys.issue_access_token(&claims).unwrap();
+        let layer = AuthLayer::from_state(state)
+            .with_resource_url(Some(Arc::<str>::from("https://lab.example.com")));
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn jwt_with_wrong_audience_rejected() {
+        let state = Arc::new(test_auth_state().await);
+        let iss = state
+            .config
+            .public_url
+            .as_ref()
+            .map(|url| url.as_str().trim_end_matches('/').to_string())
+            .unwrap();
+        let claims = crate::jwt::AccessClaims {
+            iss,
+            sub: "user@example.com".to_string(),
+            aud: "https://other.example.com/mcp".to_string(),
+            exp: (crate::util::now_unix() + 60) as usize,
+            iat: crate::util::now_unix() as usize,
+            jti: "j-1".to_string(),
+            scope: "syslog:read".to_string(),
+            azp: String::new(),
+        };
+        let token = state.signing_keys.issue_access_token(&claims).unwrap();
+        let layer = AuthLayer::from_state(state);
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn html_get_with_session_cookie_enabled_redirects_to_login_path() {
+        let state = Arc::new(test_auth_state().await);
+        let layer = AuthLayer::from_state(state)
+            .with_allow_session_cookie(true)
+            .with_login_path("/auth/login");
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe?x=1")
+                    .header(header::ACCEPT, "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            location.starts_with("/auth/login?return_to="),
+            "unexpected redirect Location: `{location}`"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn html_get_uses_configured_login_path_override() {
+        let state = Arc::new(test_auth_state().await);
+        let layer = AuthLayer::from_state(state)
+            .with_allow_session_cookie(true)
+            .with_login_path("/syslog/auth/login");
+        let app = echo_app(layer);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .header(header::ACCEPT, "text/html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            location.starts_with("/syslog/auth/login?return_to="),
+            "unexpected redirect Location: `{location}`"
+        );
+    }
+}

--- a/crates/lab-auth/src/routes.rs
+++ b/crates/lab-auth/src/routes.rs
@@ -13,7 +13,8 @@ use crate::state::AuthState;
 use crate::token::token;
 
 pub fn router(state: AuthState) -> Router {
-    Router::new()
+    let enable_registration = state.config.enable_dynamic_registration;
+    let mut app = Router::new()
         .route(
             "/.well-known/oauth-authorization-server",
             get(authorization_server_metadata),
@@ -23,12 +24,14 @@ pub fn router(state: AuthState) -> Router {
             get(protected_resource_metadata),
         )
         .route("/jwks", get(jwks))
-        .route("/register", post(register_client))
         .route("/authorize", get(authorize))
         .route("/auth/login", get(browser_login))
         .route("/auth/google/callback", get(callback))
-        .route("/token", post(token))
-        .with_state(state)
+        .route("/token", post(token));
+    if enable_registration {
+        app = app.route("/register", post(register_client));
+    }
+    app.with_state(state)
         .layer(middleware::from_fn(auth_dispatch_observability))
 }
 
@@ -159,7 +162,7 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
-    use crate::authorize::tests::test_auth_state;
+    use crate::authorize::tests::{test_auth_config, test_auth_state, test_auth_state_with_config};
 
     #[test]
     fn auth_dispatch_action_names_are_stable() {
@@ -187,7 +190,10 @@ mod tests {
             );
         let _ = tracing::subscriber::set_global_default(subscriber);
 
-        let app = router(test_auth_state().await);
+        // Build a state with dynamic registration enabled so /register is mounted.
+        let mut config = test_auth_config();
+        config.enable_dynamic_registration = true;
+        let app = router(test_auth_state_with_config(config).await);
         let response = app
             .oneshot(
                 HttpRequest::builder()

--- a/crates/lab-auth/src/routes.rs
+++ b/crates/lab-auth/src/routes.rs
@@ -1,9 +1,9 @@
-use axum::Router;
 use axum::extract::Request;
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::Response;
 use axum::routing::{get, post};
+use axum::Router;
 use std::time::Instant;
 
 use crate::authorize::{authorize, browser_login, callback, register_client};
@@ -31,6 +31,56 @@ pub fn router(state: AuthState) -> Router {
         .with_state(state)
         .layer(middleware::from_fn(auth_dispatch_observability))
 }
+
+/// Bearer-only OAuth subset router for headless consumers (e.g. syslog-mcp).
+///
+/// Mounts only the endpoints a non-browser MCP client needs to discover and
+/// exchange tokens — `/.well-known/*`, `/jwks`, `/authorize`,
+/// `/auth/google/callback`, and `/token`. Excludes:
+///
+/// - `/auth/login` (browser HTML — no UI on a headless service).
+/// - `/register` (RFC 7591 dynamic client registration — extra attack
+///   surface with no current consumer).
+/// - Any session-cookie endpoints.
+///
+/// Use [`router`] for the full surface (lab itself).
+pub fn bearer_only_router(state: AuthState) -> Router {
+    Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(authorization_server_metadata),
+        )
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(protected_resource_metadata),
+        )
+        .route("/jwks", get(jwks))
+        .route("/authorize", get(authorize))
+        .route("/auth/google/callback", get(callback))
+        .route("/token", post(token))
+        .with_state(state)
+        .layer(middleware::from_fn(auth_dispatch_observability))
+}
+
+/// Pinned snapshot of the routes mounted by [`bearer_only_router`]. Sorted.
+///
+/// If you add or remove an endpoint in `bearer_only_router`, update this
+/// list AND consider whether the change is intentional — silently
+/// drifting the headless subset is the bug this snapshot exists to catch
+/// (REVIEW-APPLIED #9).
+pub const BEARER_ONLY_ROUTER_PATHS: &[(&str, &str)] = &[
+    ("GET", "/.well-known/oauth-authorization-server"),
+    ("GET", "/.well-known/oauth-protected-resource"),
+    ("GET", "/authorize"),
+    ("GET", "/auth/google/callback"),
+    ("GET", "/jwks"),
+    ("POST", "/token"),
+];
+
+/// Paths that must NOT be mounted by [`bearer_only_router`] — verified
+/// by the snapshot test.
+pub const BEARER_ONLY_ROUTER_FORBIDDEN_PATHS: &[(&str, &str)] =
+    &[("GET", "/auth/login"), ("POST", "/register")];
 
 async fn auth_dispatch_observability(request: Request, next: Next) -> Response {
     let action = auth_dispatch_action(request.uri().path());
@@ -171,5 +221,62 @@ mod tests {
             logs.contains("\"elapsed_ms\":"),
             "missing elapsed_ms in:\n{logs}"
         );
+    }
+
+    /// Pinned-snapshot test for [`bearer_only_router`] — sends a probe
+    /// request to each path in [`BEARER_ONLY_ROUTER_PATHS`] and asserts
+    /// the response is NOT 404 (i.e. the route is mounted), then probes
+    /// each path in [`BEARER_ONLY_ROUTER_FORBIDDEN_PATHS`] and asserts
+    /// IT IS 404 (i.e. the route is NOT mounted).
+    ///
+    /// Catches future drift where lab-auth contributors add endpoints to
+    /// [`router`] but forget to keep the headless subset in lock-step.
+    #[tokio::test(flavor = "current_thread")]
+    async fn bearer_only_router_route_list_matches_pinned_snapshot() {
+        let state = test_auth_state().await;
+        let app = bearer_only_router(state);
+
+        for (method, path) in BEARER_ONLY_ROUTER_PATHS {
+            let response = app
+                .clone()
+                .oneshot(
+                    HttpRequest::builder()
+                        .method(*method)
+                        .uri(*path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_ne!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "expected `{method} {path}` to be mounted on bearer_only_router \
+                 but got 404 — did the route get removed without updating \
+                 BEARER_ONLY_ROUTER_PATHS?"
+            );
+        }
+
+        for (method, path) in BEARER_ONLY_ROUTER_FORBIDDEN_PATHS {
+            let response = app
+                .clone()
+                .oneshot(
+                    HttpRequest::builder()
+                        .method(*method)
+                        .uri(*path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "expected `{method} {path}` to be ABSENT from bearer_only_router \
+                 but got status {} — Locked Decision: bearer_only_router \
+                 must NOT mount /auth/login or /register",
+                response.status()
+            );
+        }
     }
 }

--- a/crates/lab-auth/src/session.rs
+++ b/crates/lab-auth/src/session.rs
@@ -1,4 +1,4 @@
-use axum::http::header::{COOKIE, HeaderMap, SET_COOKIE};
+use axum::http::header::{HeaderMap, COOKIE, SET_COOKIE};
 use axum::response::Response;
 
 use crate::error::AuthError;
@@ -6,6 +6,10 @@ use crate::state::AuthState;
 use crate::types::BrowserSessionRow;
 use crate::util::{expires_at, now_unix, random_token};
 
+/// Default browser session cookie name used by the lab consumer. Other
+/// consumers should not read this constant directly — instead, prefer
+/// [`AuthState::config::session_cookie_name`] and the helpers in this
+/// module that look up the configured name from state.
 pub const BROWSER_SESSION_COOKIE_NAME: &str = "lab_session";
 pub const BROWSER_CSRF_HEADER_NAME: &str = "x-csrf-token";
 
@@ -42,7 +46,7 @@ pub async fn create_browser_session(
         expires_at: expires_at(
             created_at,
             state.config.refresh_token_ttl,
-            "LAB_AUTH_REFRESH_TOKEN_TTL_SECS",
+            &format!("{}_AUTH_REFRESH_TOKEN_TTL_SECS", state.config.env_prefix),
         )?,
     };
     state.store.upsert_browser_session(session.clone()).await?;
@@ -65,7 +69,7 @@ fn secure_cookie_attr(state: &AuthState) -> &'static str {
 pub fn build_browser_session_cookie(state: &AuthState, session_id: &str) -> String {
     format!(
         "{name}={value}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age}{secure}",
-        name = BROWSER_SESSION_COOKIE_NAME,
+        name = state.config.session_cookie_name,
         value = session_id,
         max_age = state.config.refresh_token_ttl.as_secs(),
         secure = secure_cookie_attr(state),
@@ -75,7 +79,7 @@ pub fn build_browser_session_cookie(state: &AuthState, session_id: &str) -> Stri
 pub fn clear_browser_session_cookie(state: &AuthState) -> String {
     format!(
         "{name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT{secure}",
-        name = BROWSER_SESSION_COOKIE_NAME,
+        name = state.config.session_cookie_name,
         secure = secure_cookie_attr(state),
     )
 }
@@ -114,5 +118,32 @@ mod tests {
             read_cookie(&headers, super::BROWSER_SESSION_COOKIE_NAME),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn build_browser_session_cookie_uses_configured_name() {
+        use crate::authorize::tests::test_auth_state_with_config;
+        use crate::config::AuthConfig;
+
+        let mut config = AuthConfig::default();
+        // Need OAuth + bare minimums for AuthState::new.
+        config.mode = crate::config::AuthMode::OAuth;
+        config.public_url =
+            Some(url::Url::parse("https://syslog.example.com").expect("public url"));
+        config.google.client_id = "client-id".into();
+        config.google.client_secret = "client-secret".into();
+        config.admin_email = "admin@example.com".into();
+        let dir = tempfile::tempdir().expect("tempdir");
+        config.sqlite_path = dir.path().join("auth.db");
+        config.key_path = dir.path().join("auth.pem");
+        config.session_cookie_name = "syslog_session".to_string();
+
+        let state = test_auth_state_with_config(config).await;
+        let cookie = super::build_browser_session_cookie(&state, "abc");
+        assert!(cookie.starts_with("syslog_session=abc;"), "got: {cookie}");
+        assert!(!cookie.contains("lab_session"));
+
+        let cleared = super::clear_browser_session_cookie(&state);
+        assert!(cleared.starts_with("syslog_session=;"), "got: {cleared}");
     }
 }

--- a/crates/lab-auth/src/state.rs
+++ b/crates/lab-auth/src/state.rs
@@ -75,13 +75,17 @@ pub struct AuthState {
 impl AuthState {
     pub async fn new(config: AuthConfig) -> Result<Self, AuthError> {
         if !matches!(config.mode, AuthMode::OAuth) {
-            return Err(AuthError::Config(
-                "AuthState requires LAB_AUTH_MODE=oauth".to_string(),
-            ));
+            return Err(AuthError::Config(format!(
+                "AuthState requires {prefix}_AUTH_MODE=oauth",
+                prefix = config.env_prefix
+            )));
         }
 
         let public_url = config.public_url.clone().ok_or_else(|| {
-            AuthError::Config("LAB_PUBLIC_URL is required when LAB_AUTH_MODE=oauth".to_string())
+            AuthError::Config(format!(
+                "{prefix}_PUBLIC_URL is required when {prefix}_AUTH_MODE=oauth",
+                prefix = config.env_prefix
+            ))
         })?;
         let redirect_uri = build_google_redirect_uri(&public_url, &config.google.callback_path);
         let store = SqliteStore::open(config.sqlite_path.clone()).await?;
@@ -93,13 +97,15 @@ impl AuthState {
         )?;
         google.scopes.clone_from(&config.google.scopes);
         info!(
+            crate_name = "lab-auth",
+            env_prefix = %config.env_prefix,
             auth_mode = "oauth",
             public_url = %public_url,
             google_redirect_uri = %google.redirect_uri,
             sqlite_path = %config.sqlite_path.display(),
             key_path = %config.key_path.display(),
             google_scopes = ?config.google.scopes,
-            "lab-auth state initialized"
+            "auth state initialized"
         );
 
         let authorize_limiter = RateLimiter::new(config.authorize_requests_per_minute);
@@ -242,6 +248,7 @@ mod tests {
             register_requests_per_minute: 10,
             authorize_requests_per_minute: 20,
             max_pending_oauth_states: 1024,
+            ..AuthConfig::default()
         })
         .await
         .expect("auth state")
@@ -321,6 +328,7 @@ mod tests {
             register_requests_per_minute: 10,
             authorize_requests_per_minute: 20,
             max_pending_oauth_states: 1024,
+            ..AuthConfig::default()
         })
         .await
         .expect("auth state");

--- a/crates/lab/src/api/browser_session.rs
+++ b/crates/lab/src/api/browser_session.rs
@@ -141,8 +141,8 @@ pub async fn auth_session(State(state): State<AppState>, headers: HeaderMap) -> 
         && let Some(token) = headers
             .get(header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
-            .and_then(crate::api::router::parse_bearer_token)
-        && crate::api::router::tokens_equal(&token, expected.as_ref())
+            .and_then(lab_auth::parse_bearer_token)
+        && lab_auth::tokens_equal(&token, expected.as_ref())
     {
         let response = no_store_json(serde_json::json!({
             "authenticated": true,

--- a/crates/lab/src/api/oauth.rs
+++ b/crates/lab/src/api/oauth.rs
@@ -1,30 +1,8 @@
-use axum::http::request::Parts;
-use std::sync::Arc;
+//! Compatibility re-export shim — `AuthContext` now lives in the shared
+//! `lab_auth` crate. Existing `use crate::api::oauth::AuthContext;` import
+//! sites continue to compile via this re-export.
+//!
+//! `www_authenticate_value` likewise re-exported for the (rare) lab callers
+//! that build their own `WWW-Authenticate` header outside of the auth layer.
 
-/// Stored in request extensions by the HTTP auth middleware.
-///
-/// Downstream handlers can read this when they need caller identity or scope
-/// checks, but not every route consumes it yet.
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct AuthContext {
-    pub sub: String,
-    pub actor_key: Option<Arc<str>>,
-    pub scopes: Vec<String>,
-    pub issuer: String,
-    pub via_session: bool,
-    pub csrf_token: Option<String>,
-    pub email: Option<String>,
-}
-
-pub fn www_authenticate_value(resource_url: &str) -> String {
-    format!(
-        "Bearer resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
-        resource_url.trim_end_matches('/')
-    )
-}
-
-#[allow(dead_code)]
-pub fn auth_context(parts: &Parts) -> Option<&AuthContext> {
-    parts.extensions.get::<AuthContext>()
-}
+pub use lab_auth::auth_context::AuthContext;

--- a/crates/lab/src/api/oauth.rs
+++ b/crates/lab/src/api/oauth.rs
@@ -6,3 +6,7 @@
 //! that build their own `WWW-Authenticate` header outside of the auth layer.
 
 pub use lab_auth::auth_context::AuthContext;
+// Re-exported for lab callers that build WWW-Authenticate headers directly;
+// not used within this crate itself.
+#[allow(unused_imports)]
+pub use lab_auth::www_authenticate_value;

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -566,7 +566,12 @@ pub fn build_router(
     let make_auth_layer = |allow_session_cookie: bool| -> AuthLayer {
         let mut layer = match auth_state.clone() {
             Some(state) => AuthLayer::from_state(state),
-            None => AuthLayer::new(),
+            // Bearer-only path (no OAuth state): grant the same legacy scopes
+            // that the old middleware always issued for static-token requests.
+            None => AuthLayer::new().with_static_token_scopes(vec![
+                "lab:read".to_string(),
+                "lab:admin".to_string(),
+            ]),
         };
         layer = layer
             .with_static_token(static_token.clone())

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -6,14 +6,11 @@ use std::time::Duration;
 
 use axum::{
     Json, Router,
-    body::Body,
     extract::{Query, State},
-    http::{HeaderName, HeaderValue, Method, Request, StatusCode, header},
-    middleware::Next,
+    http::{HeaderName, Request, StatusCode, header},
     response::{Html, IntoResponse},
     routing::{get, post},
 };
-use subtle::ConstantTimeEq;
 use tower_http::{
     compression::CompressionLayer,
     cors::{AllowOrigin, CorsLayer},
@@ -23,7 +20,23 @@ use tower_http::{
 };
 use tracing::Level;
 
+use lab_auth::AuthLayer;
 use lab_auth::error::AuthError as LabAuthError;
+
+/// Convert lab's strongly-typed [`crate::observability::activity::ActorKeyDeriver`]
+/// into the closure-erased [`lab_auth::ActorKeyDeriver`] alias accepted by
+/// [`AuthLayer::with_actor_key_deriver`]. Keeps the lab-specific HMAC actor-key
+/// derivation while letting lab-auth stay agnostic about consumer-specific
+/// observability hooks.
+fn lab_auth_deriver(
+    deriver: Arc<crate::observability::activity::ActorKeyDeriver>,
+) -> Arc<lab_auth::ActorKeyDeriver> {
+    Arc::new(move |subject: &str| {
+        deriver
+            .derive_subject(subject)
+            .map(crate::observability::activity::ActorKey::into_arc)
+    })
+}
 
 const DEV_MARKETPLACE_READ_ACTIONS: &[&str] = &[
     "help",
@@ -43,44 +56,6 @@ const DEV_MARKETPLACE_READ_ACTIONS: &[&str] = &[
     "mcp.versions",
     "mcp.meta.get",
 ];
-
-/// Constant-time byte comparison using `subtle::ConstantTimeEq` to prevent
-/// timing-based token prefix leakage (lab-63jc).
-pub(crate) fn tokens_equal(a: &str, b: &str) -> bool {
-    a.as_bytes().ct_eq(b.as_bytes()).into()
-}
-
-fn percent_encode_path(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~' | b'/' | b'?') {
-            out.push(b as char);
-        } else {
-            out.push('%');
-            out.push(
-                char::from_digit((b >> 4) as u32, 16)
-                    .unwrap()
-                    .to_ascii_uppercase(),
-            );
-            out.push(
-                char::from_digit((b & 0xf) as u32, 16)
-                    .unwrap()
-                    .to_ascii_uppercase(),
-            );
-        }
-    }
-    out
-}
-
-pub(crate) fn parse_bearer_token(header_value: &str) -> Option<String> {
-    let mut parts = header_value.split_whitespace();
-    let scheme = parts.next()?;
-    let token = parts.next()?;
-    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
-    Some(token.to_string())
-}
 
 use super::{health, services, state::AppState};
 use crate::dispatch::error::ToolError;
@@ -142,204 +117,6 @@ async fn auth_token(
     form: axum::extract::Form<lab_auth::types::TokenRequest>,
 ) -> Result<impl IntoResponse, LabAuthError> {
     Ok(lab_auth::token::token(State(app_auth_state(&state)?), form).await?)
-}
-
-fn auth_error_response(message: &str, resource_url: Option<&str>) -> axum::response::Response {
-    let err = ToolError::Sdk {
-        sdk_kind: "auth_failed".into(),
-        message: message.into(),
-    };
-    let mut response = err.into_response();
-    if let Some(url) = resource_url {
-        let www_auth = crate::api::oauth::www_authenticate_value(url);
-        if let Ok(value) = HeaderValue::from_str(&www_auth) {
-            response
-                .headers_mut()
-                .insert(header::WWW_AUTHENTICATE, value);
-        }
-    }
-    response
-}
-
-fn csrf_error_response(message: &str) -> axum::response::Response {
-    ToolError::Sdk {
-        sdk_kind: "validation_failed".into(),
-        message: message.into(),
-    }
-    .into_response()
-}
-
-async fn authenticate_request(
-    mut request: Request<Body>,
-    next: Next,
-    static_token: Option<Arc<str>>,
-    auth_state: Option<Arc<lab_auth::state::AuthState>>,
-    actor_key_deriver: Option<Arc<crate::observability::activity::ActorKeyDeriver>>,
-    resource_url: Option<Arc<str>>,
-    allow_session_cookie: bool,
-) -> Result<axum::response::Response, std::convert::Infallible> {
-    let auth_header = request
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(parse_bearer_token);
-
-    if let Some(token) = auth_header {
-        if let Some(ref expected) = static_token
-            && tokens_equal(&token, expected.as_ref())
-        {
-            let sub = "static-bearer".to_string();
-            let actor_key = derive_actor_key(actor_key_deriver.as_deref(), &sub);
-            request
-                .extensions_mut()
-                .insert(crate::api::oauth::AuthContext {
-                    sub,
-                    actor_key,
-                    scopes: vec!["lab:read".to_string(), "lab:admin".to_string()],
-                    issuer: "local".to_string(),
-                    via_session: false,
-                    csrf_token: None,
-                    email: None,
-                });
-            return Ok(next.run(request).await);
-        }
-
-        if let Some(ref auth_state) = auth_state {
-            let Some(expected_issuer) = auth_state
-                .config
-                .public_url
-                .as_ref()
-                .map(|url| url.as_str().trim_end_matches('/').to_string())
-            else {
-                return Ok(auth_error_response(
-                    "server misconfigured: LAB_PUBLIC_URL required for JWT validation",
-                    resource_url.as_deref(),
-                ));
-            };
-            let expected_aud = lab_auth::metadata::canonical_resource_url(auth_state);
-            match auth_state
-                .signing_keys
-                .validate_access_token(&token, &expected_aud)
-            {
-                Ok(claims) => {
-                    if claims.iss != expected_issuer {
-                        return Ok(auth_error_response(
-                            "invalid bearer token",
-                            resource_url.as_deref(),
-                        ));
-                    }
-
-                    request
-                        .extensions_mut()
-                        .insert(crate::api::oauth::AuthContext {
-                            actor_key: derive_actor_key(actor_key_deriver.as_deref(), &claims.sub),
-                            sub: claims.sub,
-                            scopes: claims
-                                .scope
-                                .split_whitespace()
-                                .filter(|scope| !scope.is_empty())
-                                .map(ToOwned::to_owned)
-                                .collect(),
-                            issuer: claims.iss,
-                            via_session: false,
-                            csrf_token: None,
-                            email: None,
-                        });
-                    return Ok(next.run(request).await);
-                }
-                Err(error) => {
-                    tracing::debug!(error = %error, "lab-auth JWT validation failed");
-                }
-            }
-        }
-
-        return Ok(auth_error_response(
-            "invalid bearer token",
-            resource_url.as_deref(),
-        ));
-    }
-
-    if allow_session_cookie
-        && let Some(auth_state) = auth_state.as_ref()
-        && let Some(session_id) = lab_auth::session::read_cookie(
-            request.headers(),
-            lab_auth::session::BROWSER_SESSION_COOKIE_NAME,
-        )
-    {
-        match auth_state.store.find_browser_session(&session_id).await {
-            Ok(Some(session)) => {
-                if !matches!(
-                    *request.method(),
-                    Method::GET | Method::HEAD | Method::OPTIONS
-                ) {
-                    let csrf = request
-                        .headers()
-                        .get(lab_auth::session::BROWSER_CSRF_HEADER_NAME)
-                        .and_then(|value| value.to_str().ok());
-                    if csrf != Some(session.csrf_token.as_str()) {
-                        return Ok(csrf_error_response("missing or invalid csrf token"));
-                    }
-                }
-
-                request
-                    .extensions_mut()
-                    .insert(crate::api::oauth::AuthContext {
-                        actor_key: derive_actor_key(actor_key_deriver.as_deref(), &session.subject),
-                        sub: session.subject,
-                        scopes: vec!["lab:read".to_string(), "lab:admin".to_string()],
-                        issuer: "browser-session".to_string(),
-                        via_session: true,
-                        csrf_token: Some(session.csrf_token),
-                        email: session.email,
-                    });
-                return Ok(next.run(request).await);
-            }
-            Ok(None) => {}
-            Err(error) => {
-                tracing::debug!(error = %error, "browser session lookup failed");
-            }
-        }
-    }
-
-    // For browser GET requests with no bearer token and no valid session cookie,
-    // redirect to /auth/login so the Google OAuth flow can establish a session.
-    // Only fires on v1 routes (allow_session_cookie=true); the MCP endpoint uses bearer-only.
-    if allow_session_cookie
-        && auth_state.is_some()
-        && *request.method() == Method::GET
-        && request
-            .headers()
-            .get(header::ACCEPT)
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|accept| accept.contains("text/html"))
-    {
-        let return_to = request
-            .uri()
-            .path_and_query()
-            .map(|pq| pq.as_str())
-            .unwrap_or("/");
-        let encoded = percent_encode_path(return_to);
-        let login_url = format!("/auth/login?return_to={encoded}");
-        return Ok(axum::response::Redirect::to(&login_url).into_response());
-    }
-
-    Ok(auth_error_response(
-        if allow_session_cookie {
-            "missing bearer token or session cookie"
-        } else {
-            "missing bearer token"
-        },
-        resource_url.as_deref(),
-    ))
-}
-
-fn derive_actor_key(
-    deriver: Option<&crate::observability::activity::ActorKeyDeriver>,
-    subject: &str,
-) -> Option<Arc<str>> {
-    deriver
-        .and_then(|deriver| deriver.derive_subject(subject))
-        .map(crate::observability::activity::ActorKey::into_arc)
 }
 
 /// Build the `/v1` sub-router with all feature-gated service routes.
@@ -782,24 +559,24 @@ pub fn build_router(
                 .and_then(|cfg| cfg.public_url.as_ref().map(url::Url::as_str))
         })
         .map(Arc::from);
-    let auth_state_for_v1 = auth_state.clone();
-    let static_token_for_v1 = static_token.clone();
-    let actor_key_deriver_for_v1 = state.actor_key_deriver.clone();
-    let resource_url_for_v1 = resource_url.clone();
+    let layer_deriver = state.actor_key_deriver.clone().map(lab_auth_deriver);
+    // Build the shared AuthLayer once; per-route variants only differ in
+    // whether the session-cookie path is enabled (true for browser-facing
+    // /v1 + /dev + /v0.1; false for the bearer-only /mcp transport).
+    let make_auth_layer = |allow_session_cookie: bool| -> AuthLayer {
+        let mut layer = match auth_state.clone() {
+            Some(state) => AuthLayer::from_state(state),
+            None => AuthLayer::new(),
+        };
+        layer = layer
+            .with_static_token(static_token.clone())
+            .with_actor_key_deriver(layer_deriver.clone())
+            .with_resource_url(resource_url.clone())
+            .with_allow_session_cookie(allow_session_cookie);
+        layer
+    };
     let v1_protected = if needs_auth {
-        v1_router.route_layer(axum::middleware::from_fn(
-            move |request: Request<Body>, next: Next| {
-                authenticate_request(
-                    request,
-                    next,
-                    static_token_for_v1.clone(),
-                    auth_state_for_v1.clone(),
-                    actor_key_deriver_for_v1.clone(),
-                    resource_url_for_v1.clone(),
-                    true,
-                )
-            },
-        ))
+        v1_router.route_layer(make_auth_layer(true))
     } else {
         v1_router
     };
@@ -807,48 +584,16 @@ pub fn build_router(
     #[cfg(feature = "mcpregistry")]
     let v0_1_protected = {
         let v0_1_router = build_v0_1_router();
-        let auth_state_for_v0_1 = auth_state.clone();
-        let static_token_for_v0_1 = static_token.clone();
-        let actor_key_deriver_for_v0_1 = state.actor_key_deriver.clone();
-        let resource_url_for_v0_1 = resource_url.clone();
         if needs_auth {
-            v0_1_router.route_layer(axum::middleware::from_fn(
-                move |request: Request<Body>, next: Next| {
-                    authenticate_request(
-                        request,
-                        next,
-                        static_token_for_v0_1.clone(),
-                        auth_state_for_v0_1.clone(),
-                        actor_key_deriver_for_v0_1.clone(),
-                        resource_url_for_v0_1.clone(),
-                        true,
-                    )
-                },
-            ))
+            v0_1_router.route_layer(make_auth_layer(true))
         } else {
             v0_1_router
         }
     };
 
-    let auth_state_for_mcp = auth_state.clone();
-    let static_token_for_mcp = static_token.clone();
-    let actor_key_deriver_for_mcp = state.actor_key_deriver.clone();
-    let resource_url_for_mcp = resource_url.clone();
     let mcp_protected = mcp_router.map(|mcp| {
         if needs_auth {
-            mcp.route_layer(axum::middleware::from_fn(
-                move |request: Request<Body>, next: Next| {
-                    authenticate_request(
-                        request,
-                        next,
-                        static_token_for_mcp.clone(),
-                        auth_state_for_mcp.clone(),
-                        actor_key_deriver_for_mcp.clone(),
-                        resource_url_for_mcp.clone(),
-                        false,
-                    )
-                },
-            ))
+            mcp.route_layer(make_auth_layer(false))
         } else {
             mcp
         }
@@ -936,23 +681,7 @@ pub fn build_router(
         .route("/dev/{name}", get(dev_mockup_named))
         .route("/dev/{name}/", get(dev_mockup_named));
     let dev_routes = if needs_auth {
-        let auth_state_for_dev = auth_state.clone();
-        let static_token_for_dev = static_token.clone();
-        let actor_key_deriver_for_dev = state.actor_key_deriver.clone();
-        let resource_url_for_dev = resource_url.clone();
-        dev_routes.route_layer(axum::middleware::from_fn(
-            move |request: Request<Body>, next: Next| {
-                authenticate_request(
-                    request,
-                    next,
-                    static_token_for_dev.clone(),
-                    auth_state_for_dev.clone(),
-                    actor_key_deriver_for_dev.clone(),
-                    resource_url_for_dev.clone(),
-                    true,
-                )
-            },
-        ))
+        dev_routes.route_layer(make_auth_layer(true))
     } else {
         dev_routes
     };
@@ -1508,21 +1237,12 @@ mod tests {
             crate::observability::activity::ActorKeyDeriver::from_secret("test-secret").unwrap();
         let expected = deriver.derive_subject("static-bearer").unwrap();
         let deriver = Arc::new(deriver);
+        let layer = AuthLayer::new()
+            .with_static_token(Some(Arc::<str>::from("secret-token")))
+            .with_actor_key_deriver(Some(lab_auth_deriver(Arc::clone(&deriver))));
         let app = Router::new()
             .route("/probe", get(actor_key_probe))
-            .route_layer(axum::middleware::from_fn(
-                move |request: Request<Body>, next: Next| {
-                    authenticate_request(
-                        request,
-                        next,
-                        Some(Arc::<str>::from("secret-token")),
-                        None,
-                        Some(Arc::clone(&deriver)),
-                        None,
-                        false,
-                    )
-                },
-            ));
+            .route_layer(layer);
 
         let response = app
             .oneshot(
@@ -1552,22 +1272,12 @@ mod tests {
             crate::observability::activity::ActorKeyDeriver::from_secret("test-secret").unwrap();
         let expected = deriver.derive_subject(&session.subject).unwrap();
         let deriver = Arc::new(deriver);
-        let auth_state_for_layer = Arc::clone(&auth_state);
+        let layer = AuthLayer::from_state(Arc::clone(&auth_state))
+            .with_actor_key_deriver(Some(lab_auth_deriver(Arc::clone(&deriver))))
+            .with_allow_session_cookie(true);
         let app = Router::new()
             .route("/probe", get(actor_key_probe))
-            .route_layer(axum::middleware::from_fn(
-                move |request: Request<Body>, next: Next| {
-                    authenticate_request(
-                        request,
-                        next,
-                        None,
-                        Some(Arc::clone(&auth_state_for_layer)),
-                        Some(Arc::clone(&deriver)),
-                        None,
-                        true,
-                    )
-                },
-            ));
+            .route_layer(layer);
 
         let response = app
             .oneshot(
@@ -1598,21 +1308,11 @@ mod tests {
 
     #[tokio::test]
     async fn authenticated_bind_leaves_actor_key_null_without_deriver() {
+        let layer = AuthLayer::new()
+            .with_static_token(Some(Arc::<str>::from("secret-token")));
         let app = Router::new()
             .route("/probe", get(actor_key_probe))
-            .route_layer(axum::middleware::from_fn(
-                move |request: Request<Body>, next: Next| {
-                    authenticate_request(
-                        request,
-                        next,
-                        Some(Arc::<str>::from("secret-token")),
-                        None,
-                        None,
-                        None,
-                        false,
-                    )
-                },
-            ));
+            .route_layer(layer);
 
         let response = app
             .oneshot(


### PR DESCRIPTION
## Summary

Refactors the `lab-auth` crate from a lab-specific implementation into a parameterizable standalone library that can be consumed by both `lab` and `syslog-mcp`. This is Phase 1 of the OAuth integration epic (`syslog-mcp-brt0`).

**Three commits:**
- `L1` — Parameterize all hardcoded \`lab\`-branded constants (env var prefix, scopes, cookie name, resource path, default scope, enable_dynamic_registration, disable_static_token_with_oauth). Add AuthConfigBuilder consuming-builder pattern. JWKS fetch narrowed to 5s timeout. JWT issuer validation moved into \`jsonwebtoken::Validation::set_issuer()\` (RFC 7519 compliance).
- `L2` — Move dual-mode \`authenticate_request\` middleware + \`AuthContext\` into \`lab-auth\` crate as \`AuthLayer\` (Tower \`Layer\` impl). Add \`bearer_only_router()\` subset (excludes /auth/login, /register). Pinned snapshot test for route list.
- `L3` — Update lab consumer to use the parameterized crate; delete duplicated middleware code from \`lab/src/api/router.rs\` (net -322 LOC); collapse \`oauth.rs\` to a single re-export.

## Compatibility

- `lab` compiles and all 2,551 tests pass after the refactor
- All new fields have backward-compatible defaults (lab doesn't need config changes)
- Lab's public URL, issuer, and scope names are unchanged

## Test plan

- [x] `cargo test -p lab-auth` — 114 passed (single-threaded; 1 pre-existing wiremock race in multi-threaded)
- [x] `cargo build -p labby` — lab consumer compiles
- [x] `cargo test -p labby` — 2,551 passed
- [x] `cargo clippy -p lab-auth --all-targets -- -D warnings` — clean

## Dependency

syslog-mcp's `Cargo.toml` currently uses a path dep pointing to this branch's commit. Once this PR merges, syslog-mcp's Cargo.toml will be updated to use `git+rev` of the merged SHA (tracked in [syslog-mcp PR #17](https://github.com/jmagar/syslog-mcp/pull/17)).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted and parameterized `lab-auth` into a shared OAuth 2.0/JWT crate with a `tower` `AuthLayer` and a headless `bearer_only_router` for reuse by `lab` and `syslog-mcp`. Enforces config‑driven behavior (e.g., disabling static tokens when OAuth is on) and keeps lab defaults for compatibility, advancing the OAuth epic `syslog-mcp-brt0`.

- New Features
  - Config via `AuthConfigBuilder` (env prefix, cookie name, resource path, default scope and scopes, login path, dynamic registration).
  - `AuthLayer` injects `AuthContext`, supports bearer/JWT/cookie modes, and an optional actor‑key hook.
  - `bearer_only_router` exposing discovery/token endpoints for headless services.
  - RFC‑compliant issuer validation (`jsonwebtoken::Validation::set_issuer`), 5s JWKS fetch timeout, and metadata using `scopes_supported`/`resource_path` from config.

- Bug Fixes
  - `authorize` now accepts space‑separated multi‑scope requests and validates each scope against `scopes_supported`.

<sup>Written for commit 8b1dc2d8e9ad8e8a93474020d2e0ac8e7b50195d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-scoped authentication context available to handlers
  * HTML login redirects for unauthenticated browser requests
  * OAuth discovery advertises configurable scopes and resource path
  * JWT validation option that enforces issuer

* **Bug Fixes**
  * Added timeout protection for JWKS fetches

* **Refactor**
  * Single configurable authentication layer replacing previous wiring
  * Config moved to a builder with customizable env-prefix, cookie name, paths, and defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->