### PR TITLE
Harden portable protected MCP routes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -72,6 +72,10 @@ dev-debug:
 acp-smoke *ARGS:
     scripts/acp-smoke-check {{ARGS}}
 
+# Verify a public OAuth-protected MCP route through the deployed reverse proxy.
+protected-mcp-smoke *ARGS:
+    scripts/protected-mcp-smoke {{ARGS}}
+
 # Rebuild static Labby web assets served by labby serve
 web-build:
     cd apps/gateway-admin && pnpm build

--- a/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.test.tsx
+++ b/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.test.tsx
@@ -18,4 +18,5 @@ test('protected MCP routes panel renders management controls', () => {
   assert.match(markup, /Public host/)
   assert.match(markup, /Backend URL/)
   assert.match(markup, /Test/)
+  assert.match(markup, /Smoke/)
 })

--- a/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.tsx
+++ b/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.tsx
@@ -92,6 +92,10 @@ function isRouteComplete(draft: RouteDraft) {
   )
 }
 
+function isSmokeRouteComplete(draft: RouteDraft) {
+  return Boolean(draft.public_host.trim() && draft.public_path.trim())
+}
+
 const LAB_RESERVED_PATH_PREFIXES = [
   '/.well-known',
   '/_next',
@@ -179,7 +183,7 @@ function protectedRouteDraftHints(
         hints.push('Backend URL must use http:// or https://.')
       }
       if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
-        hints.push('Backend URL should be only an origin; put the MCP path in Backend MCP path.')
+        hints.push('Backend URL should be only an origin; remove any path, query, or fragment.')
       }
     } catch {
       hints.push('Backend URL must be a valid URL.')
@@ -298,7 +302,7 @@ export function ProtectedMcpRoutesPanel() {
   }
 
   const handleSmoke = async () => {
-    if (!isRouteComplete(draft)) {
+    if (!isSmokeRouteComplete(draft)) {
       setFormError('Public host and public path are required before running the proxy smoke check.')
       return
     }

--- a/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.tsx
+++ b/apps/gateway-admin/components/gateway/protected-mcp-routes-panel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle2, Loader2, Plus, Save, ShieldCheck, Trash2, X } from 'lucide-react'
+import { CheckCircle2, Loader2, Plus, Radar, Save, ShieldCheck, Trash2, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -20,6 +20,7 @@ import {
   useGatewayMutations,
   useProtectedMcpRoutes,
 } from '@/lib/hooks/use-gateways'
+import { doctorApi, isBlockingDoctorSeverity, type DoctorReport } from '@/lib/api/doctor-client'
 import type {
   ProtectedMcpRoute,
   ProtectedMcpRouteInput,
@@ -91,6 +92,103 @@ function isRouteComplete(draft: RouteDraft) {
   )
 }
 
+const LAB_RESERVED_PATH_PREFIXES = [
+  '/.well-known',
+  '/_next',
+  '/auth',
+  '/authorize',
+  '/callback',
+  '/dev',
+  '/health',
+  '/jwks',
+  '/mcp',
+  '/ready',
+  '/register',
+  '/settings',
+  '/setup',
+  '/success',
+  '/token',
+  '/v1',
+]
+
+function normalizedHost(value: string) {
+  return value.trim().replace(/\.$/, '').toLowerCase()
+}
+
+function normalizedPath(value: string) {
+  const trimmed = value.trim()
+  if (trimmed.length > 1 && trimmed.endsWith('/')) return trimmed.replace(/\/+$/, '')
+  return trimmed
+}
+
+function protectedRouteDraftHints(
+  draft: RouteDraft,
+  routes: ProtectedMcpRoute[],
+  editingName: string | null,
+) {
+  const hints: string[] = []
+  const name = draft.name.trim()
+  const publicHost = normalizedHost(draft.public_host)
+  const publicPath = normalizedPath(draft.public_path)
+  const backendUrl = draft.backend_url.trim()
+
+  if (name && routes.some((route) => route.name === name && route.name !== editingName)) {
+    hints.push(`A protected route named ${name} already exists.`)
+  }
+
+  if (publicHost.includes('/') || publicHost.includes(':') || publicHost.includes('@')) {
+    hints.push('Public host should be a bare host without scheme, port, path, or user info.')
+  }
+
+  if (publicPath && !publicPath.startsWith('/')) {
+    hints.push('Public path must start with /.')
+  } else if (publicPath === '/') {
+    hints.push('Public path needs a service segment, for example /tools.')
+  } else if (publicPath.includes('?') || publicPath.includes('#')) {
+    hints.push('Public path should not include query strings or fragments.')
+  } else if (publicPath.includes('//') || /(^|\/)\.{1,2}(\/|$)/.test(publicPath) || /%2f|%5c|%2e/i.test(publicPath)) {
+    hints.push('Public path contains ambiguous or unsafe path segments.')
+  }
+
+  if (publicHost && publicPath && draft.enabled) {
+    const duplicate = routes.find(
+      (route) =>
+        route.name !== editingName &&
+        route.enabled &&
+        normalizedHost(route.public_host) === publicHost &&
+        normalizedPath(route.public_path) === publicPath,
+    )
+    if (duplicate) {
+      hints.push(`Public route ${publicHost}${publicPath} is already used by ${duplicate.name}.`)
+    }
+  }
+
+  if (typeof window !== 'undefined' && publicHost === window.location.hostname.toLowerCase()) {
+    const reserved = LAB_RESERVED_PATH_PREFIXES.find(
+      (prefix) => publicPath === prefix || publicPath.startsWith(`${prefix}/`),
+    )
+    if (reserved) {
+      hints.push(`Public path ${publicPath} conflicts with Lab's ${reserved} routes on this host.`)
+    }
+  }
+
+  if (backendUrl) {
+    try {
+      const parsed = new URL(backendUrl)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        hints.push('Backend URL must use http:// or https://.')
+      }
+      if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+        hints.push('Backend URL should be only an origin; put the MCP path in Backend MCP path.')
+      }
+    } catch {
+      hints.push('Backend URL must be a valid URL.')
+    }
+  }
+
+  return hints
+}
+
 export function ProtectedMcpRoutesPanel() {
   const { data: routes = [], isLoading, error } = useProtectedMcpRoutes()
   const {
@@ -104,6 +202,7 @@ export function ProtectedMcpRoutesPanel() {
   const [draft, setDraft] = useState<RouteDraft>(EMPTY_DRAFT)
   const [pendingAction, setPendingAction] = useState<string | null>(null)
   const [testResult, setTestResult] = useState<ProtectedMcpRouteTestResult | null>(null)
+  const [smokeResult, setSmokeResult] = useState<DoctorReport | null>(null)
   const [formError, setFormError] = useState<string | null>(null)
 
   const sortedRoutes = useMemo(
@@ -117,6 +216,7 @@ export function ProtectedMcpRoutesPanel() {
       setEditingName(null)
       setDraft(EMPTY_DRAFT)
       setTestResult(null)
+      setSmokeResult(null)
       setFormError(null)
     }
   }, [editingName, isEditing, routes])
@@ -125,12 +225,14 @@ export function ProtectedMcpRoutesPanel() {
     setDraft((current) => ({ ...current, [key]: value }))
     setFormError(null)
     setTestResult(null)
+    setSmokeResult(null)
   }
 
   const startCreate = () => {
     setEditingName(null)
     setDraft(EMPTY_DRAFT)
     setTestResult(null)
+    setSmokeResult(null)
     setFormError(null)
   }
 
@@ -138,8 +240,14 @@ export function ProtectedMcpRoutesPanel() {
     setEditingName(route.name)
     setDraft(draftFromRoute(route))
     setTestResult(null)
+    setSmokeResult(null)
     setFormError(null)
   }
+
+  const validationHints = useMemo(
+    () => protectedRouteDraftHints(draft, routes, editingName),
+    [draft, editingName, routes],
+  )
 
   const handleTest = async () => {
     if (!isRouteComplete(draft)) {
@@ -182,6 +290,41 @@ export function ProtectedMcpRoutesPanel() {
       toast.success(isEditing ? 'Protected route updated' : 'Protected route added')
     } catch (error) {
       const message = getErrorMessage(error, 'Failed to save protected route')
+      setFormError(message)
+      toast.error(message)
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  const handleSmoke = async () => {
+    if (!isRouteComplete(draft)) {
+      setFormError('Public host and public path are required before running the proxy smoke check.')
+      return
+    }
+
+    const controller = new AbortController()
+    setPendingAction('smoke')
+    setFormError(null)
+    setSmokeResult(null)
+    try {
+      const report = await doctorApi.proxyCheck(
+        {
+          app_url: window.location.origin,
+          mcp_url: `https://${draft.public_host.trim()}`,
+          route: draft.public_path.trim(),
+        },
+        controller.signal,
+      )
+      setSmokeResult(report)
+      const blocked = report.findings.some((finding) => isBlockingDoctorSeverity(finding.severity))
+      if (blocked) {
+        toast.error('Protected route proxy smoke failed')
+      } else {
+        toast.success('Protected route proxy smoke passed')
+      }
+    } catch (error) {
+      const message = getErrorMessage(error, 'Failed to run protected route proxy smoke')
       setFormError(message)
       toast.error(message)
     } finally {
@@ -407,6 +550,16 @@ export function ProtectedMcpRoutesPanel() {
             </div>
           ) : null}
 
+          {validationHints.length > 0 ? (
+            <div className="mt-3 rounded-lg border border-aurora-warning/30 bg-aurora-warning/10 px-3 py-2 text-sm text-aurora-text-primary">
+              <ul className="space-y-1">
+                {validationHints.map((hint) => (
+                  <li key={hint}>{hint}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           {testResult ? (
             <div className="mt-3 rounded-lg border border-aurora-success/30 bg-aurora-success/10 px-3 py-2 text-sm">
               <div className="flex items-center gap-2 text-aurora-text-primary">
@@ -415,6 +568,29 @@ export function ProtectedMcpRoutesPanel() {
               </div>
               <p className="mt-1 break-all font-mono text-xs text-aurora-text-muted">{testResult.resource}</p>
               <p className="mt-1 break-all font-mono text-xs text-aurora-text-muted">{testResult.metadata_url}</p>
+            </div>
+          ) : null}
+
+          {smokeResult ? (
+            <div className="mt-3 rounded-lg border bg-aurora-page-bg px-3 py-2 text-sm">
+              <div className="flex items-center gap-2 text-aurora-text-primary">
+                <Radar className="size-4 text-aurora-text-muted" />
+                <span className="font-medium">Proxy smoke results</span>
+              </div>
+              <div className="mt-2 space-y-1">
+                {smokeResult.findings.map((finding) => (
+                  <div key={`${finding.category ?? 'proxy'}:${finding.message}`} className="flex gap-2 text-xs">
+                    <Badge
+                      variant={isBlockingDoctorSeverity(finding.severity) ? 'default' : 'secondary'}
+                      status={isBlockingDoctorSeverity(finding.severity) ? 'error' : 'default'}
+                      className="h-5 shrink-0"
+                    >
+                      {finding.severity}
+                    </Badge>
+                    <span className="min-w-0 text-aurora-text-muted">{finding.message}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : null}
 
@@ -432,6 +608,14 @@ export function ProtectedMcpRoutesPanel() {
                 <ShieldCheck className="mr-2 size-4" />
               )}
               Test
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleSmoke} disabled={pendingAction !== null}>
+              {pendingAction === 'smoke' ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : (
+                <Radar className="mr-2 size-4" />
+              )}
+              Smoke
             </Button>
             <Button type="button" size="sm" onClick={handleSave} disabled={pendingAction !== null}>
               {pendingAction === 'save' ? (

--- a/apps/gateway-admin/lib/api/doctor-client.test.ts
+++ b/apps/gateway-admin/lib/api/doctor-client.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { __setBrowserSessionStateForTests } from '../auth/session-store.ts'
+import { doctorApi, isBlockingDoctorSeverity } from './doctor-client.ts'
+
+test('doctorApi.proxyCheck sends proxy.check payload', async () => {
+  const originalFetch = globalThis.fetch
+  __setBrowserSessionStateForTests({ status: 'unauthenticated' })
+  let recorded: { action?: string; params?: Record<string, unknown> } | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    recorded = JSON.parse(String(init?.body ?? '{}'))
+    return new Response(JSON.stringify({ findings: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+
+  try {
+    await doctorApi.proxyCheck({
+      app_url: 'https://lab.example.test',
+      mcp_url: 'https://mcp.example.test',
+      route: '/syslog',
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.deepEqual(recorded, {
+    action: 'proxy.check',
+    params: {
+      app_url: 'https://lab.example.test',
+      mcp_url: 'https://mcp.example.test',
+      route: '/syslog',
+    },
+  })
+})
+
+test('fail and error doctor severities block setup progression', () => {
+  assert.equal(isBlockingDoctorSeverity('ok'), false)
+  assert.equal(isBlockingDoctorSeverity('warn'), false)
+  assert.equal(isBlockingDoctorSeverity('unknown'), false)
+  assert.equal(isBlockingDoctorSeverity('fail'), true)
+  assert.equal(isBlockingDoctorSeverity('error'), true)
+})

--- a/apps/gateway-admin/lib/api/doctor-client.ts
+++ b/apps/gateway-admin/lib/api/doctor-client.ts
@@ -36,7 +36,7 @@ async function doctorAction<T>(
   })
 }
 
-export type Severity = 'ok' | 'warn' | 'error' | 'unknown'
+export type Severity = 'ok' | 'warn' | 'fail' | 'error' | 'unknown'
 
 export interface DoctorFinding {
   service?: string
@@ -49,6 +49,10 @@ export interface DoctorFinding {
 
 export interface DoctorReport {
   findings: DoctorFinding[]
+}
+
+export function isBlockingDoctorSeverity(severity: Severity): boolean {
+  return severity === 'error' || severity === 'fail'
 }
 
 const MOCK_DOCTOR_REPORT: DoctorReport = {
@@ -123,6 +127,26 @@ export const doctorApi = {
     const params: Record<string, unknown> = { service }
     if (instance) params.instance = instance
     return doctorAction<DoctorFinding>('service.probe', params, signal)
+  },
+
+  proxyCheck(
+    params: { app_url: string; mcp_url: string; route: string },
+    signal?: AbortSignal,
+  ): Promise<DoctorReport> {
+    if (USE_MOCK_DATA) {
+      signal?.throwIfAborted?.()
+      return Promise.resolve({
+        findings: [
+          {
+            category: 'proxy',
+            severity: 'ok',
+            message: 'Mock public proxy endpoints are reachable.',
+            elapsed_ms: 6,
+          },
+        ],
+      })
+    }
+    return doctorAction<DoctorReport>('proxy.check', params, signal)
   },
 
   auditFull(signal?: AbortSignal): Promise<DoctorReport> {

--- a/crates/lab/src/api/router.rs
+++ b/crates/lab/src/api/router.rs
@@ -500,7 +500,9 @@ async fn proxy_protected_mcp_route(
         upstream_auth = upstream_auth_token.is_some(),
         "protected MCP route proxy start"
     );
-    let mut builder = reqwest::Client::new().request(method.clone(), upstream);
+    let mut builder = state
+        .protected_mcp_http_client
+        .request(method.clone(), upstream);
     if let Some(token) = upstream_auth_token {
         builder = builder.bearer_auth(token);
     }

--- a/crates/lab/src/api/state.rs
+++ b/crates/lab/src/api/state.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::acp::registry::AcpSessionRegistry;
 use crate::catalog::{Catalog, build_catalog};
@@ -11,6 +12,9 @@ use crate::dispatch::clients::ServiceClients;
 use crate::node::enrollment::store::EnrollmentStore;
 use crate::node::store::NodeStore;
 use crate::registry::{ToolRegistry, build_default_registry};
+
+const DEFAULT_PROTECTED_MCP_CONNECT_TIMEOUT_SECS: u64 = 10;
+const PROTECTED_MCP_CONNECT_TIMEOUT_ENV: &str = "LAB_PROTECTED_MCP_CONNECT_TIMEOUT_SECS";
 
 /// Application state passed to every axum handler via `State<AppState>`.
 #[derive(Clone)]
@@ -25,6 +29,8 @@ pub struct AppState {
     pub registry: Arc<ToolRegistry>,
     /// Pre-built service clients for connection pool reuse.
     pub clients: Arc<ServiceClients>,
+    /// Shared HTTP client for protected MCP reverse proxy requests.
+    pub protected_mcp_http_client: reqwest::Client,
     /// Runtime-enabled service names derived from the registry.
     ///
     /// The HTTP router checks this set to decide which per-service route groups
@@ -118,10 +124,12 @@ impl AppState {
             .collect();
         let catalog = Arc::new(build_catalog(&registry));
         let clients = Arc::new(ServiceClients::from_env());
+        let protected_mcp_http_client = build_protected_mcp_http_client();
         Self {
             catalog,
             registry: Arc::new(registry),
             clients,
+            protected_mcp_http_client,
             enabled_services: Arc::new(enabled_services),
             auth_config: None,
             config: Arc::new(LabConfig::default()),
@@ -309,6 +317,26 @@ impl AppState {
         self.registry_store = Some(store);
         self
     }
+}
+
+fn protected_mcp_connect_timeout() -> Duration {
+    std::env::var(PROTECTED_MCP_CONNECT_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map_or(
+            Duration::from_secs(DEFAULT_PROTECTED_MCP_CONNECT_TIMEOUT_SECS),
+            Duration::from_secs,
+        )
+}
+
+fn build_protected_mcp_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        // Keep long-lived MCP streams possible, but fail unreachable upstreams
+        // instead of letting proxy connection attempts hang indefinitely.
+        .connect_timeout(protected_mcp_connect_timeout())
+        .build()
+        .expect("protected MCP HTTP client configuration is valid")
 }
 
 impl Default for AppState {

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -25,7 +25,6 @@ fn parse_params<T: DeserializeOwned>(params_value: Value) -> Result<T, ToolError
     })
 }
 
-#[allow(clippy::large_stack_frames)]
 pub async fn dispatch_with_manager(
     manager: &GatewayManager,
     action: &str,
@@ -37,6 +36,49 @@ pub async fn dispatch_with_manager(
             let action_name = require_str(&params_value, "action")?;
             action_schema(ACTIONS, action_name)
         }
+        "tool_search" | "tool_invoke" | "gateway.tool_search.get" | "gateway.tool_search.set" => {
+            handle_tool_actions(manager, action, params_value).await
+        }
+        "gateway.list"
+        | "gateway.server.get"
+        | "gateway.supported_services"
+        | "gateway.get"
+        | "gateway.test"
+        | "gateway.add"
+        | "gateway.update"
+        | "gateway.remove"
+        | "gateway.reload"
+        | "gateway.status"
+        | "gateway.discovered_tools"
+        | "gateway.discovered_resources"
+        | "gateway.discovered_prompts" => {
+            handle_gateway_actions(manager, action, params_value).await
+        }
+        action if action.starts_with("gateway.protected_route.") => {
+            handle_protected_route_actions(manager, action, params_value).await
+        }
+        action if action.starts_with("gateway.virtual_server.") => {
+            handle_virtual_server_actions(manager, action, params_value).await
+        }
+        action if action.starts_with("gateway.service_") => {
+            handle_service_actions(manager, action, params_value).await
+        }
+        action if action.starts_with("gateway.oauth.") => {
+            handle_oauth_actions(manager, action, params_value).await
+        }
+        action if action.starts_with("gateway.mcp.") => {
+            handle_mcp_actions(manager, action, params_value).await
+        }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_tool_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "tool_search" => {
             let params: ToolSearchParams = parse_params(params_value)?;
             let top_k = match params.top_k {
@@ -92,16 +134,16 @@ pub async fn dispatch_with_manager(
             }
             to_json(manager.set_tool_search_config(next, None, None).await?)
         }
-        "gateway.list" => to_json(manager.list().await?),
-        "gateway.server.get" => {
-            let params: VirtualServerNameParams = parse_params(params_value)?;
-            to_json(manager.get_server(&params.id).await?)
-        }
-        "gateway.supported_services" => {
-            to_json(super::service_catalog::supported_services_from_registry(
-                manager.builtin_service_registry(),
-            ))
-        }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_protected_route_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "gateway.protected_route.list" => to_json(manager.protected_route_list().await),
         "gateway.protected_route.get" => {
             let params: ProtectedRouteNameParams = parse_params(params_value)?;
@@ -127,6 +169,16 @@ pub async fn dispatch_with_manager(
             let params: ProtectedRouteSpecParams = parse_params(params_value)?;
             to_json(manager.protected_route_test(params.route).await?)
         }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_virtual_server_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "gateway.virtual_server.enable" => {
             let params: VirtualServerNameParams = parse_params(params_value)?;
             to_json(manager.enable_virtual_server(&params.id).await?)
@@ -172,10 +224,7 @@ pub async fn dispatch_with_manager(
                     .any(|candidate| candidate.name == action.as_str())
                 {
                     return Err(ToolError::InvalidParam {
-                        message: format!(
-                            "action `{action}` is not valid for service `{}`",
-                            service
-                        ),
+                        message: format!("action `{action}` is not valid for service `{service}`"),
                         param: "allowed_actions".to_string(),
                     });
                 }
@@ -186,6 +235,16 @@ pub async fn dispatch_with_manager(
                     .await?,
             )
         }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_service_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "gateway.service_config.get" => {
             let params: ServiceConfigGetParams = parse_params(params_value)?;
             to_json(manager.get_service_config(&params.service).await?)
@@ -201,6 +260,26 @@ pub async fn dispatch_with_manager(
         "gateway.service_actions" => {
             let params: ServiceConfigGetParams = parse_params(params_value)?;
             to_json(compiled_service_actions(manager, &params.service)?)
+        }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_gateway_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
+        "gateway.list" => to_json(manager.list().await?),
+        "gateway.server.get" => {
+            let params: VirtualServerNameParams = parse_params(params_value)?;
+            to_json(manager.get_server(&params.id).await?)
+        }
+        "gateway.supported_services" => {
+            to_json(super::service_catalog::supported_services_from_registry(
+                manager.builtin_service_registry(),
+            ))
         }
         "gateway.get" => {
             let params: GatewayNameParams = parse_params(params_value)?;
@@ -286,6 +365,16 @@ pub async fn dispatch_with_manager(
             let params: GatewayNameParams = parse_params(params_value)?;
             to_json(manager.discovered_prompts(&params.name).await?)
         }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_oauth_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "gateway.oauth.probe" => {
             let url = require_str(&params_value, "url")?;
             to_json(crate::dispatch::gateway::oauth::probe(manager, url).await?)
@@ -324,6 +413,16 @@ pub async fn dispatch_with_manager(
             crate::dispatch::gateway::oauth::clear(manager, &params.upstream, subject).await?;
             to_json(serde_json::json!({ "ok": true }))
         }
+        unknown => unknown_action(unknown),
+    }
+}
+
+async fn handle_mcp_actions(
+    manager: &GatewayManager,
+    action: &str,
+    params_value: Value,
+) -> Result<Value, ToolError> {
+    match action {
         "gateway.mcp.enable" => {
             let params: GatewayNameParams = parse_params(params_value)?;
             to_json(
@@ -380,12 +479,16 @@ pub async fn dispatch_with_manager(
                     .await?,
             )
         }
-        unknown => Err(ToolError::UnknownAction {
-            message: format!("unknown action '{unknown}'"),
-            valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
-            hint: None,
-        }),
+        unknown => unknown_action(unknown),
     }
+}
+
+fn unknown_action(unknown: &str) -> Result<Value, ToolError> {
+    Err(ToolError::UnknownAction {
+        message: format!("unknown action '{unknown}'"),
+        valid: ACTIONS.iter().map(|a| a.name.to_string()).collect(),
+        hint: None,
+    })
 }
 
 fn compiled_service_actions(

--- a/docs/deploy/REVERSE_PROXY.md
+++ b/docs/deploy/REVERSE_PROXY.md
@@ -43,7 +43,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Authorization $http_authorization;
         proxy_set_header Accept $http_accept;
-        proxy_set_header Content-Type $content_type;
+        proxy_set_header Content-Type $http_content_type;
         proxy_set_header Mcp-Session-Id $http_mcp_session_id;
         proxy_set_header Mcp-Protocol-Version $http_mcp_protocol_version;
         proxy_set_header Last-Event-Id $http_last_event_id;

--- a/docs/deploy/REVERSE_PROXY.md
+++ b/docs/deploy/REVERSE_PROXY.md
@@ -1,0 +1,148 @@
+# Reverse Proxy Deployment
+
+Lab can serve the web UI, OAuth server, native `/mcp`, and Gateway-managed
+protected MCP routes from the same HTTP listener. Put your reverse proxy in
+front of that listener and configure public MCP routes in Lab.
+
+## Model
+
+- `LAB_PUBLIC_URL` is the Lab app and OAuth issuer, for example `https://lab.example.com`.
+- Each protected MCP route has its own public resource identity, for example `https://mcp.example.com/tools`.
+- The reverse proxy forwards public hosts to Lab without rewriting the path.
+- Lab matches `Host + path`, serves route-specific OAuth metadata, validates route-audience JWTs, and proxies accepted MCP traffic to the private backend.
+
+## Required Proxy Behavior
+
+- Preserve the original `Host` header.
+- Set `X-Forwarded-Proto` to the original scheme.
+- Forward `Authorization`, `Accept`, `Content-Type`, `Mcp-Session-Id`, `Mcp-Protocol-Version`, and `Last-Event-Id`.
+- Disable request and response buffering on MCP paths.
+- Disable compression on MCP paths.
+- Use read/write/idle timeouts suitable for long-lived Streamable HTTP and SSE.
+- Forward `/.well-known/oauth-protected-resource/<route>` to Lab.
+
+Lab intentionally uses `Host` for protected-route lookup by default. Do not rely
+on spoofable `X-Forwarded-Host` unless a future trusted-proxy mode explicitly
+enables it.
+
+## nginx or SWAG
+
+Host-level forwarding is the portable baseline. Both `lab.example.com` and
+`mcp.example.com` can point at the same Lab container/listener.
+
+```nginx
+server {
+    server_name mcp.example.com;
+
+    location / {
+        proxy_pass http://labby:8765;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Accept $http_accept;
+        proxy_set_header Content-Type $content_type;
+        proxy_set_header Mcp-Session-Id $http_mcp_session_id;
+        proxy_set_header Mcp-Protocol-Version $http_mcp_protocol_version;
+        proxy_set_header Last-Event-Id $http_last_event_id;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        gzip off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+}
+```
+
+Use the same upstream for `lab.example.com`; the app host can keep normal
+buffering for static assets if your proxy lets you scope MCP streaming behavior
+to `mcp.example.com`.
+
+## Caddy
+
+```caddyfile
+mcp.example.com {
+    reverse_proxy labby:8765 {
+        header_up Host {host}
+        header_up X-Forwarded-Proto {scheme}
+        flush_interval -1
+    }
+}
+
+lab.example.com {
+    reverse_proxy labby:8765 {
+        header_up Host {host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+}
+```
+
+## Traefik
+
+```yaml
+http:
+  routers:
+    lab-app:
+      rule: Host(`lab.example.com`)
+      entryPoints: [websecure]
+      service: labby
+      tls: {}
+    lab-mcp:
+      rule: Host(`mcp.example.com`)
+      entryPoints: [websecure]
+      service: labby
+      tls: {}
+  services:
+    labby:
+      loadBalancer:
+        passHostHeader: true
+        servers:
+          - url: http://labby:8765
+```
+
+Avoid compression and buffering middleware on the MCP router.
+
+## Cloudflare Tunnel
+
+Create public hostnames for the app and MCP gateway that both target Lab:
+
+```yaml
+ingress:
+  - hostname: lab.example.com
+    service: http://labby:8765
+  - hostname: mcp.example.com
+    service: http://labby:8765
+  - service: http_status:404
+```
+
+Do not place an Access policy in front of the MCP route unless it is compatible
+with MCP OAuth clients. Lab needs to return its own OAuth metadata and bearer
+challenge.
+
+## Tailscale Funnel
+
+Expose Lab's HTTP listener through Funnel for each public hostname you use, or
+put Funnel in front of a local reverse proxy that preserves `Host` and forwards
+to Lab. Keep the public route path intact.
+
+## Verification
+
+Run the built-in proxy doctor from any environment that resolves the public
+hosts:
+
+```bash
+just protected-mcp-smoke -- \
+  --app-url https://lab.example.com \
+  --mcp-url https://mcp.example.com \
+  --route /tools
+```
+
+The `just` target wraps `scripts/protected-mcp-smoke`, which delegates to
+`labby doctor proxy`. Use `LABBY_BIN=/path/to/labby` or `--labby-bin
+/path/to/labby` when testing a specific binary.
+
+The check verifies app health, route-specific protected-resource metadata, and
+the expected unauthenticated OAuth bearer challenge on the protected route.

--- a/docs/services/GATEWAY.md
+++ b/docs/services/GATEWAY.md
@@ -333,6 +333,19 @@ labby gateway protected-route update syslog \
 labby gateway protected-route remove syslog
 ```
 
+Route testing has two layers:
+
+- `labby gateway protected-route test ...` validates the route config and
+  backend health path before saving or updating the Lab config.
+- `just protected-mcp-smoke -- --app-url https://lab.example.com --mcp-url
+  https://mcp.example.com --route /syslog` verifies the deployed public flow:
+  Lab app health, route-specific protected-resource metadata, and the
+  unauthenticated OAuth bearer challenge through the reverse proxy.
+
+The Gateway UI exposes the same split: **Test** validates the Lab route config,
+and **Smoke** runs the public proxy check using the current browser origin as
+the Lab app URL and the route's public host/path as the MCP URL.
+
 ### Migration From Legacy Env Routes
 
 Older inline MCP proxy experiments used service-specific env vars such as

--- a/docs/services/GATEWAY.md
+++ b/docs/services/GATEWAY.md
@@ -346,6 +346,13 @@ The Gateway UI exposes the same split: **Test** validates the Lab route config,
 and **Smoke** runs the public proxy check using the current browser origin as
 the Lab app URL and the route's public host/path as the MCP URL.
 
+Operational timeout:
+
+- `LAB_PROTECTED_MCP_CONNECT_TIMEOUT_SECS` controls the connect timeout for
+  Lab's protected MCP upstream proxy HTTP client. The default is `10` seconds.
+  Set this higher only when upstream TCP/TLS connection setup is expected to be
+  slow; long-lived MCP streams are not bounded by this connect timeout.
+
 ### Migration From Legacy Env Routes
 
 Older inline MCP proxy experiments used service-specific env vars such as

--- a/scripts/protected-mcp-smoke
+++ b/scripts/protected-mcp-smoke
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  scripts/protected-mcp-smoke --app-url https://lab.example.com --mcp-url https://mcp.example.com --route /syslog
+
+Runs the same public protected-MCP reverse-proxy checks as:
+  labby doctor proxy --app-url ... --mcp-url ... --route ...
+
+Checks:
+  - Lab app /health is reachable through the public app URL
+  - protected-resource metadata exists for the public MCP route
+  - unauthenticated route access returns an OAuth bearer challenge
+USAGE
+}
+
+app_url=""
+mcp_url=""
+route=""
+labby_bin="${LABBY_BIN:-labby}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-url)
+      app_url="${2:-}"
+      shift 2
+      ;;
+    --mcp-url)
+      mcp_url="${2:-}"
+      shift 2
+      ;;
+    --route)
+      route="${2:-}"
+      shift 2
+      ;;
+    --labby-bin)
+      labby_bin="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$app_url" || -z "$mcp_url" || -z "$route" ]]; then
+  echo "error: --app-url, --mcp-url, and --route are required" >&2
+  usage
+  exit 2
+fi
+
+exec "$labby_bin" doctor proxy \
+  --app-url "$app_url" \
+  --mcp-url "$mcp_url" \
+  --route "$route"

--- a/scripts/protected-mcp-smoke
+++ b/scripts/protected-mcp-smoke
@@ -21,21 +21,35 @@ mcp_url=""
 route=""
 labby_bin="${LABBY_BIN:-labby}"
 
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "error: $flag requires a value" >&2
+    usage
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app-url)
+      require_value "$1" "${2:-}"
       app_url="${2:-}"
       shift 2
       ;;
     --mcp-url)
+      require_value "$1" "${2:-}"
       mcp_url="${2:-}"
       shift 2
       ;;
     --route)
+      require_value "$1" "${2:-}"
       route="${2:-}"
       shift 2
       ;;
     --labby-bin)
+      require_value "$1" "${2:-}"
       labby_bin="${2:-}"
       shift 2
       ;;


### PR DESCRIPTION
## Summary
- harden Gateway-managed protected MCP route matching, Host handling, dynamic registration metadata, and backend proxy error redaction
- add `doctor.proxy.check` plus CLI/API/frontend wrapper support for public reverse-proxy smoke checks
- add portable reverse proxy and SWAG migration docs, and remove homelab-specific protected-route examples from the Gateway docs/UI placeholder

## Verification
- `cargo nextest run --manifest-path crates/lab/Cargo.toml --all-features protected_route proxy_check authorization_server_metadata_omits_registration_when_disabled top_level_register_is_not_mounted_when_dynamic_registration_disabled`
- `pnpm --dir apps/gateway-admin exec tsx --test components/gateway/protected-mcp-routes-panel.test.tsx lib/api/gateway-client.test.ts`
- `pnpm --dir apps/gateway-admin build`
- `cargo fmt --all -- --check`
- `cargo build --workspace --all-features`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Gateway-managed protected MCP routes and adds a reverse-proxy doctor with one‑click Smoke checks for safer portable, multi‑host deployments. Adds UI route validation hints, a shared proxy HTTP client with a configurable connect timeout, and docs for reverse‑proxy setup and verification.

- New Features
  - Added `doctor.proxy.check` with CLI (`labby doctor proxy`), API client (`doctorApi.proxyCheck`, `isBlockingDoctorSeverity` blocks on `fail`/`error`), admin UI “Smoke” action with results, tests, and wrappers (`scripts/protected-mcp-smoke`, `just protected-mcp-smoke`).
  - Admin UI shows route validation hints (duplicate names, invalid host/path, reserved paths on the app host, backend origin-only). Docs: `REVERSE_PROXY.md` and updated `GATEWAY.md` (Test vs Smoke flow, timeout config).

- Bug Fixes
  - Hardened route resolution: Host + longest segment prefix, disabled routes don’t shadow, exact metadata, ignore `X-Forwarded-Host`, stricter route/JWT validation.
  - Proxy hardening: shared HTTP client with connect timeout via `LAB_PROTECTED_MCP_CONNECT_TIMEOUT_SECS` (default 10s), 10 MB body cap with 413, consistent 502 with redacted details, minimal header forward allowlist, IPv4/IPv6 SSRF-safe doctor checks.

<sup>Written for commit 38c8397dcb162e07aa0ed9bc870488576c153d9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Smoke" proxy-check to validate protected MCP routes through reverse proxy
  * Added validation hints for draft route configurations
  * Configurable connect timeout for protected MCP proxying

* **Documentation**
  * Added comprehensive reverse proxy setup guide with nginx, Caddy, Traefik, Cloudflare Tunnel, and Tailscale Funnel examples
  * Updated protected MCP route testing documentation

* **Tests**
  * Added test coverage for proxy checks and severity classifications

* **Chores**
  * Added protected-mcp-smoke script for deployment verification
  * Improved Docker build layer caching

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/lab/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->