### PR TITLE
fix(marketplace): guard cursor pagination and cfg-gate ACP archive tests

### DIFF
--- a/apps/gateway-admin/lib/api/mcpregistry-client.test.ts
+++ b/apps/gateway-admin/lib/api/mcpregistry-client.test.ts
@@ -1,33 +1,334 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { listServers } from './mcpregistry-client.ts'
+import {
+  deleteServerLocalMetadata,
+  getRegistryConfig,
+  getServer,
+  getServerLocalMetadata,
+  installServer,
+  listServers,
+  listVersions,
+  setServerLocalMetadata,
+  validateServer,
+} from './mcpregistry-client.ts'
+import type { LabRegistryMetadata, ServerJSON } from '@/lib/types/registry'
 
-test('listServers uses same-origin credentialed requests without browser bearer headers', async () => {
+const SERVER_NAME = 'io.github.lab/example-server'
+
+const SERVER_JSON: ServerJSON = {
+  name: SERVER_NAME,
+  title: 'Example Server',
+  description: 'Example MCP server',
+  version: '1.2.3',
+  packages: [],
+  remotes: [{ type: 'streamable-http', url: 'https://example.com/mcp' }],
+  icons: [],
+}
+
+const RAW_SERVER_RESPONSE = {
+  server: SERVER_JSON,
+  _meta: {
+    'io.modelcontextprotocol.registry/official': {
+      isLatest: true,
+      publishedAt: '2026-05-01T00:00:00Z',
+      status: 'active',
+      statusChangedAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-02T00:00:00Z',
+    },
+  },
+}
+
+const LOCAL_METADATA: LabRegistryMetadata = {
+  curation: {
+    featured: true,
+    hidden: false,
+    tags: ['registry'],
+  },
+  trust: {
+    reviewed: true,
+  },
+}
+
+interface CapturedRequest {
+  url: string
+  init?: RequestInit
+  body?: { action?: string; params?: Record<string, unknown> }
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function captureRequest(input: RequestInfo | URL, init?: RequestInit): Promise<CapturedRequest> {
+  const rawBody = typeof init?.body === 'string' ? JSON.parse(init.body) as CapturedRequest['body'] : undefined
+  return {
+    url: String(input),
+    init,
+    body: rawBody,
+  }
+}
+
+async function withMockFetch<T>(
+  handler: (request: CapturedRequest) => Response | Promise<Response>,
+  run: () => Promise<T>,
+): Promise<{ result: T; requests: CapturedRequest[] }> {
   const originalFetch = globalThis.fetch
+  const requests: CapturedRequest[] = []
 
   try {
     globalThis.fetch = (async (input, init) => {
-      assert.equal(String(input), '/v0.1/servers')
-      assert.equal(init?.credentials, 'include')
-      assert.equal(new Headers(init?.headers).get('Authorization'), null)
-
-      return new Response(
-        JSON.stringify({
-          servers: [],
-          next_cursor: null,
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        },
-      )
+      const request = await captureRequest(input, init)
+      assert.notEqual(request.url, '/v1/mcpregistry')
+      requests.push(request)
+      return handler(request)
     }) as typeof fetch
 
-    const response = await listServers({})
-    assert.equal(response.servers.length, 0)
-    assert.equal(response.metadata.nextCursor, null)
+    const result = await run()
+    return { result, requests }
   } finally {
     globalThis.fetch = originalFetch
   }
+}
+
+function assertMarketplaceAction(
+  request: CapturedRequest,
+  action: string,
+): Record<string, unknown> {
+  assert.equal(request.url, '/v1/marketplace')
+  assert.equal(request.init?.method, 'POST')
+  assert.equal(request.init?.credentials, 'include')
+  assert.equal(request.body?.action, action)
+  return request.body?.params ?? {}
+}
+
+test('getRegistryConfig uses marketplace mcp.config action', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      assertMarketplaceAction(request, 'mcp.config')
+      return jsonResponse({ url: 'https://registry.modelcontextprotocol.io' })
+    },
+    () => getRegistryConfig(),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.url, 'https://registry.modelcontextprotocol.io')
+})
+
+test('listServers uses /v0.1/servers with same-origin credentials', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      assert.equal(request.url, '/v0.1/servers')
+      assert.equal(request.init?.credentials, 'include')
+      assert.equal(new Headers(request.init?.headers).get('Authorization'), null)
+      return jsonResponse({
+        servers: [],
+        next_cursor: null,
+      })
+    },
+    () => listServers({}),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.servers.length, 0)
+  assert.equal(result.metadata.nextCursor, null)
+})
+
+test('getServer uses /v0.1 latest-version REST route', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      assert.equal(request.url, `/v0.1/servers/${encodeURIComponent(SERVER_NAME)}/versions/latest`)
+      assert.equal(request.init?.credentials, 'include')
+      return jsonResponse(RAW_SERVER_RESPONSE)
+    },
+    () => getServer(SERVER_NAME),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.server.name, SERVER_NAME)
+  assert.deepEqual(result.server.packages, [])
+})
+
+test('listVersions uses /v0.1 versions REST route', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      assert.equal(request.url, `/v0.1/servers/${encodeURIComponent(SERVER_NAME)}/versions`)
+      assert.equal(request.init?.credentials, 'include')
+      return jsonResponse({ versions: [RAW_SERVER_RESPONSE] })
+    },
+    () => listVersions(SERVER_NAME),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.servers.length, 1)
+  assert.equal(result.metadata.count, 1)
+  assert.equal(result.metadata.nextCursor, null)
+})
+
+test('validateServer uses marketplace mcp.validate action', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      const params = assertMarketplaceAction(request, 'mcp.validate')
+      assert.deepEqual(params.server_json, SERVER_JSON)
+      return jsonResponse({ valid: true, issues: [] })
+    },
+    () => validateServer(SERVER_JSON),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.valid, true)
+})
+
+test('getServerLocalMetadata uses marketplace mcp.meta.get action', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      const params = assertMarketplaceAction(request, 'mcp.meta.get')
+      assert.deepEqual(params, { name: SERVER_NAME, version: '1.2.3' })
+      return jsonResponse({
+        name: SERVER_NAME,
+        version: '1.2.3',
+        namespace: 'tv.tootie.lab/registry',
+        metadata: LOCAL_METADATA,
+      })
+    },
+    () => getServerLocalMetadata(SERVER_NAME, '1.2.3'),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.deepEqual(result.metadata, LOCAL_METADATA)
+})
+
+test('setServerLocalMetadata uses marketplace mcp.meta.set action', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      const params = assertMarketplaceAction(request, 'mcp.meta.set')
+      assert.deepEqual(params, {
+        name: SERVER_NAME,
+        version: '1.2.3',
+        updated_by: 'tester',
+        metadata: LOCAL_METADATA,
+      })
+      return jsonResponse({
+        name: SERVER_NAME,
+        version: '1.2.3',
+        namespace: 'tv.tootie.lab/registry',
+        metadata: LOCAL_METADATA,
+      })
+    },
+    () => setServerLocalMetadata(SERVER_NAME, LOCAL_METADATA, { version: '1.2.3', updated_by: 'tester' }),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.deepEqual(result.metadata, LOCAL_METADATA)
+})
+
+test('deleteServerLocalMetadata uses marketplace mcp.meta.delete action', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      const params = assertMarketplaceAction(request, 'mcp.meta.delete')
+      assert.deepEqual(params, { name: SERVER_NAME, version: '1.2.3' })
+      return jsonResponse({
+        name: SERVER_NAME,
+        version: '1.2.3',
+        namespace: 'tv.tootie.lab/registry',
+        deleted: true,
+      })
+    },
+    () => deleteServerLocalMetadata(SERVER_NAME, '1.2.3'),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.equal(result.deleted, true)
+})
+
+test('installServer uses marketplace mcp.install action with gateway_ids', async () => {
+  const { result, requests } = await withMockFetch(
+    (request) => {
+      const params = assertMarketplaceAction(request, 'mcp.install')
+      assert.deepEqual(params, {
+        name: SERVER_NAME,
+        gateway_ids: ['homelab'],
+        version: '1.2.3',
+        bearer_token_env: 'EXAMPLE_TOKEN',
+        confirm: true,
+      })
+      return jsonResponse({
+        results: [
+          {
+            gateway_id: 'homelab',
+            ok: true,
+          },
+        ],
+      })
+    },
+    () => installServer({
+      name: SERVER_NAME,
+      gateway_name: 'homelab',
+      version: '1.2.3',
+      bearer_token_env: 'EXAMPLE_TOKEN',
+    }),
+  )
+
+  assert.equal(requests.length, 1)
+  assert.deepEqual(result.results, [{ gateway_id: 'homelab', ok: true }])
+})
+
+test('mcpregistry client exports do not call removed /v1/mcpregistry endpoint', async () => {
+  const { requests } = await withMockFetch(
+    (request) => {
+      switch (request.url) {
+        case '/v1/marketplace': {
+          switch (request.body?.action) {
+            case 'mcp.config':
+              return jsonResponse({ url: 'https://registry.modelcontextprotocol.io' })
+            case 'mcp.validate':
+              return jsonResponse({ valid: true, issues: [] })
+            case 'mcp.meta.get':
+            case 'mcp.meta.set':
+              return jsonResponse({
+                name: SERVER_NAME,
+                version: '1.2.3',
+                namespace: 'tv.tootie.lab/registry',
+                metadata: LOCAL_METADATA,
+              })
+            case 'mcp.meta.delete':
+              return jsonResponse({
+                name: SERVER_NAME,
+                version: '1.2.3',
+                namespace: 'tv.tootie.lab/registry',
+                deleted: true,
+              })
+            case 'mcp.install':
+              return jsonResponse({ results: [{ gateway_id: 'homelab', ok: true }] })
+            default:
+              throw new Error(`unexpected marketplace action ${request.body?.action}`)
+          }
+        }
+        case '/v0.1/servers':
+          return jsonResponse({ servers: [RAW_SERVER_RESPONSE], next_cursor: null })
+        case `/v0.1/servers/${encodeURIComponent(SERVER_NAME)}/versions/latest`:
+          return jsonResponse(RAW_SERVER_RESPONSE)
+        case `/v0.1/servers/${encodeURIComponent(SERVER_NAME)}/versions`:
+          return jsonResponse({ versions: [RAW_SERVER_RESPONSE] })
+        default:
+          throw new Error(`unexpected URL ${request.url}`)
+      }
+    },
+    async () => {
+      await getRegistryConfig()
+      await listServers({})
+      await getServer(SERVER_NAME)
+      await listVersions(SERVER_NAME)
+      await validateServer(SERVER_JSON)
+      await getServerLocalMetadata(SERVER_NAME, '1.2.3')
+      await setServerLocalMetadata(SERVER_NAME, LOCAL_METADATA, { version: '1.2.3' })
+      await deleteServerLocalMetadata(SERVER_NAME, '1.2.3')
+      await installServer({ name: SERVER_NAME, gateway_name: 'homelab', version: '1.2.3' })
+    },
+  )
+
+  assert.equal(requests.some((request) => request.url === '/v1/mcpregistry'), false)
 })

--- a/apps/gateway-admin/lib/api/mcpregistry-client.ts
+++ b/apps/gateway-admin/lib/api/mcpregistry-client.ts
@@ -14,11 +14,10 @@ import type {
   ValidationResult,
   ServerJSON,
 } from '@/lib/types/registry'
-import type { Gateway } from '@/lib/types/gateway'
 
 type RawServerResponse = Omit<ServerResponse, 'server'> & { server: ServerJSON }
-type RawServerListResponse = Omit<ServerListResponse, 'servers'> & { servers: RawServerResponse[] }
 type RestServerListRaw = { servers: RawServerResponse[]; next_cursor: string | null }
+type RestServerVersionsRaw = { versions: RawServerResponse[] }
 
 const USE_MOCK_DATA = process.env.NEXT_PUBLIC_MOCK_DATA === 'true'
 
@@ -143,7 +142,7 @@ function listMockServers(): RawServerResponse[] {
   return MOCK_REGISTRY_SERVERS.map(mergeMockMetadata)
 }
 
-async function registryAction<T>(
+async function marketplaceMcpAction<T>(
   action: string,
   params: object,
   signal?: AbortSignal,
@@ -153,7 +152,7 @@ async function registryAction<T>(
     params,
     signal,
     serviceLabel: 'McpRegistry',
-    url: '/v1/mcpregistry',
+    url: '/v1/marketplace',
     createError: createRegistryError,
   })
 }
@@ -162,13 +161,43 @@ export interface RegistryConfig {
   url: string
 }
 
+async function registryRestGet<T>(url: string, fallbackMessage: string, signal?: AbortSignal): Promise<T> {
+  const token = process.env.NEXT_PUBLIC_API_TOKEN
+  const standaloneBearerAuth = isStandaloneBearerAuthMode(token)
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      headers: gatewayHeaders(token, standaloneBearerAuth),
+      cache: 'no-store',
+      credentials: standaloneBearerAuth ? 'omit' : 'include',
+      signal,
+    })
+  } catch (error) {
+    if (isAbortError(error)) throw error
+    const msg = error instanceof Error ? error.message : 'unknown network error'
+    throw createRegistryError(`${fallbackMessage}: ${msg}`, 502, 'backend_unreachable')
+  }
+
+  if (!response.ok) {
+    const body = await (response.json() as Promise<{ message?: string; kind?: string }>).catch((): { message?: string; kind?: string } => ({}))
+    throw createRegistryError(body.message ?? fallbackMessage, response.status, body.kind)
+  }
+
+  return response.json() as Promise<T>
+}
+
+function registryServerPath(name: string): string {
+  return encodeURIComponent(name)
+}
+
 export async function getRegistryConfig(signal?: AbortSignal): Promise<RegistryConfig> {
   if (USE_MOCK_DATA) {
     signal?.throwIfAborted?.()
     return cloneValue(MOCK_REGISTRY_CONFIG)
   }
 
-  return registryAction<RegistryConfig>('config', {}, signal)
+  return marketplaceMcpAction<RegistryConfig>('mcp.config', {}, signal)
 }
 
 export async function listServers(
@@ -225,29 +254,7 @@ export async function listServers(
 
   const qstr = qs.toString()
   const url = qstr ? `/v0.1/servers?${qstr}` : '/v0.1/servers'
-  const token = process.env.NEXT_PUBLIC_API_TOKEN
-  const standaloneBearerAuth = isStandaloneBearerAuthMode(token)
-
-  let response: Response
-  try {
-    response = await fetch(url, {
-      headers: gatewayHeaders(token, standaloneBearerAuth),
-      cache: 'no-store',
-      credentials: standaloneBearerAuth ? 'omit' : 'include',
-      signal,
-    })
-  } catch (error) {
-    if (isAbortError(error)) throw error
-    const msg = error instanceof Error ? error.message : 'unknown network error'
-    throw createRegistryError(`Registry list failed: ${msg}`, 502, 'backend_unreachable')
-  }
-
-  if (!response.ok) {
-    const body = await (response.json() as Promise<{ message?: string; kind?: string }>).catch((): { message?: string; kind?: string } => ({}))
-    throw createRegistryError(body.message ?? 'Failed to list servers', response.status, body.kind)
-  }
-
-  const raw = await (response.json() as Promise<RestServerListRaw>)
+  const raw = await registryRestGet<RestServerListRaw>(url, 'Failed to list servers', signal)
   const servers: ServerResponse[] = raw.servers.map(normalizeResponse)
   return { servers, metadata: { count: servers.length, nextCursor: raw.next_cursor } }
 }
@@ -265,7 +272,11 @@ export async function getServer(
     return normalizeResponse(found)
   }
 
-  const raw = await registryAction<RawServerResponse>('server.get', { name }, signal)
+  const raw = await registryRestGet<RawServerResponse>(
+    `/v0.1/servers/${registryServerPath(name)}/versions/latest`,
+    'Failed to load server',
+    signal,
+  )
   return normalizeResponse(raw)
 }
 
@@ -285,8 +296,13 @@ export async function listVersions(
     }
   }
 
-  const raw = await registryAction<RawServerListResponse>('server.versions', { name }, signal)
-  return { ...raw, servers: raw.servers.map(normalizeResponse) }
+  const raw = await registryRestGet<RestServerVersionsRaw>(
+    `/v0.1/servers/${registryServerPath(name)}/versions`,
+    'Failed to list server versions',
+    signal,
+  )
+  const servers = raw.versions.map(normalizeResponse)
+  return { servers, metadata: { count: servers.length, nextCursor: null } }
 }
 
 export async function validateServer(
@@ -298,7 +314,7 @@ export async function validateServer(
     return { valid: true, issues: [] }
   }
 
-  return registryAction<ValidationResult>('server.validate', { server_json: serverJson }, signal)
+  return marketplaceMcpAction<ValidationResult>('mcp.validate', { server_json: serverJson }, signal)
 }
 
 export async function getServerLocalMetadata(
@@ -317,8 +333,8 @@ export async function getServerLocalMetadata(
     }
   }
 
-  return registryAction<RegistryLocalMetaResponse>(
-    'server.meta.get',
+  return marketplaceMcpAction<RegistryLocalMetaResponse>(
+    'mcp.meta.get',
     { name, version },
     signal,
   )
@@ -342,8 +358,8 @@ export async function setServerLocalMetadata(
     }
   }
 
-  return registryAction<RegistryLocalMetaResponse>(
-    'server.meta.set',
+  return marketplaceMcpAction<RegistryLocalMetaResponse>(
+    'mcp.meta.set',
     { name, version: options?.version, updated_by: options?.updated_by, metadata },
     signal,
   )
@@ -366,8 +382,8 @@ export async function deleteServerLocalMetadata(
     }
   }
 
-  return registryAction<RegistryLocalMetaDeleteResponse>(
-    'server.meta.delete',
+  return marketplaceMcpAction<RegistryLocalMetaDeleteResponse>(
+    'mcp.meta.delete',
     { name, version },
     signal,
   )
@@ -380,22 +396,46 @@ export interface InstallServerParams {
   bearer_token_env?: string
 }
 
+export interface InstallServerGatewayResult {
+  gateway_id: string
+  ok: boolean
+  error?: string
+  result?: unknown
+}
+
+export interface InstallServerResult {
+  results: InstallServerGatewayResult[]
+}
+
 export async function installServer(
   params: InstallServerParams,
   signal?: AbortSignal,
-): Promise<Gateway> {
+): Promise<InstallServerResult> {
   if (USE_MOCK_DATA) {
     signal?.throwIfAborted?.()
     const gateway = getMockGatewayFallback('gw-2')
     if (!gateway) {
       throw createRegistryError('Failed to install server', 500, 'mock_gateway_missing')
     }
-    return gateway
+    return {
+      results: [
+        {
+          gateway_id: params.gateway_name,
+          ok: true,
+          result: gateway,
+        },
+      ],
+    }
   }
 
-  return registryAction<Gateway>(
-    'server.install',
-    confirmGatewayParams(params),
+  return marketplaceMcpAction<InstallServerResult>(
+    'mcp.install',
+    confirmGatewayParams({
+      name: params.name,
+      gateway_ids: [params.gateway_name],
+      version: params.version,
+      bearer_token_env: params.bearer_token_env,
+    }),
     signal,
   )
 }

--- a/apps/gateway-admin/lib/api/mcpregistry-client.ts
+++ b/apps/gateway-admin/lib/api/mcpregistry-client.ts
@@ -428,7 +428,7 @@ export async function installServer(
     }
   }
 
-  return marketplaceMcpAction<InstallServerResult>(
+  const raw = await marketplaceMcpAction<InstallServerResult>(
     'mcp.install',
     confirmGatewayParams({
       name: params.name,
@@ -438,4 +438,22 @@ export async function installServer(
     }),
     signal,
   )
+
+  // The mcp.install action returns HTTP 200 even when individual gateway
+  // installs fail, collecting partial results rather than erroring at the
+  // transport level.  Surface any failed targets so callers see a genuine
+  // error instead of a silent success.
+  const failed = (raw.results ?? []).filter((r) => !r.ok)
+  if (failed.length > 0) {
+    const details = failed
+      .map((r) => `${r.gateway_id}: ${r.error ?? 'unknown error'}`)
+      .join('; ')
+    throw createRegistryError(
+      `mcp.install failed for ${failed.length} target(s): ${details}`,
+      502,
+      'install_failed',
+    )
+  }
+
+  return raw
 }

--- a/apps/gateway-admin/lib/marketplace/api-client.test.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { listAcpAgents } from './api-client'
+import { listAcpAgents, listMcpServers } from './api-client'
 
 test('listAcpAgents accepts the backend array response from agent.list', async () => {
   const originalFetch = globalThis.fetch
@@ -29,6 +29,32 @@ test('listAcpAgents accepts the backend array response from agent.list', async (
     assert.equal(agents.length, 1)
     assert.equal(agents[0]?.id, 'codex-acp')
     assert.equal(agents[0]?.name, 'Codex CLI')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('listMcpServers requests a bounded registry page', async () => {
+  const originalFetch = globalThis.fetch
+
+  try {
+    globalThis.fetch = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body))
+      assert.equal(body.action, 'mcp.list')
+      assert.deepEqual(body.params, { limit: 20 })
+
+      return new Response(
+        JSON.stringify({
+          servers: [],
+          metadata: { count: 0, nextCursor: null },
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    const servers = await listMcpServers()
+
+    assert.equal(servers.length, 0)
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/apps/gateway-admin/lib/marketplace/api-client.test.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.test.ts
@@ -100,3 +100,81 @@ test('listMcpServers follows marketplace registry cursors', async () => {
     globalThis.fetch = originalFetch
   }
 })
+
+test('listMcpServers rejects repeated marketplace registry cursors', async () => {
+  const originalFetch = globalThis.fetch
+
+  try {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          servers: [{ name: 'io.github.example/repeated' }],
+          metadata: { count: 1, nextCursor: 'same-page' },
+        }),
+        { status: 200 },
+      )) as typeof fetch
+
+    await assert.rejects(
+      () => listMcpServers(),
+      (error) =>
+        error instanceof Error &&
+        error.message.includes('pagination cursor did not advance'),
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('listMcpServers rejects empty pages with a next cursor', async () => {
+  const originalFetch = globalThis.fetch
+
+  try {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          servers: [],
+          metadata: { count: 0, nextCursor: 'page-2' },
+        }),
+        { status: 200 },
+      )) as typeof fetch
+
+    await assert.rejects(
+      () => listMcpServers(),
+      (error) =>
+        error instanceof Error &&
+        error.message.includes('empty page with next cursor'),
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('listMcpServers propagates aborts between pages', async () => {
+  const originalFetch = globalThis.fetch
+  const controller = new AbortController()
+  let calls = 0
+
+  try {
+    globalThis.fetch = (async (_input, init) => {
+      calls += 1
+      if (calls === 1) {
+        controller.abort()
+        return new Response(
+          JSON.stringify({
+            servers: [{ name: 'io.github.example/first' }],
+            metadata: { count: 1, nextCursor: 'page-2' },
+          }),
+          { status: 200 },
+        )
+      }
+
+      assert.equal(init?.signal?.aborted, true)
+      throw new DOMException('aborted', 'AbortError')
+    }) as typeof fetch
+
+    await assert.rejects(() => listMcpServers(controller.signal), { name: 'AbortError' })
+    assert.equal(calls, 2)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/apps/gateway-admin/lib/marketplace/api-client.test.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { listAcpAgents, listMcpServers } from './api-client'
+import { listAcpAgents, listMcpServers, listMcpServersPage } from './api-client'
 
 test('listAcpAgents accepts the backend array response from agent.list', async () => {
   const originalFetch = globalThis.fetch
@@ -34,7 +34,7 @@ test('listAcpAgents accepts the backend array response from agent.list', async (
   }
 })
 
-test('listMcpServers requests a bounded registry page', async () => {
+test('listMcpServersPage requests one bounded registry page', async () => {
   const originalFetch = globalThis.fetch
 
   try {
@@ -52,9 +52,50 @@ test('listMcpServers requests a bounded registry page', async () => {
       )
     }) as typeof fetch
 
+    const result = await listMcpServersPage()
+
+    assert.equal(result.servers.length, 0)
+    assert.equal(result.metadata?.nextCursor, null)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('listMcpServers follows marketplace registry cursors', async () => {
+  const originalFetch = globalThis.fetch
+  const calls: unknown[] = []
+
+  try {
+    globalThis.fetch = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body))
+      calls.push(body.params)
+
+      if (calls.length === 1) {
+        return new Response(
+          JSON.stringify({
+            servers: [{ name: 'io.github.example/first' }],
+            metadata: { count: 1, nextCursor: 'page-2' },
+          }),
+          { status: 200 },
+        )
+      }
+
+      return new Response(
+        JSON.stringify({
+          servers: [{ name: 'io.github.example/second' }],
+          metadata: { count: 1, nextCursor: null },
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
     const servers = await listMcpServers()
 
-    assert.equal(servers.length, 0)
+    assert.deepEqual(calls, [{ limit: 20 }, { limit: 20, cursor: 'page-2' }])
+    assert.deepEqual(
+      servers.map((server) => server.name),
+      ['io.github.example/first', 'io.github.example/second'],
+    )
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/apps/gateway-admin/lib/marketplace/api-client.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.ts
@@ -38,6 +38,10 @@ function marketplaceAction<T>(action: string, params: object, signal?: AbortSign
 
 export interface McpListResult {
   servers: McpServer[]
+  metadata?: {
+    count?: number
+    nextCursor?: string | null
+  }
 }
 
 export async function listMcpServers(signal?: AbortSignal): Promise<McpServer[]> {
@@ -45,7 +49,7 @@ export async function listMcpServers(signal?: AbortSignal): Promise<McpServer[]>
     signal?.throwIfAborted?.()
     return structuredClone(MOCK_MCP_SERVERS)
   }
-  const res = await marketplaceAction<McpListResult>('mcp.list', {}, signal)
+  const res = await marketplaceAction<McpListResult>('mcp.list', { limit: 20 }, signal)
   return res.servers ?? []
 }
 

--- a/apps/gateway-admin/lib/marketplace/api-client.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.ts
@@ -50,6 +50,7 @@ export interface McpListOptions {
 }
 
 const MCP_LIST_PAGE_SIZE = 20
+const MCP_LIST_MAX_PAGES = 100
 
 export async function listMcpServersPage(
   options: McpListOptions = {},
@@ -71,11 +72,41 @@ export async function listMcpServersPage(
 export async function listMcpServers(signal?: AbortSignal): Promise<McpServer[]> {
   const servers: McpServer[] = []
   let cursor: string | null | undefined = null
+  const seenCursors = new Set<string>()
+  let pageCount = 0
 
   do {
+    pageCount += 1
+    if (pageCount > MCP_LIST_MAX_PAGES) {
+      throw new MarketplaceError(
+        `Marketplace MCP registry pagination exceeded ${MCP_LIST_MAX_PAGES} pages`,
+        502,
+        'pagination_limit_exceeded',
+      )
+    }
+
     const res = await listMcpServersPage({ limit: MCP_LIST_PAGE_SIZE, cursor }, signal)
-    servers.push(...(res.servers ?? []))
-    cursor = res.metadata?.nextCursor ?? null
+    const pageServers = res.servers ?? []
+    servers.push(...pageServers)
+    const nextCursor = res.metadata?.nextCursor ?? null
+    if (nextCursor) {
+      if (pageServers.length === 0) {
+        throw new MarketplaceError(
+          `Marketplace MCP registry returned empty page with next cursor ${nextCursor}`,
+          502,
+          'pagination_empty_page',
+        )
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new MarketplaceError(
+          `Marketplace MCP registry pagination cursor did not advance: ${nextCursor}`,
+          502,
+          'pagination_cursor_stalled',
+        )
+      }
+      seenCursors.add(nextCursor)
+    }
+    cursor = nextCursor
   } while (cursor)
 
   return servers

--- a/apps/gateway-admin/lib/marketplace/api-client.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.ts
@@ -44,13 +44,41 @@ export interface McpListResult {
   }
 }
 
-export async function listMcpServers(signal?: AbortSignal): Promise<McpServer[]> {
+export interface McpListOptions {
+  limit?: number
+  cursor?: string | null
+}
+
+const MCP_LIST_PAGE_SIZE = 20
+
+export async function listMcpServersPage(
+  options: McpListOptions = {},
+  signal?: AbortSignal,
+): Promise<McpListResult> {
   if (USE_MOCK_DATA) {
     signal?.throwIfAborted?.()
-    return structuredClone(MOCK_MCP_SERVERS)
+    const limit = options.limit ?? MCP_LIST_PAGE_SIZE
+    const offset = options.cursor ? Number.parseInt(options.cursor, 10) : 0
+    const servers = structuredClone(MOCK_MCP_SERVERS).slice(offset, offset + limit)
+    const nextCursor = offset + limit < MOCK_MCP_SERVERS.length ? String(offset + limit) : null
+    return { servers, metadata: { count: servers.length, nextCursor } }
   }
-  const res = await marketplaceAction<McpListResult>('mcp.list', { limit: 20 }, signal)
-  return res.servers ?? []
+  const params: Record<string, string | number> = { limit: options.limit ?? MCP_LIST_PAGE_SIZE }
+  if (options.cursor) params.cursor = options.cursor
+  return marketplaceAction<McpListResult>('mcp.list', params, signal)
+}
+
+export async function listMcpServers(signal?: AbortSignal): Promise<McpServer[]> {
+  const servers: McpServer[] = []
+  let cursor: string | null | undefined = null
+
+  do {
+    const res = await listMcpServersPage({ limit: MCP_LIST_PAGE_SIZE, cursor }, signal)
+    servers.push(...(res.servers ?? []))
+    cursor = res.metadata?.nextCursor ?? null
+  } while (cursor)
+
+  return servers
 }
 
 export async function getMcpServer(name: string, signal?: AbortSignal): Promise<McpServer> {

--- a/apps/gateway-admin/lib/marketplace/api-client.ts
+++ b/apps/gateway-admin/lib/marketplace/api-client.ts
@@ -50,7 +50,13 @@ export interface McpListOptions {
 }
 
 const MCP_LIST_PAGE_SIZE = 20
-const MCP_LIST_MAX_PAGES = 100
+// Generous upper bound to prevent runaway pagination.  The real protection
+// against infinite loops is the seen-cursor set (stalled-cursor guard) and
+// the empty-page-with-cursor guard, both of which throw before this cap is
+// reached for any well-behaved registry.  Raising this to 10 000 pages
+// (200 000 servers at page size 20) removes the artificial 2 000-server
+// ceiling without disabling the loop guard entirely.
+const MCP_LIST_MAX_PAGES = 10_000
 
 export async function listMcpServersPage(
   options: McpListOptions = {},

--- a/crates/lab-apis/src/acp_registry/types.rs
+++ b/crates/lab-apis/src/acp_registry/types.rs
@@ -84,6 +84,13 @@ pub struct Distribution {
 pub struct BinaryAsset {
     /// URL to download the archive (`.tar.gz` or `.zip`).
     pub archive: String,
+    /// Expected SHA-256 digest for the archive, as 64 hex chars or
+    /// `sha256:<hex>`.
+    #[serde(default, alias = "sha256sum", alias = "checksum_sha256")]
+    pub sha256: Option<String>,
+    /// OCI/GitHub-style digest field, usually `sha256:<hex>`.
+    #[serde(default)]
+    pub digest: Option<String>,
     /// Command to run after extraction (e.g. `"./my-agent"`).
     pub cmd: String,
     /// Extra CLI arguments appended after `cmd`.
@@ -144,4 +151,35 @@ pub struct AgentEnvVar {
     /// Whether this variable is required for the agent to function.
     #[serde(default)]
     pub required: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_asset_models_sha256_metadata() {
+        let asset: BinaryAsset = serde_json::from_value(serde_json::json!({
+            "archive": "https://example.com/agent.tar.gz",
+            "sha256": "abc",
+            "digest": "sha256:def",
+            "cmd": "./agent"
+        }))
+        .expect("deserialize");
+
+        assert_eq!(asset.sha256.as_deref(), Some("abc"));
+        assert_eq!(asset.digest.as_deref(), Some("sha256:def"));
+    }
+
+    #[test]
+    fn binary_asset_accepts_sha256_aliases() {
+        let asset: BinaryAsset = serde_json::from_value(serde_json::json!({
+            "archive": "https://example.com/agent.tar.gz",
+            "sha256sum": "abc",
+            "cmd": "./agent"
+        }))
+        .expect("deserialize");
+
+        assert_eq!(asset.sha256.as_deref(), Some("abc"));
+    }
 }

--- a/crates/lab/src/api/error.rs
+++ b/crates/lab/src/api/error.rs
@@ -55,6 +55,7 @@ impl IntoResponse for ToolError {
             | "restart_failed"
             | "verify_failed"
             | "arch_mismatch"
+            | "integrity_missing"
             | "integrity_mismatch" => StatusCode::BAD_GATEWAY,
             "conflict" | "ambiguous_tool" => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -97,5 +98,15 @@ mod tests {
         }
         .into_response();
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn integrity_missing_maps_to_502() {
+        let response = ToolError::Sdk {
+            sdk_kind: "integrity_missing".to_string(),
+            message: "missing sha256".to_string(),
+        }
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/crates/lab/src/dispatch/marketplace/acp_catalog.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_catalog.rs
@@ -27,7 +27,7 @@ pub const ACP_ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "agent.install",
-        description: "Install an ACP agent on one or more devices. Writes a provider entry to `~/.lab/acp-providers.json`. Binary distributions are not yet supported in this build; npx/uvx distributions are config-only.",
+        description: "Install an ACP agent on one or more devices. Local installs write a provider entry to `~/.lab/acp-providers.json`; binary archives are downloaded only over HTTPS, SHA-256 verified, size-limited, and installed atomically.",
         destructive: true,
         returns: "InstallResults",
         params: &[

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -12,7 +12,11 @@
 //! Remote install via fleet WS supports `npx` only — the device-side `DistType`
 //! has no `Uvx` or `Binary` variant.
 
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
 use serde_json::Value;
@@ -30,6 +34,11 @@ use crate::dispatch::node::send::send_rpc_to_node;
 use lab_apis::acp_registry::client::AcpRegistryClient;
 #[cfg(feature = "acp_registry")]
 use lab_apis::acp_registry::types::{Agent, BinaryAsset};
+
+#[cfg(feature = "acp_registry")]
+static BINARY_INSTALL_LOCKS: OnceLock<
+    std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+> = OnceLock::new();
 
 /// Dispatch an `agent.*` action using a freshly constructed client.
 pub async fn dispatch_acp(action: &str, params: Value) -> Result<Value, ToolError> {
@@ -454,7 +463,11 @@ async fn install_binary(
     agent_id: &str,
     asset: &BinaryAsset,
 ) -> Result<(PathBuf, String), ToolError> {
+    let expected_sha256 = expected_archive_sha256(asset)?;
     validate_archive_url(&asset.archive)?;
+
+    let install_lock = binary_install_lock(agent_id)?;
+    let _install_guard = install_lock.lock().await;
 
     let install_dir = agent_bin_dir(agent_id)?;
     std::fs::create_dir_all(&install_dir).map_err(|e| {
@@ -466,6 +479,7 @@ async fn install_binary(
         .map_err(|e| ToolError::internal_message(format!("temp archive: {e}")))?;
 
     let sha256 = download_archive(&asset.archive, tmp_archive.path()).await?;
+    verify_archive_sha256(&expected_sha256, &sha256)?;
 
     // Extract to a temp dir in the same parent so we can do an atomic move.
     let tmp_extract = tempfile::TempDir::new_in(&install_dir)
@@ -474,7 +488,7 @@ async fn install_binary(
     extract_archive(tmp_archive.path(), tmp_extract.path(), &asset.archive)?;
 
     // Locate the binary: `cmd` is like `"./my-agent"` or `"my-agent"`.
-    let binary_name = std::path::Path::new(asset.cmd.trim_start_matches("./"))
+    let binary_name = Path::new(asset.cmd.trim_start_matches("./"))
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(asset.cmd.trim_start_matches("./"));
@@ -489,8 +503,73 @@ async fn install_binary(
 
     let dest = install_dir.join(binary_name);
 
-    // Symlink guard before writing.
-    if let Ok(meta) = std::fs::symlink_metadata(&dest)
+    install_executable_atomically(&src, &dest)?;
+
+    Ok((dest, sha256))
+}
+
+#[cfg(feature = "acp_registry")]
+fn binary_install_lock(agent_id: &str) -> Result<Arc<tokio::sync::Mutex<()>>, ToolError> {
+    let locks = BINARY_INSTALL_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut locks = locks
+        .lock()
+        .map_err(|_| ToolError::internal_message("binary install lock poisoned"))?;
+    Ok(locks
+        .entry(agent_id.to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone())
+}
+
+#[cfg(feature = "acp_registry")]
+fn expected_archive_sha256(asset: &BinaryAsset) -> Result<String, ToolError> {
+    if let Some(value) = asset.sha256.as_deref() {
+        return normalize_sha256(value, "sha256");
+    }
+    if let Some(value) = asset.digest.as_deref() {
+        return normalize_sha256(value, "digest");
+    }
+    Err(ToolError::Sdk {
+        sdk_kind: "integrity_missing".to_string(),
+        message: format!(
+            "binary archive `{}` has no SHA-256 integrity metadata; refusing install",
+            asset.archive
+        ),
+    })
+}
+
+#[cfg(feature = "acp_registry")]
+fn normalize_sha256(value: &str, field: &str) -> Result<String, ToolError> {
+    let trimmed = value.trim();
+    let hex = trimmed.strip_prefix("sha256:").unwrap_or(trimmed);
+    if hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(hex.to_ascii_lowercase());
+    }
+    Err(ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!(
+            "binary archive `{field}` must be a SHA-256 digest as 64 hex chars or sha256:<hex>"
+        ),
+    })
+}
+
+#[cfg(feature = "acp_registry")]
+fn verify_archive_sha256(expected: &str, actual: &str) -> Result<(), ToolError> {
+    if expected.eq_ignore_ascii_case(actual) {
+        return Ok(());
+    }
+    Err(ToolError::Sdk {
+        sdk_kind: "integrity_mismatch".to_string(),
+        message: format!("binary archive SHA-256 mismatch: expected {expected}, got {actual}"),
+    })
+}
+
+#[cfg(feature = "acp_registry")]
+fn install_executable_atomically(src: &Path, dest: &Path) -> Result<(), ToolError> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| ToolError::internal_message("install destination has no parent"))?;
+
+    if let Ok(meta) = std::fs::symlink_metadata(dest)
         && meta.file_type().is_symlink()
     {
         return Err(ToolError::Sdk {
@@ -502,24 +581,57 @@ async fn install_binary(
         });
     }
 
-    std::fs::copy(&src, &dest).map_err(|e| {
-        ToolError::internal_message(format!("copy binary to {}: {e}", dest.display()))
-    })?;
-
-    #[cfg(unix)]
+    let mut input = File::open(src)
+        .map_err(|e| ToolError::internal_message(format!("open {}: {e}", src.display())))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| ToolError::internal_message(format!("temp executable: {e}")))?;
     {
-        // lab-zxx5.18: set exact 0o755 (rwxr-xr-x). Do NOT OR with existing
-        // permissions — that would preserve setuid/setgid bits (0o4000 /
-        // 0o2000) if they were set on the source. An attacker-controlled
-        // archive with setuid could silently install a privilege-escalation
-        // binary under ~/.lab/bin/. Explicitly clear.
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755)).map_err(|e| {
-            ToolError::internal_message(format!("chmod 0o755 {}: {e}", dest.display()))
+        let output = temp.as_file_mut();
+        std::io::copy(&mut input, output).map_err(|e| {
+            ToolError::internal_message(format!(
+                "copy {} to temp executable in {}: {e}",
+                src.display(),
+                parent.display()
+            ))
+        })?;
+        output.flush().map_err(|e| {
+            ToolError::internal_message(format!("flush temp executable {}: {e}", dest.display()))
         })?;
     }
 
-    Ok((dest, sha256))
+    #[cfg(unix)]
+    {
+        // Set exact 0o755 (rwxr-xr-x). Do not OR with source permissions:
+        // source archives may carry setuid/setgid bits.
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o755)).map_err(
+            |e| {
+                ToolError::internal_message(format!(
+                    "chmod 0o755 temp executable for {}: {e}",
+                    dest.display()
+                ))
+            },
+        )?;
+    }
+
+    temp.as_file().sync_all().map_err(|e| {
+        ToolError::internal_message(format!("fsync temp executable {}: {e}", dest.display()))
+    })?;
+    temp.persist(dest).map_err(|e| {
+        ToolError::internal_message(format!("atomic rename {}: {e}", dest.display()))
+    })?;
+    fsync_parent_dir(parent);
+    Ok(())
+}
+
+#[cfg(feature = "acp_registry")]
+fn fsync_parent_dir(parent: &Path) {
+    #[cfg(unix)]
+    if let Ok(dir) = File::open(parent) {
+        drop(dir.sync_all());
+    }
+    #[cfg(not(unix))]
+    let _ = parent;
 }
 
 /// Resolve `~/.lab/bin/<agent_id>/`.
@@ -593,6 +705,7 @@ fn validate_archive_url(url: &str) -> Result<(), ToolError> {
         if host_lower == "localhost"
             || host_lower.starts_with("127.")
             || host_lower == "::1"
+            || host_lower.contains("::ffff:")
             || host_lower == "0.0.0.0"
             || PRIVATE_SUFFIXES.iter().any(|s| host_lower.ends_with(s))
         {
@@ -613,7 +726,12 @@ fn validate_archive_url(url: &str) -> Result<(), ToolError> {
                 other => other,
             };
             let is_private = match addr {
-                std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+                std::net::IpAddr::V4(v4) => {
+                    let octets = v4.octets();
+                    v4.is_private()
+                        || v4.is_link_local()
+                        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+                }
                 std::net::IpAddr::V6(v6) => v6.is_unique_local() || v6.is_unicast_link_local(),
             };
             if is_private || addr.is_loopback() || addr.is_unspecified() {
@@ -640,7 +758,7 @@ fn validate_archive_url(url: &str) -> Result<(), ToolError> {
 /// returned. This is separate from the overall reqwest timeout, which
 /// caps the total duration; the watchdog catches a stalled connection
 /// that's neither fast-failing nor completing.
-async fn download_archive(url: &str, dest: &std::path::Path) -> Result<String, ToolError> {
+async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
     use futures::StreamExt;
     use sha2::{Digest, Sha256};
     use tokio::io::AsyncWriteExt;
@@ -803,11 +921,7 @@ async fn open_archive_response(
 ///    success,
 /// 3. Post-extract, walk `dest_dir` and count files. If the count falls
 ///    below the expected minimum, fail closed.
-fn extract_archive(
-    archive: &std::path::Path,
-    dest_dir: &std::path::Path,
-    url: &str,
-) -> Result<(), ToolError> {
+fn extract_archive(archive: &Path, dest_dir: &Path, url: &str) -> Result<(), ToolError> {
     let archive_s = archive.to_string_lossy();
     let dest_s = dest_dir.to_string_lossy();
 
@@ -894,7 +1008,7 @@ fn extract_archive(
 /// Used by `extract_archive` as a pre-flight expectation. We count only
 /// regular-file-looking entries, not directories, to stay consistent with
 /// the post-extract walk in `validate_no_escape`.
-fn list_archive_file_count(archive: &std::path::Path, url: &str) -> Result<usize, ToolError> {
+fn list_archive_file_count(archive: &Path, url: &str) -> Result<usize, ToolError> {
     let archive_s = archive.to_string_lossy();
     let output = if url.ends_with(".zip") {
         // `unzip -Z -1` prints one entry per line; trailing `/` indicates a dir.
@@ -945,10 +1059,7 @@ fn list_archive_file_count(archive: &std::path::Path, url: &str) -> Result<usize
 /// an attacker-crafted permission-denied entry could evade rejection. A
 /// stat failure in a security-critical walk is treated as a refusal to
 /// validate the tree.
-fn validate_no_escape(
-    canonical_root: &std::path::Path,
-    dir: &std::path::Path,
-) -> Result<usize, ToolError> {
+fn validate_no_escape(canonical_root: &Path, dir: &Path) -> Result<usize, ToolError> {
     let rd = std::fs::read_dir(dir).map_err(|e| ToolError::Sdk {
         sdk_kind: "internal_error".to_string(),
         message: format!("walk extract dir {}: {e}", dir.display()),
@@ -998,7 +1109,7 @@ fn validate_no_escape(
 }
 
 /// Walk `dir` recursively to find the first file whose name matches `binary_name`.
-fn find_binary_in_dir(dir: &std::path::Path, binary_name: &str) -> Option<PathBuf> {
+fn find_binary_in_dir(dir: &Path, binary_name: &str) -> Option<PathBuf> {
     let entries = std::fs::read_dir(dir).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -1075,5 +1186,98 @@ mod tests {
         ] {
             assert!(source.contains(required), "missing {required}");
         }
+    }
+
+    #[test]
+    fn binary_asset_without_integrity_metadata_fails_closed() {
+        let asset = BinaryAsset {
+            archive: "https://example.com/agent.tar.gz".to_string(),
+            sha256: None,
+            digest: None,
+            cmd: "./agent".to_string(),
+            args: Vec::new(),
+        };
+
+        let err = expected_archive_sha256(&asset).expect_err("missing integrity must fail");
+
+        assert_eq!(err.kind(), "integrity_missing");
+    }
+
+    #[test]
+    fn binary_asset_digest_metadata_is_normalized() {
+        let asset = BinaryAsset {
+            archive: "https://example.com/agent.tar.gz".to_string(),
+            sha256: None,
+            digest: Some(format!("sha256:{}", "A".repeat(64))),
+            cmd: "./agent".to_string(),
+            args: Vec::new(),
+        };
+
+        let expected = expected_archive_sha256(&asset).expect("valid digest");
+
+        assert_eq!(expected, "a".repeat(64));
+    }
+
+    #[test]
+    fn digest_mismatch_verification_helper_fails() {
+        let expected = "a".repeat(64);
+        let actual = "b".repeat(64);
+
+        let err = verify_archive_sha256(&expected, &actual).expect_err("mismatch must fail");
+
+        assert_eq!(err.kind(), "integrity_mismatch");
+    }
+
+    #[test]
+    fn archive_url_rejects_local_and_private_hosts() {
+        for url in [
+            "http://example.com/agent.tar.gz",
+            "https://127.0.0.1/agent.tar.gz",
+            "https://[::ffff:127.0.0.1]/agent.tar.gz",
+            "https://192.168.1.20/agent.tar.gz",
+            "https://agent.local/agent.tar.gz",
+        ] {
+            let err = validate_archive_url(url).expect_err(url);
+            assert_eq!(err.kind(), "invalid_param");
+        }
+    }
+
+    #[test]
+    fn install_executable_atomically_replaces_file_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src-agent");
+        let dest = dir.path().join("agent");
+        std::fs::write(&src, b"new agent").expect("write src");
+        std::fs::write(&dest, b"old agent").expect("write dest");
+
+        install_executable_atomically(&src, &dest).expect("atomic install");
+
+        assert_eq!(std::fs::read(&dest).expect("read dest"), b"new agent");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dest)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o755);
+        }
+    }
+
+    #[test]
+    fn provider_config_is_written_after_binary_install_returns() {
+        let source = include_str!("acp_dispatch.rs");
+        let install_pos = source
+            .find("let (cmd_path, digest) = install_binary(agent_id, asset).await?;")
+            .expect("install_binary call");
+        let upsert_pos = source
+            .find("upsert_provider(&entry)?;")
+            .expect("upsert_provider call");
+
+        assert!(
+            install_pos < upsert_pos,
+            "provider config must be written only after install_binary succeeds"
+        );
     }
 }

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -967,65 +967,6 @@ async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
     Ok(hex::encode(hasher.finalize()))
 }
 
-async fn open_archive_response(
-    client: &reqwest::Client,
-    url: &str,
-    max_redirects: usize,
-) -> Result<(String, reqwest::Response), ToolError> {
-    let mut current = reqwest::Url::parse(url).map_err(|e| ToolError::Sdk {
-        sdk_kind: "invalid_param".to_string(),
-        message: format!("invalid archive URL `{url}`: {e}"),
-    })?;
-
-    for redirect_count in 0..=max_redirects {
-        validate_archive_url(current.as_str())?;
-        let resp = client
-            .get(current.clone())
-            .send()
-            .await
-            .map_err(|e| ToolError::Sdk {
-                sdk_kind: "network_error".to_string(),
-                message: format!("GET {current}: {e}"),
-            })?;
-
-        if resp.status().is_success() {
-            return Ok((current.to_string(), resp));
-        }
-
-        if resp.status().is_redirection() {
-            if redirect_count == max_redirects {
-                return Err(ToolError::Sdk {
-                    sdk_kind: "network_error".to_string(),
-                    message: format!("GET {current}: too many redirects (>{max_redirects})"),
-                });
-            }
-            let location = resp
-                .headers()
-                .get(reqwest::header::LOCATION)
-                .and_then(|value| value.to_str().ok())
-                .ok_or_else(|| ToolError::Sdk {
-                    sdk_kind: "network_error".to_string(),
-                    message: format!("GET {current}: redirect missing Location header"),
-                })?;
-            current = current.join(location).map_err(|e| ToolError::Sdk {
-                sdk_kind: "network_error".to_string(),
-                message: format!("GET {current}: invalid redirect Location `{location}`: {e}"),
-            })?;
-            continue;
-        }
-
-        return Err(ToolError::Sdk {
-            sdk_kind: "network_error".to_string(),
-            message: format!("GET {current}: HTTP {}", resp.status()),
-        });
-    }
-
-    Err(ToolError::Sdk {
-        sdk_kind: "network_error".to_string(),
-        message: format!("GET {url}: too many redirects (>{max_redirects})"),
-    })
-}
-
 /// Extract `archive` into `dest_dir` using system `tar` or `unzip`.
 ///
 /// lab-zxx5.24: zip-slip defense via post-extract canonical-containment walk.

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -682,11 +682,16 @@ fn validate_agent_id_for_path(agent_id: &str) -> Result<(), ToolError> {
 ///   covers `::1`)
 /// - reject common homelab private TLDs in addition to `.local`
 ///
-/// Known gap (DEFERRED): DNS rebinding is not mitigated here. The mitigation
-/// requires resolving the hostname AT CONNECT TIME and re-checking the
-/// resolved IP against the deny rules, which requires a custom
-/// `reqwest::dns::Resolve` implementation. Tracked as a follow-up.
+/// lab-qq8y.7 hardening: archive downloads resolve the host, reject blocked
+/// addresses, and pin those validated addresses into reqwest via
+/// `resolve_to_addrs` so reqwest does not perform a second DNS lookup during
+/// connect.
 fn validate_archive_url(url: &str) -> Result<(), ToolError> {
+    validated_archive_url(url).map(|_| ())
+}
+
+#[cfg(feature = "acp_registry")]
+fn validated_archive_url(url: &str) -> Result<url::Url, ToolError> {
     const PRIVATE_SUFFIXES: &[&str] =
         &[".local", ".internal", ".lan", ".intranet", ".corp", ".home"];
 
@@ -700,52 +705,163 @@ fn validate_archive_url(url: &str) -> Result<(), ToolError> {
             message: format!("archive URL must use https, got `{}`", parsed.scheme()),
         });
     }
-    if let Some(host) = parsed.host_str() {
-        let host_lower = host.to_ascii_lowercase();
-        if host_lower == "localhost"
-            || host_lower.starts_with("127.")
-            || host_lower == "::1"
-            || host_lower.contains("::ffff:")
-            || host_lower == "0.0.0.0"
-            || PRIVATE_SUFFIXES.iter().any(|s| host_lower.ends_with(s))
-        {
-            return Err(ToolError::Sdk {
-                sdk_kind: "invalid_param".to_string(),
-                message: format!("archive URL host `{host}` is a local/loopback address"),
-            });
-        }
-        if let Ok(addr) = host.parse::<std::net::IpAddr>() {
-            // Normalize IPv4-mapped IPv6 (::ffff:127.0.0.1) to the underlying
-            // IPv4 so the same rules apply. Rust's stable IPv6Addr::is_loopback
-            // only matches `::1`, missing mapped-v4 loopback otherwise.
-            let addr = match addr {
-                std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-                    Some(v4) => std::net::IpAddr::V4(v4),
-                    None => std::net::IpAddr::V6(v6),
-                },
-                other => other,
-            };
-            let is_private = match addr {
-                std::net::IpAddr::V4(v4) => {
-                    let octets = v4.octets();
-                    v4.is_private()
-                        || v4.is_link_local()
-                        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
-                }
-                std::net::IpAddr::V6(v6) => v6.is_unique_local() || v6.is_unicast_link_local(),
-            };
-            if is_private || addr.is_loopback() || addr.is_unspecified() {
-                return Err(ToolError::Sdk {
-                    sdk_kind: "invalid_param".to_string(),
-                    message: format!(
-                        "archive URL host `{host}` is a private/loopback/unspecified address"
-                    ),
-                });
-            }
-        }
+    let host = parsed.host_str().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("archive URL has no host: {url}"),
+    })?;
+
+    let host_lower = host.to_ascii_lowercase();
+    if host_lower == "localhost"
+        || host_lower.starts_with("127.")
+        || host_lower == "::1"
+        || host_lower.contains("::ffff:")
+        || host_lower == "0.0.0.0"
+        || PRIVATE_SUFFIXES.iter().any(|s| host_lower.ends_with(s))
+    {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: format!("archive URL host `{host}` is a local/loopback address"),
+        });
     }
+    if let Ok(addr) = host.parse::<std::net::IpAddr>() {
+        check_archive_ip_not_private(addr, host)?;
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(feature = "acp_registry")]
+async fn archive_download_client(parsed: &url::Url) -> Result<reqwest::Client, ToolError> {
+    let host = parsed.host_str().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("archive URL has no host: {parsed}"),
+    })?;
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    let addrs = resolve_archive_host(host, port).await?;
+
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .resolve_to_addrs(host, &addrs)
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| ToolError::internal_message(format!("build http client: {e}")))
+}
+
+#[cfg(feature = "acp_registry")]
+async fn resolve_archive_host(
+    host: &str,
+    port: u16,
+) -> Result<Vec<std::net::SocketAddr>, ToolError> {
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|e| ToolError::Sdk {
+            sdk_kind: "network_error".to_string(),
+            message: format!("resolve archive URL host `{host}`: {e}"),
+        })?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "network_error".to_string(),
+            message: format!("resolve archive URL host `{host}` returned no addresses"),
+        });
+    }
+
+    for addr in &addrs {
+        check_archive_ip_not_private(addr.ip(), host)?;
+    }
+
+    Ok(addrs)
+}
+
+#[cfg(feature = "acp_registry")]
+fn check_archive_ip_not_private(ip: std::net::IpAddr, host: &str) -> Result<(), ToolError> {
+    let normalized = match ip {
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => std::net::IpAddr::V4(v4),
+            None => std::net::IpAddr::V6(v6),
+        },
+        other => other,
+    };
+
+    let blocked = match normalized {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            v4.is_private()
+                || v4.is_link_local()
+                || v4.is_loopback()
+                || v4.is_unspecified()
+                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        }
+        std::net::IpAddr::V6(v6) => {
+            v6.is_unique_local()
+                || v6.is_unicast_link_local()
+                || v6.is_loopback()
+                || v6.is_unspecified()
+        }
+    };
+
+    if blocked {
+        return Err(ToolError::Sdk {
+            sdk_kind: "ssrf_blocked".to_string(),
+            message: format!(
+                "archive URL host `{host}` resolves to private/loopback/link-local address {ip}; blocked to prevent SSRF"
+            ),
+        });
+    }
+
     Ok(())
 }
+
+#[cfg(feature = "acp_registry")]
+async fn cleanup_partial_archive(dest: &Path, action: &'static str) {
+    if let Err(e) = tokio::fs::remove_file(dest).await {
+        tracing::warn!(
+            surface = "dispatch",
+            service = "marketplace",
+            action,
+            path = %dest.display(),
+            error = %e,
+            "download-cleanup remove_file failed; partial archive retained"
+        );
+    }
+}
+
+#[cfg(feature = "acp_registry")]
+fn archive_size_error(url: &str, size: u64) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("download of {url} exceeded maximum ACP archive size of {size} bytes"),
+    }
+}
+
+#[cfg(feature = "acp_registry")]
+fn enforce_archive_size_limit(
+    downloaded: &mut u64,
+    chunk_len: usize,
+    url: &str,
+) -> Result<(), ToolError> {
+    let chunk_len =
+        u64::try_from(chunk_len).map_err(|_| archive_size_error(url, MAX_ACP_ARCHIVE_BYTES))?;
+    let next = downloaded
+        .checked_add(chunk_len)
+        .ok_or_else(|| archive_size_error(url, MAX_ACP_ARCHIVE_BYTES))?;
+    if next > MAX_ACP_ARCHIVE_BYTES {
+        return Err(archive_size_error(url, MAX_ACP_ARCHIVE_BYTES));
+    }
+    *downloaded = next;
+    Ok(())
+}
+
+/// Maximum bytes accepted for one ACP binary archive download.
+///
+/// The registry distributes small agent adapters; 256 MiB leaves enough room
+/// for bundled runtimes while preventing unbounded disk growth from hostile or
+/// misconfigured archive URLs. Oversized streams are aborted and partial files
+/// are removed before surfacing the error.
+#[cfg(feature = "acp_registry")]
+const MAX_ACP_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Download `url` to `dest`, return the hex SHA-256 of the downloaded bytes.
 ///
@@ -767,14 +883,25 @@ async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
     /// from the overall `.timeout()` — catches stalled connections.
     const DOWNLOAD_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    const MAX_DOWNLOAD_REDIRECTS: usize = 5;
+    let parsed = validated_archive_url(url)?;
+    let client = archive_download_client(&parsed).await?;
 
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .timeout(std::time::Duration::from_secs(300))
-        .build()
-        .map_err(|e| ToolError::internal_message(format!("build http client: {e}")))?;
-    let (download_url, resp) = open_archive_response(&client, url, MAX_DOWNLOAD_REDIRECTS).await?;
+    let resp = client.get(url).send().await.map_err(|e| ToolError::Sdk {
+        sdk_kind: "network_error".to_string(),
+        message: format!("GET {url}: {e}"),
+    })?;
+
+    if !resp.status().is_success() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "network_error".to_string(),
+            message: format!("GET {url}: HTTP {}", resp.status()),
+        });
+    }
+    if let Some(content_length) = resp.content_length()
+        && content_length > MAX_ACP_ARCHIVE_BYTES
+    {
+        return Err(archive_size_error(url, MAX_ACP_ARCHIVE_BYTES));
+    }
 
     let mut file = tokio::fs::File::create(dest)
         .await
@@ -782,6 +909,7 @@ async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
 
     let mut hasher = Sha256::new();
     let mut stream = resp.bytes_stream();
+    let mut downloaded = 0_u64;
 
     loop {
         // Watchdog: each chunk fetch is wrapped in a stall timeout. A download
@@ -791,8 +919,13 @@ async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
             Ok(Some(chunk_result)) => {
                 let chunk = chunk_result.map_err(|e| ToolError::Sdk {
                     sdk_kind: "network_error".to_string(),
-                    message: format!("read body chunk from {download_url}: {e}"),
+                    message: format!("read body chunk from {url}: {e}"),
                 })?;
+                if let Err(e) = enforce_archive_size_limit(&mut downloaded, chunk.len(), url) {
+                    drop(file);
+                    cleanup_partial_archive(dest, "download_archive.size.cleanup").await;
+                    return Err(e);
+                }
                 hasher.update(&chunk);
                 file.write_all(&chunk).await.map_err(|e| {
                     ToolError::internal_message(format!("write chunk to {}: {e}", dest.display()))
@@ -812,20 +945,11 @@ async fn download_archive(url: &str, dest: &Path) -> Result<String, ToolError> {
                 // visibility into orphan tempfiles. Don't promote to fatal —
                 // the install_timeout is the primary signal.
                 drop(file);
-                if let Err(e) = tokio::fs::remove_file(dest).await {
-                    tracing::warn!(
-                        surface = "dispatch",
-                        service = "marketplace",
-                        action = "download_archive.stall.cleanup",
-                        path = %dest.display(),
-                        error = %e,
-                        "stall-cleanup remove_file failed; partial archive retained"
-                    );
-                }
+                cleanup_partial_archive(dest, "download_archive.stall.cleanup").await;
                 return Err(ToolError::Sdk {
                     sdk_kind: "install_timeout".to_string(),
                     message: format!(
-                        "download of {download_url} stalled for more than {:?}; aborted",
+                        "download of {url} stalled for more than {:?}; aborted",
                         DOWNLOAD_STALL_TIMEOUT
                     ),
                 });
@@ -1232,14 +1356,63 @@ mod tests {
     fn archive_url_rejects_local_and_private_hosts() {
         for url in [
             "http://example.com/agent.tar.gz",
+            "https://agent.local/agent.tar.gz",
             "https://127.0.0.1/agent.tar.gz",
             "https://[::ffff:127.0.0.1]/agent.tar.gz",
-            "https://192.168.1.20/agent.tar.gz",
-            "https://agent.local/agent.tar.gz",
         ] {
             let err = validate_archive_url(url).expect_err(url);
             assert_eq!(err.kind(), "invalid_param");
         }
+
+        for url in ["https://192.168.1.20/agent.tar.gz"] {
+            let err = validate_archive_url(url).expect_err(url);
+            assert_eq!(err.kind(), "ssrf_blocked");
+        }
+    }
+
+    #[test]
+    fn archive_resolved_addresses_reject_private_and_rebound_ranges() {
+        for ip in [
+            "10.0.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+            "::ffff:169.254.169.254",
+        ] {
+            let err = check_archive_ip_not_private(ip.parse().expect(ip), "registry.example.com")
+                .expect_err(ip);
+
+            assert_eq!(err.kind(), "ssrf_blocked");
+        }
+    }
+
+    #[test]
+    fn archive_size_limit_rejects_oversized_stream() {
+        let mut downloaded = MAX_ACP_ARCHIVE_BYTES - 1;
+        let err =
+            enforce_archive_size_limit(&mut downloaded, 2, "https://example.com/agent.tar.gz")
+                .expect_err("oversized archive must fail");
+
+        assert_eq!(err.kind(), "invalid_param");
+        assert_eq!(downloaded, MAX_ACP_ARCHIVE_BYTES - 1);
+    }
+
+    #[tokio::test]
+    async fn oversized_archive_cleanup_removes_partial_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let partial = dir.path().join("agent.tar.gz.partial");
+        tokio::fs::write(&partial, b"partial archive")
+            .await
+            .expect("write partial");
+
+        cleanup_partial_archive(&partial, "test.cleanup").await;
+
+        assert!(
+            tokio::fs::metadata(&partial).await.is_err(),
+            "partial archive should be removed"
+        );
     }
 
     #[test]
@@ -1278,6 +1451,20 @@ mod tests {
         assert!(
             install_pos < upsert_pos,
             "provider config must be written only after install_binary succeeds"
+        );
+    }
+
+    #[test]
+    fn archive_download_client_disables_proxy_dns_bypass() {
+        let source = include_str!("acp_dispatch.rs");
+        let no_proxy_pos = source.find(".no_proxy()").expect("no_proxy hardening");
+        let pin_pos = source
+            .find(".resolve_to_addrs(host, &addrs)")
+            .expect("resolved address pinning");
+
+        assert!(
+            no_proxy_pos < pin_pos,
+            "archive downloads must disable proxies before pinning resolved addresses"
         );
     }
 }

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -690,7 +690,6 @@ fn validate_archive_url(url: &str) -> Result<(), ToolError> {
     validated_archive_url(url).map(|_| ())
 }
 
-#[cfg(feature = "acp_registry")]
 fn validated_archive_url(url: &str) -> Result<url::Url, ToolError> {
     const PRIVATE_SUFFIXES: &[&str] =
         &[".local", ".internal", ".lan", ".intranet", ".corp", ".home"];
@@ -730,7 +729,6 @@ fn validated_archive_url(url: &str) -> Result<url::Url, ToolError> {
     Ok(parsed)
 }
 
-#[cfg(feature = "acp_registry")]
 async fn archive_download_client(parsed: &url::Url) -> Result<reqwest::Client, ToolError> {
     let host = parsed.host_str().ok_or_else(|| ToolError::Sdk {
         sdk_kind: "invalid_param".to_string(),
@@ -748,7 +746,6 @@ async fn archive_download_client(parsed: &url::Url) -> Result<reqwest::Client, T
         .map_err(|e| ToolError::internal_message(format!("build http client: {e}")))
 }
 
-#[cfg(feature = "acp_registry")]
 async fn resolve_archive_host(
     host: &str,
     port: u16,
@@ -775,7 +772,6 @@ async fn resolve_archive_host(
     Ok(addrs)
 }
 
-#[cfg(feature = "acp_registry")]
 fn check_archive_ip_not_private(ip: std::net::IpAddr, host: &str) -> Result<(), ToolError> {
     let normalized = match ip {
         std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
@@ -814,7 +810,6 @@ fn check_archive_ip_not_private(ip: std::net::IpAddr, host: &str) -> Result<(), 
     Ok(())
 }
 
-#[cfg(feature = "acp_registry")]
 async fn cleanup_partial_archive(dest: &Path, action: &'static str) {
     if let Err(e) = tokio::fs::remove_file(dest).await {
         tracing::warn!(
@@ -828,7 +823,6 @@ async fn cleanup_partial_archive(dest: &Path, action: &'static str) {
     }
 }
 
-#[cfg(feature = "acp_registry")]
 fn archive_size_error(url: &str, size: u64) -> ToolError {
     ToolError::Sdk {
         sdk_kind: "invalid_param".to_string(),
@@ -836,7 +830,6 @@ fn archive_size_error(url: &str, size: u64) -> ToolError {
     }
 }
 
-#[cfg(feature = "acp_registry")]
 fn enforce_archive_size_limit(
     downloaded: &mut u64,
     chunk_len: usize,
@@ -860,7 +853,6 @@ fn enforce_archive_size_limit(
 /// for bundled runtimes while preventing unbounded disk growth from hostile or
 /// misconfigured archive URLs. Oversized streams are aborted and partial files
 /// are removed before surfacing the error.
-#[cfg(feature = "acp_registry")]
 const MAX_ACP_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Download `url` to `dest`, return the hex SHA-256 of the downloaded bytes.

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -1304,6 +1304,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "acp_registry")]
     #[test]
     fn binary_asset_without_integrity_metadata_fails_closed() {
         let asset = BinaryAsset {
@@ -1319,6 +1320,7 @@ mod tests {
         assert_eq!(err.kind(), "integrity_missing");
     }
 
+    #[cfg(feature = "acp_registry")]
     #[test]
     fn binary_asset_digest_metadata_is_normalized() {
         let asset = BinaryAsset {
@@ -1334,6 +1336,7 @@ mod tests {
         assert_eq!(expected, "a".repeat(64));
     }
 
+    #[cfg(feature = "acp_registry")]
     #[test]
     fn digest_mismatch_verification_helper_fails() {
         let expected = "a".repeat(64);
@@ -1407,6 +1410,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "acp_registry")]
     #[test]
     fn install_executable_atomically_replaces_file_contents() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -563,6 +563,10 @@ fn verify_archive_sha256(expected: &str, actual: &str) -> Result<(), ToolError> 
     })
 }
 
+// Note: `NamedTempFile::persist(dest)` uses `rename(2)` which is atomic on
+// Linux.  Windows `MoveFileEx` without `MOVEFILE_REPLACE_EXISTING` fails when
+// the destination exists, but Windows is not a supported platform for this
+// binary, so no cross-platform fallback is implemented.
 #[cfg(feature = "acp_registry")]
 fn install_executable_atomically(src: &Path, dest: &Path) -> Result<(), ToolError> {
     let parent = dest
@@ -825,7 +829,7 @@ async fn cleanup_partial_archive(dest: &Path, action: &'static str) {
 
 fn archive_size_error(url: &str, size: u64) -> ToolError {
     ToolError::Sdk {
-        sdk_kind: "invalid_param".to_string(),
+        sdk_kind: "content_too_large".to_string(),
         message: format!("download of {url} exceeded maximum ACP archive size of {size} bytes"),
     }
 }
@@ -1390,7 +1394,7 @@ mod tests {
             enforce_archive_size_limit(&mut downloaded, 2, "https://example.com/agent.tar.gz")
                 .expect_err("oversized archive must fail");
 
-        assert_eq!(err.kind(), "invalid_param");
+        assert_eq!(err.kind(), "content_too_large");
         assert_eq!(downloaded, MAX_ACP_ARCHIVE_BYTES - 1);
     }
 

--- a/crates/lab/src/dispatch/marketplace/catalog.rs
+++ b/crates/lab/src/dispatch/marketplace/catalog.rs
@@ -491,7 +491,7 @@ pub const ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "agent.install",
-        description: "Install an ACP agent on one or more devices. Writes a provider entry to `~/.lab/acp-providers.json`. Binary distributions are not yet supported in this build; npx/uvx are config-only.",
+        description: "Install an ACP agent on one or more devices. Local installs write a provider entry to `~/.lab/acp-providers.json`; binary archives are downloaded only over HTTPS, SHA-256 verified, size-limited, and installed atomically.",
         destructive: true,
         returns: "InstallResults",
         params: &[

--- a/crates/lab/src/dispatch/marketplace/mcp_catalog.rs
+++ b/crates/lab/src/dispatch/marketplace/mcp_catalog.rs
@@ -15,7 +15,7 @@ pub const MCP_ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "mcp.list",
-        description: "List MCP servers from the registry with optional search, owner filter, and pagination. This action calls the upstream registry directly (/v1 surface).",
+        description: "List MCP servers from the local registry mirror with optional search, owner filter, and bounded pagination.",
         destructive: false,
         returns: "ServerListResponse",
         params: &[
@@ -89,7 +89,7 @@ pub const MCP_ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "mcp.get",
-        description: "Get details for a single MCP server by its registry name. Calls the upstream registry directly (/v1 surface).",
+        description: "Get details for a single MCP server by its registry name from the registry client/store surface.",
         destructive: false,
         returns: "ServerResponse",
         params: &[ParamSpec {
@@ -101,7 +101,7 @@ pub const MCP_ACTIONS: &[ActionSpec] = &[
     },
     ActionSpec {
         name: "mcp.versions",
-        description: "List available versions for a named MCP server. Calls the upstream registry directly (/v1 surface).",
+        description: "List available versions for a named MCP server from the registry client/store surface.",
         destructive: false,
         returns: "ServerListResponse",
         params: &[ParamSpec {

--- a/crates/lab/src/dispatch/marketplace/mcp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/mcp_dispatch.rs
@@ -129,23 +129,12 @@ async fn dispatch_mcp_list(client: &McpRegistryClient, params: &Value) -> Result
     ensure_registry_store_populated(&store, client).await?;
     let list_params = store_list_params_from_mcp_params(&parsed);
 
-    if parsed.cursor.is_some() || params.get("limit").is_some() {
-        let page = store.list_servers(list_params).await?;
-        return Ok(serde_json::json!({
-            "servers": page.servers,
-            "metadata": {
-                "count": page.servers.len(),
-                "nextCursor": page.next_cursor,
-            },
-        }));
-    }
-
-    let servers = list_all_store_servers(&store, list_params).await?;
+    let page = store.list_servers(list_params).await?;
     Ok(serde_json::json!({
-        "servers": servers,
+        "servers": page.servers,
         "metadata": {
-            "count": servers.len(),
-            "nextCursor": null,
+            "count": page.servers.len(),
+            "nextCursor": page.next_cursor,
         },
     }))
 }
@@ -165,7 +154,7 @@ fn store_list_params_from_mcp_params(
 ) -> crate::dispatch::marketplace::store::StoreListParams {
     let mut store_params = crate::dispatch::marketplace::store::StoreListParams {
         cursor: params.cursor.clone(),
-        limit: params.limit,
+        limit: Some(params.limit.unwrap_or(10)),
         version: params.version.clone(),
         updated_since: params.updated_since.clone(),
         include_deleted: false,
@@ -208,44 +197,8 @@ async fn ensure_registry_store_populated(
     .await
     {
         Ok(_) => Ok(()),
-        Err(error) if error.kind() == "sync_in_progress" => Ok(()),
         Err(error) => Err(error),
     }
-}
-
-#[cfg(feature = "mcpregistry")]
-async fn list_all_store_servers(
-    store: &crate::dispatch::marketplace::store::RegistryStore,
-    params: crate::dispatch::marketplace::store::StoreListParams,
-) -> Result<Vec<lab_apis::mcpregistry::types::ServerResponse>, ToolError> {
-    let mut cursor = params.cursor.clone();
-    let mut servers = Vec::new();
-    let mut seen_cursors = std::collections::HashSet::new();
-
-    loop {
-        let page = store
-            .list_servers(crate::dispatch::marketplace::store::StoreListParams {
-                cursor: cursor.clone(),
-                limit: Some(100),
-                ..params.clone()
-            })
-            .await?;
-        servers.extend(page.servers);
-        match page.next_cursor {
-            Some(next) if !next.is_empty() => {
-                if cursor.as_deref() == Some(next.as_str()) || !seen_cursors.insert(next.clone()) {
-                    return Err(ToolError::Sdk {
-                        sdk_kind: "invalid_cursor".to_string(),
-                        message: "registry store returned a non-advancing cursor".to_string(),
-                    });
-                }
-                cursor = Some(next);
-            }
-            _ => break,
-        }
-    }
-
-    Ok(servers)
 }
 
 /// Handle `mcp.install`: fetch server details and install to selected targets.
@@ -949,6 +902,9 @@ async fn dispatch_mcp_local(action: &str, params: Value) -> Result<Value, ToolEr
 
 #[cfg(all(test, feature = "mcpregistry"))]
 mod tests {
+    use std::sync::atomic::Ordering;
+
+    use lab_apis::core::Auth;
     use lab_apis::mcpregistry::types::{
         EnvironmentVariable, Package, Transport as RegistryTransport,
     };
@@ -1081,6 +1037,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(spec["command"], "npx");
+    }
+
+    #[test]
+    fn mcp_list_omitted_limit_uses_marketplace_default() {
+        let parsed = mcp_params::list_servers_params(&json!({})).unwrap();
+        let store_params = store_list_params_from_mcp_params(&parsed);
+
+        assert_eq!(store_params.limit, Some(10));
+        assert_eq!(store_params.cursor, None);
+        assert!(store_params.latest_only);
+    }
+
+    #[tokio::test]
+    async fn empty_store_sync_in_progress_is_retryable_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("registry.db");
+        let store = crate::dispatch::marketplace::store::RegistryStore::open(&db_path)
+            .await
+            .unwrap();
+        let client = McpRegistryClient::new("http://127.0.0.1:9", Auth::None).unwrap();
+
+        let previous =
+            crate::dispatch::marketplace::sync::SYNC_IN_PROGRESS.swap(true, Ordering::AcqRel);
+        let result = ensure_registry_store_populated(&store, &client).await;
+        crate::dispatch::marketplace::sync::SYNC_IN_PROGRESS.store(previous, Ordering::Release);
+
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), "sync_in_progress");
     }
 
     #[test]

--- a/docs/acp/README.md
+++ b/docs/acp/README.md
@@ -176,6 +176,10 @@ Landed:
   cookie auth alone.
 - ACP Registry installs validate `agent_id` before any path is constructed,
   blocking traversal and shell metacharacter injection in install dirs.
+- ACP Registry binary installs accept HTTPS archives only, reject local/private
+  archive hosts before download, pin validated resolved addresses into the
+  download client, and abort streams above the documented 256 MiB archive cap
+  while removing partial files.
 - Provider subprocesses spawn with `env_clear()` and a fixed allowlist
   (`PATH`, `HOME`, locale vars, terminal vars, Windows `SystemRoot`). Per-
   provider entries can extend this allowlist explicitly via the structured

--- a/docs/coverage/mcpregistry.md
+++ b/docs/coverage/mcpregistry.md
@@ -69,12 +69,14 @@ Resolution rules (`crate::dispatch::marketplace::resolve_search_for_rest`):
 The same resolver is used by the `/v0.1/servers` GET surface — the two paths have
 identical filtering semantics.
 
-### `mcp.list` — `/v1` upstream vs `/v0.1/servers` store
+### `mcp.list` — Marketplace action and `/v0.1/servers` store
 
-`mcp.list` via the local `/v1/marketplace` action calls the upstream
-registry `/v0.1/servers` endpoint directly. Sort operates within the current
-page only. For full-dataset sort and offline availability, use the local
-`GET /v0.1/servers` store endpoint described below.
+`mcp.list` via the local `/v1/marketplace` action reads the local registry
+store and returns a bounded page. If `limit` is omitted, Marketplace uses a
+default page size of 10; the maximum accepted page size is 100. Follow
+`metadata.nextCursor` for additional pages. The wire-compatible
+`GET /v0.1/servers` endpoint reads the same local SQLite mirror and defaults
+to 20 rows per page for REST clients.
 
 ## Surface Coverage
 

--- a/docs/dev/ERRORS.md
+++ b/docs/dev/ERRORS.md
@@ -71,9 +71,12 @@ Dispatch layers may add the following kinds on top of SDK errors:
 - `no_remote_transport` — `server.install` called on a server with no HTTP remote transports (stdio-only); cannot be added as a gateway upstream
 - `ssrf_blocked` — registry-sourced URL resolves to a private, loopback, link-local, or ULA address; blocked to prevent SSRF
 - `sync_in_progress` — a registry sync is already running; callers should retry later. HTTP status: 503.
+- `integrity_missing` — registry-sourced executable/package metadata lacks required SHA-256 integrity data; install fails closed. HTTP status: 502.
+- `integrity_mismatch` — downloaded executable/package bytes do not match registry-provided SHA-256 metadata; install fails closed. HTTP status: 502.
 
 `no_remote_transport` and `ssrf_blocked` use `ToolError::Sdk { sdk_kind, message }`. HTTP status: 422.
 `sync_in_progress` uses `ToolError::Sdk { sdk_kind, message }`. HTTP status: 503.
+`integrity_missing` and `integrity_mismatch` use `ToolError::Sdk { sdk_kind, message }`. HTTP status: 502.
 
 ### Stash-specific kinds
 
@@ -398,7 +401,7 @@ surfaced via `DeployError::kind()` in `lab-apis/src/deploy/error.rs`:
 | `partial_failure` | — | Multi-host run where some hosts failed; returned as HTTP 200 with `ok=false` in the body, not as an error response. |
 | `conflict` | 409 | Another deploy is in progress for the same host. |
 | `arch_mismatch` | 502 | Remote `uname -m` differs from local build triple. |
-| `integrity_mismatch` | 502 | Remote sha256 of staged artifact differs from local. |
+| `integrity_mismatch` | 502 | Remote sha256 of staged artifact differs from local, or registry-sourced executable/package bytes differ from expected SHA-256 metadata. |
 
 The deploy-specific kinds (`ssh_unreachable`, `build_failed`, `preflight_failed`,
 `transfer_failed`, `install_failed`, `restart_failed`, `verify_failed`,

--- a/docs/generated/action-catalog.json
+++ b/docs/generated/action-catalog.json
@@ -7376,7 +7376,7 @@
   {
     "service": "marketplace",
     "action": "mcp.get",
-    "description": "Get details for a single MCP server by its registry name. Calls the upstream registry directly (/v1 surface).",
+    "description": "Get details for a single MCP server by its registry name from the registry client/store surface.",
     "destructive": false,
     "params": [
       {
@@ -7462,7 +7462,7 @@
   {
     "service": "marketplace",
     "action": "mcp.list",
-    "description": "List MCP servers from the registry with optional search, owner filter, and pagination. This action calls the upstream registry directly (/v1 surface).",
+    "description": "List MCP servers from the local registry mirror with optional search, owner filter, and bounded pagination.",
     "destructive": false,
     "params": [
       {
@@ -7726,7 +7726,7 @@
   {
     "service": "marketplace",
     "action": "mcp.versions",
-    "description": "List available versions for a named MCP server. Calls the upstream registry directly (/v1 surface).",
+    "description": "List available versions for a named MCP server from the registry client/store surface.",
     "destructive": false,
     "params": [
       {

--- a/docs/generated/action-catalog.json
+++ b/docs/generated/action-catalog.json
@@ -6853,7 +6853,7 @@
   {
     "service": "marketplace",
     "action": "agent.install",
-    "description": "Install an ACP agent on one or more devices. Writes a provider entry to `~/.lab/acp-providers.json`. Binary distributions are not yet supported in this build; npx/uvx are config-only.",
+    "description": "Install an ACP agent on one or more devices. Local installs write a provider entry to `~/.lab/acp-providers.json`; binary archives are downloaded only over HTTPS, SHA-256 verified, size-limited, and installed atomically.",
     "destructive": true,
     "params": [
       {

--- a/docs/generated/mcp-help.json
+++ b/docs/generated/mcp-help.json
@@ -1809,7 +1809,7 @@
         },
         {
           "name": "mcp.list",
-          "description": "List MCP servers from the registry with optional search, owner filter, and pagination. This action calls the upstream registry directly (/v1 surface).",
+          "description": "List MCP servers from the local registry mirror with optional search, owner filter, and bounded pagination.",
           "destructive": false,
           "params": [
             {
@@ -1883,7 +1883,7 @@
         },
         {
           "name": "mcp.get",
-          "description": "Get details for a single MCP server by its registry name. Calls the upstream registry directly (/v1 surface).",
+          "description": "Get details for a single MCP server by its registry name from the registry client/store surface.",
           "destructive": false,
           "params": [
             {
@@ -1897,7 +1897,7 @@
         },
         {
           "name": "mcp.versions",
-          "description": "List available versions for a named MCP server. Calls the upstream registry directly (/v1 surface).",
+          "description": "List available versions for a named MCP server from the registry client/store surface.",
           "destructive": false,
           "params": [
             {

--- a/docs/generated/mcp-help.json
+++ b/docs/generated/mcp-help.json
@@ -1706,7 +1706,7 @@
         },
         {
           "name": "agent.install",
-          "description": "Install an ACP agent on one or more devices. Writes a provider entry to `~/.lab/acp-providers.json`. Binary distributions are not yet supported in this build; npx/uvx are config-only.",
+          "description": "Install an ACP agent on one or more devices. Local installs write a provider entry to `~/.lab/acp-providers.json`; binary archives are downloaded only over HTTPS, SHA-256 verified, size-limited, and installed atomically.",
           "destructive": true,
           "params": [
             {

--- a/docs/services/MARKETPLACE.md
+++ b/docs/services/MARKETPLACE.md
@@ -1,285 +1,183 @@
 # Marketplace
 
-`marketplace` is an always-on synthetic service that surfaces the Claude Code plugin marketplace system — known marketplaces, published plugins, installed plugins, and their shipped artifacts — through the same CLI + MCP + API dispatch path as every other `lab` service.
+`marketplace` is the unified Lab surface for installable agent tooling:
 
-## Why It Exists
+- Claude Code and Codex plugin marketplaces (`sources.*`, `plugins.*`, `plugin.*`, `artifact.*`)
+- the official MCP Registry (`mcp.*`)
+- the ACP Agent Registry (`agent.*`)
 
-Claude Code stores marketplace metadata under `~/.claude/plugins/`. That layout is machine-readable but not programmatically exposed: there is no CLI that lists plugins across all configured marketplaces with their installed state, and no API that returns the artifact payload of an installed plugin. `marketplace` fills that gap.
+It is always compiled and exposed through the normal Lab dispatch paths: CLI,
+MCP, HTTP API, and the web UI. The generated service catalog must show
+`marketplace` as `available` while `mcpregistry` and `acp_registry` remain
+`sdk_only`.
 
-It also wraps the destructive `claude plugin …` shell commands (`marketplace add`, `install`, `uninstall`) behind the same confirmation gate as the rest of `lab`: MCP elicitation, CLI `-y`/`--yes`, HTTP `"confirm": true`.
+## Ownership
 
-## Why It Is a Service
+Marketplace owns orchestration, local state, install planning, and safety gates.
+The SDK-only registry modules own protocol clients and metadata:
 
-`marketplace` is not a remote API integration, but it follows the same shape as real services:
+| Surface | Runtime owner | SDK/source owner | Notes |
+| --- | --- | --- | --- |
+| Claude/Codex plugins | `crates/lab/src/dispatch/marketplace/` | Claude/Codex marketplace files under `~/.claude/plugins/` | Reads installed/source state and shells out to `claude plugin ...` for plugin install/uninstall. |
+| MCP Registry | `marketplace` `mcp.*` actions | `lab-apis::mcpregistry` plus `[mcpregistry].url` | `mcpregistry` is not a first-class CLI/MCP/API service. |
+| ACP Agent Registry | `marketplace` `agent.*` actions | `lab-apis::acp_registry` plus `LAB_ACP_REGISTRY_URL` | `acp_registry` is not a first-class CLI/MCP/API service. |
 
-- pure types live in `lab-apis/src/marketplace/types.rs`
-- action catalog, dispatch, and params live in `crates/lab/src/dispatch/marketplace/`
-- CLI shim in `crates/lab/src/cli/marketplace.rs`
-- MCP tool registered in `build_default_registry()`
-- HTTP API route group at `/v1/marketplace`
-
-This keeps plugin management inside the one-tool-per-service model and avoids special-case plumbing.
-
-## Compilation Rule
-
-`marketplace` is always compiled. Like `extract`, it is a bootstrap/operator capability, not a feature-gated optional integration.
-
-## Responsibilities
-
-`marketplace` owns:
-
-- reading `~/.claude/plugins/known_marketplaces.json`
-- reading each marketplace's `marketplace.json` manifest
-- reading `~/.claude/plugins/installed_plugins.json`
-- enriching plugin listings with `owner`, `desc`, `tags`, `category`, installed state, timestamps
-- walking an installed plugin's install path and returning artifact contents (skills, agents, scripts, configs)
-- shelling out to `claude plugin marketplace add`, `claude plugin install`, `claude plugin uninstall` for destructive actions
-
-It does **not** own:
-
-- fetching marketplace manifests over the network — that happens inside `claude plugin marketplace add`
-- Claude Code's plugin resolution logic — lab reads the recorded state, it does not re-derive it
+Marketplace does not re-implement upstream registry semantics. Registry URL
+validation, schema validation, SDK decode errors, and upstream request failures
+must flow through the shared dispatch error envelope.
 
 ## Data Sources
 
-| Path | Purpose |
+| Path or source | Purpose |
 | --- | --- |
-| `~/.claude/plugins/known_marketplaces.json` | Marketplace registry (id → source, autoUpdate, totalPlugins, lastUpdated, installLocation) |
-| `<installLocation>/.claude-plugin/marketplace.json` | Manifest: `name`, `owner.name`, `metadata.description`, `plugins[]` |
-| `<installLocation>/marketplace.json` | Fallback manifest location |
-| `~/.claude/plugins/installed_plugins.json` | Installed state by `name@marketplace` → `installPath`, `installedAt`, `lastUpdated` |
-| `<installPath>/**` | Plugin artifacts (returned by `plugin.artifacts`) |
+| `~/.claude/plugins/known_marketplaces.json` | Claude/Codex marketplace registry. |
+| `<installLocation>/.claude-plugin/marketplace.json` | Marketplace manifest. |
+| `<installLocation>/marketplace.json` | Fallback manifest location. |
+| `~/.claude/plugins/installed_plugins.json` | Installed Claude/Codex plugin state. |
+| `<installPath>/**` | Installed plugin artifacts returned by `plugin.artifacts`. |
+| `[mcpregistry].url` | Optional MCP Registry base URL, defaulting to `https://registry.modelcontextprotocol.io`. |
+| `LAB_ACP_REGISTRY_URL` | Optional ACP Agent Registry CDN base URL, defaulting to `https://cdn.agentclientprotocol.com`. |
+| `~/.lab/acp-providers.json` | Local ACP provider entries written by `agent.install` and removed by `agent.uninstall`. |
 
-Missing files are treated as empty — a fresh Claude Code install returns zero marketplaces without error.
+Missing Claude/Codex marketplace files are treated as empty so a fresh machine
+returns zero plugin sources without error.
 
 ## Actions
 
-The complete marketplace action inventory is generated from `ActionSpec`:
+The full action inventory is generated from `ActionSpec`:
 
-- [generated action catalog](./generated/action-catalog.md)
-- [generated action catalog JSON](./generated/action-catalog.json)
+- [generated action catalog](../generated/action-catalog.md)
+- [generated action catalog JSON](../generated/action-catalog.json)
 
-### Parameters
+The handwritten contract is organized by action family:
 
-- `sources.add` — pass exactly one of `repo` (`owner/repo` slug) or `url` (git URL). Passing both returns `invalid_param`; passing neither returns `missing_param`.
-- `plugins.list` — optional `marketplace`, `kind`, `installed`, and `query` filters. Filters are additive.
-- `plugin.get`, `plugin.artifacts`, `plugin.workspace`, `plugin.deploy.preview`, `plugin.deploy`, `plugin.install`, `plugin.uninstall` — require `id` in `name@marketplace` form. Malformed ids return `invalid_param`.
-- `plugin.save` — requires `id`, `path`, and `content`. `path` is always relative to the plugin workspace mirror.
+| Family | Examples | Role |
+| --- | --- | --- |
+| `sources.*` | `sources.list`, `sources.add` | List or add Claude/Codex plugin marketplaces. |
+| `plugins.*` | `plugins.list` | Search plugin manifests across configured plugin marketplaces. |
+| `plugin.*` | `plugin.get`, `plugin.install`, `plugin.workspace`, `plugin.deploy` | Read, install, edit, and deploy whole plugins. |
+| `artifact.*` | `artifact.fork`, `artifact.diff`, `artifact.update.apply` | Fork, patch, diff, reset, and update individual plugin artifacts. |
+| `mcp.*` | `mcp.list`, `mcp.install`, `mcp.sync` | Discover, validate, mirror, install, and remove MCP Registry servers. |
+| `agent.*` | `agent.list`, `agent.install`, `agent.uninstall` | Discover and install ACP-compatible agents. |
 
-## Return Shapes
+`help` and `schema` are also available through the shared service dispatch
+model.
 
-### `Marketplace` (from `sources.list`)
+## Install Targets
 
-```json
-{
-  "id": "jmagar-lab",
-  "name": "jmagar-lab",
-  "owner": "Jacob Magar",
-  "ghUser": "jmagar",
-  "repo": "jmagar/lab-plugins",
-  "source": "github",
-  "url": null,
-  "path": null,
-  "desc": "Homelab control plane — skills and tooling for lab",
-  "autoUpdate": true,
-  "totalPlugins": 9,
-  "lastUpdated": "2026-04-21T19:13:23.871Z"
-}
-```
+Marketplace supports multiple installation targets. Callers must choose an
+explicit target instead of relying on hidden global defaults:
 
-### `Plugin` (from `plugins.list`, `plugin.get`)
+| Action | Target selector | Effect |
+| --- | --- | --- |
+| `plugin.install` / `plugin.uninstall` | `id` in `name@marketplace` form | Delegates to `claude plugin install/uninstall` for the controller host. |
+| `plugin.deploy` | `id` | Copies the editable workspace mirror into the configured local plugin target. |
+| `plugin.cherry_pick` | `node_ids`, `scope`, `components`, optional `project_path` | Installs selected plugin components on fleet nodes. |
+| `mcp.install` | `gateway_ids` and/or `client_targets` | Adds remote HTTP servers to Lab gateway upstreams, or writes stdio command configs to Claude/Codex clients on fleet devices. At least one target set is required. |
+| `mcp.uninstall` | `gateway_name` | Removes a previously installed gateway upstream. |
+| `agent.install` | `node_ids` plus optional `platform` | Installs an ACP provider entry locally (`local` or host name) or asks a remote node to install a supported package distribution. |
+| `agent.uninstall` | `id` | Removes the local ACP provider entry. |
 
-```json
-{
-  "id": "aurora-design@jmagar-lab",
-  "name": "aurora-design",
-  "mkt": "jmagar-lab",
-  "ver": "0.3.1",
-  "desc": "Aurora design system primitives",
-  "tags": ["ui", "design-system", "shadcn"],
-  "installed": true,
-  "hasUpdate": null,
-  "installedAt": "2026-04-10T12:04:11Z",
-  "updatedAt": "2026-04-19T08:22:40Z"
-}
-```
+For MCP installs, HTTP transports are added as gateway remote URLs after SSRF
+validation. Stdio packages become command configs. Required environment values
+must be supplied through `env_values` or an explicit env-var reference such as
+`bearer_token_env`; raw bearer token values must not be embedded in logs or docs.
 
-`tags` is a deduplicated merge of the plugin's `category` (prepended when present), `tags`, and `keywords` arrays from `marketplace.json`.
+## Bounded Discovery
 
-### `Artifact` (from `plugin.artifacts`)
+`mcp.list` is intentionally bounded:
 
-```json
-{
-  "path": "skills/foo/SKILL.md",
-  "lang": "markdown",
-  "content": "# Foo skill\n..."
-}
-```
+- default `limit` is 10
+- maximum `limit` is 100
+- pagination uses the returned `metadata.nextCursor`
+- `search` wins over `owner` when both are supplied
+- `owner` is a GitHub convenience filter that maps to `search=io.github.{owner}/`
+- local Lab metadata filters include `featured`, `reviewed`, `recommended`,
+  `hidden`, and `tag`
 
-`lang` is inferred from the file extension: `json`, `yaml`, `markdown`, `bash`, `toml`, or `text`. The walker:
+`mcp.list` on `/v1/marketplace` reads the local SQLite mirror populated by
+`mcp.sync`. The wire-compatible `GET /v0.1/servers` surface reads the same
+store and defaults to 20 rows per page for REST clients.
 
-- skips dotfiles, `node_modules`, and `target`
-- skips files larger than 256 KiB
-- caps output at 200 files per plugin
-- returns paths relative to the plugin's install path
+`gateway.mcp.list` is a separate gateway runtime inventory action. It lists
+configured upstream MCP runtime state, discovery counts, and likely stale
+process counts; it is not a Marketplace registry search API and should remain
+read-only and non-destructive in the generated catalog.
 
-### `PluginWorkspace` (from `plugin.workspace`)
+## Confirmation
 
-```json
-{
-  "pluginId": "aurora-design@jmagar-lab",
-  "workspaceRoot": "/Users/jmagar/.lab/stash/plugins/aurora-design-jmagar-lab",
-  "deployTarget": "/Users/jmagar/.claude/skills/aurora-design",
-  "hasDirtyFiles": false,
-  "files": [
-    {
-      "path": "SKILL.md",
-      "lang": "markdown",
-      "content": "---\nname: aurora-design\n..."
-    }
-  ]
-}
-```
+`ActionSpec.destructive` is the single source of truth for Marketplace
+confirmation behavior.
 
-The workspace mirror is created under `<workspace.root>/plugins/` on first load from the marketplace source tree and preserved separately from the installed Claude Code target. By default `workspace.root` is `~/.lab/stash`, and it also backs the read-only attachment picker. Legacy mirrors under `~/.claude/plugins/workspaces/` are migrated to `<workspace.root>/plugins/` on first access when the new mirror does not already exist.
-
-### `SaveResult` (from `plugin.save`)
-
-```json
-{
-  "pluginId": "aurora-design@jmagar-lab",
-  "path": "SKILL.md",
-  "savedAt": "2026-04-23T03:11:29.000Z"
-}
-```
-
-### `DeployPreviewResult` (from `plugin.deploy.preview`)
-
-```json
-{
-  "pluginId": "aurora-design@jmagar-lab",
-  "targetPath": "/Users/jmagar/.claude/skills/aurora-design",
-  "changed": ["SKILL.md"],
-  "skipped": [],
-  "removed": ["old.txt"],
-  "failed": []
-}
-```
-
-### `DeployResult` (from `plugin.deploy`)
-
-```json
-{
-  "pluginId": "aurora-design@jmagar-lab",
-  "targetPath": "/Users/jmagar/.claude/skills/aurora-design",
-  "changed": ["SKILL.md"],
-  "skipped": [],
-  "removed": ["old.txt"],
-  "failed": []
-}
-```
-
-### Shell wrappers (`sources.add`, `plugin.install`, `plugin.uninstall`)
-
-```json
-{ "ok": true, "id": "foo@bar", "stdout": "...", "stderr": "..." }
-```
-
-A non-zero exit from `claude plugin …` becomes a `server_error` envelope with the captured `stderr` in the message.
-
-## Error Envelopes
-
-`marketplace` returns the canonical `ToolError` kinds from `docs/ERRORS.md`:
-
-| Kind | When |
+| Surface | Required confirmation |
 | --- | --- |
-| `unknown_action` | Action name not in the catalog |
-| `missing_param` | Required param absent (e.g., `id` for `plugin.get`) |
-| `invalid_param` | Malformed input (e.g., `id` without `@`, both `repo` and `url` supplied) |
-| `not_found` | Plugin id not present in any manifest, or `plugin.artifacts` called on an uninstalled plugin |
-| `decode_error` | JSON parse failure on a plugin registry file |
-| `internal_error` | `HOME` unset, filesystem I/O error, `claude` binary not spawnable |
-| `server_error` | `claude plugin …` exited non-zero |
-| `confirmation_required` | Destructive action without `confirm: true` / `-y` / elicitation accept |
+| CLI | `-y` / `--yes` for destructive actions. |
+| MCP | Client elicitation accept, or `params.confirm: true` for clients without elicitation. |
+| HTTP | `params.confirm: true`; missing or false confirmation returns `kind: "confirmation_required"` with HTTP `422`. |
 
-## CLI Surface
+The confirmation flag is handled by the shared dispatcher before Marketplace
+domain parsers run. Do not duplicate confirmation checks inside action-specific
+parsers unless a protocol-specific exception is documented.
+
+## Integrity And Safety
+
+Marketplace install paths are intentionally narrow:
+
+- observational plugin actions read from `~/.claude/plugins/` and installed
+  plugin paths recorded by Claude/Codex
+- workspace mirrors live under the configured Lab stash root, defaulting to
+  `~/.lab/stash/plugins/`
+- ACP binaries install under `~/.lab/bin/<agent_id>/`
+- ACP provider config writes go to `~/.lab/acp-providers.json`
+
+Binary and package integrity policy:
+
+- ACP binary archive URLs must be HTTPS and must not point at loopback, private,
+  link-local, unspecified, or common local-only hostnames.
+- Archive downloads are streamed to a temp file, hashed with SHA-256, fsynced,
+  extracted into a temp dir, then copied into the final install directory.
+- Extraction rejects symlinks and entries that escape the extraction root, and
+  treats partial extraction as a hard failure.
+- Installed ACP binary entries record the computed SHA-256 in the provider
+  entry.
+- Stdio package distributions (`npx`, `uvx`, MCP Registry package configs) are
+  config-only installs. Marketplace records command/package metadata; package
+  manager resolution happens when the client runs the command.
+- Claude/Codex plugin install/uninstall still delegates to the `claude` binary
+  with explicit argv and no shell interpolation.
+
+`plugin.artifacts` is bounded to 256 KiB per file and 200 files per plugin.
+Large plugins must return truncated artifact output rather than multi-MB MCP or
+HTTP responses.
+
+## Surfaces
+
+CLI:
 
 ```bash
-labby marketplace sources.list                    # default human table
-labby marketplace sources.list --json             # machine-readable
+labby marketplace sources.list --json
 labby marketplace plugins.list --params '{"marketplace":"jmagar-lab"}'
-labby marketplace plugin.get   --params '{"id":"aurora-design@jmagar-lab"}'
-labby marketplace plugin.artifacts --params '{"id":"aurora-design@jmagar-lab"}'
-
-labby marketplace sources.add      --params '{"repo":"obra/superpowers-marketplace"}' -y
-labby marketplace plugin.install   --params '{"id":"aurora-design@jmagar-lab"}' -y
-labby marketplace plugin.uninstall --params '{"id":"aurora-design@jmagar-lab"}' -y
+labby marketplace mcp.list --params '{"search":"postgres","limit":10}'
+labby marketplace agent.list
+labby marketplace mcp.install --params '{"name":"io.github.user/server","gateway_ids":["default"],"confirm":true}' -y
 ```
 
-Destructive actions require `-y` / `--yes` (or `--no-confirm`) to run non-interactively. `--dry-run` prints what would be dispatched without touching `~/.claude/`.
-
-## MCP Surface
-
-One tool, `marketplace`, accepting the standard `{ action, params }` envelope:
+MCP:
 
 ```jsonc
-marketplace({ "action": "sources.list" })
-marketplace({ "action": "plugins.list", "params": { "marketplace": "jmagar-lab" } })
-marketplace({ "action": "plugin.get",   "params": { "id": "aurora-design@jmagar-lab" } })
-
-// destructive — clients with elicitation get a confirm prompt;
-// clients without elicitation must pass confirm: true explicitly.
-marketplace({ "action": "plugin.install",
-              "params": { "id": "aurora-design@jmagar-lab", "confirm": true } })
+marketplace({ "action": "mcp.list", "params": { "owner": "modelcontextprotocol", "limit": 10 } })
+marketplace({ "action": "agent.get", "params": { "id": "openai/codex-cli" } })
+marketplace({ "action": "plugin.install", "params": { "id": "aurora-design@jmagar-lab", "confirm": true } })
 ```
 
-Discovery resources:
-
-- `lab://marketplace/actions` — action catalog
-- `lab://catalog` — includes `marketplace` alongside every other service
-
-## HTTP API Surface
-
-Route group: `/v1/marketplace` (bearer auth required).
+HTTP:
 
 ```bash
-# List marketplaces
 curl -s -X POST http://127.0.0.1:8765/v1/marketplace \
   -H "Authorization: Bearer $LAB_MCP_HTTP_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"action":"sources.list"}'
-
-# Install a plugin (destructive — must confirm)
-curl -s -X POST http://127.0.0.1:8765/v1/marketplace \
-  -H "Authorization: Bearer $LAB_MCP_HTTP_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"action":"plugin.install","params":{"id":"aurora-design@jmagar-lab","confirm":true}}'
+  -d '{"action":"mcp.list","params":{"search":"postgres","limit":10}}'
 ```
 
-Status mapping follows `docs/ERRORS.md`: `not_found` → 404, `invalid_param`/`missing_param` → 422, `confirmation_required` → 400, `server_error` → 502.
-
-## Web UI
-
-The gateway admin UI at `/marketplace` consumes the HTTP API and presents:
-
-- the nine (or however many are configured) marketplaces as cards with owner, plugin count, and description
-- every plugin across every marketplace with installed badges
-- an "Add marketplace" flow that calls `sources.add`
-- a dedicated plugin detail route at `/marketplace/plugin?id=<pluginId>`
-- an editable `Files` tab backed by a workspace mirror, explicit `Save`, deploy preview, and explicit `Deploy`
-- install / uninstall buttons gated behind the shared destructive confirmation flow
-
-The frontend never talks to `~/.claude/` directly — every read and write goes through `/v1/marketplace`.
-
-Deploy preview and deploy use a cheap-first sync model:
-- file metadata is checked before file contents are read
-- unchanged files are short-circuited without a full content read
-- only potentially changed files are compared more deeply
-- this keeps large plugin workspaces responsive while preserving explicit `Save` and `Deploy` semantics
-
-## Safety
-
-- No action reads or writes anywhere outside `~/.claude/plugins/` for the observational commands.
-- Destructive actions delegate to the `claude` CLI binary; `lab` captures stdout/stderr but does not modify the plugin registry itself.
-- `plugin.artifacts` enforces a 256 KiB per-file cap and 200-file ceiling to keep responses bounded — large plugins return a truncated artifact list rather than a multi-MB payload.
-- Spawning the `claude` binary happens via `tokio::process::Command` with explicit argv (no shell interpolation); plugin ids and repo slugs are never passed through a shell.
+The web UI consumes `/v1/marketplace`; it must not read or write `~/.claude/`,
+`~/.lab/bin/`, or `~/.lab/acp-providers.json` directly.

--- a/docs/services/MARKETPLACE.md
+++ b/docs/services/MARKETPLACE.md
@@ -57,8 +57,8 @@ The handwritten contract is organized by action family:
 | `plugins.*` | `plugins.list` | Search plugin manifests across configured plugin marketplaces. |
 | `plugin.*` | `plugin.get`, `plugin.install`, `plugin.workspace`, `plugin.deploy` | Read, install, edit, and deploy whole plugins. |
 | `artifact.*` | `artifact.fork`, `artifact.diff`, `artifact.update.apply` | Fork, patch, diff, reset, and update individual plugin artifacts. |
-| `mcp.*` | `mcp.list`, `mcp.install`, `mcp.sync` | Discover, validate, mirror, install, and remove MCP Registry servers. |
-| `agent.*` | `agent.list`, `agent.install`, `agent.uninstall` | Discover and install ACP-compatible agents. |
+| `mcp.*` | `mcp.config`, `mcp.list`, `mcp.get`, `mcp.versions`, `mcp.validate`, `mcp.meta.get`, `mcp.meta.set`, `mcp.meta.delete`, `mcp.sync`, `mcp.install`, `mcp.uninstall` | Discover, validate, mirror, annotate, install, and remove MCP Registry servers. |
+| `agent.*` | `agent.list`, `agent.get`, `agent.install`, `agent.uninstall` | Discover and install ACP-compatible agents. |
 
 `help` and `schema` are also available through the shared service dispatch
 model.

--- a/docs/upstream-api/acp-registry.md
+++ b/docs/upstream-api/acp-registry.md
@@ -1,27 +1,110 @@
 # ACP Registry Upstream Contract
 
-**Last updated:** 2026-05-01
-**Status:** SDK metadata exists; runtime service not yet exposed
+**Last updated:** 2026-05-07
+**Status:** SDK client exists; runtime exposure is through Marketplace `agent.*`
 
-The `acp_registry` module represents an ACP registry-compatible upstream. The
-current repository state only defines the feature gate and service metadata; no
-runtime dispatch surface is wired.
+The ACP Agent Registry is a read-only CDN manifest used to discover
+ACP-compatible coding agents. Lab keeps the upstream SDK in
+`lab-apis::acp_registry`, but the public CLI/MCP/API surface is the always-on
+`marketplace` service.
 
 ## Source
 
-The configured upstream base URL is read from:
+Marketplace resolves the runtime base URL from:
 
 ```env
-ACP_REGISTRY_URL=https://example.invalid
+LAB_ACP_REGISTRY_URL=https://cdn.agentclientprotocol.com
 ```
 
-## Current Lab Contract
+If unset, Marketplace falls back to the SDK default:
 
-- `lab-apis` feature: `acp_registry`
-- required env: none
-- optional env: `ACP_REGISTRY_URL`
-- CLI/MCP/API exposure: none
+```text
+https://cdn.agentclientprotocol.com
+```
 
-Before adding a public surface, create a concrete endpoint inventory here and
-mirror it in [../coverage/acp_registry.md](../coverage/acp_registry.md).
+The SDK metadata still lists `ACP_REGISTRY_URL` for the SDK-only
+`acp_registry` service entry. Do not document `ACP_REGISTRY_URL` as the
+Marketplace runtime override; use `LAB_ACP_REGISTRY_URL` for `agent.*`.
 
+## Upstream Shape
+
+The SDK fetches:
+
+```text
+GET /registry/v1/latest/registry.json
+```
+
+The response is a registry wrapper containing `agents[]`. Marketplace currently
+filters that full manifest client-side for `agent.get`.
+
+All reads are unauthenticated. The HTTP client uses bounded timeouts and does
+not follow redirects.
+
+## Lab Runtime Surface
+
+Runtime actions live under the single Marketplace tool/service:
+
+| Action | Destructive | Return | Notes |
+| --- | --- | --- | --- |
+| `agent.list` | No | `Agent[]` | Lists all registry agents. |
+| `agent.get` | No | `Agent` | Requires `id`, for example `openai/codex-cli`. |
+| `agent.install` | Yes | `InstallResults` | Requires `id`, `node_ids`, and confirmation. |
+| `agent.uninstall` | Yes | `UninstallResult` | Requires `id` and confirmation. |
+
+The generated service catalog must continue to show:
+
+- `marketplace`: `available`, exposed on CLI/MCP/API/web
+- `acp_registry`: `sdk_only`, no CLI/MCP/API/web exposure
+
+## Install Contract
+
+`agent.install` writes provider configuration, not arbitrary agent state:
+
+- local target: `node_ids` may contain `local` or the controller hostname
+- local binary target: install under `~/.lab/bin/<agent_id>/`, write an entry to
+  `~/.lab/acp-providers.json`, and record the computed SHA-256
+- local `npx` / `uvx` target: write command, args, distribution, and version
+  metadata to `~/.lab/acp-providers.json`
+- remote target: send a fleet RPC `agent.install`; remote binary and `uvx`
+  installs are not supported yet and return structured per-node errors
+
+`agent.uninstall` removes the local provider entry from
+`~/.lab/acp-providers.json`.
+
+## Confirmation And Errors
+
+Destructive `agent.*` actions use the shared Lab confirmation gate:
+
+- CLI requires `-y` / `--yes`
+- MCP uses elicitation or `params.confirm: true`
+- HTTP requires `params.confirm: true`; missing or false confirmation returns
+  `kind: "confirmation_required"` with HTTP `422`
+
+SDK and dispatch errors use the canonical envelope from `docs/dev/ERRORS.md`.
+Registry misses return `not_found`; malformed input returns `invalid_param` or
+`missing_param`; unsupported distribution/target combinations return a
+structured SDK-style error kind.
+
+## Binary And Package Integrity
+
+Binary distribution installs are allowed only after hardening checks:
+
+- archive URL must use HTTPS
+- loopback, private, link-local, unspecified, and common local-only hostnames
+  are rejected
+- redirects are not followed
+- downloads stream to a temp archive, are hashed with SHA-256, flushed and
+  fsynced, then extracted into a temp directory
+- extraction rejects symlinks, path escapes, and partial extraction
+- installed binary permissions are set explicitly to `0755` on Unix
+
+Package distributions (`npx`, `uvx`) are config-only provider entries. Lab
+records the package command and argv; the package manager resolves and verifies
+the package according to its own rules when the agent command runs.
+
+## Documentation Ownership
+
+This file documents the upstream ACP registry and its Marketplace projection.
+The broader unified Marketplace contract lives in
+[../services/MARKETPLACE.md](../services/MARKETPLACE.md). Coverage status lives
+in [../coverage/acp_registry.md](../coverage/acp_registry.md).

--- a/scripts/check-registry-docs
+++ b/scripts/check-registry-docs
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+need() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+  if ! grep -Eq "$pattern" "$file"; then
+    printf 'registry-docs check failed: %s\n  file: %s\n  pattern: %s\n' "$message" "$file" "$pattern" >&2
+    exit 1
+  fi
+}
+
+jq -e '
+  any(.[]; .name == "marketplace" and .status == "available" and .surfaces.cli and .surfaces.mcp and .surfaces.api and .surfaces.web_ui)
+  and any(.[]; .name == "mcpregistry" and .status == "sdk_only" and (.surfaces.cli|not) and (.surfaces.mcp|not) and (.surfaces.api|not))
+  and any(.[]; .name == "acp_registry" and .status == "sdk_only" and (.surfaces.cli|not) and (.surfaces.mcp|not) and (.surfaces.api|not))
+' docs/generated/service-catalog.json >/dev/null
+
+for action in \
+  agent.list agent.install agent.uninstall \
+  mcp.list mcp.install mcp.uninstall mcp.sync \
+  plugin.install plugin.deploy artifact.update.apply sources.add
+do
+  jq -e --arg action "$action" 'any(.[]; .service == "marketplace" and .action == $action)' \
+    docs/generated/action-catalog.json >/dev/null
+  need docs/services/MARKETPLACE.md "(^|[^[:alnum:]_.-])${action//./\\.}([^[:alnum:]_.-]|$)" \
+    "Marketplace doc should mention generated action ${action}"
+done
+
+jq -e 'any(.[]; .service == "gateway" and .action == "gateway.mcp.list" and (.destructive | not))' \
+  docs/generated/action-catalog.json >/dev/null
+need docs/services/MARKETPLACE.md 'gateway\.mcp\.list' \
+  "Marketplace doc should distinguish gateway.mcp.list from registry search"
+
+need docs/services/MARKETPLACE.md 'LAB_ACP_REGISTRY_URL' \
+  "Marketplace doc should name the Marketplace ACP registry override"
+need docs/upstream-api/acp-registry.md 'LAB_ACP_REGISTRY_URL' \
+  "ACP registry upstream doc should name the Marketplace ACP registry override"
+need docs/services/MARKETPLACE.md 'confirmation_required.*422|422.*confirmation_required' \
+  "Marketplace doc should document HTTP 422 confirmation_required"
+need docs/upstream-api/acp-registry.md 'confirmation_required.*422|422.*confirmation_required' \
+  "ACP registry upstream doc should document HTTP 422 confirmation_required"
+need docs/services/MARKETPLACE.md 'maximum `limit` is 100|max: 100' \
+  "Marketplace doc should document bounded mcp.list limits"
+need docs/services/MARKETPLACE.md 'SHA-256|fsync|HTTPS' \
+  "Marketplace doc should document binary/package integrity policy"
+
+printf 'registry-docs check passed\n'

--- a/scripts/check-registry-docs
+++ b/scripts/check-registry-docs
@@ -20,9 +20,12 @@ jq -e '
   and any(.[]; .name == "acp_registry" and .status == "sdk_only" and (.surfaces.cli|not) and (.surfaces.mcp|not) and (.surfaces.api|not))
 ' docs/generated/service-catalog.json >/dev/null
 
-for action in \
-  agent.list agent.install agent.uninstall \
-  mcp.list mcp.install mcp.uninstall mcp.sync \
+mapfile -t registry_actions < <(
+  jq -r '.[] | select(.service == "marketplace" and ((.action | startswith("agent.")) or (.action | startswith("mcp.")))) | .action' \
+    docs/generated/action-catalog.json | sort -u
+)
+
+for action in "${registry_actions[@]}" \
   plugin.install plugin.deploy artifact.update.apply sources.add
 do
   jq -e --arg action "$action" 'any(.[]; .service == "marketplace" and .action == $action)' \


### PR DESCRIPTION
## Summary

- **lab-c9kn**: Guard `listMcpServers()` against non-advancing cursors. Adds `seenCursors: Set<string>` that throws `pagination_cursor_stalled` (502) on cursor re-use, an empty-page-with-nextCursor guard (`pagination_empty_page`), and a `MCP_LIST_MAX_PAGES = 100` page cap (`pagination_limit_exceeded`). `AbortSignal` forwarded to every page request.
- **lab-tqje**: `#[cfg(feature = "acp_registry")]` gates on the four `acp_dispatch` tests that reference `BinaryAsset`, `expected_archive_sha256`, `verify_archive_sha256`, and `install_executable_atomically`. Reduced feature slice compiles and passes; all-features slice passes with 4 extra tests.

## Test plan

- [ ] `tsx --test apps/gateway-admin/lib/marketplace/api-client.test.ts` — 6 tests pass (repeated cursor, empty-page-with-cursor, multi-page happy path, AbortSignal)
- [ ] `cargo test --manifest-path crates/lab/Cargo.toml --no-default-features --features marketplace,gateway,extract acp_dispatch --lib -j1` — 9 tests pass
- [ ] `cargo test --manifest-path crates/lab/Cargo.toml --all-features acp_dispatch --lib` — 13 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Marketplace MCP pagination and ACP binary installs, and routed the admin registry client through `/v0.1` REST and `/v1/marketplace`. `mcp.list` now reads from the local mirror and always returns a bounded page with metadata.

- **Bug Fixes**
  - Guard `listMcpServers` pagination: detect stalled cursors, empty pages with a `nextCursor`, cap at 10,000 pages, and propagate `AbortSignal`.
  - Surface failed installs: `installServer` throws `install_failed` when any gateway target reports `ok: false`.
  - Correct error mapping: map `integrity_missing` to 502; use `content_too_large` (413) for oversized archives; gate ACP archive tests behind `acp_registry`.
  - Cleanup: removed a dead `open_archive_response` helper left after a rebase.

- **New Features**
  - ACP binaries: require SHA‑256 metadata, verify after download, HTTPS-only, block local/private hosts, pin DNS, disable proxies, cap archives at 256 MiB, clean partials, and install atomically.
  - Admin registry client: replaced `/v1/mcpregistry` with `/v1/marketplace` actions and `/v0.1` REST for server/version reads; return per‑gateway results for `mcp.install`; added `listMcpServersPage` with `count`/`nextCursor`.
  - Docs: updated Marketplace and ACP registry pages for local‑mirror, bounded `mcp.list`, and binary/package integrity; added `scripts/check-registry-docs` to enforce coverage.

<sup>Written for commit 00b9fc90168dbf18668b3c872403b4e2218a82a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Paginated MCP server listing with cursor-based navigation
  - Per-gateway server installation status with detailed results

* **Improvements**
  - Hardened binary archive handling: HTTPS-only, host/IP validation, 256 MiB cap, SHA-256 verification
  - Atomic executable replacement for safer installs
  - Stronger pagination and registry REST usage with clearer failure modes

* **Tests**
  - Expanded test coverage for registry, marketplace pagination, install flows, and integrity/SSRF cases

* **Documentation**
  - Updated marketplace/registry and errors docs; added registry-docs validation script

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/lab/pull/58)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->