### PR TITLE
feat(gateway): expose lab://gateway/* synthetic MCP resources

### DIFF
--- a/crates/lab/src/dispatch/gateway/catalog.rs
+++ b/crates/lab/src/dispatch/gateway/catalog.rs
@@ -594,6 +594,27 @@ pub const ACTIONS: &[ActionSpec] = &[
         params: &[NAME_PARAM],
     },
     ActionSpec {
+        name: "gateway.servers",
+        description: "List upstream MCP servers connected to the gateway, with cached \
+                       tool/prompt/resource counts and tools-capability health.",
+        destructive: false,
+        returns: "GatewayServersDoc",
+        params: &[],
+    },
+    ActionSpec {
+        name: "gateway.schema",
+        description: "Return the cached tool schemas (input_schema + meta) for one upstream \
+                       MCP server, filtered by its exposure policy.",
+        destructive: false,
+        returns: "GatewayServerSchema",
+        params: &[ParamSpec {
+            name: "name",
+            ty: "string",
+            required: true,
+            description: "Upstream server name (as listed by gateway.servers).",
+        }],
+    },
+    ActionSpec {
         name: "gateway.oauth.probe",
         description: "Probe a URL for OAuth support via RFC 8414 AS metadata discovery. \
                        Rejects userinfo, query strings, and fragments. Registers a transient \

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -857,7 +857,10 @@ mod tests {
             .await
             .expect_err("no pool configured");
         let body = serde_json::to_value(&err).expect("serialize");
-        assert_eq!(body["kind"], "not_found", "sdk_kind must be promoted to kind");
+        assert_eq!(
+            body["kind"], "not_found",
+            "sdk_kind must be promoted to kind"
+        );
     }
 
     #[tokio::test]
@@ -878,7 +881,10 @@ mod tests {
             .await
             .expect_err("no pool configured");
         let body = serde_json::to_value(&err).expect("serialize");
-        assert_eq!(body["kind"], "not_found", "sdk_kind must be promoted to kind");
+        assert_eq!(
+            body["kind"], "not_found",
+            "sdk_kind must be promoted to kind"
+        );
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -871,6 +871,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_schema_unknown_upstream_returns_not_found_envelope() {
+        let manager = test_manager();
+        let err = dispatch_with_manager(&manager, "gateway.schema", json!({"name": "nope"}))
+            .await
+            .expect_err("no pool configured");
+        let body = serde_json::to_value(&err).expect("serialize");
+        assert_eq!(body["kind"], "not_found", "sdk_kind must be promoted to kind");
+    }
+
+    #[tokio::test]
     async fn gateway_dispatch_rejects_synthetic_tool_execution_actions() {
         let manager = test_manager();
 

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -59,6 +59,11 @@ pub async fn dispatch_with_manager(
         | "gateway.import_tombstones.restore" => {
             handle_import_tombstone_actions(manager, action, params_value).await
         }
+        "gateway.servers" => to_json(manager.gateway_servers_doc().await?),
+        "gateway.schema" => {
+            let name = require_str(&params_value, "name")?;
+            to_json(manager.gateway_server_schema(&name).await?)
+        }
         "gateway.list"
         | "gateway.server.get"
         | "gateway.supported_services"
@@ -826,10 +831,43 @@ mod tests {
         }
     }
 
+    #[test]
+    fn gateway_actions_include_servers_and_schema() {
+        let names: Vec<&str> = ACTIONS.iter().map(|a| a.name).collect();
+        assert!(
+            names.contains(&"gateway.servers"),
+            "missing gateway.servers; have {names:?}"
+        );
+        assert!(
+            names.contains(&"gateway.schema"),
+            "missing gateway.schema; have {names:?}"
+        );
+    }
+
     fn test_manager() -> GatewayManager {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
         GatewayManager::new(path, GatewayRuntimeHandle::default())
+    }
+
+    #[tokio::test]
+    async fn gateway_servers_action_returns_empty_when_no_pool() {
+        let manager = test_manager();
+        let result = dispatch_with_manager(&manager, "gateway.servers", json!({}))
+            .await
+            .expect("dispatch ok");
+        assert_eq!(result["servers"].as_array().map(|a| a.len()), Some(0));
+    }
+
+    #[tokio::test]
+    async fn gateway_schema_missing_name_returns_missing_param() {
+        let manager = test_manager();
+        let err = dispatch_with_manager(&manager, "gateway.schema", json!({}))
+            .await
+            .expect_err("missing name");
+        let body = serde_json::to_value(&err).expect("serialize");
+        assert_eq!(body["kind"], "missing_param");
+        assert_eq!(body["param"], "name");
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -851,12 +851,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gateway_servers_action_returns_empty_when_no_pool() {
+    async fn gateway_servers_action_returns_not_found_when_no_pool() {
         let manager = test_manager();
-        let result = dispatch_with_manager(&manager, "gateway.servers", json!({}))
+        let err = dispatch_with_manager(&manager, "gateway.servers", json!({}))
             .await
-            .expect("dispatch ok");
-        assert_eq!(result["servers"].as_array().map(|a| a.len()), Some(0));
+            .expect_err("no pool configured");
+        let body = serde_json::to_value(&err).expect("serialize");
+        assert_eq!(body["kind"], "not_found", "sdk_kind must be promoted to kind");
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -2021,7 +2021,10 @@ impl GatewayManager {
 
     pub async fn gateway_servers_doc(&self) -> Result<serde_json::Value, ToolError> {
         let Some(pool) = self.runtime.current_pool().await else {
-            return Ok(serde_json::json!({ "servers": [] }));
+            return Err(ToolError::Sdk {
+                sdk_kind: "not_found".to_string(),
+                message: "upstream pool not configured".to_string(),
+            });
         };
         Ok(pool.gateway_servers_doc().await)
     }

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -2019,6 +2019,28 @@ impl GatewayManager {
         Ok(prompts)
     }
 
+    pub async fn gateway_servers_doc(&self) -> Result<serde_json::Value, ToolError> {
+        let Some(pool) = self.runtime.current_pool().await else {
+            return Ok(serde_json::json!({ "servers": [] }));
+        };
+        Ok(pool.gateway_servers_doc().await)
+    }
+
+    pub async fn gateway_server_schema(&self, name: &str) -> Result<serde_json::Value, ToolError> {
+        let Some(pool) = self.runtime.current_pool().await else {
+            return Err(ToolError::Sdk {
+                sdk_kind: "not_found".to_string(),
+                message: "upstream pool not configured".to_string(),
+            });
+        };
+        pool.gateway_server_schema(name)
+            .await
+            .ok_or_else(|| ToolError::Sdk {
+                sdk_kind: "not_found".to_string(),
+                message: format!("unknown upstream: {name}"),
+            })
+    }
+
     pub async fn tool_search_enabled(&self) -> bool {
         self.config.read().await.tool_search.enabled
     }

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -12,8 +12,8 @@ use futures::StreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, GetPromptRequestParams, GetPromptResult, LoggingLevel,
-    Prompt, ReadResourceResult, Resource, ResourceContents,
+    AnnotateAble, CallToolRequestParams, CallToolResult, GetPromptRequestParams, GetPromptResult,
+    LoggingLevel, Prompt, RawResource, ReadResourceResult, Resource, ResourceContents,
 };
 use rmcp::transport::streamable_http_client::{
     StreamableHttpClientTransportConfig, StreamableHttpClientWorker,
@@ -2152,6 +2152,11 @@ impl UpstreamPool {
         self.catalog.write().await.insert(name.to_string(), entry);
     }
 
+    /// Test-only: insert a fully-formed `UpstreamEntry` into the catalog.
+    pub async fn insert_entry_for_test(&self, name: &str, entry: UpstreamEntry) {
+        self.catalog.write().await.insert(name.to_string(), entry);
+    }
+
     /// Check if an upstream capability is due for a re-probe.
     #[allow(clippy::significant_drop_tightening)]
     pub async fn should_reprobe(&self, upstream_name: &str) -> bool {
@@ -2212,6 +2217,90 @@ impl UpstreamPool {
             .values()
             .map(|e| (e.name.to_string(), e.tool_health))
             .collect()
+    }
+
+    /// Render the synthetic `lab://gateway/servers` document.
+    ///
+    /// Lists every registered upstream (regardless of health) with the
+    /// tool count an agent would see in the corresponding schema document.
+    pub async fn gateway_servers_doc(&self) -> Value {
+        let catalog = self.catalog.read().await;
+        let mut servers: Vec<Value> = catalog
+            .iter()
+            .map(|(name, e)| {
+                let tool_count = e
+                    .tools
+                    .values()
+                    .filter(|t| e.exposure_policy.matches(&t.tool.name))
+                    .count();
+                serde_json::json!({
+                    "name": name,
+                    "tool_count": tool_count,
+                    "prompt_count": e.prompt_count,
+                    "resource_count": e.resource_count,
+                    "tool_health": health_str(e.tool_health),
+                    "tool_last_error": e.tool_last_error,
+                })
+            })
+            .collect();
+        servers.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+        serde_json::json!({ "servers": servers })
+    }
+
+    /// Render the synthetic `lab://gateway/<name>/schema` document.
+    ///
+    /// Returns `None` when the upstream is not registered. Tools hidden by
+    /// the upstream's `ToolExposurePolicy` are omitted. `input_schema` and
+    /// `meta` are passed through verbatim from the cached tool definition.
+    pub async fn gateway_server_schema(&self, name: &str) -> Option<Value> {
+        let catalog = self.catalog.read().await;
+        let entry = catalog.get(name)?;
+        let mut tools: Vec<Value> = entry
+            .tools
+            .values()
+            .filter(|t| entry.exposure_policy.matches(&t.tool.name))
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.tool.name.as_ref(),
+                    "description": t.tool.description.as_ref().map(|s| s.as_ref()),
+                    "input_schema": t.input_schema,
+                    "meta": t.tool.meta,
+                })
+            })
+            .collect();
+        tools.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+        Some(serde_json::json!({
+            "name": name,
+            "tools": tools,
+            "health": health_str(entry.tool_health),
+            "last_error": entry.tool_last_error,
+        }))
+    }
+
+    /// Synthetic gateway resources to emit from `list_resources`.
+    ///
+    /// Returns one entry for `lab://gateway/servers` plus one
+    /// `lab://gateway/<name>/schema` entry per registered upstream.
+    pub async fn gateway_synthetic_resources(&self) -> Vec<Resource> {
+        let mut out = vec![RawResource::new("lab://gateway/servers", "gateway/servers")
+            .with_description("Index of upstream MCP servers connected to the gateway")
+            .with_mime_type("application/json")
+            .no_annotation()];
+        let catalog = self.catalog.read().await;
+        let mut names: Vec<&String> = catalog.keys().collect();
+        names.sort();
+        for name in names {
+            out.push(
+                RawResource::new(
+                    format!("lab://gateway/{name}/schema"),
+                    format!("gateway/{name}/schema"),
+                )
+                .with_description(format!("Tool schemas for upstream `{name}`"))
+                .with_mime_type("application/json")
+                .no_annotation(),
+            );
+        }
+        out
     }
 
     /// List resources from all resource-proxy-enabled upstreams.
@@ -3393,6 +3482,18 @@ async fn connect_in_process_service_peer(
         },
         tools,
     ))
+}
+
+fn health_str(health: UpstreamHealth) -> &'static str {
+    match health {
+        UpstreamHealth::Healthy => "healthy",
+        UpstreamHealth::Unhealthy { consecutive_failures }
+            if consecutive_failures >= types::CIRCUIT_BREAKER_THRESHOLD =>
+        {
+            "open"
+        }
+        UpstreamHealth::Unhealthy { .. } => "degraded",
+    }
 }
 
 fn healthy_in_process_entry(name: Arc<str>, tools: HashMap<String, UpstreamTool>) -> UpstreamEntry {
@@ -4822,5 +4923,97 @@ mod tests {
                 "missing upstream pool observability field `{expected}`"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn gateway_servers_doc_lists_one_healthy_upstream() {
+        use std::borrow::Cow;
+        use std::sync::Arc;
+
+        let pool = UpstreamPool::new();
+        let mut tools = HashMap::new();
+        tools.insert(
+            "search".to_string(),
+            UpstreamTool {
+                tool: rmcp::model::Tool::new(
+                    "search",
+                    "search the index",
+                    Arc::new(serde_json::Map::new()),
+                ),
+                input_schema: Some(serde_json::json!({"type": "object"})),
+                upstream_name: Arc::from("alpha"),
+            },
+        );
+        let entry = healthy_in_process_entry(Arc::from("alpha"), tools);
+        pool.catalog.write().await.insert("alpha".to_string(), entry);
+
+        let doc = pool.gateway_servers_doc().await;
+        let servers = doc.get("servers").and_then(|v| v.as_array()).expect("servers array");
+        assert_eq!(servers.len(), 1);
+        let s = &servers[0];
+        assert_eq!(s["name"], "alpha");
+        assert_eq!(s["tool_count"], 1);
+        assert_eq!(s["tool_health"], "healthy");
+        assert!(s["tool_last_error"].is_null());
+        assert_eq!(s["prompt_count"], 0);
+        assert_eq!(s["resource_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn gateway_server_schema_respects_exposure_policy() {
+        use std::sync::Arc;
+
+        let make_tool = |name: &'static str| UpstreamTool {
+            tool: rmcp::model::Tool::new(name, "desc", Arc::new(serde_json::Map::new())),
+            input_schema: Some(serde_json::json!({"type": "object"})),
+            upstream_name: Arc::from("alpha"),
+        };
+
+        let mut tools = HashMap::new();
+        tools.insert("github_create".into(), make_tool("github_create"));
+        tools.insert("delete_repo".into(), make_tool("delete_repo"));
+
+        let mut entry = healthy_in_process_entry(Arc::from("alpha"), tools);
+        entry.exposure_policy =
+            ToolExposurePolicy::from_patterns(vec!["github_*".into()]).expect("policy");
+
+        let pool = UpstreamPool::new();
+        pool.catalog.write().await.insert("alpha".to_string(), entry);
+
+        let doc = pool.gateway_server_schema("alpha").await.expect("doc");
+        let names: Vec<&str> = doc["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|t| t["name"].as_str().expect("name"))
+            .collect();
+        assert_eq!(names, vec!["github_create"]);
+        assert_eq!(doc["health"], "healthy");
+        assert!(doc["last_error"].is_null());
+        assert_eq!(doc["name"], "alpha");
+    }
+
+    #[tokio::test]
+    async fn gateway_server_schema_unknown_upstream_returns_none() {
+        let pool = UpstreamPool::new();
+        assert!(pool.gateway_server_schema("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn gateway_synthetic_resources_lists_index_and_per_upstream() {
+        use std::sync::Arc;
+
+        let pool = UpstreamPool::new();
+        let entry = healthy_in_process_entry(Arc::from("alpha"), HashMap::new());
+        pool.catalog.write().await.insert("alpha".to_string(), entry);
+        let entry = healthy_in_process_entry(Arc::from("beta"), HashMap::new());
+        pool.catalog.write().await.insert("beta".to_string(), entry);
+
+        let resources = pool.gateway_synthetic_resources().await;
+        let uris: Vec<String> = resources.iter().map(|r| r.uri.clone()).collect();
+        assert!(uris.iter().any(|u| u == "lab://gateway/servers"));
+        assert!(uris.iter().any(|u| u == "lab://gateway/alpha/schema"));
+        assert!(uris.iter().any(|u| u == "lab://gateway/beta/schema"));
+        assert_eq!(uris.len(), 3);
     }
 }

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -2282,10 +2282,12 @@ impl UpstreamPool {
     /// Returns one entry for `lab://gateway/servers` plus one
     /// `lab://gateway/<name>/schema` entry per registered upstream.
     pub async fn gateway_synthetic_resources(&self) -> Vec<Resource> {
-        let mut out = vec![RawResource::new("lab://gateway/servers", "gateway/servers")
-            .with_description("Index of upstream MCP servers connected to the gateway")
-            .with_mime_type("application/json")
-            .no_annotation()];
+        let mut out = vec![
+            RawResource::new("lab://gateway/servers", "gateway/servers")
+                .with_description("Index of upstream MCP servers connected to the gateway")
+                .with_mime_type("application/json")
+                .no_annotation(),
+        ];
         let catalog = self.catalog.read().await;
         let mut names: Vec<&String> = catalog.keys().collect();
         names.sort();
@@ -3487,11 +3489,9 @@ async fn connect_in_process_service_peer(
 fn health_str(health: UpstreamHealth) -> &'static str {
     match health {
         UpstreamHealth::Healthy => "healthy",
-        UpstreamHealth::Unhealthy { consecutive_failures }
-            if consecutive_failures >= types::CIRCUIT_BREAKER_THRESHOLD =>
-        {
-            "open"
-        }
+        UpstreamHealth::Unhealthy {
+            consecutive_failures,
+        } if consecutive_failures >= types::CIRCUIT_BREAKER_THRESHOLD => "open",
         UpstreamHealth::Unhealthy { .. } => "degraded",
     }
 }
@@ -4944,10 +4944,16 @@ mod tests {
             },
         );
         let entry = healthy_in_process_entry(Arc::from("alpha"), tools);
-        pool.catalog.write().await.insert("alpha".to_string(), entry);
+        pool.catalog
+            .write()
+            .await
+            .insert("alpha".to_string(), entry);
 
         let doc = pool.gateway_servers_doc().await;
-        let servers = doc.get("servers").and_then(|v| v.as_array()).expect("servers array");
+        let servers = doc
+            .get("servers")
+            .and_then(|v| v.as_array())
+            .expect("servers array");
         assert_eq!(servers.len(), 1);
         let s = &servers[0];
         assert_eq!(s["name"], "alpha");
@@ -4977,7 +4983,10 @@ mod tests {
             ToolExposurePolicy::from_patterns(vec!["github_*".into()]).expect("policy");
 
         let pool = UpstreamPool::new();
-        pool.catalog.write().await.insert("alpha".to_string(), entry);
+        pool.catalog
+            .write()
+            .await
+            .insert("alpha".to_string(), entry);
 
         let doc = pool.gateway_server_schema("alpha").await.expect("doc");
         let names: Vec<&str> = doc["tools"]
@@ -5004,7 +5013,10 @@ mod tests {
 
         let pool = UpstreamPool::new();
         let entry = healthy_in_process_entry(Arc::from("alpha"), HashMap::new());
-        pool.catalog.write().await.insert("alpha".to_string(), entry);
+        pool.catalog
+            .write()
+            .await
+            .insert("alpha".to_string(), entry);
         let entry = healthy_in_process_entry(Arc::from("beta"), HashMap::new());
         pool.catalog.write().await.insert("beta".to_string(), entry);
 

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -4927,7 +4927,6 @@ mod tests {
 
     #[tokio::test]
     async fn gateway_servers_doc_lists_one_healthy_upstream() {
-        use std::borrow::Cow;
         use std::sync::Arc;
 
         let pool = UpstreamPool::new();

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -648,8 +648,31 @@ impl ServerHandler for LabMcpServer {
                 "dispatch route selected"
             );
             let Some(pool) = self.current_upstream_pool().await else {
+                let elapsed_ms = start.elapsed().as_millis();
+                tracing::warn!(
+                    surface = "mcp",
+                    service = "labby",
+                    action = "read_resource",
+                    subject,
+                    resource_uri = uri.as_str(),
+                    route = "gateway",
+                    elapsed_ms,
+                    kind = "unavailable",
+                    "upstream pool not configured"
+                );
+                self.emit_dispatch_notification(
+                    &context,
+                    "lab",
+                    "read_resource",
+                    elapsed_ms,
+                    DispatchLogOutcome::Failure {
+                        level: LoggingLevel::Warning,
+                        kind: "unavailable",
+                    },
+                )
+                .await;
                 return Err(ErrorData::resource_not_found(
-                    format!("upstream pool not configured"),
+                    "upstream pool not configured".to_string(),
                     None,
                 ));
             };

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -643,7 +643,8 @@ impl ServerHandler for LabMcpServer {
                 service = "labby",
                 action = "read_resource",
                 subject,
-                resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
+                resource_uri =
+                    crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                 route = "gateway",
                 "dispatch route selected"
             );
@@ -654,7 +655,8 @@ impl ServerHandler for LabMcpServer {
                     service = "labby",
                     action = "read_resource",
                     subject,
-                    resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
+                    resource_uri =
+                        crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                     route = "gateway",
                     elapsed_ms,
                     kind = "unavailable",
@@ -714,7 +716,8 @@ impl ServerHandler for LabMcpServer {
                         service = "labby",
                         action = "read_resource",
                         subject,
-                        resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
+                        resource_uri =
+                            crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                         route = "gateway",
                         elapsed_ms,
                         "synthetic resource ok"
@@ -728,7 +731,8 @@ impl ServerHandler for LabMcpServer {
                     )
                     .await;
                     Ok(ReadResourceResult::new(vec![
-                        ResourceContents::text(text, uri.clone()).with_mime_type("application/json"),
+                        ResourceContents::text(text, uri.clone())
+                            .with_mime_type("application/json"),
                     ]))
                 }
                 None => {
@@ -737,7 +741,8 @@ impl ServerHandler for LabMcpServer {
                         service = "labby",
                         action = "read_resource",
                         subject,
-                        resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
+                        resource_uri =
+                            crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                         route = "gateway",
                         elapsed_ms,
                         kind = "not_found",

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -591,6 +591,7 @@ impl ServerHandler for LabMcpServer {
         }
 
         if let Some(pool) = self.current_upstream_pool().await {
+            resources.extend(pool.gateway_synthetic_resources().await);
             resources.extend(pool.list_upstream_resources().await);
             if let Some(subject) = self.request_subject(&context) {
                 let configs = self.oauth_upstream_configs().await;
@@ -635,6 +636,92 @@ impl ServerHandler for LabMcpServer {
             resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
             "dispatch start"
         );
+
+        if uri.starts_with("lab://gateway/") {
+            tracing::info!(
+                surface = "mcp",
+                service = "labby",
+                action = "read_resource",
+                subject,
+                resource_uri = uri.as_str(),
+                route = "gateway",
+                "dispatch route selected"
+            );
+            let Some(pool) = self.current_upstream_pool().await else {
+                return Err(ErrorData::resource_not_found(
+                    format!("upstream pool not configured"),
+                    None,
+                ));
+            };
+
+            let json = if uri == "lab://gateway/servers" {
+                Some(pool.gateway_servers_doc().await)
+            } else if let Some(name) = uri
+                .strip_prefix("lab://gateway/")
+                .and_then(|rest| rest.strip_suffix("/schema"))
+                .filter(|name| !name.is_empty() && !name.contains('/'))
+            {
+                pool.gateway_server_schema(name).await
+            } else {
+                None
+            };
+
+            let elapsed_ms = start.elapsed().as_millis();
+            return match json {
+                Some(value) => {
+                    let text = serde_json::to_string_pretty(&value).unwrap_or_default();
+                    tracing::info!(
+                        surface = "mcp",
+                        service = "labby",
+                        action = "read_resource",
+                        subject,
+                        resource_uri = uri.as_str(),
+                        route = "gateway",
+                        elapsed_ms,
+                        "synthetic resource ok"
+                    );
+                    self.emit_dispatch_notification(
+                        &context,
+                        "lab",
+                        "read_resource",
+                        elapsed_ms,
+                        DispatchLogOutcome::Success,
+                    )
+                    .await;
+                    Ok(ReadResourceResult::new(vec![
+                        ResourceContents::text(text, uri.clone()).with_mime_type("application/json"),
+                    ]))
+                }
+                None => {
+                    tracing::warn!(
+                        surface = "mcp",
+                        service = "labby",
+                        action = "read_resource",
+                        subject,
+                        resource_uri = uri.as_str(),
+                        route = "gateway",
+                        elapsed_ms,
+                        kind = "not_found",
+                        "synthetic resource not found"
+                    );
+                    self.emit_dispatch_notification(
+                        &context,
+                        "lab",
+                        "read_resource",
+                        elapsed_ms,
+                        DispatchLogOutcome::Failure {
+                            level: LoggingLevel::Warning,
+                            kind: "not_found",
+                        },
+                    )
+                    .await;
+                    Err(ErrorData::resource_not_found(
+                        format!("unknown resource: {uri}"),
+                        None,
+                    ))
+                }
+            };
+        }
 
         if let Some(pool) = self.current_upstream_pool().await
             && uri.starts_with("lab://upstream/")

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -643,7 +643,7 @@ impl ServerHandler for LabMcpServer {
                 service = "labby",
                 action = "read_resource",
                 subject,
-                resource_uri = uri.as_str(),
+                resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                 route = "gateway",
                 "dispatch route selected"
             );
@@ -654,7 +654,7 @@ impl ServerHandler for LabMcpServer {
                     service = "labby",
                     action = "read_resource",
                     subject,
-                    resource_uri = uri.as_str(),
+                    resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                     route = "gateway",
                     elapsed_ms,
                     kind = "unavailable",
@@ -692,13 +692,29 @@ impl ServerHandler for LabMcpServer {
             let elapsed_ms = start.elapsed().as_millis();
             return match json {
                 Some(value) => {
-                    let text = serde_json::to_string_pretty(&value).unwrap_or_default();
+                    let text = match serde_json::to_string_pretty(&value) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            tracing::error!(
+                                surface = "mcp",
+                                service = "labby",
+                                action = "read_resource",
+                                resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
+                                error = %e,
+                                "failed to serialize synthetic gateway resource"
+                            );
+                            return Err(ErrorData::internal_error(
+                                format!("failed to serialize resource: {e}"),
+                                None,
+                            ));
+                        }
+                    };
                     tracing::info!(
                         surface = "mcp",
                         service = "labby",
                         action = "read_resource",
                         subject,
-                        resource_uri = uri.as_str(),
+                        resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                         route = "gateway",
                         elapsed_ms,
                         "synthetic resource ok"
@@ -721,7 +737,7 @@ impl ServerHandler for LabMcpServer {
                         service = "labby",
                         action = "read_resource",
                         subject,
-                        resource_uri = uri.as_str(),
+                        resource_uri = crate::dispatch::upstream::pool::redact_resource_uri_for_logging(uri),
                         route = "gateway",
                         elapsed_ms,
                         kind = "not_found",

--- a/crates/lab/tests/gateway_schema_resources.rs
+++ b/crates/lab/tests/gateway_schema_resources.rs
@@ -1,0 +1,130 @@
+//! Architecture test: pins the `lab://gateway/*` URI scheme, the JSON
+//! shape of the synthetic documents, and exposure-policy filtering.
+//!
+//! Any change to a top-level key here is a contract change — update
+//! `docs/contracts/gateway-schema-resources.md` in the same PR.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use labby::dispatch::upstream::pool::UpstreamPool;
+use labby::dispatch::upstream::types::{
+    ToolExposurePolicy, UpstreamEntry, UpstreamHealth, UpstreamTool,
+};
+
+fn make_tool(name: &'static str, upstream: &str) -> UpstreamTool {
+    UpstreamTool {
+        tool: rmcp::model::Tool::new(name, "desc", Arc::new(serde_json::Map::new())),
+        input_schema: Some(json!({"type": "object", "properties": {}})),
+        upstream_name: Arc::from(upstream),
+    }
+}
+
+fn make_entry(name: &str, tools: Vec<UpstreamTool>, policy: ToolExposurePolicy) -> UpstreamEntry {
+    let mut map = HashMap::new();
+    for t in tools {
+        map.insert(t.tool.name.to_string(), t);
+    }
+    UpstreamEntry {
+        name: Arc::from(name),
+        tools: map,
+        exposure_policy: policy,
+        prompt_count: 0,
+        resource_count: 0,
+        prompt_names: Vec::new(),
+        resource_uris: Vec::new(),
+        tool_health: UpstreamHealth::Healthy,
+        prompt_health: UpstreamHealth::Healthy,
+        resource_health: UpstreamHealth::Healthy,
+        tool_unhealthy_since: None,
+        prompt_unhealthy_since: None,
+        resource_unhealthy_since: None,
+        tool_last_error: None,
+        prompt_last_error: None,
+        resource_last_error: None,
+    }
+}
+
+#[tokio::test]
+async fn gateway_servers_doc_shape_is_contract_stable() {
+    let pool = UpstreamPool::new();
+    pool.insert_entry_for_test(
+        "alpha",
+        make_entry(
+            "alpha",
+            vec![make_tool("search", "alpha")],
+            ToolExposurePolicy::All,
+        ),
+    )
+    .await;
+
+    let doc = pool.gateway_servers_doc().await;
+    let servers = doc["servers"].as_array().expect("servers array");
+    assert_eq!(servers.len(), 1);
+    let s = &servers[0];
+
+    for key in [
+        "name",
+        "tool_count",
+        "prompt_count",
+        "resource_count",
+        "tool_health",
+        "tool_last_error",
+    ] {
+        assert!(s.get(key).is_some(), "missing required field: {key}");
+    }
+    assert_eq!(s["tool_health"].as_str(), Some("healthy"));
+    assert!(s["tool_last_error"].is_null());
+}
+
+#[tokio::test]
+async fn gateway_server_schema_shape_is_contract_stable() {
+    let policy = ToolExposurePolicy::from_patterns(vec!["github_*".into()]).expect("policy");
+    let tools = vec![
+        make_tool("github_create", "alpha"),
+        make_tool("delete_repo", "alpha"),
+    ];
+
+    let pool = UpstreamPool::new();
+    pool.insert_entry_for_test("alpha", make_entry("alpha", tools, policy))
+        .await;
+
+    let doc = pool.gateway_server_schema("alpha").await.expect("doc");
+
+    for key in ["name", "tools", "health", "last_error"] {
+        assert!(doc.get(key).is_some(), "missing top-level field: {key}");
+    }
+    let tools = doc["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 1, "exposure policy must filter hidden tools");
+
+    let t = &tools[0];
+    for key in ["name", "description", "input_schema", "meta"] {
+        assert!(t.get(key).is_some(), "missing tool-entry field: {key}");
+    }
+    assert_eq!(t["name"], "github_create");
+}
+
+#[tokio::test]
+async fn gateway_server_schema_unknown_upstream_returns_none() {
+    let pool = UpstreamPool::new();
+    assert!(pool.gateway_server_schema("nope").await.is_none());
+}
+
+#[tokio::test]
+async fn gateway_synthetic_resources_uri_scheme_is_pinned() {
+    let pool = UpstreamPool::new();
+    pool.insert_entry_for_test(
+        "alpha",
+        make_entry("alpha", vec![], ToolExposurePolicy::All),
+    )
+    .await;
+
+    let resources = pool.gateway_synthetic_resources().await;
+    let uris: Vec<String> = resources.iter().map(|r| r.uri.clone()).collect();
+    assert!(uris.contains(&"lab://gateway/servers".to_string()));
+    assert!(uris.contains(&"lab://gateway/alpha/schema".to_string()));
+    // Nothing should leak into the lab://upstream/ namespace from here.
+    assert!(!uris.iter().any(|u| u.starts_with("lab://upstream/")));
+}

--- a/docs/sessions/2026-05-21-gateway-schema-resources.md
+++ b/docs/sessions/2026-05-21-gateway-schema-resources.md
@@ -1,0 +1,123 @@
+---
+date: 2026-05-21 02:49:58 EST
+repo: git@github.com:jmagar/lab.git
+branch: feat/gateway-schema-resources
+head: 7bfca340
+plan: docs/superpowers/plans/2026-05-21-gateway-schema-resources.md
+agent: Claude (claude-sonnet-4-6)
+session id: 9312ee58-e000-40ad-af9d-48fe15322949
+transcript: (not available — worktree session)
+working directory: /home/jmagar/workspace/lab/.worktrees/gateway-schema-resources
+worktree: /home/jmagar/workspace/lab/.worktrees/gateway-schema-resources 7bfca340 [feat/gateway-schema-resources]
+pr: "#67 feat(gateway): expose lab://gateway/* synthetic MCP resources — https://github.com/jmagar/lab/pull/67"
+---
+
+## User Request
+
+Execute the implementation plan at `docs/superpowers/plans/2026-05-21-gateway-schema-resources.md` via the `/work-it` skill, which creates a worktree, implements all tasks, creates a PR, and runs multi-wave reviews.
+
+## Session Overview
+
+Implemented synthetic `lab://gateway/*` MCP resources for the lab Rust homelab control plane. Added `lab://gateway/servers` (upstream index) and `lab://gateway/<name>/schema` (per-server tool catalog) as both MCP resources and dispatch actions, fully tested and reviewed. PR #67 is open.
+
+## Sequence of Events
+
+1. Read plan file; invoked executing-plans and work-it skills
+2. Created isolated worktree at `.worktrees/gateway-schema-resources` on branch `feat/gateway-schema-resources`
+3. Explored key files: `pool.rs`, `manager.rs`, `dispatch.rs`, `catalog.rs`, `server.rs`; called advisor before writing
+4. Advisor corrected plan literals: `ActionSpec` needs `returns:` field; `ParamSpec` needs `ty:`; dispatch param is `params_value` not `params`; arch test uses `labby::` not `lab::` crate name
+5. Symlinked `apps/gateway-admin/out` from main workspace (build artifact, gitignored, needed by proc macro)
+6. Implemented Task 1: `health_str`, `gateway_servers_doc`, `gateway_server_schema`, `gateway_synthetic_resources` pool methods + unit tests
+7. Fixed import: added `AnnotateAble` and `RawResource` to pool.rs rmcp imports
+8. Implemented Task 2: `gateway.servers`/`gateway.schema` ActionSpecs in catalog.rs; manager wrappers; dispatch arms; tests
+9. Implemented Task 3: MCP server.rs — `gateway_synthetic_resources` in `list_resources`; `lab://gateway/` branch in `read_resource`
+10. Implemented Task 4: arch test `crates/lab/tests/gateway_schema_resources.rs`; made `insert_entry_for_test` unconditionally `pub`
+11. Implemented Task 5: `docs/surfaces/MCP.md` documentation update
+12. All 2629 workspace tests passed; pushed branch; created PR #67
+13. lavra-review wave: found `format!` with no args (clippy), missing observability on pool-not-configured path, test gap for `not_found` envelope; fixed all three
+14. code_simplifier wave: confirmed code is clean; one nit (`use std::borrow::Cow` unused in test)
+15. silent-failure-hunter wave: found `unwrap_or_default()` on serialization, unredacted URI log fields; fixed both
+16. Removed unused `Cow` import from pool.rs tests
+
+## Key Findings
+
+- `insert_entry_for_tests` (plural, `#[cfg(test)]`) already existed at `pool.rs:2151` — added new `insert_entry_for_test` (singular, `pub`) since `#[cfg(test)]` doesn't expose to `crates/lab/tests/` integration tests
+- `ActionSpec` has a `returns: &'static str` field not shown in the plan — all existing entries have it; plan was missing it
+- `RawResource` and `AnnotateAble` needed in pool.rs imports for the `.no_annotation()` call
+- `lab://gateway/` branch must come before `lab://upstream/` branch in `read_resource` (cheaper, no pool RPC needed)
+- `serde_json::to_string_pretty(&value).unwrap_or_default()` is a silent failure pattern — fixed to `ErrorData::internal_error`
+- All four new log events used `uri.as_str()` instead of `redact_resource_uri_for_logging(uri)` — fixed for logging discipline consistency
+
+## Technical Decisions
+
+- **`gateway_servers_doc` returns empty list when pool is None** (not error): deliberate design per plan — agents get an empty index rather than an error during startup race; `gateway_server_schema` correctly returns `not_found` because a specific missing resource is an error
+- **`health_str` is a free function, not a `Display` impl on `UpstreamHealth`**: embeds circuit-breaker threshold semantics that belong to the gateway view layer, not the type itself
+- **`insert_entry_for_test` is unconditionally `pub`** (not `#[cfg(test)]`): required for `crates/lab/tests/` integration test crate; documented with `/// Test-only` comment
+- **`gateway_synthetic_resources` sorts upstream names**: deterministic output for MCP client cache-key stability; costs nothing at expected scale (dozens of upstreams)
+- **New dispatch arms placed as top-level arms**: not inside `handle_gateway_actions`; they call manager methods directly without needing the helper
+
+## Files Modified
+
+| File | Purpose |
+|------|---------|
+| `crates/lab/src/dispatch/upstream/pool.rs` | Added `health_str`, three pool methods, `insert_entry_for_test`, unit tests; fixed imports |
+| `crates/lab/src/dispatch/gateway/catalog.rs` | Added `gateway.servers` and `gateway.schema` ActionSpec entries |
+| `crates/lab/src/dispatch/gateway/manager.rs` | Added `gateway_servers_doc()` and `gateway_server_schema()` manager wrappers |
+| `crates/lab/src/dispatch/gateway/dispatch.rs` | Added two match arms, four dispatch tests |
+| `crates/lab/src/mcp/server.rs` | Extended `list_resources`; added `lab://gateway/` branch in `read_resource` with proper error handling and URI redaction |
+| `crates/lab/tests/gateway_schema_resources.rs` | New arch test: pins URI scheme and JSON document shape |
+| `docs/surfaces/MCP.md` | Documented two new resource URIs |
+
+## Commands Executed
+
+```bash
+git worktree add -b feat/gateway-schema-resources .worktrees/gateway-schema-resources HEAD
+ln -s /home/jmagar/workspace/lab/apps/gateway-admin/out .worktrees/gateway-schema-resources/apps/gateway-admin/out
+cargo nextest run --workspace --all-features   # 2629 passed, 0 failed
+git push -u origin feat/gateway-schema-resources
+gh pr create --title "feat(gateway): expose lab://gateway/* synthetic MCP resources"
+```
+
+## Errors Encountered
+
+- **`AnnotateAble` not in scope**: `pool.rs` needed `use rmcp::model::{AnnotateAble, ..., RawResource}` added to use `.no_annotation()`; fixed by updating the import
+- **`apps/gateway-admin/out` proc macro panic**: directory is gitignored and absent in worktree; fixed by symlinking from main workspace
+- **`clippy::useless_format`**: `format!("upstream pool not configured")` with no args; fixed to `.to_string()`
+
+## Behavior Changes (Before/After)
+
+| Surface | Before | After |
+|---------|--------|-------|
+| `list_resources` | No `lab://gateway/` entries | Returns `lab://gateway/servers` + `lab://gateway/<name>/schema` for each upstream |
+| `read_resource` | `lab://gateway/*` → unknown resource error | Returns JSON document (servers index or tool schema) |
+| Gateway dispatch | `gateway.servers` / `gateway.schema` → `unknown_action` | Returns live server index / filtered tool schema |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---------|----------|--------|--------|
+| `cargo check --all-features` | 0 errors | 0 errors (4 pre-existing warnings) | PASS |
+| `cargo nextest run --all-features --test gateway_schema_resources` | 4 pass | 4 pass | PASS |
+| `cargo nextest run --all-features gateway_*` | 15 pass | 15 pass | PASS |
+| `cargo nextest run --workspace --all-features` | 2629 pass | 2629 pass, 51 skipped | PASS |
+| `cargo clippy --all-features` | 0 errors | 0 errors | PASS |
+
+## Risks and Rollback
+
+- **New `pub` method `insert_entry_for_test`** leaks into release binary (unconditional `pub`); safe — no behavioral effect, no secret exposure, just a dead-code path in production
+- **Rollback**: `git revert` the 6 feature commits on this branch or simply close PR #67
+
+## Decisions Not Taken
+
+- **`gateway_servers_doc` returning error on pool-None**: reviewer suggested matching `gateway_server_schema`; kept graceful-empty because it's the plan's explicit design for the index endpoint and aligns with startup-race scenarios
+- **`pub(crate)` test-helpers feature flag**: plan mentioned `#[cfg(any(test, feature = "test-helpers"))]`; used unconditional `pub` with `/// Test-only` doc comment — simpler, no new feature flag
+
+## Open Questions
+
+- Upstream named `servers` would shadow `lab://gateway/servers` in the schema URI space (`lab://gateway/servers/schema` is rejected by the filter, but `gateway_synthetic_resources` would still emit it). Low risk unless a gateway operator literally names an upstream `servers`.
+- `insert_entry_for_tests` (plural, old) vs `insert_entry_for_test` (singular, new) duplication: the `#[cfg(test)]` old one is only used by inlined unit tests; the new unconditional one is used by the arch test. A follow-up cleanup PR could consolidate to one.
+
+## Next Steps
+
+- **Unfinished in this session**: review wave 3 (pr-review-toolkit type-design and comment-analyzer) and PR comment resolution from CodeRabbit/Copilot — to be done after PR reviewers post comments
+- **Follow-on**: consolidate `insert_entry_for_tests` / `insert_entry_for_test` duplication; upstream name `servers` reservation documentation

--- a/docs/surfaces/MCP.md
+++ b/docs/surfaces/MCP.md
@@ -428,5 +428,12 @@ Primary resource surfaces:
 - `lab://catalog`
 - `lab://<service>/actions`
 - `lab://upstream/{name}/{original_uri}` (when upstream resource proxying is enabled)
+- `lab://gateway/servers` — synthetic index of upstream MCP servers connected to the
+  gateway (name, cached tool/prompt/resource counts, tools-capability health). See
+  [`docs/contracts/gateway-schema-resources.md`](../contracts/gateway-schema-resources.md).
+- `lab://gateway/<name>/schema` — synthetic per-upstream tool catalog
+  (name, description, input_schema, meta), filtered by the upstream's
+  `ToolExposurePolicy`. Lets agents inspect a server's full schema in
+  one read without paying a `tool_search` round-trip.
 
 These are generated from the same catalog data as tool-based help, with upstream resources appended at runtime.


### PR DESCRIPTION
## Summary

- Adds `lab://gateway/servers` synthetic MCP resource — index of all upstream MCP servers with cached tool/prompt/resource counts and health status
- Adds `lab://gateway/<name>/schema` synthetic MCP resource per upstream — full tool catalog filtered by `ToolExposurePolicy`, letting agents fetch a server's complete schema in one read
- Adds `gateway.servers` and `gateway.schema` dispatch actions accessible via MCP, CLI, and HTTP
- Architecture test pins URI scheme and JSON document shape as a contract guard

## Architecture

Three thin layers:
1. **Pool methods** (`pool.rs`): `gateway_servers_doc()`, `gateway_server_schema()`, `gateway_synthetic_resources()` — pure reshaping of the already-cached `UpstreamEntry` catalog, no new upstream calls
2. **Gateway dispatch** (`manager.rs` + `dispatch.rs` + `catalog.rs`): two new actions wiring into the existing dispatch path
3. **MCP surface** (`server.rs`): `list_resources` extended with synthetic entries; `read_resource` gains a `lab://gateway/` branch before the upstream proxy branch

## Test plan

- [x] 4 pool unit tests covering `gateway_servers_doc`, `gateway_server_schema` (exposure filtering), `gateway_synthetic_resources`
- [x] 3 dispatch unit tests covering action presence, empty-pool behavior, missing-param error
- [x] 4 integration/arch tests in `crates/lab/tests/gateway_schema_resources.rs` pinning URI scheme and JSON shape
- [x] All 15 new tests pass; full workspace test suite green
- [x] Clippy clean; no new warnings introduced

## Spec

`docs/specs/gateway-schema-resources.md` and `docs/contracts/gateway-schema-resources.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes synthetic MCP resources `lab://gateway/servers` and `lab://gateway/<name>/schema` so agents can list upstream servers and fetch a server’s full, policy-filtered tool schema in one read. Adds matching actions and integrates them into MCP list/read with clear errors and logging.

- **New Features**
  - Synthetic resources: `lab://gateway/servers` (index with counts and tools health) and `lab://gateway/<name>/schema` (tools with `name`, `description`, `input_schema`, `meta`), filtered by `ToolExposurePolicy`.
  - Actions: `gateway.servers` (no params) and `gateway.schema` (`name` required); both return the same JSON docs as the resources.
  - MCP: `list_resources` now includes these synthetic entries; `read_resource` serves their JSON directly.

- **Bug Fixes**
  - Consistent errors: return `not_found` when the upstream pool is not configured for all `lab://gateway/*` reads/actions.
  - Reliability and observability: return `internal_error` on JSON serialization failures; redact resource URIs in logs.

<sup>Written for commit 162af04aac1f80bc572d51c1b70766a82ed05501. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/lab/pull/67?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

