### PR TITLE
chore: pin pnpm to CI version + canonicalize code_mode error kinds

### DIFF
--- a/.github/actions/build-gateway-admin/action.yml
+++ b/.github/actions/build-gateway-admin/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 9.15.9
 
     - uses: actions/setup-node@v4
       with:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+# Pin pnpm to match CI (.github/actions/build-gateway-admin uses pnpm 9) and the
+# committed apps/gateway-admin/pnpm-lock.yaml (pnpm-9 lockfile format).
+# Without this, a globally-newer pnpm (e.g. 11.x) rewrites the lockfile and
+# trips `pnpm install --frozen-lockfile` in CI, and pnpm 10+ also hard-errors on
+# unapproved esbuild/sharp build scripts during local `just dev`.
+[tools]
+pnpm = "9.15.9"

--- a/apps/gateway-admin/package.json
+++ b/apps/gateway-admin/package.json
@@ -3,6 +3,7 @@
   "version": "0.20.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -1165,7 +1165,7 @@ fn evaluate_code_search(code: &str, catalog: &[CodeModeCatalogEntry]) -> Result<
 
     for _ in 0..CODE_MODE_LOOP_ITERATION_LIMIT {
         context.run_jobs().map_err(|err| ToolError::Sdk {
-            sdk_kind: "code_execution_failed".to_string(),
+            sdk_kind: "server_error".to_string(),
             message: err.to_string(),
         })?;
         match promise.state() {
@@ -1173,17 +1173,17 @@ fn evaluate_code_search(code: &str, catalog: &[CodeModeCatalogEntry]) -> Result<
                 return value
                     .to_json(&mut context)
                     .map_err(|err| ToolError::Sdk {
-                        sdk_kind: "code_execution_failed".to_string(),
+                        sdk_kind: "server_error".to_string(),
                         message: format!("failed to serialize Code Mode search result: {err}"),
                     })?
                     .ok_or_else(|| ToolError::Sdk {
-                        sdk_kind: "code_execution_failed".to_string(),
+                        sdk_kind: "server_error".to_string(),
                         message: "Code Mode search result is not JSON-serializable".to_string(),
                     });
             }
             PromiseState::Rejected(reason) => {
                 return Err(ToolError::Sdk {
-                    sdk_kind: "code_execution_failed".to_string(),
+                    sdk_kind: "server_error".to_string(),
                     message: js_value_message(&reason, &mut context),
                 });
             }
@@ -1192,7 +1192,7 @@ fn evaluate_code_search(code: &str, catalog: &[CodeModeCatalogEntry]) -> Result<
     }
 
     Err(ToolError::Sdk {
-        sdk_kind: "code_execution_failed".to_string(),
+        sdk_kind: "server_error".to_string(),
         message: "Code Mode search script did not settle before the iteration limit".to_string(),
     })
 }
@@ -2009,7 +2009,7 @@ mod tests {
         let err = super::evaluate_code_search("42", &[]).expect_err("non-function must error");
         match err {
             super::ToolError::Sdk { sdk_kind, .. } => {
-                assert_eq!(sdk_kind, "code_execution_failed");
+                assert_eq!(sdk_kind, "server_error");
             }
             other => panic!("unexpected error: {other:?}"),
         }


### PR DESCRIPTION
Housekeeping from the search/execute restoration work. Three issues; #1 was operational (no commit).

## 1. sccache cache cleared (operational)
The shared sccache cache (`~/.cache/sccache`, 2.2 GiB) was poisoned and produced bad artifacts all session — every build had to bypass it with `--config 'build.rustc-wrapper=""'`. Stopped the server, wiped the cache dir, restarted clean. No repo change.

## 2. pnpm version skew (this PR)
CI pins **pnpm 9** (`pnpm/action-setup@v4`), local was **11.3.0** via mise. That mismatch rewrote the lockfile and broke `pnpm install --frozen-lockfile` in CI, and pnpm 10+ also hard-errors on unapproved esbuild/sharp build scripts during local `just dev` (the reason a CI-breaking `pnpm-workspace.yaml` got introduced and reverted earlier).
- `.mise.toml` pins pnpm **9.15.9** locally (matches the pnpm-9 lockfile)
- `apps/gateway-admin/package.json` gains `packageManager: pnpm@9.15.9`
- CI action pinned `9` → `9.15.9` (exact)

Result: local and CI both on 9.15.9; `pnpm install --frozen-lockfile` is clean with the lockfile unchanged; the esbuild approval annoyance is gone (pnpm 9 tolerates it).

## 3. Non-canonical error kind — bead `lab-rc37w` (this PR)
`code_mode.rs` emitted `code_execution_failed`, which isn't in the canonical error vocabulary, so agents switching on `err.kind` hit the default branch. Per `docs/dev/ERRORS.md` ("Sandbox/runner JS evaluation failure → `server_error`"), the 5 search-evaluator sites + their test now emit `server_error`. (`code_mode_disabled` was already removed with the enabled-flag cleanup.) Every error kind `code_mode.rs` now emits is present in the contract / ERRORS.md vocabulary.

## Verification
`RUSTFLAGS=-D warnings` nextest green; pnpm 9.15.9 `--frozen-lockfile` install clean with lockfile byte-unchanged.

Refs: lab-rc37w