### PR TITLE
chore(sccache): doctor/restart recipes + troubleshooting docs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -166,3 +166,55 @@ mcp-token:
 smoke-setup:
     rm -rf /tmp/lab-smoke-home
     LAB_HOME=/tmp/lab-smoke-home cargo run --all-features -- setup --no-browser --smoke
+
+# Diagnose the sccache build cache. Reports daemon health (systemd-owned),
+# binary-vs-daemon version skew, cache stats, distributed-build config, and the
+# tail of the error log. Run this FIRST when builds behave oddly (stale/wrong
+# artifacts) before reaching for a wipe. See docs/RUST.md §sccache troubleshooting.
+sccache-doctor:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    # MUST match the systemd unit's socket, or sccache spawns an unmanaged
+    # ephemeral server and reports misleading zero stats.
+    export SCCACHE_SERVER_UDS=/tmp/sccache-jmagar.sock
+    echo "── daemon (systemd --user) ─────────────────────────"
+    systemctl --user is-active sccache.service 2>/dev/null && \
+      systemctl --user show sccache.service -p MainPID -p ActiveEnterTimestamp -p NRestarts 2>/dev/null
+    echo "── version skew (binary vs running daemon) ─────────"
+    bin_ver=$(/home/jmagar/.local/sccache --version 2>/dev/null)
+    echo "binary:  $bin_ver"
+    echo "  (daemon is long-lived; if the mise-pinned binary changed, restart with 'just sccache-restart')"
+    echo "── distributed build config ────────────────────────"
+    if grep -qs '^\[dist\]' ~/.config/sccache/config; then
+      echo "DIST ENABLED — scheduler: $(grep -soE 'https?://[^\"]+' ~/.config/sccache/config | head -1)"
+      echo "  ⚠ remote builds can cache cross-machine artifacts; mismatched toolchains poison the cache."
+    else
+      echo "dist disabled (local-only) ✓"
+    fi
+    echo "── cache stats ─────────────────────────────────────"
+    /home/jmagar/.local/sccache --show-stats 2>/dev/null | grep -iE "compile requests|cache hits|cache misses|errors|cache location|cache size" || true
+    echo "── error log tail (real errors only) ───────────────"
+    log=/home/jmagar/.local/state/sccache/error.log
+    if [ -f "$log" ]; then
+      sz=$(du -h "$log" | cut -f1); echo "log: $log ($sz)"
+      grep -aE "ERROR|WARN|panic|corrupt|CacheReadError|CacheWriteError" "$log" 2>/dev/null | grep -avE "DEBUG|CannotCache" | tail -15 || echo "(no error/warn lines)"
+    else
+      echo "(no error log)"
+    fi
+
+# Cleanly restart the sccache daemon via systemd (NEVER use bare
+# 'sccache --start-server' — Restart=always means systemd owns it and a manual
+# start races the unit). Use after the mise-pinned sccache binary changes, or as
+# the FIRST recovery step for suspected cache poisoning (fixes daemon-state
+# causes without wiping on-disk artifacts). Only wipe the cache if this fails.
+sccache-restart:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export SCCACHE_SERVER_UDS=/tmp/sccache-jmagar.sock
+    echo "restarting sccache.service (systemd --user)…"
+    systemctl --user restart sccache.service
+    sleep 1
+    systemctl --user is-active sccache.service
+    /home/jmagar/.local/sccache --show-stats 2>/dev/null | grep -iE "compile requests|cache location" || true
+    echo "✓ restarted. If poisoning persists, wipe on-disk cache:"
+    echo "    systemctl --user stop sccache.service && rm -rf ~/.cache/sccache && systemctl --user start sccache.service"

--- a/docs/RUST.md
+++ b/docs/RUST.md
@@ -51,3 +51,56 @@ Developers without sccache take no penalty from this override — Rust simply
 recompiles changed crates in full rather than using incremental fragments.
 
 This repo has no xtask crate, so no `[alias]` section is needed.
+
+## sccache troubleshooting (cache "poisoning")
+
+sccache is optional but, when configured here, runs as a **long-lived systemd
+user service** (`~/.config/systemd/user/sccache.service`, `Restart=always`)
+backed by a **mise-pinned binary** behind the stable symlink `~/.local/sccache`.
+The cargo `rustc-wrapper` (`~/.local/bin/sccache-wrapper`) resolves the active
+rustup toolchain before handing off to sccache.
+
+**Symptom — "poisoning":** builds produce stale or wrong artifacts (code you
+deleted still seems present, link errors that don't match source, nondeterministic
+failures). The cache is returning artifacts that don't match the current inputs.
+
+**Likely causes, highest first:**
+
+1. **Distributed compilation across mismatched machines.** If `~/.config/sccache/config`
+   has a `[dist]` section, compiles are farmed to remote build servers. Artifacts
+   built on a remote host with a different toolchain/glibc/linker than the local
+   host, then cached and linked locally, are the prime poisoning vector — made
+   worse when the dist transport is flaky (e.g. self-signed-cert TLS failures cause
+   an inconsistent mix of local and remote artifacts). Check the error log for
+   `Could not perform distributed compile` / `certificate verify failed`. Fix:
+   either disable `[dist]` (local-only) or ensure every scheduler/build-server/client
+   runs an **identical** pinned toolchain with valid certs.
+2. **Long-lived daemon + swapped binary.** The systemd daemon does not reload when
+   the mise-pinned sccache binary changes. After `mise upgrade`/re-pin, the running
+   daemon and the client binary can disagree on cache format. Always
+   `just sccache-restart` after the binary changes.
+3. **On-disk corruption** (interrupted writes, disk pressure) — least likely;
+   only this one needs a cache wipe.
+
+**Recovery — tiered, least-destructive first:**
+
+```bash
+just sccache-doctor      # diagnose: daemon health, dist config, errors, stats
+just sccache-restart     # fixes daemon-state/version-skew causes (no wipe)
+# only if restart doesn't clear it — wipe on-disk artifacts:
+systemctl --user stop sccache.service && rm -rf ~/.cache/sccache && systemctl --user start sccache.service
+SCCACHE_RECACHE=1 cargo build   # force-overwrite suspect entries without a full wipe
+```
+
+**Bypass for a single build** (e.g. release/CI-parity verification you don't want
+to trust the cache for):
+
+```bash
+cargo build --workspace --all-features --config 'build.rustc-wrapper=""'
+```
+
+**Logging:** the daemon writes to `~/.local/state/sccache/error.log`
+(`SCCACHE_ERROR_LOG` in the unit). Keep `SCCACHE_LOG=warn` — a `debug` level turns
+this file into multi-GB noise that buries real errors and grows unbounded. The
+`sccache.service.d/` drop-in directory holds level overrides; remove the debug
+drop-in when you're done debugging.


### PR DESCRIPTION
Follow-up to the "how did sccache get poisoned" investigation.

## Root cause (from the forensic trail)
`~/.local/state/sccache/error.log` revealed the actual mechanism, not my earlier guesses: **distributed compilation is enabled** (`[dist]` in `~/.config/sccache/config`, scheduler `100.75.111.118:10600`) and toolchain submission to the remote build servers (tootie) **fails TLS with a self-signed-cert error**. Result: an inconsistent mix of locally- and remotely-built artifacts in one cache — the prime "poisoning" vector — whenever a remote builder's toolchain/env differs from the local host. The log was also 78 MB of debug spam (a `SCCACHE_LOG=debug` drop-in) burying the real errors.

## This PR (in-repo)
- **`just sccache-doctor`** — daemon health (systemd `--user`), version-skew note, **dist-enabled warning**, cache stats, and the real error-log tail. Exports `SCCACHE_SERVER_UDS` so it talks to the actual daemon instead of spawning an unmanaged ephemeral server (which reports misleading zeros).
- **`just sccache-restart`** — clean `systemctl --user restart` (never bare `sccache --start-server`: `Restart=always` means systemd owns it). The first recovery step for suspected poisoning, before any cache wipe.
- **docs/RUST.md** — sccache troubleshooting: causes ranked (dist mismatch > long-lived-daemon/binary version skew > on-disk corruption), tiered least-destructive recovery, single-build bypass, and logging hygiene.

## Machine-side (applied, not version-controlled)
- `SCCACHE_LOG` debug → `warn` in `~/.config/systemd/user/sccache.service.d/` and truncated the 78 MB log; daemon restarted clean (**0 cache errors**, verified).

## Still your call (infra)
The `[dist]` distributed build farm is deliberately configured but currently broken (TLS failing → falling back to local). See the follow-up note — recommend either disabling `[dist]` for local-only correctness, or fixing the certs + pinning identical toolchains across all build servers.