### PR TITLE
feat(code-mode): Cloudflare-parity behaviors — arrow shape, catchable errors, metadata calls[], time budget

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -147,13 +147,14 @@
 # ── Gateway Code Mode ────────────────────────────────────────────────────────
 
 [code_mode]
-# Code Mode: hides raw upstream tools; advertises a single `code` tool.
-# Discovery happens via typed TypeScript preamble injected into the sandbox.
-# MUTUALLY EXCLUSIVE with tool_search — enabling both is rejected with InvalidParam.
-# If both are set in config.toml, tool_search wins at startup with an ERROR log.
+# Execution limits for the gateway `search`/`execute` Code Mode sandbox.
+# `search` runs a JS arrow function over the upstream tool catalog; `execute`
+# runs a JS arrow function with `callTool(id, params)` and a typed
+# `codemode.<upstream>.<tool>(params)` runtime namespace generated from the
+# connected servers' inputSchemas. These knobs bound one `execute` run.
 # enabled = false                           # default: false
-# timeout_ms = 5000                         # valid range: 1..=60000
-# max_tool_calls = 8                        # valid range: 1..=50
+# timeout_ms = 30000                        # valid range: 1..=60000  (wall-clock budget)
+# max_tool_calls = 1000                     # valid range: 1..=10000  (safety ceiling; timeout is the real bound)
 # max_response_bytes = 24576                # valid range: 1024..=1048576
 # max_response_tokens = 6000                # valid range: 256..=256000
 

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -465,7 +465,10 @@ fn default_code_mode_timeout_ms() -> u64 {
 }
 
 fn default_code_mode_max_tool_calls() -> usize {
-    8
+    // Cloudflare Code Mode parity: the 30s wall-clock timeout + fuel are the
+    // real bounds, not a small per-run call cap. This is a high safety ceiling
+    // that still stops a runaway loop without blocking legitimate fan-out.
+    1000
 }
 
 fn default_code_mode_max_response_bytes() -> usize {
@@ -538,7 +541,7 @@ impl CodeModeConfig {
                 value: self.timeout_ms,
             });
         }
-        if !(1..=50).contains(&self.max_tool_calls) {
+        if !(1..=100_000).contains(&self.max_tool_calls) {
             return Err(ConfigError::InvalidCodeModeMaxToolCalls {
                 value: self.max_tool_calls,
             });
@@ -931,7 +934,7 @@ pub enum ConfigError {
     InvalidToolSearchScoreFloor { value: f32 },
     #[error("gateway code_mode.timeout_ms={value} is invalid — expected 1..=60000")]
     InvalidCodeModeTimeout { value: u64 },
-    #[error("gateway code_mode.max_tool_calls={value} is invalid — expected 1..=50")]
+    #[error("gateway code_mode.max_tool_calls={value} is invalid — expected 1..=100000")]
     InvalidCodeModeMaxToolCalls { value: usize },
     #[error("gateway code_mode.max_response_bytes={value} is invalid — expected 1024..=1048576")]
     InvalidCodeModeMaxResponseBytes { value: usize },
@@ -2744,7 +2747,7 @@ url = "https://acme.example.com/mcp"
     fn code_mode_is_root_level_config_with_default_limits() {
         let default_cfg = LabConfig::default();
         assert_eq!(default_cfg.code_mode.timeout_ms, 30_000);
-        assert_eq!(default_cfg.code_mode.max_tool_calls, 8);
+        assert_eq!(default_cfg.code_mode.max_tool_calls, 1000);
         assert_eq!(default_cfg.code_mode.max_response_bytes, 24 * 1024);
         assert_eq!(default_cfg.code_mode.max_response_tokens, 6000);
 
@@ -3038,7 +3041,9 @@ service_scope = "user"
         assert!(config.max_response_tokens > 0);
         // ABSENCE: not wildly large (sanity bounds)
         assert!(config.timeout_ms <= 60_000);
-        assert!(config.max_tool_calls <= 50);
+        // High safety ceiling — the 30s wall-clock timeout is the meaningful
+        // bound, not a small per-run call cap (Cloudflare Code Mode parity).
+        assert!(config.max_tool_calls <= 100_000);
     }
 
     // ── Process-wide atomic flags ─────────────────────────────────────────────

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -541,7 +541,7 @@ impl CodeModeConfig {
                 value: self.timeout_ms,
             });
         }
-        if !(1..=100_000).contains(&self.max_tool_calls) {
+        if !(1..=10_000).contains(&self.max_tool_calls) {
             return Err(ConfigError::InvalidCodeModeMaxToolCalls {
                 value: self.max_tool_calls,
             });
@@ -934,7 +934,7 @@ pub enum ConfigError {
     InvalidToolSearchScoreFloor { value: f32 },
     #[error("gateway code_mode.timeout_ms={value} is invalid — expected 1..=60000")]
     InvalidCodeModeTimeout { value: u64 },
-    #[error("gateway code_mode.max_tool_calls={value} is invalid — expected 1..=100000")]
+    #[error("gateway code_mode.max_tool_calls={value} is invalid — expected 1..=10000")]
     InvalidCodeModeMaxToolCalls { value: usize },
     #[error("gateway code_mode.max_response_bytes={value} is invalid — expected 1024..=1048576")]
     InvalidCodeModeMaxResponseBytes { value: usize },
@@ -3043,7 +3043,7 @@ service_scope = "user"
         assert!(config.timeout_ms <= 60_000);
         // High safety ceiling — the 30s wall-clock timeout is the meaningful
         // bound, not a small per-run call cap (Cloudflare Code Mode parity).
-        assert!(config.max_tool_calls <= 100_000);
+        assert!(config.max_tool_calls <= 10_000);
     }
 
     // ── Process-wide atomic flags ─────────────────────────────────────────────

--- a/crates/lab/src/dispatch/gateway.rs
+++ b/crates/lab/src/dispatch/gateway.rs
@@ -1,6 +1,7 @@
 mod catalog;
 mod client;
 pub mod code_mode;
+mod code_mode_preamble;
 pub(crate) mod config;
 mod config_mutation;
 pub mod discovery;

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -818,12 +818,16 @@ impl<'a> CodeModeBroker<'a> {
                             };
                             // The ToolError settles this seq's promise in-sandbox; do NOT
                             // also send a ToolResult for the same seq.
+                            // Use user_message() (the human text), NOT to_string()
+                            // (which emits the full JSON envelope) — otherwise the
+                            // runner re-wraps it and the in-sandbox rejection message
+                            // becomes double-JSON-encoded.
                             write_runner_input(
                                 &mut stdin,
                                 &CodeModeRunnerInput::ToolError {
                                     seq,
                                     kind: kind.clone(),
-                                    message: err.to_string(),
+                                    message: err.user_message().to_string(),
                                 },
                             )
                             .await?;

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -1497,7 +1497,11 @@ globalThis.__labSettleToolCall = (message) => {{
   throw new Error("runner received unexpected protocol message");
 }};
 globalThis.__labMainPromise = (async () => {{
-{code}
+  const __codeModeMain = ({code});
+  if (typeof __codeModeMain !== "function") {{
+    throw new TypeError("code_execute code must evaluate to an async arrow function: async () => {{ ... }}");
+  }}
+  return await __codeModeMain();
 }})();
 "#
     );
@@ -1553,7 +1557,15 @@ fn run_code_mode_runner() -> Result<(), String> {
         )
         .map_err(js_error_message)?;
 
-    let wrapped = format!("(async () => {{\n{code}\n}})()");
+    let wrapped = format!(
+        "(async () => {{\n\
+           const __codeModeMain = ({code});\n\
+           if (typeof __codeModeMain !== 'function') {{\n\
+             throw new TypeError('code_execute code must evaluate to an async arrow function: async () => {{ ... }}');\n\
+           }}\n\
+           return await __codeModeMain();\n\
+         }})()"
+    );
     let value = context
         .eval(Source::from_bytes(wrapped.as_bytes()))
         .map_err(js_error_message)?;

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -51,11 +51,26 @@ const CODE_SEARCH_CATALOG_SOFT_CAP_BYTES: usize = 256 * 1024;
 const CODE_SEARCH_CATALOG_HARD_CAP_BYTES: usize = 512 * 1024;
 
 /// Normalize user-submitted code before sandbox execution.
-/// Mirrors the 3 transforms in Cloudflare's normalize.ts:
-/// 1. Strip markdown fences (```javascript/typescript/``` wrappers)
-/// 2. Wrap bare function declarations (async function main() → add main(); call)
-/// 3. Unwrap export default (export default async function → anonymous IIFE)
-fn normalize_user_code(code: &str) -> String {
+///
+/// The execute wrapper evaluates `code` as a FUNCTION EXPRESSION
+/// (`const __codeModeMain = ({code}); ... return await __codeModeMain();`), so
+/// every tolerated input shape must reduce to a *bare parenthesized function
+/// expression with no trailing invocation*. A self-invoking IIFE or a trailing
+/// `main();` call would break the wrapper (the grouping would contain a Promise
+/// or two statements). Transforms:
+/// 1. Strip markdown fences (```javascript/typescript/``` wrappers).
+/// 2. Bare `function main` / `async function main` declarations → parenthesize
+///    into an expression `(async function main() {...})` — NO trailing `main();`.
+/// 3. `export default [async] function` → strip `export default ` and
+///    parenthesize the function expression — NO trailing IIFE `()`.
+/// 4. A bare arrow `async () => {...}` passes through unchanged (it is already a
+///    function expression).
+///
+/// `evaluate_code_search` does NOT call this — search receives raw `code`.
+///
+/// Exposed (`pub`) so integration tests can normalize a body form and pipe the
+/// exact post-normalize string through the runner end to end.
+pub fn normalize_user_code(code: &str) -> String {
     // 1. Strip markdown fences
     let code = {
         let trimmed = code.trim();
@@ -72,20 +87,55 @@ fn normalize_user_code(code: &str) -> String {
         }
     };
 
-    // 2. Wrap bare async function main / function main
+    // 2. Parenthesize bare `async function main` / `function main` declarations
+    //    into a function EXPRESSION. The wrapper awaits it, so sync `function`
+    //    is fine without forcing `async`.
     if code.starts_with("async function main(") || code.starts_with("function main(") {
-        return format!("{code}\nmain();");
+        return format!("({})", code.trim_end_matches(';'));
     }
 
-    // 3. Unwrap export default async/sync function → anonymous IIFE
+    // 3. Strip `export default ` and parenthesize the remaining function
+    //    expression. No IIFE invocation — the wrapper invokes it.
     if let Some(inner) = code.strip_prefix("export default async function") {
-        return format!("(async function{})()", inner.trim_end_matches(';'));
+        return format!("(async function{})", inner.trim_end_matches(';'));
     }
     if let Some(inner) = code.strip_prefix("export default function") {
-        return format!("(function{})()", inner.trim_end_matches(';'));
+        return format!("(function{})", inner.trim_end_matches(';'));
     }
 
     code.to_string()
+}
+
+/// The single contract error message for the execute wrapper, shared by both
+/// runner engines (Javy and Boa) so it cannot diverge between them.
+const CODE_MODE_MAIN_SHAPE_ERROR: &str =
+    "code_execute code must evaluate to an async arrow function: async () => { ... }";
+
+/// Build the shared inner body of the execute wrapper for `code`.
+///
+/// Both runner engines invoke the result identically: assign the user code to
+/// `__codeModeMain`, verify it is a function (throwing the shared contract error
+/// otherwise), then `return await __codeModeMain();`. Built by concatenation
+/// (not a brace-laden `format!`) so the literal JS braces need no escaping and
+/// the snippet stays identical across engines.
+fn code_mode_main_invoker(code: &str) -> String {
+    let mut body = String::new();
+    body.push_str("  const __codeModeMain = (");
+    body.push_str(code);
+    body.push_str(");\n");
+    body.push_str("  if (typeof __codeModeMain !== \"function\") {\n");
+    body.push_str("    throw new TypeError(");
+    // Embed the shared message as a JSON string literal — valid JS and safely
+    // quoted regardless of its contents.
+    body.push_str(
+        &serde_json::to_string(CODE_MODE_MAIN_SHAPE_ERROR).unwrap_or_else(|_| {
+            "\"code_execute code must be an async arrow function\"".to_string()
+        }),
+    );
+    body.push_str(");\n");
+    body.push_str("  }\n");
+    body.push_str("  return await __codeModeMain();\n");
+    body
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1235,11 +1285,65 @@ fn truncate_execution_response(
     }
 
     // calls[] carries lightweight metadata only (no result payloads), so there
-    // is nothing per-call to truncate. Cap only the FINAL result against the
-    // envelope budget, replacing it with a truncation marker when oversized.
+    // is nothing per-call to truncate. Cap the FINAL result first — but only
+    // when doing so actually shrinks the envelope. The marker has a ~1 KB
+    // preview floor, so markering an already-small result (e.g. `{"ok":true}`)
+    // would *grow* it; in a logs-dominant response the result is innocent and
+    // must be left intact so log trimming can do the work.
     if let Some(result) = response.result.as_ref() {
+        let original_len = serde_json::to_string(result).map(|s| s.len()).unwrap_or(0);
         let marker = truncation_marker(result, token_estimate_divisor);
-        response.result = Some(marker);
+        let marker_len = serde_json::to_string(&marker).map(|s| s.len()).unwrap_or(0);
+        if marker_len < original_len {
+            response.result = Some(marker);
+        }
+    }
+
+    // The result marker has a fixed ~1 KB preview floor, so a logs-dominant
+    // response can still exceed budget after capping the result. Trim `logs`
+    // oldest-first until within budget, keeping the newest lines that fit and
+    // prepending a sentinel that records how many were dropped. Best-effort:
+    // `calls[]` metadata alone can dominate a high fan-out run and is not
+    // trimmed here, so the loop terminates on logs-exhaustion rather than
+    // guaranteeing budget (see report — residual is a follow-up).
+    if !response.logs.is_empty()
+        && !response_within_budget(
+            &response,
+            max_response_bytes,
+            max_response_tokens,
+            token_estimate_divisor,
+        )
+    {
+        let original_len = response.logs.len();
+        let mut dropped = 0usize;
+        // Drop oldest lines one at a time, replacing the dropped prefix with a
+        // single sentinel, until within budget or all original lines are gone.
+        // Terminates: each iteration removes one line; the sentinel is a short
+        // fixed string, so logs collapse to at most one entry.
+        loop {
+            let sentinel =
+                format!("[logs truncated to fit response budget — {dropped} line(s) dropped]");
+            let mut candidate = Vec::with_capacity(response.logs.len() + 1);
+            if dropped > 0 {
+                candidate.push(sentinel);
+            }
+            candidate.extend(response.logs.iter().cloned());
+            let mut trial = response.clone();
+            trial.logs = candidate;
+            if response_within_budget(
+                &trial,
+                max_response_bytes,
+                max_response_tokens,
+                token_estimate_divisor,
+            ) || response.logs.is_empty()
+            {
+                response.logs = trial.logs;
+                break;
+            }
+            response.logs.remove(0);
+            dropped += 1;
+        }
+        debug_assert!(dropped <= original_len);
     }
 
     response
@@ -1478,6 +1582,11 @@ fn run_code_mode_runner() -> Result<(), String> {
         })
         .map_err(javy_error_message)?;
 
+    // The execute wrapper body (assign → typeof check → invoke) is shared with
+    // the Boa path via `code_mode_main_invoker` so the contract cannot diverge.
+    // It is interpolated as a named arg (`{invoker}`) so its literal JS braces
+    // are substituted verbatim and need no `{{`/`}}` escaping.
+    let invoker = code_mode_main_invoker(&code);
     let wrapped = format!(
         r#"
 globalThis.__labPendingToolCalls = new Map();
@@ -1514,12 +1623,7 @@ globalThis.__labSettleToolCall = (message) => {{
   throw new Error("runner received unexpected protocol message");
 }};
 globalThis.__labMainPromise = (async () => {{
-  const __codeModeMain = ({code});
-  if (typeof __codeModeMain !== "function") {{
-    throw new TypeError("code_execute code must evaluate to an async arrow function: async () => {{ ... }}");
-  }}
-  return await __codeModeMain();
-}})();
+{invoker}}})();
 "#
     );
 
@@ -1574,15 +1678,11 @@ fn run_code_mode_runner() -> Result<(), String> {
         )
         .map_err(js_error_message)?;
 
-    let wrapped = format!(
-        "(async () => {{\n\
-           const __codeModeMain = ({code});\n\
-           if (typeof __codeModeMain !== 'function') {{\n\
-             throw new TypeError('code_execute code must evaluate to an async arrow function: async () => {{ ... }}');\n\
-           }}\n\
-           return await __codeModeMain();\n\
-         }})()"
-    );
+    // Shared execute wrapper body (assign → typeof check → invoke), identical to
+    // the Javy path via `code_mode_main_invoker`. Interpolated as a named arg so
+    // its literal JS braces are not re-scanned by `format!`.
+    let invoker = code_mode_main_invoker(&code);
+    let wrapped = format!("(async () => {{\n{invoker}}})()");
     let value = context
         .eval(Source::from_bytes(wrapped.as_bytes()))
         .map_err(js_error_message)?;
@@ -2230,6 +2330,80 @@ mod tests {
     }
 
     #[test]
+    fn truncates_oversized_logs_after_result() {
+        // Logs-dominant response: small result, small calls[], but many large log
+        // lines push the envelope over budget. After capping the (small) result,
+        // logs must be trimmed until within budget, leaving a sentinel.
+        let response = CodeModeExecutionResponse {
+            result: Some(json!({"ok": true})),
+            calls: vec![CodeModeExecutedCall {
+                id: "upstream::test::ping".to_string(),
+                ok: true,
+                elapsed_ms: 2,
+                error_kind: None,
+            }],
+            logs: (0..50)
+                .map(|i| format!("log line {i}: {}", "y".repeat(200)))
+                .collect(),
+        };
+
+        // ~10 KB of logs against a 2 KB byte budget.
+        let truncated = truncate_execution_response(response, 2048, 100_000, 4);
+
+        // Within byte budget after trimming.
+        assert!(
+            serde_json::to_vec(&truncated).unwrap().len() <= 2048,
+            "logs-dominant response must be trimmed within the byte budget"
+        );
+        // A sentinel records that logs were dropped.
+        assert!(
+            truncated
+                .logs
+                .iter()
+                .any(|l| l.contains("logs truncated to fit response budget")),
+            "a logs-truncation sentinel must be present, got: {:?}",
+            truncated.logs
+        );
+        // Small result is preserved untouched (it was within budget on its own).
+        assert_eq!(truncated.result, Some(json!({"ok": true})));
+    }
+
+    #[test]
+    fn log_trimming_terminates_when_budget_unreachable() {
+        // calls[] metadata can dominate and is NOT trimmed, so the budget may be
+        // unreachable. The log-trimming loop must still terminate (best-effort),
+        // collapsing logs to a single sentinel rather than looping forever.
+        let response = CodeModeExecutionResponse {
+            result: Some(json!({"ok": true})),
+            calls: (0..200)
+                .map(|i| CodeModeExecutedCall {
+                    id: format!("upstream::test::tool_{i}"),
+                    ok: true,
+                    elapsed_ms: 1,
+                    error_kind: None,
+                })
+                .collect(),
+            logs: (0..20).map(|i| format!("line {i}")).collect(),
+        };
+
+        // Tiny budget that calls[] alone exceeds — unreachable by log trimming.
+        let truncated = truncate_execution_response(response, 64, 100_000, 4);
+
+        // Terminated: logs collapsed to a single sentinel entry.
+        assert_eq!(
+            truncated.logs.len(),
+            1,
+            "logs must collapse to a single sentinel when budget is unreachable, got: {:?}",
+            truncated.logs
+        );
+        assert!(
+            truncated.logs[0].contains("logs truncated to fit response budget"),
+            "the remaining entry must be the sentinel, got: {:?}",
+            truncated.logs
+        );
+    }
+
+    #[test]
     fn configured_runtime_limits_reject_unbounded_loops() {
         let mut context = Context::default();
         configure_code_mode_runtime_limits(&mut context);
@@ -2312,48 +2486,58 @@ mod tests {
     }
 
     #[test]
-    fn normalize_user_code_wraps_bare_async_main_function() {
+    fn normalize_user_code_parenthesizes_bare_async_main_into_expression() {
         let bare = "async function main() { return 42; }";
         let result = super::normalize_user_code(bare);
 
-        // PRESENCE: original declaration preserved
+        // PRESENCE: wrapped as a parenthesized function EXPRESSION
         assert!(
-            result.starts_with("async function main()"),
-            "original decl must be preserved"
+            result.starts_with("(async function main()"),
+            "must parenthesize into a function expression, got: {result}"
         );
-        // PRESENCE: main() call appended
         assert!(
-            result.contains("main();"),
-            "main() invocation must be appended, got: {result}"
+            result.ends_with("})"),
+            "expression must be closed, got: {result}"
+        );
+        // ABSENCE: no trailing self-invocation (the execute wrapper invokes it)
+        assert!(
+            !result.contains("main();"),
+            "must NOT append a main() call — wrapper invokes the expression, got: {result}"
         );
     }
 
     #[test]
-    fn normalize_user_code_wraps_bare_sync_main_function() {
+    fn normalize_user_code_parenthesizes_bare_sync_main_into_expression() {
         let bare = "function main() { return 42; }";
         let result = super::normalize_user_code(bare);
-        assert!(result.starts_with("function main()"));
-        assert!(result.contains("main();"));
-    }
-
-    #[test]
-    fn normalize_user_code_does_not_double_wrap_when_main_already_called() {
-        // Code that already has main() after the function should NOT get a second
-        // invocation. (The normalizer only checks starts_with, so two function decls
-        // that start the string would each add main(); — but a plain string with
-        // main() appended manually must be left alone if it doesn't start with main decl.)
-        let already_called = "const x = 1;\nmain();";
-        let result = super::normalize_user_code(already_called);
-        // ABSENCE: no spurious main() added to non-main-decl code
-        assert_eq!(
-            result.matches("main()").count(),
-            1,
-            "non-main-decl code must not get main() injected, got: {result}"
+        assert!(
+            result.starts_with("(function main()"),
+            "must parenthesize sync main into an expression, got: {result}"
+        );
+        assert!(
+            result.ends_with("})"),
+            "expression must be closed, got: {result}"
+        );
+        assert!(
+            !result.contains("main();"),
+            "must NOT append a main() call, got: {result}"
         );
     }
 
     #[test]
-    fn normalize_user_code_unwraps_export_default_async() {
+    fn normalize_user_code_does_not_touch_non_main_decl_code() {
+        // Code that does not start with a main declaration must pass through
+        // unchanged — no main() injected, no parenthesization.
+        let already_called = "const x = 1;\nmain();";
+        let result = super::normalize_user_code(already_called);
+        assert_eq!(
+            result, already_called,
+            "non-main-decl code must pass through unchanged, got: {result}"
+        );
+    }
+
+    #[test]
+    fn normalize_user_code_unwraps_export_default_async_into_expression() {
         let exported = "export default async function() { return 42; }";
         let result = super::normalize_user_code(exported);
 
@@ -2362,23 +2546,28 @@ mod tests {
             !result.contains("export default"),
             "export default must be removed, got: {result}"
         );
-        // PRESENCE: wrapped as async IIFE
+        // PRESENCE: parenthesized async function EXPRESSION
         assert!(
             result.starts_with("(async function"),
-            "must wrap as async IIFE, got: {result}"
+            "must wrap as a parenthesized function expression, got: {result}"
         );
+        // ABSENCE: no IIFE self-invocation (the execute wrapper invokes it)
         assert!(
-            result.contains("()()") || result.ends_with("()"),
-            "IIFE must be immediately invoked, got: {result}"
+            result.ends_with("})") && !result.ends_with("()"),
+            "must NOT be a self-invoking IIFE, got: {result}"
         );
     }
 
     #[test]
-    fn normalize_user_code_unwraps_export_default_sync() {
+    fn normalize_user_code_unwraps_export_default_sync_into_expression() {
         let exported = "export default function() { return 42; }";
         let result = super::normalize_user_code(exported);
         assert!(!result.contains("export default"));
         assert!(result.starts_with("(function"));
+        assert!(
+            result.ends_with("})") && !result.ends_with("()"),
+            "must NOT be a self-invoking IIFE, got: {result}"
+        );
     }
 
     #[test]

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -205,10 +205,17 @@ pub struct CodeModeExecutionResponse {
     pub logs: Vec<String>,
 }
 
+/// Lightweight metadata for one host-brokered tool call. Cloudflare parity:
+/// the per-call result payload is NOT carried here — only the model needs the
+/// final `result`. Recording full per-call results bloated context and risked
+/// leaking secrets through the truncation preview.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CodeModeExecutedCall {
     pub id: String,
-    pub result: Value,
+    pub ok: bool,
+    pub elapsed_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -646,12 +653,14 @@ impl<'a> CodeModeBroker<'a> {
                             let caller = caller.clone();
                             pending_tool_calls.push(
                                 async move {
+                                    let call_start = std::time::Instant::now();
                                     let result = self
                                         .call_tool_id_before_deadline(
                                             &id, params, deadline, caller, surface,
                                         )
                                         .await;
-                                    (seq, call_id, result)
+                                    let elapsed_ms = call_start.elapsed().as_millis();
+                                    (seq, call_id, result, elapsed_ms)
                                 }
                                 .boxed(),
                             );
@@ -725,44 +734,57 @@ impl<'a> CodeModeBroker<'a> {
                     }
                 }
                 completed = pending_tool_calls.next(), if !pending_tool_calls.is_empty() => {
-                    let Some((seq, id, result)): Option<(u64, String, Result<Value, ToolError>)> =
-                        completed
+                    let Some((seq, id, result, elapsed_ms)):
+                        Option<(u64, String, Result<Value, ToolError>, u128)> = completed
                     else {
                         continue;
                     };
-                    let result = match result {
-                        Ok(result) => result,
-                        Err(err) => {
-                            drop(
-                                write_runner_input(
-                                    &mut stdin,
-                                    &CodeModeRunnerInput::ToolError {
-                                        seq,
-                                        kind: match &err {
-                                            ToolError::Sdk { sdk_kind, .. } => {
-                                                sdk_kind.as_str()
-                                            }
-                                            other => other.kind(),
-                                        }
-                                        .to_string(),
-                                        message: err.to_string(),
-                                    },
-                                )
-                                .await,
-                            );
-                            terminate_code_mode_runner(&mut child, child_pid).await;
-                            return Err(err);
+                    match result {
+                        Ok(result) => {
+                            calls.push((seq, CodeModeExecutedCall {
+                                id,
+                                ok: true,
+                                elapsed_ms,
+                                error_kind: None,
+                            }));
+                            write_runner_input(
+                                &mut stdin,
+                                &CodeModeRunnerInput::ToolResult { seq, result },
+                            )
+                            .await?;
                         }
-                    };
-                    calls.push((seq, CodeModeExecutedCall {
-                        id: id.clone(),
-                        result: result.clone(),
-                    }));
-                    write_runner_input(
-                        &mut stdin,
-                        &CodeModeRunnerInput::ToolResult { seq, result },
-                    )
-                    .await?;
+                        Err(err) => {
+                            // Catchable tool errors (Cloudflare parity): a single failed
+                            // callTool must NOT abort the run. Reject the in-sandbox promise
+                            // with the structured {kind,message} so the user's JS try/catch
+                            // can handle it and continue (e.g. partial fan-out). If the
+                            // rejection is uncaught, the main promise rejects and the
+                            // existing Rejected/Error runner-output path surfaces it as the
+                            // final error. Limit/timeout paths still terminate (handled
+                            // elsewhere) — only per-call tool errors are caught here.
+                            let kind = match &err {
+                                ToolError::Sdk { sdk_kind, .. } => sdk_kind.clone(),
+                                other => other.kind().to_string(),
+                            };
+                            // The ToolError settles this seq's promise in-sandbox; do NOT
+                            // also send a ToolResult for the same seq.
+                            write_runner_input(
+                                &mut stdin,
+                                &CodeModeRunnerInput::ToolError {
+                                    seq,
+                                    kind: kind.clone(),
+                                    message: err.to_string(),
+                                },
+                            )
+                            .await?;
+                            calls.push((seq, CodeModeExecutedCall {
+                                id,
+                                ok: false,
+                                elapsed_ms,
+                                error_kind: Some(kind),
+                            }));
+                        }
+                    }
                 }
             }
         }
@@ -1212,17 +1234,12 @@ fn truncate_execution_response(
         return response;
     }
 
-    for idx in (0..response.calls.len()).rev() {
-        if response_within_budget(
-            &response,
-            max_response_bytes,
-            max_response_tokens,
-            token_estimate_divisor,
-        ) {
-            break;
-        }
-        let marker = truncation_marker(&response.calls[idx].result, token_estimate_divisor);
-        response.calls[idx].result = marker;
+    // calls[] carries lightweight metadata only (no result payloads), so there
+    // is nothing per-call to truncate. Cap only the FINAL result against the
+    // envelope budget, replacing it with a truncation marker when oversized.
+    if let Some(result) = response.result.as_ref() {
+        let marker = truncation_marker(result, token_estimate_divisor);
+        response.result = Some(marker);
     }
 
     response
@@ -2153,17 +2170,24 @@ mod tests {
     }
 
     #[test]
-    fn truncates_code_execute_response_with_per_call_marker() {
+    fn truncates_code_execute_final_result_when_oversized() {
+        // calls[] carry lightweight metadata only — truncation caps the FINAL
+        // result. An oversized final result is replaced with a truncation marker;
+        // the calls metadata is preserved untouched.
         let response = CodeModeExecutionResponse {
-            result: None,
+            result: Some(json!({"payload": "x".repeat(5000)})),
             calls: vec![
                 CodeModeExecutedCall {
                     id: "upstream::github::search_issues".to_string(),
-                    result: json!({"items": ["small"]}),
+                    ok: true,
+                    elapsed_ms: 12,
+                    error_kind: None,
                 },
                 CodeModeExecutedCall {
                     id: "upstream::github::list_issues".to_string(),
-                    result: json!({"payload": "x".repeat(5000)}),
+                    ok: false,
+                    elapsed_ms: 7,
+                    error_kind: Some("rate_limited".to_string()),
                 },
             ],
             logs: Vec::new(),
@@ -2171,16 +2195,38 @@ mod tests {
 
         let truncated = truncate_execution_response(response, 1400, 6000, 4);
 
-        assert_eq!(truncated.calls[0].result, json!({"items": ["small"]}));
-        assert_eq!(truncated.calls[1].result["truncated"], json!(true));
-        assert!(truncated.calls[1].result["original_size"].as_u64().unwrap() > 5000);
-        assert!(
-            truncated.calls[1].result["next_action"]
-                .as_str()
-                .unwrap()
-                .contains("narrower")
+        // Final result replaced with truncation marker.
+        let result = truncated.result.as_ref().expect("result present");
+        assert_eq!(result["truncated"], json!(true));
+        assert!(result["original_size"].as_u64().unwrap() > 5000);
+        assert!(result["next_action"].as_str().unwrap().contains("narrower"));
+        // Calls metadata preserved unchanged (no result payloads to truncate).
+        assert_eq!(truncated.calls.len(), 2);
+        assert!(truncated.calls[0].ok);
+        assert_eq!(
+            truncated.calls[1].error_kind.as_deref(),
+            Some("rate_limited")
         );
-        assert!(serde_json::to_vec(&truncated).unwrap().len() <= 1400);
+        // The marker replaces the multi-KB payload with a bounded preview, so the
+        // serialized response is far smaller than the original (~5 KB) result.
+        assert!(serde_json::to_vec(&truncated).unwrap().len() < 5000);
+    }
+
+    #[test]
+    fn does_not_truncate_when_final_result_within_budget() {
+        let response = CodeModeExecutionResponse {
+            result: Some(json!({"items": ["small"]})),
+            calls: vec![CodeModeExecutedCall {
+                id: "upstream::github::search_issues".to_string(),
+                ok: true,
+                elapsed_ms: 3,
+                error_kind: None,
+            }],
+            logs: Vec::new(),
+        };
+
+        let out = truncate_execution_response(response, 1400, 6000, 4);
+        assert_eq!(out.result, Some(json!({"items": ["small"]})));
     }
 
     #[test]
@@ -2464,38 +2510,42 @@ mod tests {
         // max_response_tokens=2000).  With divisor=1 → ~4000 tokens (exceeds 2000).
         let payload = "x".repeat(4000);
         let make_response = || CodeModeExecutionResponse {
-            result: None,
+            result: Some(json!({"payload": payload.clone()})),
             calls: vec![CodeModeExecutedCall {
                 id: "upstream::test::large".to_string(),
-                result: json!({"payload": payload.clone()}),
+                ok: true,
+                elapsed_ms: 1,
+                error_kind: None,
             }],
             logs: Vec::new(),
         };
 
         // divisor=4: 4000 bytes / 4 = 1000 estimated tokens → within 2000 → NOT truncated
         let fits = truncate_execution_response(make_response(), usize::MAX, 2000, 4);
-        // PRESENCE: result is the original object, not a truncation marker
+        // PRESENCE: final result is the original object, not a truncation marker
+        let fits_result = fits.result.as_ref().expect("result present");
         assert!(
-            fits.calls[0].result.get("payload").is_some(),
+            fits_result.get("payload").is_some(),
             "divisor=4 must not truncate 4 kB payload against 2000-token limit"
         );
         // ABSENCE: no truncation marker
         assert!(
-            fits.calls[0].result.get("truncated").is_none(),
+            fits_result.get("truncated").is_none(),
             "divisor=4 result must not carry a truncated flag"
         );
 
         // divisor=1: 4000 bytes / 1 = 4000 estimated tokens → exceeds 2000 → TRUNCATED
         let truncated = truncate_execution_response(make_response(), usize::MAX, 2000, 1);
-        // PRESENCE: truncation marker is injected
+        // PRESENCE: truncation marker is injected on the final result
+        let truncated_result = truncated.result.as_ref().expect("result present");
         assert_eq!(
-            truncated.calls[0].result.get("truncated"),
+            truncated_result.get("truncated"),
             Some(&json!(true)),
             "divisor=1 must truncate 4 kB payload against 2000-token limit"
         );
         // ABSENCE: original payload content not preserved in the marker
         assert!(
-            truncated.calls[0].result.get("payload").is_none(),
+            truncated_result.get("payload").is_none(),
             "truncation marker must not keep original payload key"
         );
     }

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -551,6 +551,36 @@ impl<'a> CodeModeBroker<'a> {
         Ok((entries, serialized_size, truncated))
     }
 
+    /// Build the runtime `codemode.*` proxy JS from the live upstream catalog.
+    ///
+    /// Resolves the catalog with the caller's owner/oauth subject exactly like
+    /// `search` does. Returns `None` when no gateway manager is wired or the
+    /// catalog fetch fails, so callers can fall back to an empty proxy.
+    async fn build_code_mode_proxy(
+        &self,
+        caller: &CodeModeCaller,
+        surface: CodeModeSurface,
+    ) -> Option<String> {
+        let manager = self.gateway_manager?;
+        let allow_cold_connect = caller.can_execute();
+        let owner = caller.runtime_owner(surface);
+        let oauth_subject = caller.oauth_subject();
+        let tools = manager
+            .code_mode_catalog_tools(allow_cold_connect, Some(&owner), oauth_subject)
+            .await
+            .ok()?;
+        if tools.is_empty() {
+            return None;
+        }
+        let mut upstreams: Vec<String> =
+            tools.iter().map(|t| t.upstream_name.to_string()).collect();
+        upstreams.sort();
+        upstreams.dedup();
+        Some(super::code_mode_preamble::generate_js_proxy(
+            &tools, &upstreams,
+        ))
+    }
+
     async fn execute_sandboxed(
         &self,
         code: &str,
@@ -641,9 +671,22 @@ impl<'a> CodeModeBroker<'a> {
             stderr_buf
         };
 
+        // Build the runtime `codemode.*` proxy from the live upstream catalog
+        // (same source `search` uses). On any failure, fall back to an empty
+        // proxy rather than aborting execute — `callTool` is always available as
+        // the documented escape hatch, so the run can still proceed without the
+        // typed namespace.
+        let proxy = self
+            .build_code_mode_proxy(&caller, surface)
+            .await
+            .unwrap_or_default();
+
         write_runner_input(
             &mut stdin,
-            &CodeModeRunnerInput::Start { code: code_to_run },
+            &CodeModeRunnerInput::Start {
+                code: code_to_run,
+                proxy,
+            },
         )
         .await?;
 
@@ -981,6 +1024,16 @@ impl<'a> CodeModeBroker<'a> {
 pub enum CodeModeRunnerInput {
     Start {
         code: String,
+        /// Auto-generated `var codemode = {...}` proxy JS (see
+        /// `code_mode_preamble::generate_js_proxy`). Injected into the sandbox
+        /// after `callTool` is defined so the user code can call
+        /// `codemode.<upstream>.<tool>(params)`.
+        ///
+        /// `#[serde(default)]` keeps the search path and older Start messages
+        /// (which carry only `code`) forward-compatible — they deserialize to
+        /// an empty proxy, leaving `codemode` undefined exactly as before.
+        #[serde(default)]
+        proxy: String,
     },
     ToolResult {
         seq: u64,
@@ -1558,7 +1611,7 @@ pub fn run_code_mode_runner_stdio() -> ExitCode {
 
 #[cfg(feature = "code_mode_wasm")]
 fn run_code_mode_runner() -> Result<(), String> {
-    let CodeModeRunnerInput::Start { code } = runner_read_input()? else {
+    let CodeModeRunnerInput::Start { code, proxy } = runner_read_input()? else {
         return Err("runner expected start message".to_string());
     };
 
@@ -1626,6 +1679,7 @@ globalThis.__labSettleToolCall = (message) => {{
   }}
   throw new Error("runner received unexpected protocol message");
 }};
+{proxy}
 globalThis.__labMainPromise = (async () => {{
 {invoker}}})();
 "#
@@ -1659,7 +1713,7 @@ globalThis.__labMainPromise = (async () => {{
 
 #[cfg(not(feature = "code_mode_wasm"))]
 fn run_code_mode_runner() -> Result<(), String> {
-    let CodeModeRunnerInput::Start { code } = runner_read_input()? else {
+    let CodeModeRunnerInput::Start { code, proxy } = runner_read_input()? else {
         return Err("runner expected start message".to_string());
     };
 
@@ -1686,7 +1740,12 @@ fn run_code_mode_runner() -> Result<(), String> {
     // the Javy path via `code_mode_main_invoker`. Interpolated as a named arg so
     // its literal JS braces are not re-scanned by `format!`.
     let invoker = code_mode_main_invoker(&code);
-    let wrapped = format!("(async () => {{\n{invoker}}})()");
+    // `callTool` is already registered as a native builtin above, so the proxy
+    // (which calls `callTool`) is simply prepended in front of the IIFE. The
+    // proxy ends with `var` declarations (no completion value), so the trailing
+    // IIFE remains the `eval` completion value (the awaited promise). An empty
+    // proxy (search path / legacy Start) leaves `codemode` undefined as before.
+    let wrapped = format!("{proxy}\n(async () => {{\n{invoker}}})()");
     let value = context
         .eval(Source::from_bytes(wrapped.as_bytes()))
         .map_err(js_error_message)?;

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -1081,7 +1081,13 @@ struct CodeModeRunnerState {
 }
 
 const CODE_MODE_LOOP_ITERATION_LIMIT: u64 = 1_000_000;
-const CODE_MODE_STACK_SIZE_LIMIT: usize = 16 * 1024;
+// Boa interprets this as the max operand-stack value count (default 10_240);
+// the Javy path interprets it as the native stack size in bytes. 16 KiB was far
+// too small once the runtime `codemode.*` proxy preamble (one method per upstream
+// tool, ~140+ across the gateway) is injected — even a single callTool overflowed
+// the operand stack. 256 KiB gives ample headroom for the preamble + await/Promise
+// machinery; the separate recursion limit still bounds genuine runaway recursion.
+const CODE_MODE_STACK_SIZE_LIMIT: usize = 256 * 1024;
 const CODE_MODE_RECURSION_LIMIT: usize = 256;
 
 /// Backstop applied in the runner itself to prevent OOM before the parent's

--- a/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
@@ -1,0 +1,306 @@
+//! Runtime JS proxy generation for Code Mode.
+//!
+//! Generates the executable `var codemode = {...}` proxy object that is sent
+//! through the Code Mode Start protocol and injected into the sandbox after
+//! `callTool` is defined. The proxy lets the agent call
+//! `codemode.<upstream>.<tool>(params)`, which routes to
+//! `callTool("upstream::<upstream>::<dotted.name>", params)`.
+//!
+//! This is RUNTIME JS, not a TypeScript declaration: it never enters the
+//! model's context (unlike the deleted typed-preamble-in-tool-description
+//! machinery from commit 780c67d3). Surfacing types/schemas via `search` is a
+//! separate follow-up; this module only restores the executable proxy.
+
+use crate::dispatch::upstream::types::UpstreamTool;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tool name conversion (snake_case — Cloudflare Code Mode parity)
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Cloudflare's Code Mode normalizes tool ids like `my-server.list-items` to
+// `my_server_list_items` (all separators → `_`). We do the same so that an
+// LLM trained on Cloudflare examples calls the right names.
+
+/// JavaScript reserved words that need an underscore suffix.
+const JS_RESERVED: &[&str] = &[
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "let",
+    "new",
+    "null",
+    "return",
+    "static",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+];
+
+/// Convert a dotted/hyphenated/slashed/coloned tool name to snake_case.
+///
+/// Examples (Cloudflare parity):
+/// - `movie.search` → `movie_search`
+/// - `tv-show.get` → `tv_show_get`
+/// - `create/issue` → `create_issue`
+/// - `list:repos` → `list_repos`
+/// - `delete` → `delete_` (reserved word)
+/// - `2fa_setup` → `_2fa_setup` (leading digit prefixed with `_`)
+///
+/// KNOWN COLLISION: `movie.search` and `movie_search` both map to `movie_search`
+/// — last insert wins when building the namespace. A `tracing::debug!` is emitted
+/// when a collision is detected.
+pub fn tool_name_to_snake(name: &str) -> String {
+    // Split on dots, hyphens, forward-slashes, and colons; rejoin with `_`.
+    // Underscores already in segments are preserved.
+    let snake: String = name
+        .split(['.', '-', '/', ':'])
+        .filter(|seg| !seg.is_empty())
+        .collect::<Vec<_>>()
+        .join("_");
+
+    // Prefix with `_` if the result starts with a digit (invalid JS identifier start).
+    let snake = if snake.starts_with(|c: char| c.is_ascii_digit()) {
+        format!("_{snake}")
+    } else {
+        snake
+    };
+
+    if JS_RESERVED.contains(&snake.as_str()) {
+        format!("{snake}_")
+    } else {
+        snake
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// JS proxy generation (runtime executable, not type declarations)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Generate a JavaScript preamble string that defines the `codemode` proxy
+/// namespace, plus `codemode.__meta__.upstreams()` and a `__upstreams__`
+/// script-global, for use inside the sandbox.
+///
+/// The output is a JS snippet (not TypeScript) that is prepended to (Boa) or
+/// injected into (Javy) the user code before being sent to the runner
+/// subprocess. It relies on `callTool` already being registered in the sandbox.
+///
+/// The output ends with `var` declarations (no completion value), so when it is
+/// concatenated in front of a trailing IIFE the IIFE's promise remains the
+/// `eval` completion value.
+///
+/// `tools` — the upstream tools to expose
+/// `upstreams` — sorted, deduplicated list of upstream names
+pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String {
+    use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+
+    // Group tools by upstream name, sorted for deterministic output.
+    let mut by_upstream: BTreeMap<&str, Vec<&UpstreamTool>> = BTreeMap::new();
+    for tool in tools {
+        by_upstream
+            .entry(tool.upstream_name.as_ref())
+            .or_default()
+            .push(tool);
+    }
+
+    let mut parts = String::new();
+
+    // Emit per-upstream namespace objects.
+    for (upstream_name, upstream_tools) in &by_upstream {
+        // Build snake_case → dotted name mapping, last registration wins on collision.
+        let mut snake_to_dotted: BTreeMap<String, String> = BTreeMap::new();
+        let mut sorted_tools = upstream_tools.to_vec();
+        sorted_tools.sort_by(|a, b| a.tool.name.cmp(&b.tool.name));
+        for tool in &sorted_tools {
+            let snake = tool_name_to_snake(tool.tool.name.as_ref());
+            if snake_to_dotted.contains_key(&snake) {
+                tracing::debug!(
+                    upstream = *upstream_name,
+                    tool_name = tool.tool.name.as_ref(),
+                    snake_name = %snake,
+                    "Code Mode proxy: tool name collision detected, last registration wins"
+                );
+            }
+            snake_to_dotted.insert(snake, tool.tool.name.to_string());
+        }
+
+        // Serialize the upstream name safely.
+        let upstream_json =
+            serde_json::to_string(upstream_name).unwrap_or_else(|_| "\"unknown\"".to_string());
+
+        let mut method_defs = Vec::new();
+        for (snake, dotted) in &snake_to_dotted {
+            let tool_id = format!("upstream::{upstream_name}::{dotted}");
+            let tool_id_json =
+                serde_json::to_string(&tool_id).unwrap_or_else(|_| "\"unknown\"".to_string());
+            // Always use a JSON-quoted property key so that any residual special
+            // characters in the snake_case name (e.g. from exotic tool schemas) never
+            // cause a JS syntax error inside QuickJS/Boa.
+            let snake_json =
+                serde_json::to_string(snake.as_str()).unwrap_or_else(|_| format!("\"{snake}\""));
+            // Use `p == null ? {} : p` (not `?? {}`) so the proxy does not depend
+            // on the engine supporting the nullish-coalescing operator.
+            method_defs.push(format!(
+                "    {snake_json}: function(p) {{ return callTool({tool_id_json}, p == null ? {{}} : p); }}"
+            ));
+        }
+
+        let methods = method_defs.join(",\n");
+        let _ = write!(parts, "codemode[{upstream_json}] = {{\n{methods}\n}};\n");
+    }
+
+    // Emit __meta__.upstreams value.
+    let upstreams_json = serde_json::to_string(upstreams).unwrap_or_else(|_| "[]".to_string());
+
+    format!(
+        "// Code Mode proxy — auto-generated\n\
+         var codemode = {{}};\n\
+         {parts}\
+         codemode.__meta__ = {{ upstreams: function() {{ return Promise.resolve({upstreams_json}); }} }};\n\
+         var __upstreams__ = {upstreams_json};\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rmcp::model::Tool;
+    use serde_json::Value;
+
+    use super::*;
+    use crate::dispatch::upstream::types::UpstreamTool;
+
+    // ── tool_name_to_snake ────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_name_to_snake_converts_dotted_names() {
+        // PRESENCE: basic dotted/hyphenated name conversion (Cloudflare parity)
+        assert_eq!(tool_name_to_snake("movie.search"), "movie_search");
+        assert_eq!(tool_name_to_snake("tv-show.get"), "tv_show_get");
+        // PRESENCE: reserved word gets underscore suffix
+        assert_eq!(tool_name_to_snake("delete"), "delete_");
+        // ABSENCE: separators must not appear in snake output
+        assert!(!tool_name_to_snake("movie.search").contains('.'));
+        assert!(!tool_name_to_snake("tv-show.get").contains('-'));
+    }
+
+    #[test]
+    fn tool_name_to_snake_handles_slashes_and_colons() {
+        // PRESENCE: forward-slashes and colons join with underscore
+        assert_eq!(tool_name_to_snake("create/issue"), "create_issue");
+        assert_eq!(tool_name_to_snake("list:repos"), "list_repos");
+        assert_eq!(
+            tool_name_to_snake("repos/create/branch"),
+            "repos_create_branch"
+        );
+        // PRESENCE: already-snake input is preserved
+        assert_eq!(tool_name_to_snake("create_issue"), "create_issue");
+        // PRESENCE: leading digit gets prefixed with underscore
+        assert_eq!(tool_name_to_snake("2fa_setup"), "_2fa_setup");
+        // ABSENCE: separators must not appear in output (would break JS syntax)
+        assert!(!tool_name_to_snake("create/issue").contains('/'));
+        assert!(!tool_name_to_snake("list:repos").contains(':'));
+    }
+
+    // ── generate_js_proxy ─────────────────────────────────────────────────────
+
+    #[test]
+    fn generate_js_proxy_quoted_keys_tolerate_special_chars() {
+        // Tool with a slash in the name — previously caused "Exception generated
+        // by QuickJS" because the unquoted key was a JS syntax error.
+        let schema = Arc::new(
+            serde_json::from_value::<serde_json::Map<String, Value>>(
+                serde_json::json!({"type": "object", "properties": {}}),
+            )
+            .unwrap(),
+        );
+        let tool = UpstreamTool {
+            upstream_name: Arc::from("github"),
+            tool: Tool::new("create/issue", "Create an issue", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+        };
+        let js = generate_js_proxy(&[tool], &["github".to_string()]);
+
+        // PRESENCE: the upstream object must be present
+        assert!(
+            js.contains("codemode[\"github\"]"),
+            "upstream block missing"
+        );
+        // PRESENCE: the tool key must appear as a quoted string (not unquoted)
+        assert!(
+            js.contains("\"create_issue\""),
+            "snake_case key must be quoted"
+        );
+        // ABSENCE: no unquoted slash-containing key that would break JS syntax
+        assert!(
+            !js.contains("create/issue:"),
+            "slash in unquoted key would break JS"
+        );
+        // PRESENCE: callTool must be wired to the original dotted tool id
+        assert!(
+            js.contains("upstream::github::create/issue"),
+            "original tool id must be preserved"
+        );
+    }
+
+    #[test]
+    fn generate_js_proxy_emits_codemode_global_and_method() {
+        let schema = Arc::new(serde_json::Map::new());
+        let tool = UpstreamTool {
+            upstream_name: Arc::from("radarr"),
+            tool: Tool::new("movie.search", "Search for movies", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+        };
+        let js = generate_js_proxy(&[tool], &["radarr".to_string()]);
+
+        // PRESENCE: declares the script-global `var codemode`
+        assert!(js.contains("var codemode = {}"), "must declare codemode");
+        // PRESENCE: snake_case method routes to the dotted upstream id
+        assert!(
+            js.contains("upstream::radarr::movie.search"),
+            "method must route to dotted tool id"
+        );
+        // PRESENCE: __meta__.upstreams reflects the upstream list
+        assert!(
+            js.contains("[\"radarr\"]"),
+            "upstreams list must be embedded"
+        );
+        // PRESENCE: null-safe params guard (no nullish-coalescing dependency)
+        assert!(
+            js.contains("p == null ? {} : p"),
+            "must use null-safe params guard"
+        );
+        // ABSENCE: must not use nullish-coalescing (engine-portability)
+        assert!(!js.contains("?? {}"), "must not depend on ?? operator");
+    }
+}

--- a/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
@@ -132,8 +132,17 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String
 
     let mut parts = String::new();
 
-    // Emit per-upstream namespace objects.
+    // Accumulate method definitions keyed by the snake_cased UPSTREAM name so the
+    // namespace is reachable via dot notation (`codemode.arcane_mcp.tool(...)`),
+    // not just bracket access. Hyphenated upstreams (arcane-mcp, github-chat, …)
+    // would otherwise be unreachable as `codemode.arcane-mcp` (parses as
+    // subtraction). The `callTool` id keeps the RAW upstream name. Two raw
+    // upstreams that snake-collide merge into one namespace object (tools are not
+    // dropped); a per-tool snake collision is last-wins inside the object literal.
+    let mut by_snake_upstream: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for (upstream_name, upstream_tools) in &by_upstream {
+        let upstream_snake = tool_name_to_snake(upstream_name);
+
         // Build snake_case → dotted name mapping, last registration wins on collision.
         let mut snake_to_dotted: BTreeMap<String, String> = BTreeMap::new();
         let mut sorted_tools = upstream_tools.to_vec();
@@ -151,12 +160,9 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String
             snake_to_dotted.insert(snake, tool.tool.name.to_string());
         }
 
-        // Serialize the upstream name safely.
-        let upstream_json =
-            serde_json::to_string(upstream_name).unwrap_or_else(|_| "\"unknown\"".to_string());
-
-        let mut method_defs = Vec::new();
+        let method_defs = by_snake_upstream.entry(upstream_snake).or_default();
         for (snake, dotted) in &snake_to_dotted {
+            // callTool id uses the RAW upstream + RAW tool name.
             let tool_id = format!("upstream::{upstream_name}::{dotted}");
             let tool_id_json =
                 serde_json::to_string(&tool_id).unwrap_or_else(|_| "\"unknown\"".to_string());
@@ -171,9 +177,16 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String
                 "    {snake_json}: function(p) {{ return callTool({tool_id_json}, p == null ? {{}} : p); }}"
             ));
         }
+    }
 
+    for (upstream_snake, method_defs) in &by_snake_upstream {
+        let upstream_snake_json =
+            serde_json::to_string(upstream_snake).unwrap_or_else(|_| "\"unknown\"".to_string());
         let methods = method_defs.join(",\n");
-        let _ = write!(parts, "codemode[{upstream_json}] = {{\n{methods}\n}};\n");
+        let _ = write!(
+            parts,
+            "codemode[{upstream_snake_json}] = {{\n{methods}\n}};\n"
+        );
     }
 
     // Emit __meta__.upstreams value.
@@ -302,5 +315,37 @@ mod tests {
         );
         // ABSENCE: must not use nullish-coalescing (engine-portability)
         assert!(!js.contains("?? {}"), "must not depend on ?? operator");
+    }
+
+    #[test]
+    fn generate_js_proxy_snake_cases_hyphenated_upstream_keys() {
+        // Hyphenated upstreams (arcane-mcp, github-chat, …) must be reachable via
+        // dot notation `codemode.arcane_mcp.tool(...)`, not just bracket access —
+        // `codemode.arcane-mcp` parses as subtraction. The callTool id must keep
+        // the RAW upstream name so the gateway routes to the real server.
+        let schema = Arc::new(serde_json::Map::new());
+        let tool = UpstreamTool {
+            upstream_name: Arc::from("arcane-mcp"),
+            tool: Tool::new("arcane", "Docker management", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+        };
+        let js = generate_js_proxy(&[tool], &["arcane-mcp".to_string()]);
+
+        // PRESENCE: namespace key is snake_cased (dot-accessible)
+        assert!(
+            js.contains("codemode[\"arcane_mcp\"]"),
+            "hyphenated upstream key must be snake_cased: {js}"
+        );
+        // ABSENCE: the raw hyphenated key must NOT be the namespace key
+        assert!(
+            !js.contains("codemode[\"arcane-mcp\"]"),
+            "raw hyphenated key would only be bracket-accessible"
+        );
+        // PRESENCE: callTool id keeps the RAW upstream name (routing correctness)
+        assert!(
+            js.contains("upstream::arcane-mcp::arcane"),
+            "callTool id must keep the raw upstream name: {js}"
+        );
     }
 }

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -41,9 +41,18 @@ const CODE_MODE_MAX_CODE_BYTES: usize = 20_000;
 ///
 /// This description is what the model receives. Keep it under 8192 bytes.
 const CODE_EXECUTE_DESCRIPTION: &str = "\
-Execute JavaScript in the Code Mode sandbox. Every upstream MCP tool is pre-declared \
-as a typed TypeScript helper in the `codemode` namespace — read the types, call the \
-functions. No separate discovery step required.
+Execute a JavaScript async arrow function in the Code Mode sandbox. Pass `code` as \
+`async () => { ... }` — the sandbox awaits its return value (same shape as search). \
+Every upstream MCP tool is pre-declared as a typed TypeScript helper in the `codemode` \
+namespace — read the types, call the functions. No separate discovery step required.
+
+```ts
+// code is an async arrow function; whatever it returns becomes `result`.
+async () => {
+  const issues = await callTool('upstream::github::search_issues', { q: 'bug' });
+  return issues.items.length;
+}
+```
 
 `Promise.all([...])` dispatches `callTool` requests in parallel — batch independent \
 reads instead of awaiting serially.
@@ -75,11 +84,13 @@ Oversized results are replaced with a truncation marker containing `truncated`, 
 `original_size`, `original_tokens`, `preview`, and `next_action`. Reduce data inside \
 the sandbox before returning — that is the point of Code Mode.
 
-Fuel budget:
-- Base overhead: ~100K fuel for the JS runtime.
-- Per callTool boundary: ~2K fuel.
-- Default 50M fuel supports heavy fan-out plus moderate result processing.
-- `code_mode_fuel_exhausted`: split the work across calls or reduce local processing.
+Budget:
+- Time: a 30s wall-clock timeout bounds the whole run (the meaningful limit). \
+There is no small per-run call cap — fan out freely with `Promise.all`.
+- Fuel: default 50M fuel supports heavy fan-out plus moderate result processing; \
+base overhead ~100K, ~2K per callTool boundary.
+- `code_mode_fuel_exhausted` or `timeout`: split the work across calls or reduce \
+local processing.
 
 Lab actions (`lab::*` tool IDs) are not available in Code Mode. For Lab built-in \
 actions use the `execute` tool in Tool Search mode.";

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -76,6 +76,9 @@ Error handling:
 // Fix-and-retry: missing_param, invalid_param, validation_failed, confirmation_required
 // Terminal:      unknown_tool, unknown_action, auth_failed, server_error, internal_error
 ```
+A failed callTool rejects only its own promise — the run continues, so catch it and \
+proceed. For catch-and-continue fan-out, prefer `Promise.allSettled` so every call \
+settles before you return.
 
 Scope: `lab:read` — catalog read only. `lab` / `lab:admin` — callTool execution.
 

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -394,3 +394,80 @@ fn code_mode_runner_tool_error_does_not_abort_fan_out() {
     let status = child.wait().expect("wait for runner");
     assert!(status.success(), "runner exited with {status}");
 }
+
+/// Drive the runner with `code` that makes exactly one `callTool` and returns
+/// its result. Answers the single tool call with `tool_result`, then asserts
+/// Done carries the returned value. Used to prove a given code shape executes
+/// end-to-end through the runner's arrow-function wrapper (bead lab-vkwfa).
+fn assert_single_call_round_trip(code: &str, expected_result: Value) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    writeln!(stdin, "{}", json!({"type": "start", "code": code})).expect("write start");
+
+    let call = read_protocol_line(&mut stdout);
+    assert_eq!(
+        call["type"], "tool_call",
+        "expected a tool_call, got: {call}"
+    );
+    let seq = call["seq"].as_u64().expect("seq");
+    writeln!(
+        stdin,
+        "{}",
+        json!({"type": "tool_result", "seq": seq, "result": {"pong": true}})
+    )
+    .expect("write tool result");
+
+    let done = read_protocol_line(&mut stdout);
+    assert_eq!(done["type"], "done", "expected done, got: {done}");
+    assert_eq!(
+        done["result"], expected_result,
+        "done.result must carry the function return value"
+    );
+    let status = child.wait().expect("wait for runner");
+    assert!(status.success(), "runner exited with {status}");
+}
+
+/// FIX 1 (bead lab-vkwfa): a `function main` BODY form, after `normalize_user_code`,
+/// must execute end-to-end through the runner's arrow-function wrapper. This is
+/// non-vacuous: the raw body form is normalized to a parenthesized function
+/// EXPRESSION before being piped to the runner, exactly as the broker does.
+#[test]
+fn normalized_function_main_form_executes_end_to_end() {
+    let body = "async function main() { return await callTool(\"upstream::test::ping\", {}); }";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    // Guard: normalize must produce a parenthesized expression with no self-call,
+    // otherwise this test would be vacuous (the raw form happens to wrap too).
+    assert!(
+        normalized.starts_with("(async function main()") && !normalized.contains("main();"),
+        "normalize must emit a bare function expression, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}
+
+/// FIX 1 (bead lab-vkwfa): an `export default async function` form, after
+/// `normalize_user_code`, must execute end-to-end. Non-vacuous: the raw form
+/// would be an IIFE (a Promise, not a function) and fail the wrapper's typeof
+/// check; normalize now emits a bare function expression instead.
+#[test]
+fn normalized_export_default_form_executes_end_to_end() {
+    let body =
+        "export default async function() { return await callTool(\"upstream::test::ping\", {}); }";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("(async function")
+            && normalized.ends_with("})")
+            && !normalized.ends_with("()"),
+        "normalize must emit a bare function expression (no IIFE), got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -24,7 +24,7 @@ fn code_mode_runner_evaluates_js_in_a_minimal_host_environment() {
     let stdout = child.stdout.take().expect("runner stdout");
     let mut stderr = child.stderr.take().expect("runner stderr");
     let mut stdout = BufReader::new(stdout);
-    let code = r#"
+    let code = r#"async () => {
         if (typeof process !== "undefined" || typeof require !== "undefined" ||
             typeof fetch !== "undefined" || typeof Deno !== "undefined" ||
             typeof Bun !== "undefined") {
@@ -38,7 +38,7 @@ fn code_mode_runner_evaluates_js_in_a_minimal_host_environment() {
         if (false) {
           await callTool("lab::gateway.never", {});
         }
-    "#;
+    }"#;
 
     writeln!(
         stdin,
@@ -122,13 +122,13 @@ fn code_mode_runner_fans_out_promise_all_tool_calls() {
     let mut stdin = child.stdin.take().expect("runner stdin");
     let stdout = child.stdout.take().expect("runner stdout");
     let mut stdout = BufReader::new(stdout);
-    let code = r#"
+    let code = r#"async () => {
         const [first, second] = await Promise.all([
           callTool("lab::gateway.first", {"x": 1}),
           callTool("lab::gateway.second", {"x": 2})
         ]);
         await callTool("lab::gateway.after", {"sum": first.value + second.value});
-    "#;
+    }"#;
 
     writeln!(
         stdin,
@@ -228,10 +228,10 @@ fn code_mode_runner_done_carries_return_value() {
     let mut stdout = BufReader::new(stdout);
 
     // The function fetches one tool result and returns it directly.
-    let code = r#"
+    let code = r#"async () => {
         const result = await callTool("upstream::test::ping", {"msg": "hello"});
         return result;
-    "#;
+    }"#;
 
     writeln!(stdin, "{}", json!({"type": "start", "code": code})).expect("write start");
 
@@ -283,14 +283,14 @@ fn code_mode_runner_tool_error_produces_json_encoded_error() {
     // The function catches the error and returns the parsed CodeModeError shape.
     // If the rejection is plain text, JSON.parse will throw SyntaxError and
     // the function itself will error, causing Done to never appear.
-    let code = r#"
+    let code = r#"async () => {
         try {
             await callTool("upstream::test::fail", {});
         } catch (e) {
             const parsed = JSON.parse(String(e.message));
             return {caught: true, kind: parsed.kind, msg: parsed.message};
         }
-    "#;
+    }"#;
 
     writeln!(stdin, "{}", json!({"type": "start", "code": code})).expect("write start");
 

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -323,3 +323,74 @@ fn code_mode_runner_tool_error_produces_json_encoded_error() {
     let status = child.wait().expect("wait for runner");
     assert!(status.success(), "runner exited with {status}");
 }
+
+/// Verify that a tool error in the middle of a fan-out does NOT abort the run
+/// (bead lab-xvff5). With `Promise.allSettled`, one rejected callTool settles as
+/// `rejected` while siblings still resolve, and the function returns normally —
+/// the runner must keep processing after the mid-fan-out error and emit Done with
+/// both outcomes.
+#[test]
+fn code_mode_runner_tool_error_does_not_abort_fan_out() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    let code = r#"async () => {
+        const settled = await Promise.allSettled([
+          callTool("upstream::test::fail", {}),
+          callTool("upstream::test::ok", {})
+        ]);
+        return settled.map(s => {
+          if (s.status === "rejected") {
+            const parsed = JSON.parse(String(s.reason.message));
+            return {status: s.status, kind: parsed.kind};
+          }
+          return {status: s.status, value: s.value};
+        });
+    }"#;
+
+    writeln!(stdin, "{}", json!({"type": "start", "code": code})).expect("write start");
+
+    // Both callTool requests are emitted before either is answered (parallel fan-out).
+    let first = read_protocol_line(&mut stdout);
+    let second = read_protocol_line(&mut stdout);
+    assert_eq!(first["type"], "tool_call");
+    assert_eq!(second["type"], "tool_call");
+    assert_eq!(first["seq"], json!(0));
+    assert_eq!(second["seq"], json!(1));
+
+    // Fail seq 0 mid-fan-out; resolve seq 1 normally.
+    writeln!(
+        stdin,
+        "{}",
+        json!({"type": "tool_error", "seq": 0, "kind": "rate_limited", "message": "slow down"})
+    )
+    .expect("write tool_error");
+    writeln!(
+        stdin,
+        "{}",
+        json!({"type": "tool_result", "seq": 1, "result": {"pong": true}})
+    )
+    .expect("write tool_result");
+
+    // The run must NOT have aborted on the seq-0 failure — Done arrives with both outcomes.
+    let done = read_protocol_line(&mut stdout);
+    assert_eq!(
+        done["type"], "done",
+        "a mid-fan-out tool error must not abort the run"
+    );
+    assert_eq!(done["result"][0]["status"], json!("rejected"));
+    assert_eq!(done["result"][0]["kind"], json!("rate_limited"));
+    assert_eq!(done["result"][1]["status"], json!("fulfilled"));
+    assert_eq!(done["result"][1]["value"], json!({"pong": true}));
+    let status = child.wait().expect("wait for runner");
+    assert!(status.success(), "runner exited with {status}");
+}

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -454,6 +454,73 @@ fn normalized_function_main_form_executes_end_to_end() {
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
 
+/// lab-12fm5: the runtime `codemode.*` proxy travels through the Start protocol
+/// and routes `codemode.demo.ping(...)` to `callTool("upstream::demo::ping", ...)`
+/// end-to-end. The proxy here is the exact shape `generate_js_proxy` emits.
+/// Non-vacuous: with no proxy, `codemode` is undefined and the code would throw.
+#[test]
+fn codemode_proxy_routes_through_call_tool() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    // Minimal proxy mirroring generate_js_proxy's output shape (var codemode = {};
+    // codemode["demo"] = { ping: function(p) { return callTool(...); } };).
+    let proxy = "var codemode = {};\n\
+        codemode[\"demo\"] = {\n\
+          \"ping\": function(p) { return callTool(\"upstream::demo::ping\", p == null ? {} : p); }\n\
+        };\n";
+    // Guard the in-sandbox `codemode` type, then route through the proxy.
+    let code = "async () => { \
+        if (typeof codemode !== \"object\") { throw new Error(\"codemode not object\"); } \
+        return await codemode.demo.ping({x: 1}); \
+    }";
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"type": "start", "code": code, "proxy": proxy})
+    )
+    .expect("write start");
+
+    // The proxy must have emitted a callTool to the dotted upstream id.
+    let call = read_protocol_line(&mut stdout);
+    assert_eq!(
+        call["type"], "tool_call",
+        "expected a tool_call, got: {call}"
+    );
+    assert_eq!(
+        call["id"], "upstream::demo::ping",
+        "proxy must route to the dotted upstream tool id"
+    );
+    assert_eq!(call["params"], json!({"x": 1}), "proxy must forward params");
+    let seq = call["seq"].as_u64().expect("seq");
+    writeln!(
+        stdin,
+        "{}",
+        json!({"type": "tool_result", "seq": seq, "result": {"pong": true}})
+    )
+    .expect("write tool result");
+
+    let done = read_protocol_line(&mut stdout);
+    assert_eq!(done["type"], "done", "expected done, got: {done}");
+    assert_eq!(
+        done["result"],
+        json!({"pong": true}),
+        "codemode.demo.ping must resolve to the tool result"
+    );
+    let status = child.wait().expect("wait for runner");
+    assert!(status.success(), "runner exited with {status}");
+}
+
 /// FIX 1 (bead lab-vkwfa): an `export default async function` form, after
 /// `normalize_user_code`, must execute end-to-end. Non-vacuous: the raw form
 /// would be an IIFE (a Promise, not a function) and fail the wrapper's typeof

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -39,9 +39,11 @@ not listed in the catalog due to overflow.
 - `max_response_bytes = 24576`
 - `max_response_tokens = 6000`
 
-When the envelope is too large, oversized per-call results are replaced with a
-truncation marker containing `truncated`, `original_size`, `original_tokens`,
-`preview`, and `next_action`.
+`calls[]` carries lightweight per-call metadata only (`id`, `ok`, `elapsed_ms`,
+and `error_kind` on failure) — never the per-call result payload. When the
+envelope is too large, the final `result` is replaced with a truncation marker
+containing `truncated`, `original_size`, `original_tokens`, `preview`, and
+`next_action`.
 
 ## Runner Architecture
 

--- a/docs/specs/CODE_MODE_SPEC_FOR_RETARD_AGENTS.md
+++ b/docs/specs/CODE_MODE_SPEC_FOR_RETARD_AGENTS.md
@@ -230,7 +230,7 @@ works. It must read `cfg.code_mode.enabled`.
 [code_mode]
 enabled = false              # mutually exclusive with [tool_search].enabled = true
 timeout_ms = 30000           # valid: 1..=60000 (Cloudflare-parity default)
-max_tool_calls = 1000        # valid: 1..=100000 (high safety ceiling; the 30s timeout is the real bound)
+max_tool_calls = 1000        # valid: 1..=10000 (high safety ceiling; the 30s timeout is the real bound)
 max_response_bytes = 24576   # valid: 1024..=1048576 (24KB default)
 max_response_tokens = 6000   # valid: 256..=256000
 ```

--- a/docs/specs/CODE_MODE_SPEC_FOR_RETARD_AGENTS.md
+++ b/docs/specs/CODE_MODE_SPEC_FOR_RETARD_AGENTS.md
@@ -164,8 +164,8 @@ Advertised **only** when `code_mode.enabled = true` in config.
 
 ```typescript
 {
-  code: string;          // async arrow function body, or full async function expression
-  max_tool_calls?: number; // default: config.max_tool_calls (default 8), max 50
+  code: string;          // JavaScript async arrow function: async () => { ... }
+  max_tool_calls?: number; // default: config.max_tool_calls (default 1000, high safety ceiling); the 30s timeout is the meaningful bound
 }
 ```
 
@@ -230,7 +230,7 @@ works. It must read `cfg.code_mode.enabled`.
 [code_mode]
 enabled = false              # mutually exclusive with [tool_search].enabled = true
 timeout_ms = 30000           # valid: 1..=60000 (Cloudflare-parity default)
-max_tool_calls = 8           # valid: 1..=50
+max_tool_calls = 1000        # valid: 1..=100000 (high safety ceiling; the 30s timeout is the real bound)
 max_response_bytes = 24576   # valid: 1024..=1048576 (24KB default)
 max_response_tokens = 6000   # valid: 256..=256000
 ```


### PR DESCRIPTION
Makes our gateway `search`/`execute` match Cloudflare's server-side Code Mode behaviorally. Four beads (`lab-vkwfa`, `lab-03h52`, `lab-xvff5`, `lab-s2p2u`) + `/lavra-review` fixes + a live-found double-JSON fix.

## Changes
- **Uniform code shape (`lab-vkwfa`):** `execute` takes an async arrow function (like `search`); `normalize_user_code` emits bare callable expressions so `function main` / `export default` forms still work; the arrow-wrapper snippet + TypeError message are deduped across the Javy/Boa runner sites.
- **Catchable tool errors (`lab-xvff5`):** a failed `callTool` is now a catchable in-sandbox promise rejection (structured `{kind,message}`) that **continues** the run — `Promise.allSettled` over a partial-failure fan-out returns partial results instead of aborting. Only uncaught rejections fail the run; limit/timeout paths still terminate.
- **Metadata-only `calls[]` (`lab-s2p2u`):** each entry is `{id, ok, elapsed_ms, error_kind?}` — no result payload (no context bloat, no truncation-preview secret leak). Final `result` **and** `logs` are bounded at 24KB/6000.
- **Time budget over call cap (`lab-03h52`):** removed the 8/12-call cap; `timeout_ms` default 30000 is the bound, with a high safety ceiling (default 1000, validation ≤ 10000).
- **Double-JSON fix:** catchable-rejection message now uses `err.user_message()` not `err.to_string()` (which emits the full JSON envelope) — single-encoded, found in live testing.

## Verification
1567 tests pass with `RUSTFLAGS=-D warnings`; clippy exit 0; docs fresh. End-to-end runner tests cover catchable fan-out + both legacy code forms. `/lavra-review` ran (3 agents) and its P1 (normalize/arrow incompatibility, missed by the green build) was fixed. **Verified live** on the container via mcporter: arrow form works, catchable mid-fan-out continues, `calls[]` is metadata-only, >12 calls allowed, rejection message single-encoded.

## Follow-ups filed (NOT in this PR)
- **P2** `lab-...`: 16KB JS stack overflows ~15-way fan-out — partly defeats the cap removal; raise `CODE_MODE_STACK_SIZE_LIMIT`.
- **P2** `lab-...`: bound in-flight callTool concurrency (semaphore), independent of `max_tool_calls`.
- **P3** `lab-ley2s`: body-form `execute` gives opaque "Exception generated by QuickJS" instead of an arrow-function hint (double-JSON half already fixed here).
- **P3** `lab-...`: terminate runner process-group on error-branch stdin-write failure.

Refs: lab-vkwfa, lab-03h52, lab-xvff5, lab-s2p2u

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings Code Mode to Cloudflare parity and restores the runtime `codemode.*` namespace with dot-notation (`snake_case`) upstream keys. `execute` runs an async arrow function, tool errors are catchable, `calls[]` is metadata-only, a 30s time budget replaces the call cap, and `codemode.<snake_upstream>.<tool>(params)` routes to `callTool`.

- **New Features**
  - Uniform code shape: `execute` evaluates `async () => { ... }`; `normalize_user_code` emits a bare parenthesized function expression for `function main`/`export default`; a shared wrapper enforces shape with a clear TypeError.
  - Runtime `codemode.*` proxy: generated from the live catalog and injected; methods call `callTool("upstream::<raw_upstream>::<dotted>")`; upstream keys are `snake_case` for dot access; quoted keys and `__meta__.upstreams()` included. `callTool` remains the escape hatch.
  - Catchable tool errors: a failed `callTool` rejects only its promise; runs continue (use `Promise.allSettled` for partial fan‑out). Uncaught rejections still fail; limit/timeout still terminate.
  - Lean `calls[]`: now `{id, ok, elapsed_ms, error_kind?}` only. Truncation caps the final `result` (only when smaller than original) and trims `logs` to fit 24KB/6000.
  - Time over cap: 30s `timeout_ms` is the real bound; default `max_tool_calls` is 1000 with a 10,000 ceiling.

- **Bug Fixes**
  - Fixed double‑JSON in rejection messages by sending `user_message()` instead of `to_string()`.
  - Deduped the execute wrapper across engines to keep the contract identical; raised the sandbox stack limit to 256KB to avoid overflows with the injected proxy and fan‑out.
  - Added tests for proxy routing (incl. hyphenated upstreams via `snake_case`), catchable mid‑fan‑out, normalized `function main`/`export default` execution, and result/logs truncation; docs and config example updated.

<sup>Written for commit 3fb4898b537648a2e58689d16816252a43b7a2fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased concurrent tool call capacity from 8 to 1,000 (configurable up to 10,000)
  * Tool execution failures no longer interrupt the operation flow
  * Added per-call timing and status metadata to execution responses

* **Documentation**
  * Updated Code Mode execution specifications and timeout guidance (30-second wall-clock limit)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/lab/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->