### PR TITLE
feat: close Code Mode Cloudflare parity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.21.0] - 2026-05-31
+
+### Highlights
+
+- **Code Mode normalization now follows Cloudflare's AST behavior** — snippets are
+  parsed structurally so trailing expressions, named functions, export defaults,
+  arrows, classes, and parse fallback cases are wrapped consistently before
+  sandbox execution.
+- **Typed Code Mode parity tightened** — generated TypeScript now handles
+  boolean schemas, tuple arrays, exact empty objects, format JSDoc, stable
+  property order, safer identifier sanitization, and sanitized method collision
+  rejection.
+- **Runtime parity gaps closed** — MCP tool results now unwrap text and mixed
+  content like Cloudflare, recursive JSON Schema validation runs before dispatch,
+  and binary values are preserved across sandbox results and tool calls.
+
+| Commit | Change |
+|--------|--------|
+| *(this)* | feat: close Code Mode Cloudflare parity gaps |
+
+### Version bumps
+
+- Rust workspace: `0.20.0 -> 0.21.0`
+- Gateway admin package: `0.20.0 -> 0.21.0`
+
+---
+
 ## [0.20.0] - 2026-05-27
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "lab-apis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64",
  "futures",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "lab-auth"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum",
  "base64",
@@ -2617,14 +2617,17 @@ dependencies = [
 
 [[package]]
 name = "labby"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
  "arc-swap",
  "axum",
  "base64",
+ "boa_ast",
  "boa_engine",
+ "boa_interner",
+ "boa_parser",
  "boa_runtime",
  "bytes",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = ["crates/lab-apis", "crates/lab", "crates/lab-auth"]
 agent-client-protocol = { path = "crates/vendor/agent-client-protocol" }
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/apps/gateway-admin/package.json
+++ b/apps/gateway-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gateway-admin",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -43,6 +43,9 @@ anyhow.workspace = true
 thiserror.workspace = true
 jiff.workspace = true
 boa_engine = "0.21.1"
+boa_ast = "0.21.1"
+boa_interner = "0.21.1"
+boa_parser = "0.21.1"
 boa_runtime = "0.21"
 javy = { version = "7.0.0", optional = true }
 wasmtime = { version = "44.0.1", optional = true, default-features = false, features = [

--- a/crates/lab/src/cli/gateway.rs
+++ b/crates/lab/src/cli/gateway.rs
@@ -734,7 +734,14 @@ async fn run_gateway_code(
             let config = manager.code_mode_config().await;
             let max_tool_calls = config.max_tool_calls;
             let response = broker
-                .execute(&code, max_tool_calls, caller, surface, config)
+                .execute(
+                    &code,
+                    max_tool_calls,
+                    caller,
+                    surface,
+                    config,
+                    crate::dispatch::gateway::code_mode::CodeModeCapabilityFilter::default(),
+                )
                 .await?;
             crate::output::print(&response, format)?;
         }

--- a/crates/lab/src/dispatch/gateway.rs
+++ b/crates/lab/src/dispatch/gateway.rs
@@ -2,6 +2,7 @@ mod catalog;
 mod client;
 pub mod code_mode;
 mod code_mode_preamble;
+mod code_mode_types;
 pub(crate) mod config;
 mod config_mutation;
 pub mod discovery;

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -150,18 +150,10 @@ fn normalize_module_code(source: &str) -> Option<String> {
             Some(normalize_user_code(&expr.to_interned_string(&interner)))
         }
         boa_ast::declaration::ExportDeclaration::DefaultFunctionDeclaration(function) => Some(
-            format!(
-                "async () => {{\nreturn ({} )();\n}}",
-                function.to_indented_string(&interner, 0)
-            )
-            .replace("} )", "})"),
+            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0)),
         ),
         boa_ast::declaration::ExportDeclaration::DefaultAsyncFunctionDeclaration(function) => Some(
-            format!(
-                "async () => {{\nreturn ({} )();\n}}",
-                function.to_indented_string(&interner, 0)
-            )
-            .replace("} )", "})"),
+            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0)),
         ),
         boa_ast::declaration::ExportDeclaration::DefaultClassDeclaration(class) => Some(format!(
             "async () => {{\nreturn ({});\n}}",
@@ -169,6 +161,12 @@ fn normalize_module_code(source: &str) -> Option<String> {
         )),
         _ => None,
     }
+}
+
+/// Wrap a rendered `export default` function declaration as an immediately
+/// invoked expression inside an async arrow wrapper.
+fn wrap_default_fn_as_iife(rendered: &str) -> String {
+    format!("async () => {{\nreturn ({rendered})();\n}}")
 }
 
 fn normalize_script_code(source: &str) -> Option<String> {
@@ -563,21 +561,16 @@ impl CodeModeSurface {
     }
 }
 
-/// Whether a destructive upstream tool call is permitted for this `surface` and
-/// `caller`.
+/// Whether a destructive upstream tool call is explicitly permitted for this
+/// `surface`.
 ///
-/// Permitted when EITHER the surface explicitly allows destructive actions (the
-/// CLI, or MCP with `confirm:true`) OR the caller carries an execute-capable
-/// scope (`lab` / `lab:admin`).
-///
-/// Allowlisted operators are auto-elevated to `lab:admin` at auth time (see
-/// lab-auth `elevate_scope_for_allowed_user`) precisely so MCP clients can drive
-/// destructive gateway actions without a separate confirmation flow. Honoring
-/// `can_execute()` here realigns the gate with that intent instead of ignoring
-/// the granted scope — a `lab:read` caller is still denied.
+/// Execute-capable scopes (`lab` / `lab:admin`) authorize running Code Mode, but
+/// they do not confirm destructive upstream effects. MCP callers must pass
+/// `confirm:true`; CLI is operator-driven and always permits destructive tools.
 #[must_use]
 fn destructive_permitted(surface: CodeModeSurface, caller: &CodeModeCaller) -> bool {
-    surface.allow_destructive_actions() || caller.can_execute()
+    let _ = caller;
+    surface.allow_destructive_actions()
 }
 
 impl CodeModeCaller {
@@ -651,17 +644,16 @@ pub struct CodeModeCapabilityFilter {
 impl CodeModeCapabilityFilter {
     #[must_use]
     pub fn new(upstreams: Vec<String>, tools: Vec<String>) -> Self {
+        fn clean_set(values: Vec<String>) -> BTreeSet<String> {
+            values
+                .into_iter()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect()
+        }
         Self {
-            upstreams: upstreams
-                .into_iter()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
-            tools: tools
-                .into_iter()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
+            upstreams: clean_set(upstreams),
+            tools: clean_set(tools),
         }
     }
 
@@ -1367,7 +1359,7 @@ fn validate_code_mode_params_against_schema(
     schema: Option<&Value>,
 ) -> Result<(), ToolError> {
     if let Some(schema) = schema {
-        validate_json_schema_value(params, schema, "params", true)?;
+        validate_json_schema_value(params, schema, "params")?;
     }
     Ok(())
 }
@@ -1385,15 +1377,38 @@ fn json_value_matches_schema_type(value: &Value, expected: &str) -> bool {
     }
 }
 
-fn validate_json_schema_value(
+fn validate_json_schema_value(value: &Value, schema: &Value, path: &str) -> Result<(), ToolError> {
+    let mut seen_refs = BTreeSet::new();
+    validate_json_schema_value_inner(value, schema, schema, path, &mut seen_refs)
+}
+
+fn validate_json_schema_value_inner(
     value: &Value,
     schema: &Value,
+    root_schema: &Value,
     path: &str,
-    required_missing_is_missing_param: bool,
+    seen_refs: &mut BTreeSet<String>,
 ) -> Result<(), ToolError> {
     let Some(schema_object) = schema.as_object() else {
         return Ok(());
     };
+
+    if let Some(reference) = schema_object.get("$ref").and_then(Value::as_str) {
+        let pointer = reference.strip_prefix('#').ok_or_else(|| {
+            invalid_schema_param(path, "uses an unsupported non-local $ref in inputSchema")
+        })?;
+        if !seen_refs.insert(reference.to_string()) {
+            return Err(invalid_schema_param(
+                path,
+                "contains a cyclic $ref in inputSchema",
+            ));
+        }
+        let referenced_schema = root_schema.pointer(pointer).ok_or_else(|| {
+            invalid_schema_param(path, "uses an unresolved local $ref in inputSchema")
+        })?;
+        validate_json_schema_value_inner(value, referenced_schema, root_schema, path, seen_refs)?;
+        seen_refs.remove(reference);
+    }
 
     if let Some(values) = schema_object.get("enum").and_then(Value::as_array)
         && !values.iter().any(|candidate| candidate == value)
@@ -1406,30 +1421,54 @@ fn validate_json_schema_value(
         return Err(invalid_schema_param(path, "must match const"));
     }
 
-    for keyword in ["anyOf", "oneOf"] {
-        if let Some(variants) = schema_object.get(keyword).and_then(Value::as_array) {
-            if variants.iter().any(|variant| {
-                validate_json_schema_value(value, variant, path, required_missing_is_missing_param)
-                    .is_ok()
-            }) {
-                return Ok(());
-            }
+    if let Some(variants) = schema_object.get("anyOf").and_then(Value::as_array) {
+        if !variants.iter().any(|variant| {
+            validate_json_schema_value_inner(
+                value,
+                variant,
+                root_schema,
+                path,
+                &mut seen_refs.clone(),
+            )
+            .is_ok()
+        }) {
             return Err(invalid_schema_param(path, "must match at least one schema"));
+        }
+    }
+    if let Some(variants) = schema_object.get("oneOf").and_then(Value::as_array) {
+        let matches = variants
+            .iter()
+            .filter(|variant| {
+                validate_json_schema_value_inner(
+                    value,
+                    variant,
+                    root_schema,
+                    path,
+                    &mut seen_refs.clone(),
+                )
+                .is_ok()
+            })
+            .count();
+        if matches != 1 {
+            return Err(invalid_schema_param(path, "must match exactly one schema"));
         }
     }
     if let Some(variants) = schema_object.get("allOf").and_then(Value::as_array) {
         for variant in variants {
-            validate_json_schema_value(value, variant, path, required_missing_is_missing_param)?;
+            validate_json_schema_value_inner(value, variant, root_schema, path, seen_refs)?;
         }
     }
 
     if let Some(type_value) = schema_object.get("type") {
         let matches_type = match type_value {
-            Value::String(expected) => json_value_matches_schema_type(value, expected),
-            Value::Array(types) => types
-                .iter()
-                .filter_map(Value::as_str)
-                .any(|expected| json_value_matches_schema_type(value, expected)),
+            Value::String(expected) => {
+                json_value_matches_schema_type(value, expected)
+                    || schema_accepts_binary_sentinel(value, schema_object, expected)
+            }
+            Value::Array(types) => types.iter().filter_map(Value::as_str).any(|expected| {
+                json_value_matches_schema_type(value, expected)
+                    || schema_accepts_binary_sentinel(value, schema_object, expected)
+            }),
             _ => true,
         };
         if !matches_type {
@@ -1448,11 +1487,31 @@ fn validate_json_schema_value(
         return Err(invalid_schema_param(path, "is above maximum"));
     }
 
+    if let Some(actual) = value.as_str() {
+        if let Some(min_length) = schema_object.get("minLength").and_then(Value::as_u64)
+            && actual.chars().count() < min_length as usize
+        {
+            return Err(invalid_schema_param(path, "is shorter than minLength"));
+        }
+        if let Some(max_length) = schema_object.get("maxLength").and_then(Value::as_u64)
+            && actual.chars().count() > max_length as usize
+        {
+            return Err(invalid_schema_param(path, "is longer than maxLength"));
+        }
+        if let Some(pattern) = schema_object.get("pattern").and_then(Value::as_str) {
+            let regex = regex::Regex::new(pattern)
+                .map_err(|_| invalid_schema_param(path, "has an invalid pattern in inputSchema"))?;
+            if !regex.is_match(actual) {
+                return Err(invalid_schema_param(path, "does not match pattern"));
+            }
+        }
+    }
+
     if let Some(object) = value.as_object() {
         if let Some(required) = schema_object.get("required").and_then(Value::as_array) {
             for key in required.iter().filter_map(Value::as_str) {
                 if !object.contains_key(key) {
-                    return Err(if required_missing_is_missing_param && path == "params" {
+                    return Err(if path == "params" {
                         ToolError::Sdk {
                             sdk_kind: "missing_param".to_string(),
                             message: format!("callTool params missing required field `{key}`"),
@@ -1464,13 +1523,38 @@ fn validate_json_schema_value(
             }
         }
         let properties = schema_object.get("properties").and_then(Value::as_object);
-        if schema_object
-            .get("additionalProperties")
-            .and_then(Value::as_bool)
-            == Some(false)
-        {
+        let pattern_properties = schema_object
+            .get("patternProperties")
+            .and_then(Value::as_object);
+        let mut matched_pattern_keys = BTreeSet::new();
+        if let Some(pattern_properties) = pattern_properties {
+            for (pattern, pattern_schema) in pattern_properties {
+                let regex = regex::Regex::new(pattern).map_err(|_| {
+                    invalid_schema_param(
+                        path,
+                        "has an invalid patternProperties key in inputSchema",
+                    )
+                })?;
+                for (key, property_value) in object {
+                    if regex.is_match(key) {
+                        matched_pattern_keys.insert(key.clone());
+                        validate_json_schema_value_inner(
+                            property_value,
+                            pattern_schema,
+                            root_schema,
+                            &format!("{path}.{key}"),
+                            seen_refs,
+                        )?;
+                    }
+                }
+            }
+        }
+        let additional_properties = schema_object.get("additionalProperties");
+        if additional_properties.and_then(Value::as_bool) == Some(false) {
             for key in object.keys() {
-                if properties.is_none_or(|properties| !properties.contains_key(key)) {
+                if properties.is_none_or(|properties| !properties.contains_key(key))
+                    && !matched_pattern_keys.contains(key)
+                {
                     return Err(invalid_schema_param(
                         &format!("{path}.{key}"),
                         "is not allowed by inputSchema",
@@ -1481,39 +1565,106 @@ fn validate_json_schema_value(
         if let Some(properties) = properties {
             for (key, property_schema) in properties {
                 if let Some(property_value) = object.get(key) {
-                    validate_json_schema_value(
+                    validate_json_schema_value_inner(
                         property_value,
                         property_schema,
+                        root_schema,
                         &format!("{path}.{key}"),
-                        false,
+                        seen_refs,
                     )?;
                 }
             }
         }
+        if let Some(additional_schema) = additional_properties.filter(|value| value.is_object()) {
+            for (key, property_value) in object {
+                if properties.is_some_and(|properties| properties.contains_key(key))
+                    || matched_pattern_keys.contains(key)
+                {
+                    continue;
+                }
+                validate_json_schema_value_inner(
+                    property_value,
+                    additional_schema,
+                    root_schema,
+                    &format!("{path}.{key}"),
+                    seen_refs,
+                )?;
+            }
+        }
     }
 
-    if let Some(array) = value.as_array()
-        && let Some(items) = schema_object.get("items")
-    {
-        if let Some(tuple_items) = items.as_array() {
-            for (index, item_schema) in tuple_items.iter().enumerate() {
-                if let Some(item_value) = array.get(index) {
-                    validate_json_schema_value(
-                        item_value,
-                        item_schema,
-                        &format!("{path}[{index}]"),
-                        false,
-                    )?;
+    if let Some(array) = value.as_array() {
+        if let Some(min_items) = schema_object.get("minItems").and_then(Value::as_u64)
+            && array.len() < min_items as usize
+        {
+            return Err(invalid_schema_param(path, "has fewer items than minItems"));
+        }
+        if let Some(max_items) = schema_object.get("maxItems").and_then(Value::as_u64)
+            && array.len() > max_items as usize
+        {
+            return Err(invalid_schema_param(path, "has more items than maxItems"));
+        }
+        if schema_object
+            .get("uniqueItems")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            for (left_index, left) in array.iter().enumerate() {
+                if array.iter().skip(left_index + 1).any(|right| right == left) {
+                    return Err(invalid_schema_param(path, "must contain unique items"));
                 }
             }
-        } else {
-            for (index, item_value) in array.iter().enumerate() {
-                validate_json_schema_value(item_value, items, &format!("{path}[{index}]"), false)?;
+        }
+        if let Some(items) = schema_object.get("items") {
+            if let Some(tuple_items) = items.as_array() {
+                for (index, item_schema) in tuple_items.iter().enumerate() {
+                    if let Some(item_value) = array.get(index) {
+                        validate_json_schema_value_inner(
+                            item_value,
+                            item_schema,
+                            root_schema,
+                            &format!("{path}[{index}]"),
+                            seen_refs,
+                        )?;
+                    }
+                }
+            } else {
+                for (index, item_value) in array.iter().enumerate() {
+                    validate_json_schema_value_inner(
+                        item_value,
+                        items,
+                        root_schema,
+                        &format!("{path}[{index}]"),
+                        seen_refs,
+                    )?;
+                }
             }
         }
     }
 
     Ok(())
+}
+
+fn schema_accepts_binary_sentinel(
+    value: &Value,
+    schema_object: &Map<String, Value>,
+    expected_type: &str,
+) -> bool {
+    expected_type == "string"
+        && schema_object.get("format").and_then(Value::as_str) == Some("binary")
+        && is_lab_binary_sentinel(value)
+}
+
+fn is_lab_binary_sentinel(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object.get("__labBinary").and_then(Value::as_str) == Some("base64")
+        && object.get("data").and_then(Value::as_str).is_some()
+        && matches!(
+            object.get("type").and_then(Value::as_str),
+            Some("Uint8Array" | "ArrayBuffer")
+        )
 }
 
 fn invalid_schema_param(path: &str, detail: &str) -> ToolError {
@@ -2167,7 +2318,12 @@ pub fn run_code_mode_runner_stdio() -> ExitCode {
     let result = run_code_mode_runner();
     if let Err(err) = result {
         drop(runner_emit(CodeModeRunnerOutput::Error {
-            kind: "server_error".to_string(),
+            kind: if err.contains("JSON-serializable") {
+                "invalid_param"
+            } else {
+                "server_error"
+            }
+            .to_string(),
             message: err,
         }));
         return ExitCode::from(1);
@@ -2330,17 +2486,22 @@ fn run_code_mode_runner() -> Result<(), String> {
 
         match promise.state() {
             PromiseState::Fulfilled(value) => {
-                // JsValue::to_json returns None for undefined/null — both map to
-                // Option::None per the contract (result field is None when function
-                // returns undefined or has no explicit return).
-                resolved_result = match value.to_json(&mut context) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        let msg = js_error_message(&err);
-                        eprintln!("WARNING: failed to serialize Code Mode result to JSON: {msg}");
-                        None
-                    }
-                };
+                if value.is_undefined() || value.is_null() {
+                    resolved_result = None;
+                } else {
+                    resolved_result = match value.to_json(&mut context) {
+                        Ok(Some(value)) if !value.is_null() => Some(value),
+                        Ok(_) => {
+                            return Err("Code Mode result must be JSON-serializable".to_string());
+                        }
+                        Err(err) => {
+                            return Err(format!(
+                                "Code Mode result must be JSON-serializable: {}",
+                                js_error_message(&err)
+                            ));
+                        }
+                    };
+                }
                 break;
             }
             PromiseState::Rejected(reason) => return Err(js_value_message(&reason, &mut context)),
@@ -2456,10 +2617,34 @@ fn javy_main_promise_state(runtime: &javy::Runtime) -> Result<JavyMainPromiseSta
                         None
                     } else {
                         match cx.json_stringify(val) {
-                            Ok(Some(json_str)) => serde_json::from_str(&json_str.to_string()?)
-                                .ok()
-                                .and_then(|v: Value| if v.is_null() { None } else { Some(v) }),
-                            _ => None,
+                            Ok(Some(json_str)) => {
+                                let json_text = json_str.to_string()?;
+                                let value: Value = match serde_json::from_str(&json_text) {
+                                    Ok(value) => value,
+                                    Err(err) => {
+                                        return Ok(JavyMainPromiseState::Rejected(format!(
+                                            "Code Mode result must be JSON-serializable: {err}"
+                                        )));
+                                    }
+                                };
+                                if value.is_null() {
+                                    return Ok(JavyMainPromiseState::Rejected(
+                                        "Code Mode result must be JSON-serializable".to_string(),
+                                    ));
+                                }
+                                Some(value)
+                            }
+                            Ok(None) => {
+                                return Ok(JavyMainPromiseState::Rejected(
+                                    "Code Mode result must be JSON-serializable".to_string(),
+                                ));
+                            }
+                            Err(err) => {
+                                return Ok(JavyMainPromiseState::Rejected(format!(
+                                    "Code Mode result must be JSON-serializable: {}",
+                                    javy::from_js_error(cx.clone(), err)
+                                )));
+                            }
                         }
                     };
                     Ok(JavyMainPromiseState::Resolved(result))
@@ -2652,12 +2837,38 @@ mod tests {
     use boa_engine::{Context, Source};
     use rmcp::model::{CallToolResult, Content};
     use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
     use super::{
         CodeModeCatalogEntry, CodeModeExecutedCall, CodeModeExecutionResponse, CodeModeToolId,
         CodeModeToolRef, code_mode_upstream_error_info, configure_code_mode_runtime_limits,
         sanitize_code_mode_schema, truncate_execution_response,
     };
+
+    fn fixture_upstream_entry(
+        upstream: &str,
+        tools: HashMap<String, crate::dispatch::upstream::types::UpstreamTool>,
+    ) -> crate::dispatch::upstream::types::UpstreamEntry {
+        crate::dispatch::upstream::types::UpstreamEntry {
+            name: Arc::from(upstream),
+            tools,
+            exposure_policy: crate::dispatch::upstream::types::ToolExposurePolicy::All,
+            prompt_count: 0,
+            resource_count: 0,
+            prompt_names: Vec::new(),
+            resource_uris: Vec::new(),
+            tool_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,
+            prompt_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,
+            resource_health: crate::dispatch::upstream::types::UpstreamHealth::Healthy,
+            tool_unhealthy_since: None,
+            prompt_unhealthy_since: None,
+            resource_unhealthy_since: None,
+            tool_last_error: None,
+            prompt_last_error: None,
+            resource_last_error: None,
+        }
+    }
 
     #[test]
     fn parse_rejects_lab_id() {
@@ -2856,6 +3067,86 @@ mod tests {
         }
     }
 
+    #[test]
+    fn validates_code_mode_params_through_local_refs_and_constraints() {
+        let schema = json!({
+            "$ref": "#/$defs/Params",
+            "$defs": {
+                "Params": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "minLength": 2,
+                            "maxLength": 5,
+                            "pattern": "^[a-z]+$"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 2,
+                            "uniqueItems": true,
+                            "items": { "type": "string" }
+                        },
+                        "meta": {
+                            "type": "object",
+                            "properties": {
+                                "known": { "type": "string" }
+                            },
+                            "additionalProperties": { "type": "integer" }
+                        },
+                        "flag": {
+                            "oneOf": [
+                                { "type": "string", "const": "on" },
+                                { "type": "boolean" }
+                            ]
+                        },
+                        "labels": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^x-": { "type": "string" }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": ["query", "tags", "flag"]
+                }
+            }
+        });
+
+        super::validate_code_mode_params_against_schema(
+            &json!({
+                "query": "abc",
+                "tags": ["one", "two"],
+                "meta": {"known": "ok", "count": 1},
+                "flag": true,
+                "labels": {"x-owner": "me"}
+            }),
+            Some(&schema),
+        )
+        .expect("valid params through local ref pass");
+
+        for params in [
+            json!({"tags": ["one"], "flag": true}),
+            json!({"query": "a", "tags": ["one"], "flag": true}),
+            json!({"query": "abcdef", "tags": ["one"], "flag": true}),
+            json!({"query": "ABC", "tags": ["one"], "flag": true}),
+            json!({"query": "abc", "tags": [], "flag": true}),
+            json!({"query": "abc", "tags": ["one", "two", "three"], "flag": true}),
+            json!({"query": "abc", "tags": ["one", "one"], "flag": true}),
+            json!({"query": "abc", "tags": ["one"], "flag": 1}),
+            json!({"query": "abc", "tags": ["one"], "flag": true, "meta": {"count": "one"}}),
+            json!({"query": "abc", "tags": ["one"], "flag": true, "labels": {"owner": "me"}}),
+        ] {
+            let err = super::validate_code_mode_params_against_schema(&params, Some(&schema))
+                .expect_err("invalid params fail through local ref");
+            assert!(
+                matches!(err.kind(), "missing_param" | "invalid_param"),
+                "{params}: {err}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn search_without_manager_returns_empty_array() {
         // No gateway manager → no upstream catalog → search returns an empty
@@ -2873,6 +3164,165 @@ mod tests {
             .expect("search ok without manager");
 
         assert_eq!(result, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn broker_search_exposes_typed_schema_metadata_from_live_catalog() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = super::super::runtime::GatewayRuntimeHandle::default();
+        let pool = Arc::new(crate::dispatch::upstream::pool::UpstreamPool::new());
+        runtime.swap(Some(Arc::clone(&pool))).await;
+        let manager = super::GatewayManager::new(dir.path().join("config.toml"), runtime);
+        manager
+            .seed_config(crate::config::LabConfig {
+                tool_search: crate::config::ToolSearchConfig {
+                    enabled: true,
+                    ..crate::config::ToolSearchConfig::default()
+                },
+                ..crate::config::LabConfig::default()
+            })
+            .await;
+        let upstream_name: Arc<str> = Arc::from("typed");
+        let upstream_tool = crate::dispatch::upstream::types::UpstreamTool {
+            tool: rmcp::model::Tool::new(
+                "lookup".to_string(),
+                "Lookup typed data",
+                Arc::new(serde_json::Map::new()),
+            ),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"]
+            })),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {"answer": {"type": "integer"}}
+            })),
+            upstream_name: Arc::clone(&upstream_name),
+            destructive: false,
+        };
+        pool.insert_entry_for_tests(
+            "typed",
+            fixture_upstream_entry(
+                "typed",
+                HashMap::from([("lookup".to_string(), upstream_tool)]),
+            ),
+        )
+        .await;
+
+        let registry = super::ToolRegistry::new();
+        let broker = super::CodeModeBroker::new(&registry, Some(&manager));
+        let result = broker
+            .search(
+                "async () => tools.map(t => ({id: t.id, schema: t.schema, output_schema: t.output_schema, signature: t.signature, dts: t.dts}))",
+                super::CodeModeCaller::Scoped {
+                    scopes: vec!["lab:read".to_string()],
+                    sub: None,
+                },
+                super::CodeModeSurface::Mcp {
+                    allow_destructive_actions: false,
+                },
+            )
+            .await
+            .expect("search evaluates over live catalog");
+
+        let entries = result.as_array().expect("array");
+        let entry = entries
+            .iter()
+            .find(|entry| entry["id"] == "upstream::typed::lookup")
+            .expect("typed lookup entry");
+        assert_eq!(entry["schema"]["required"], json!(["q"]));
+        assert_eq!(
+            entry["output_schema"]["properties"]["answer"]["type"],
+            "integer"
+        );
+        assert!(
+            entry["signature"]
+                .as_str()
+                .is_some_and(|signature| signature.contains("Promise<"))
+        );
+        assert!(
+            entry["dts"]
+                .as_str()
+                .is_some_and(|dts| dts.contains("interface Codemode"))
+        );
+    }
+
+    #[tokio::test]
+    async fn broker_call_tool_validates_schema_before_upstream_dispatch() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = super::super::runtime::GatewayRuntimeHandle::default();
+        let pool = Arc::new(crate::dispatch::upstream::pool::UpstreamPool::new());
+        runtime.swap(Some(Arc::clone(&pool))).await;
+        let manager = super::GatewayManager::new(dir.path().join("config.toml"), runtime);
+        manager
+            .seed_config(crate::config::LabConfig {
+                tool_search: crate::config::ToolSearchConfig {
+                    enabled: true,
+                    ..crate::config::ToolSearchConfig::default()
+                },
+                upstream: vec![crate::config::UpstreamConfig {
+                    enabled: true,
+                    name: "fixture".to_string(),
+                    url: Some("http://127.0.0.1:9/mcp".to_string()),
+                    bearer_token_env: None,
+                    command: None,
+                    args: Vec::new(),
+                    env: std::collections::BTreeMap::new(),
+                    proxy_resources: false,
+                    proxy_prompts: false,
+                    expose_tools: None,
+                    expose_resources: None,
+                    expose_prompts: None,
+                    oauth: None,
+                    imported_from: None,
+                    priority: 1.0,
+                    tool_search: crate::config::ToolSearchConfig::default(),
+                }],
+                ..crate::config::LabConfig::default()
+            })
+            .await;
+        let upstream_name: Arc<str> = Arc::from("fixture");
+        let upstream_tool = crate::dispatch::upstream::types::UpstreamTool {
+            tool: rmcp::model::Tool::new(
+                "needs_action".to_string(),
+                "Needs action",
+                Arc::new(serde_json::Map::new()),
+            ),
+            input_schema: Some(json!({
+                "type": "object",
+                "required": ["action"],
+                "properties": {
+                    "action": {"type": "string"}
+                }
+            })),
+            output_schema: None,
+            upstream_name: Arc::clone(&upstream_name),
+            destructive: false,
+        };
+        pool.insert_entry_for_tests(
+            "fixture",
+            fixture_upstream_entry(
+                "fixture",
+                HashMap::from([("needs_action".to_string(), upstream_tool)]),
+            ),
+        )
+        .await;
+        let registry = super::ToolRegistry::new();
+        let broker = super::CodeModeBroker::new(&registry, Some(&manager));
+        let tool_id = "upstream::fixture::needs_action";
+
+        let err = broker
+            .call_tool_id(
+                tool_id,
+                json!({}),
+                super::CodeModeCaller::TrustedLocal,
+                super::CodeModeSurface::Cli,
+                &super::CodeModeCapabilityFilter::default(),
+            )
+            .await
+            .expect_err("missing action must fail before dispatch");
+        assert_eq!(err.kind(), "missing_param");
     }
 
     #[cfg(not(feature = "code_mode_wasm"))]
@@ -3464,7 +3914,7 @@ mod tests {
         );
     }
 
-    // ── destructive_permitted: surface flag OR execute-capable scope ──────────
+    // ── destructive_permitted: surface confirmation gate ─────────────────────
 
     fn scoped(scopes: &[&str]) -> super::CodeModeCaller {
         super::CodeModeCaller::Scoped {
@@ -3474,21 +3924,17 @@ mod tests {
     }
 
     #[test]
-    fn destructive_permitted_for_admin_scope_on_mcp_deny_surface() {
-        // REGRESSION: an allowlisted operator is auto-elevated to `lab:admin`;
-        // that scope must satisfy the destructive gate even when the MCP surface
-        // did not pass `confirm:true`. Previously denied — the gate ignored scope.
+    fn destructive_denied_for_execute_scope_on_mcp_deny_surface() {
         let surface = super::CodeModeSurface::Mcp {
             allow_destructive_actions: false,
         };
         assert!(
-            super::destructive_permitted(surface, &scoped(&["lab:admin"])),
-            "lab:admin caller must be permitted destructive actions on the MCP surface"
+            !super::destructive_permitted(surface, &scoped(&["lab:admin"])),
+            "lab:admin caller still needs explicit confirm for destructive MCP Code Mode calls"
         );
-        // `lab` (full, non-admin) is also execute-capable.
         assert!(
-            super::destructive_permitted(surface, &scoped(&["lab"])),
-            "lab caller must be permitted destructive actions on the MCP surface"
+            !super::destructive_permitted(surface, &scoped(&["lab"])),
+            "lab caller still needs explicit confirm for destructive MCP Code Mode calls"
         );
     }
 
@@ -3519,15 +3965,14 @@ mod tests {
             super::destructive_permitted(super::CodeModeSurface::Cli, &scoped(&["lab:read"])),
             "CLI surface must permit destructive actions for any caller"
         );
-        // TrustedLocal is execute-capable too.
         assert!(
-            super::destructive_permitted(
+            !super::destructive_permitted(
                 super::CodeModeSurface::Mcp {
                     allow_destructive_actions: false
                 },
                 &super::CodeModeCaller::TrustedLocal,
             ),
-            "TrustedLocal caller must be permitted destructive actions"
+            "TrustedLocal MCP caller must still provide destructive confirmation"
         );
     }
 

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 #[cfg(not(feature = "code_mode_wasm"))]
 use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
@@ -20,10 +21,13 @@ use boa_engine::object::builtins::JsPromise;
 use boa_engine::{JsArgs, JsError, JsNativeError, JsResult, NativeFunction, js_string};
 #[cfg(not(feature = "code_mode_wasm"))]
 use boa_gc::{Finalize, Trace};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
+use boa_parser::{Parser, Source as ParserSource};
 #[cfg(not(feature = "code_mode_wasm"))]
 use boa_runtime::console::{ConsoleState, Logger};
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use rmcp::model::CallToolRequestParams;
+use rmcp::model::CallToolResult;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
@@ -65,51 +69,289 @@ const CODE_SEARCH_CATALOG_HARD_CAP_BYTES: usize = 512 * 1024;
 ///    parenthesize the function expression — NO trailing IIFE `()`.
 /// 4. A bare arrow `async () => {...}` passes through unchanged (it is already a
 ///    function expression).
+/// 5. Loose statements / trailing expressions are wrapped in `async () => { ... }`;
+///    if the trailing statement looks like an expression, it is returned.
 ///
 /// `evaluate_code_search` does NOT call this — search receives raw `code`.
 ///
 /// Exposed (`pub`) so integration tests can normalize a body form and pipe the
 /// exact post-normalize string through the runner end to end.
 pub fn normalize_user_code(code: &str) -> String {
-    // 1. Strip markdown fences
-    let code = {
-        let trimmed = code.trim();
-        if let Some(stripped) = trimmed
-            .strip_prefix("```javascript\n")
-            .or_else(|| trimmed.strip_prefix("```typescript\n"))
-            .or_else(|| trimmed.strip_prefix("```js\n"))
-            .or_else(|| trimmed.strip_prefix("```ts\n"))
-            .or_else(|| trimmed.strip_prefix("```\n"))
-        {
-            stripped.trim_end_matches("```").trim_end()
-        } else {
-            trimmed
+    let code = strip_code_fences(code.trim()).trim();
+    if code.is_empty() {
+        return "async () => {}".to_string();
+    }
+    if let Some(inner) = code.strip_prefix("export default ") {
+        let inner = inner.trim().trim_end_matches(';').trim();
+        if inner.starts_with("async function") || inner.starts_with("function") {
+            return format!("async () => {{\nreturn ({inner})();\n}}");
         }
+        if inner.starts_with("class") {
+            return format!("async () => {{\nreturn ({inner});\n}}");
+        }
+        return normalize_user_code(inner);
+    }
+    normalize_user_code_parsed(code).unwrap_or_else(|| wrap_loose_code_as_async_arrow(code))
+}
+
+fn wrap_loose_code_as_async_arrow(code: &str) -> String {
+    let code = code.trim().trim_end_matches(';').trim();
+    if code.is_empty() {
+        return "async () => {}".to_string();
+    }
+    if let Some((before, after)) = code.rsplit_once(';') {
+        let trailing = after.trim();
+        if !trailing.is_empty() && looks_like_returnable_expression(trailing) {
+            return format!("async () => {{\n{before};\nreturn ({trailing})\n}}");
+        }
+    } else if looks_like_returnable_expression(code) && !code.trim_start().starts_with("return ") {
+        return format!("async () => {{\nreturn ({code})\n}}");
+    }
+
+    format!("async () => {{\n{code}\n}}")
+}
+
+fn strip_code_fences(code: &str) -> &str {
+    let trimmed = code.trim();
+    for lang in ["javascript", "typescript", "tsx", "jsx", "js", "ts", ""] {
+        let prefix = if lang.is_empty() {
+            "```\n".to_string()
+        } else {
+            format!("```{lang}\n")
+        };
+        if let Some(stripped) = trimmed.strip_prefix(&prefix)
+            && let Some(inner) = stripped.strip_suffix("```")
+        {
+            return inner.trim();
+        }
+    }
+    trimmed
+}
+
+fn normalize_user_code_parsed(source: &str) -> Option<String> {
+    normalize_module_code(source).or_else(|| normalize_script_code(source))
+}
+
+fn normalize_module_code(source: &str) -> Option<String> {
+    let mut interner = Interner::default();
+    let mut parser = Parser::new(ParserSource::from_bytes(source.as_bytes()));
+    let module = parser
+        .parse_module(&boa_ast::scope::Scope::new_global(), &mut interner)
+        .ok()?;
+    let items = module.items().items();
+    let [item] = items else {
+        return None;
     };
+    let boa_ast::ModuleItem::ExportDeclaration(export) = item else {
+        return None;
+    };
+    match export.as_ref() {
+        boa_ast::declaration::ExportDeclaration::DefaultAssignmentExpression(expr) => {
+            Some(normalize_user_code(&expr.to_interned_string(&interner)))
+        }
+        boa_ast::declaration::ExportDeclaration::DefaultFunctionDeclaration(function) => Some(
+            format!(
+                "async () => {{\nreturn ({} )();\n}}",
+                function.to_indented_string(&interner, 0)
+            )
+            .replace("} )", "})"),
+        ),
+        boa_ast::declaration::ExportDeclaration::DefaultAsyncFunctionDeclaration(function) => Some(
+            format!(
+                "async () => {{\nreturn ({} )();\n}}",
+                function.to_indented_string(&interner, 0)
+            )
+            .replace("} )", "})"),
+        ),
+        boa_ast::declaration::ExportDeclaration::DefaultClassDeclaration(class) => Some(format!(
+            "async () => {{\nreturn ({});\n}}",
+            class.to_indented_string(&interner, 0)
+        )),
+        _ => None,
+    }
+}
 
-    // 2. Parenthesize bare `async function main` / `function main` declarations
-    //    into a function EXPRESSION. The wrapper awaits it, so sync `function`
-    //    is fine without forcing `async`.
-    if code.starts_with("async function main(") || code.starts_with("function main(") {
-        return format!("({})", code.trim_end_matches(';'));
+fn normalize_script_code(source: &str) -> Option<String> {
+    let mut interner = Interner::default();
+    let mut parser = Parser::new(ParserSource::from_bytes(source.as_bytes()));
+    let script = parser
+        .parse_script(&boa_ast::scope::Scope::new_global(), &mut interner)
+        .ok()?;
+    let statements = script.statements().statements();
+    if statements.is_empty() {
+        return Some("async () => {}".to_string());
     }
 
-    // 3. Strip `export default ` and parenthesize the remaining function
-    //    expression. No IIFE invocation — the wrapper invokes it.
-    if let Some(inner) = code.strip_prefix("export default async function") {
-        return format!("(async function{})", inner.trim_end_matches(';'));
-    }
-    if let Some(inner) = code.strip_prefix("export default function") {
-        return format!("(function{})", inner.trim_end_matches(';'));
+    if let [item] = statements {
+        match item {
+            boa_ast::StatementListItem::Statement(statement) => {
+                if let boa_ast::Statement::Expression(expr) = statement.as_ref() {
+                    if matches!(
+                        expr.flatten(),
+                        boa_ast::Expression::ArrowFunction(_)
+                            | boa_ast::Expression::AsyncArrowFunction(_)
+                    ) {
+                        return Some(source.to_string());
+                    }
+                    return Some(format!(
+                        "async () => {{\nreturn ({})\n}}",
+                        expr.to_interned_string(&interner)
+                    ));
+                }
+            }
+            boa_ast::StatementListItem::Declaration(declaration) => {
+                if let Some(name) = function_declaration_name(declaration.as_ref(), &interner) {
+                    return Some(format!(
+                        "async () => {{\n{}\nreturn {name}();\n}}",
+                        declaration.to_indented_string(&interner, 0)
+                    ));
+                }
+            }
+        }
     }
 
-    code.to_string()
+    if let Some((last, before)) = statements.split_last()
+        && let boa_ast::StatementListItem::Statement(statement) = last
+        && let boa_ast::Statement::Expression(expr) = statement.as_ref()
+    {
+        let before = before
+            .iter()
+            .map(|item| item.to_indented_string(&interner, 0))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let expr = expr.to_interned_string(&interner);
+        return Some(if before.trim().is_empty() {
+            format!("async () => {{\nreturn ({expr})\n}}")
+        } else {
+            format!("async () => {{\n{before}\nreturn ({expr})\n}}")
+        });
+    }
+
+    let body = statements
+        .iter()
+        .map(|item| item.to_indented_string(&interner, 0))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(format!("async () => {{\n{body}\n}}"))
+}
+
+fn function_declaration_name(
+    declaration: &boa_ast::Declaration,
+    interner: &Interner,
+) -> Option<String> {
+    match declaration {
+        boa_ast::Declaration::FunctionDeclaration(function) => {
+            Some(function.name().to_interned_string(interner))
+        }
+        boa_ast::Declaration::AsyncFunctionDeclaration(function) => {
+            Some(function.name().to_interned_string(interner))
+        }
+        boa_ast::Declaration::GeneratorDeclaration(function) => {
+            Some(function.name().to_interned_string(interner))
+        }
+        boa_ast::Declaration::AsyncGeneratorDeclaration(function) => {
+            Some(function.name().to_interned_string(interner))
+        }
+        _ => None,
+    }
+}
+
+fn looks_like_returnable_expression(statement: &str) -> bool {
+    let statement = statement.trim();
+    !statement.is_empty()
+        && !matches!(
+            statement.split_whitespace().next(),
+            Some(
+                "const"
+                    | "let"
+                    | "var"
+                    | "return"
+                    | "if"
+                    | "for"
+                    | "while"
+                    | "switch"
+                    | "try"
+                    | "catch"
+                    | "function"
+                    | "class"
+                    | "throw"
+            )
+        )
 }
 
 /// The single contract error message for the execute wrapper, shared by both
 /// runner engines (Javy and Boa) so it cannot diverge between them.
 const CODE_MODE_MAIN_SHAPE_ERROR: &str =
     "code_execute code must evaluate to an async arrow function: async () => { ... }";
+
+const CODE_MODE_VALUE_CODEC_JS: &str = r#"
+function __labBase64FromBytes(bytes) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i];
+    const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
+    const triple = (a << 16) | (b << 8) | c;
+    out += alphabet[(triple >> 18) & 63];
+    out += alphabet[(triple >> 12) & 63];
+    out += i + 1 < bytes.length ? alphabet[(triple >> 6) & 63] : "=";
+    out += i + 2 < bytes.length ? alphabet[triple & 63] : "=";
+  }
+  return out;
+}
+function __labBytesFromBase64(data) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let clean = String(data || "").replace(/=+$/, "");
+  let buffer = 0;
+  let bits = 0;
+  const out = [];
+  for (let i = 0; i < clean.length; i++) {
+    const value = alphabet.indexOf(clean[i]);
+    if (value < 0) continue;
+    buffer = (buffer << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push((buffer >> bits) & 255);
+    }
+  }
+  return new Uint8Array(out);
+}
+function __labEncodeResult(value) {
+  if (value == null) return value;
+  if (typeof ArrayBuffer !== "undefined" && value instanceof ArrayBuffer) {
+    return { __labBinary: "base64", type: "ArrayBuffer", data: __labBase64FromBytes(new Uint8Array(value)) };
+  }
+  if (typeof ArrayBuffer !== "undefined" && ArrayBuffer.isView && ArrayBuffer.isView(value)) {
+    return { __labBinary: "base64", type: value.constructor && value.constructor.name || "TypedArray", data: __labBase64FromBytes(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)) };
+  }
+  if (Array.isArray(value)) return value.map(__labEncodeResult);
+  if (typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value)) out[key] = __labEncodeResult(value[key]);
+    return out;
+  }
+  return value;
+}
+function __labDecodeResult(value) {
+  if (value == null) return value;
+  if (typeof value === "object" && value.__labBinary === "base64" && typeof value.data === "string") {
+    const bytes = __labBytesFromBase64(value.data);
+    if (value.type === "ArrayBuffer") {
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    }
+    return bytes;
+  }
+  if (Array.isArray(value)) return value.map(__labDecodeResult);
+  if (typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value)) out[key] = __labDecodeResult(value[key]);
+    return out;
+  }
+  return value;
+}
+"#;
 
 /// Build the shared inner body of the execute wrapper for `code`.
 ///
@@ -134,7 +376,7 @@ fn code_mode_main_invoker(code: &str) -> String {
     );
     body.push_str(");\n");
     body.push_str("  }\n");
-    body.push_str("  return await __codeModeMain();\n");
+    body.push_str("  return __labEncodeResult(await __codeModeMain());\n");
     body
 }
 
@@ -203,6 +445,10 @@ pub struct CodeModeCatalogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+    pub signature: String,
+    pub dts: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dropped_count: Option<usize>,
@@ -215,13 +461,24 @@ impl CodeModeCatalogEntry {
         tool: &str,
         description: &str,
         schema: Option<Value>,
+        output_schema: Option<Value>,
     ) -> Self {
+        let types = super::code_mode_types::generate_tool_types(
+            upstream,
+            tool,
+            description,
+            schema.as_ref(),
+            output_schema.as_ref(),
+        );
         Self {
             id: upstream_tool_id(upstream, tool),
             name: tool.to_string(),
             upstream: upstream.to_string(),
             description: description.to_string(),
             schema,
+            output_schema,
+            signature: types.signature,
+            dts: types.dts,
             note: None,
             dropped_count: None,
         }
@@ -236,6 +493,9 @@ impl CodeModeCatalogEntry {
             description: "Catalog entries were dropped to fit the Code Mode inline catalog budget"
                 .to_string(),
             schema: None,
+            output_schema: None,
+            signature: String::new(),
+            dts: String::new(),
             note: Some(
                 "Some entries were dropped to fit the 256KB inline catalog cap. Use scout for full RRF discovery.".to_string(),
             ),
@@ -382,6 +642,38 @@ pub struct CodeModeBroker<'a> {
     gateway_manager: Option<&'a GatewayManager>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CodeModeCapabilityFilter {
+    upstreams: BTreeSet<String>,
+    tools: BTreeSet<String>,
+}
+
+impl CodeModeCapabilityFilter {
+    #[must_use]
+    pub fn new(upstreams: Vec<String>, tools: Vec<String>) -> Self {
+        Self {
+            upstreams: upstreams
+                .into_iter()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect(),
+            tools: tools
+                .into_iter()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn allows(&self, upstream: &str, tool: &str) -> bool {
+        (self.upstreams.is_empty() || self.upstreams.contains(upstream))
+            && (self.tools.is_empty()
+                || self.tools.contains(tool)
+                || self.tools.contains(&upstream_tool_id(upstream, tool)))
+    }
+}
+
 impl<'a> CodeModeBroker<'a> {
     #[must_use]
     pub fn new(_registry: &'a ToolRegistry, gateway_manager: Option<&'a GatewayManager>) -> Self {
@@ -435,6 +727,7 @@ impl<'a> CodeModeBroker<'a> {
         caller: CodeModeCaller,
         surface: CodeModeSurface,
         config: crate::config::CodeModeConfig,
+        capability_filter: CodeModeCapabilityFilter,
     ) -> Result<CodeModeExecutionResponse, ToolError> {
         // `execute` is exposed only when the gateway search/execute surface is
         // enabled (tool_search.enabled → RootSynthetic), and the MCP handler
@@ -457,6 +750,7 @@ impl<'a> CodeModeBroker<'a> {
                 surface,
                 config.max_log_entries,
                 config.max_log_bytes,
+                capability_filter,
             )
             .await?;
         let was_truncated = !response_within_budget(
@@ -514,6 +808,7 @@ impl<'a> CodeModeBroker<'a> {
                     &name,
                     &super::projection::sanitize_tool_text(&description, 2048),
                     sanitize_code_mode_schema(tool.input_schema),
+                    sanitize_code_mode_schema(tool.output_schema),
                 )
             })
             .collect::<Vec<_>>();
@@ -577,25 +872,40 @@ impl<'a> CodeModeBroker<'a> {
         &self,
         caller: &CodeModeCaller,
         surface: CodeModeSurface,
-    ) -> Option<String> {
-        let manager = self.gateway_manager?;
+        capability_filter: &CodeModeCapabilityFilter,
+    ) -> Result<String, ToolError> {
+        let Some(manager) = self.gateway_manager else {
+            return Ok(String::new());
+        };
         let allow_cold_connect = caller.can_execute();
         let owner = caller.runtime_owner(surface);
         let oauth_subject = caller.oauth_subject();
         let tools = manager
             .code_mode_catalog_tools(allow_cold_connect, Some(&owner), oauth_subject)
             .await
-            .ok()?;
+            .map_err(|err| ToolError::Sdk {
+                sdk_kind: err.kind().to_string(),
+                message: err.user_message().to_string(),
+            })?;
+        let tools = tools
+            .into_iter()
+            .filter(|tool| {
+                capability_filter.allows(tool.upstream_name.as_ref(), tool.tool.name.as_ref())
+            })
+            .collect::<Vec<_>>();
         if tools.is_empty() {
-            return None;
+            return Ok(String::new());
         }
         let mut upstreams: Vec<String> =
             tools.iter().map(|t| t.upstream_name.to_string()).collect();
         upstreams.sort();
         upstreams.dedup();
-        Some(super::code_mode_preamble::generate_js_proxy(
-            &tools, &upstreams,
-        ))
+        super::code_mode_preamble::generate_js_proxy(&tools, &upstreams).map_err(|message| {
+            ToolError::Sdk {
+                sdk_kind: "invalid_param".to_string(),
+                message,
+            }
+        })
     }
 
     async fn execute_sandboxed(
@@ -607,6 +917,7 @@ impl<'a> CodeModeBroker<'a> {
         surface: CodeModeSurface,
         max_log_entries: usize,
         max_log_bytes: usize,
+        capability_filter: CodeModeCapabilityFilter,
     ) -> Result<CodeModeExecutionResponse, ToolError> {
         // Cloudflare-parity: no typed TypeScript preamble is injected. The
         // sandbox exposes only `callTool(id, params)`; the agent uses tool ids
@@ -694,9 +1005,8 @@ impl<'a> CodeModeBroker<'a> {
         // the documented escape hatch, so the run can still proceed without the
         // typed namespace.
         let proxy = self
-            .build_code_mode_proxy(&caller, surface)
-            .await
-            .unwrap_or_default();
+            .build_code_mode_proxy(&caller, surface, &capability_filter)
+            .await?;
 
         write_runner_input(
             &mut stdin,
@@ -761,12 +1071,14 @@ impl<'a> CodeModeBroker<'a> {
                             started_tool_calls += 1;
                             let call_id = id.clone();
                             let caller = caller.clone();
+                            let capability_filter = capability_filter.clone();
                             pending_tool_calls.push(
                                 async move {
                                     let call_start = std::time::Instant::now();
                                     let result = self
                                         .call_tool_id_before_deadline(
                                             &id, params, deadline, caller, surface,
+                                            &capability_filter,
                                         )
                                         .await;
                                     let elapsed_ms = call_start.elapsed().as_millis();
@@ -911,9 +1223,13 @@ impl<'a> CodeModeBroker<'a> {
         deadline: tokio::time::Instant,
         caller: CodeModeCaller,
         surface: CodeModeSurface,
+        capability_filter: &CodeModeCapabilityFilter,
     ) -> Result<Value, ToolError> {
-        match tokio::time::timeout_at(deadline, self.call_tool_id(id, params, caller, surface))
-            .await
+        match tokio::time::timeout_at(
+            deadline,
+            self.call_tool_id(id, params, caller, surface, capability_filter),
+        )
+        .await
         {
             Ok(result) => result,
             Err(_) => Err(ToolError::Sdk {
@@ -929,6 +1245,7 @@ impl<'a> CodeModeBroker<'a> {
         params: Value,
         caller: CodeModeCaller,
         surface: CodeModeSurface,
+        capability_filter: &CodeModeCapabilityFilter,
     ) -> Result<Value, ToolError> {
         let parsed = CodeModeToolId::parse(id)?;
         let Some(manager) = self.gateway_manager else {
@@ -939,6 +1256,15 @@ impl<'a> CodeModeBroker<'a> {
         };
         match parsed.reference {
             CodeModeToolRef::UpstreamTool { upstream, tool } => {
+                if !capability_filter.allows(&upstream, &tool) {
+                    return Err(ToolError::Sdk {
+                        sdk_kind: "unknown_tool".to_string(),
+                        message: format!(
+                            "upstream tool `{}` is outside this Code Mode execution capability set",
+                            parsed.raw
+                        ),
+                    });
+                }
                 let owner = caller.runtime_owner(surface);
                 let oauth_subject = caller.oauth_subject();
                 self.call_upstream_tool(
@@ -982,6 +1308,7 @@ impl<'a> CodeModeBroker<'a> {
                 ),
             });
         }
+        validate_code_mode_params_against_schema(&params, upstream_tool.input_schema.as_ref())?;
         let Some(pool) = manager.current_pool().await else {
             return Err(ToolError::Sdk {
                 sdk_kind: "upstream_error".to_string(),
@@ -1014,10 +1341,7 @@ impl<'a> CodeModeBroker<'a> {
                     });
                 }
                 pool.record_success(upstream).await;
-                serde_json::to_value(result).map_err(|err| ToolError::Sdk {
-                    sdk_kind: "internal_error".to_string(),
-                    message: format!("failed to serialize upstream tool result: {err}"),
-                })
+                Ok(unwrap_code_mode_upstream_result(result))
             }
             Some(Err(err)) => {
                 pool.record_failure(upstream, err.clone()).await;
@@ -1035,6 +1359,195 @@ impl<'a> CodeModeBroker<'a> {
                 })
             }
         }
+    }
+}
+
+fn validate_code_mode_params_against_schema(
+    params: &Value,
+    schema: Option<&Value>,
+) -> Result<(), ToolError> {
+    if let Some(schema) = schema {
+        validate_json_schema_value(params, schema, "params", true)?;
+    }
+    Ok(())
+}
+
+fn json_value_matches_schema_type(value: &Value, expected: &str) -> bool {
+    match expected {
+        "string" => value.is_string(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+fn validate_json_schema_value(
+    value: &Value,
+    schema: &Value,
+    path: &str,
+    required_missing_is_missing_param: bool,
+) -> Result<(), ToolError> {
+    let Some(schema_object) = schema.as_object() else {
+        return Ok(());
+    };
+
+    if let Some(values) = schema_object.get("enum").and_then(Value::as_array)
+        && !values.iter().any(|candidate| candidate == value)
+    {
+        return Err(invalid_schema_param(path, "must match enum"));
+    }
+    if let Some(const_value) = schema_object.get("const")
+        && const_value != value
+    {
+        return Err(invalid_schema_param(path, "must match const"));
+    }
+
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(variants) = schema_object.get(keyword).and_then(Value::as_array) {
+            if variants.iter().any(|variant| {
+                validate_json_schema_value(value, variant, path, required_missing_is_missing_param)
+                    .is_ok()
+            }) {
+                return Ok(());
+            }
+            return Err(invalid_schema_param(path, "must match at least one schema"));
+        }
+    }
+    if let Some(variants) = schema_object.get("allOf").and_then(Value::as_array) {
+        for variant in variants {
+            validate_json_schema_value(value, variant, path, required_missing_is_missing_param)?;
+        }
+    }
+
+    if let Some(type_value) = schema_object.get("type") {
+        let matches_type = match type_value {
+            Value::String(expected) => json_value_matches_schema_type(value, expected),
+            Value::Array(types) => types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|expected| json_value_matches_schema_type(value, expected)),
+            _ => true,
+        };
+        if !matches_type {
+            return Err(invalid_schema_param(path, "has wrong type"));
+        }
+    }
+
+    if let Some(minimum) = schema_object.get("minimum").and_then(Value::as_f64)
+        && value.as_f64().is_some_and(|actual| actual < minimum)
+    {
+        return Err(invalid_schema_param(path, "is below minimum"));
+    }
+    if let Some(maximum) = schema_object.get("maximum").and_then(Value::as_f64)
+        && value.as_f64().is_some_and(|actual| actual > maximum)
+    {
+        return Err(invalid_schema_param(path, "is above maximum"));
+    }
+
+    if let Some(object) = value.as_object() {
+        if let Some(required) = schema_object.get("required").and_then(Value::as_array) {
+            for key in required.iter().filter_map(Value::as_str) {
+                if !object.contains_key(key) {
+                    return Err(if required_missing_is_missing_param && path == "params" {
+                        ToolError::Sdk {
+                            sdk_kind: "missing_param".to_string(),
+                            message: format!("callTool params missing required field `{key}`"),
+                        }
+                    } else {
+                        invalid_schema_param(&format!("{path}.{key}"), "is required")
+                    });
+                }
+            }
+        }
+        let properties = schema_object.get("properties").and_then(Value::as_object);
+        if schema_object
+            .get("additionalProperties")
+            .and_then(Value::as_bool)
+            == Some(false)
+        {
+            for key in object.keys() {
+                if properties.is_none_or(|properties| !properties.contains_key(key)) {
+                    return Err(invalid_schema_param(
+                        &format!("{path}.{key}"),
+                        "is not allowed by inputSchema",
+                    ));
+                }
+            }
+        }
+        if let Some(properties) = properties {
+            for (key, property_schema) in properties {
+                if let Some(property_value) = object.get(key) {
+                    validate_json_schema_value(
+                        property_value,
+                        property_schema,
+                        &format!("{path}.{key}"),
+                        false,
+                    )?;
+                }
+            }
+        }
+    }
+
+    if let Some(array) = value.as_array()
+        && let Some(items) = schema_object.get("items")
+    {
+        if let Some(tuple_items) = items.as_array() {
+            for (index, item_schema) in tuple_items.iter().enumerate() {
+                if let Some(item_value) = array.get(index) {
+                    validate_json_schema_value(
+                        item_value,
+                        item_schema,
+                        &format!("{path}[{index}]"),
+                        false,
+                    )?;
+                }
+            }
+        } else {
+            for (index, item_value) in array.iter().enumerate() {
+                validate_json_schema_value(item_value, items, &format!("{path}[{index}]"), false)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn invalid_schema_param(path: &str, detail: &str) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("callTool params `{path}` {detail}"),
+    }
+}
+
+fn unwrap_code_mode_upstream_result(result: CallToolResult) -> Value {
+    if let Some(value) = result.structured_content {
+        return value;
+    }
+
+    let all_text = !result.content.is_empty()
+        && result
+            .content
+            .iter()
+            .all(|content| content.as_text().is_some());
+    if all_text {
+        let text = result
+            .content
+            .iter()
+            .filter_map(|content| content.as_text())
+            .map(|content| content.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        return serde_json::from_str(&text).unwrap_or_else(|_| Value::String(text));
+    }
+
+    if result.content.is_empty() {
+        Value::Null
+    } else {
+        json!(result)
     }
 }
 
@@ -1200,16 +1713,39 @@ fn drain_runner_logs() -> Vec<String> {
 #[cfg(feature = "code_mode_wasm")]
 #[allow(dead_code)]
 mod wasm_runner {
+    use std::collections::HashMap;
+    use std::sync::{Arc, LazyLock, Mutex};
+
     use wasmtime::{Config, Engine, Instance, Module, Store, Trap};
 
     pub const DEFAULT_SEARCH_FUEL: u64 = 10_000_000;
     pub const DEFAULT_EXECUTE_FUEL: u64 = 50_000_000;
-
-    pub fn engine() -> Result<Engine, wasmtime::Error> {
+    static ENGINE: LazyLock<Result<Engine, String>> = LazyLock::new(|| {
         let mut config = Config::new();
         config.consume_fuel(true);
         config.epoch_interruption(true);
-        Engine::new(&config)
+        Engine::new(&config).map_err(|err| err.to_string())
+    });
+    static MODULE_CACHE: LazyLock<Mutex<HashMap<String, Arc<Module>>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    pub fn engine() -> Result<Engine, wasmtime::Error> {
+        match ENGINE.as_ref() {
+            Ok(engine) => Ok(engine.clone()),
+            Err(message) => Err(wasmtime::Error::msg(message.clone())),
+        }
+    }
+
+    fn cached_module(engine: &Engine, wat: &str) -> Result<Arc<Module>, wasmtime::Error> {
+        let mut cache = MODULE_CACHE
+            .lock()
+            .map_err(|_| wasmtime::Error::msg("wasm module cache lock poisoned"))?;
+        if let Some(module) = cache.get(wat) {
+            return Ok(Arc::clone(module));
+        }
+        let module = Arc::new(Module::new(engine, wat)?);
+        cache.insert(wat.to_string(), Arc::clone(&module));
+        Ok(module)
     }
 
     pub fn run_wasm_i32_export_for_smoke(
@@ -1218,13 +1754,18 @@ mod wasm_runner {
         fuel: u64,
     ) -> Result<i32, wasmtime::Error> {
         let engine = engine()?;
-        let module = Module::new(&engine, wat)?;
+        let module = cached_module(&engine, wat)?;
         let mut store = Store::new(&engine, ());
         store.set_fuel(fuel)?;
         store.set_epoch_deadline(u64::MAX);
-        let instance = Instance::new(&mut store, &module, &[])?;
+        let instance = Instance::new(&mut store, module.as_ref(), &[])?;
         let func = instance.get_typed_func::<(), i32>(&mut store, export_name)?;
         func.call(&mut store, ())
+    }
+
+    #[cfg(test)]
+    pub fn cached_module_count_for_tests() -> usize {
+        MODULE_CACHE.lock().map(|cache| cache.len()).unwrap_or(0)
     }
 
     pub fn trap_kind(error: &wasmtime::Error) -> Option<&'static str> {
@@ -1672,6 +2213,7 @@ fn run_code_mode_runner() -> Result<(), String> {
     let wrapped = format!(
         r#"
 globalThis.__labPendingToolCalls = new Map();
+{codec}
 globalThis.callTool = (id, params = {{}}) => {{
   if (typeof id !== "string" || id.trim() === "") {{
     throw new TypeError("callTool id must be a non-empty string");
@@ -1680,7 +2222,7 @@ globalThis.callTool = (id, params = {{}}) => {{
     throw new TypeError("callTool params must be a JSON object");
   }}
   return new Promise((resolve, reject) => {{
-    const seq = globalThis.__labEmitToolCall(id, params);
+    const seq = globalThis.__labEmitToolCall(id, __labEncodeResult(params));
     globalThis.__labPendingToolCalls.set(seq, {{ resolve, reject }});
   }});
 }};
@@ -1692,7 +2234,7 @@ globalThis.__labSettleToolCall = (message) => {{
   }}
   globalThis.__labPendingToolCalls.delete(input.seq);
   if (input.type === "tool_result") {{
-    pending.resolve(input.result);
+    pending.resolve(__labDecodeResult(input.result));
     return;
   }}
   if (input.type === "tool_error") {{
@@ -1707,7 +2249,10 @@ globalThis.__labSettleToolCall = (message) => {{
 {proxy}
 globalThis.__labMainPromise = (async () => {{
 {invoker}}})();
-"#
+"#,
+        codec = CODE_MODE_VALUE_CODEC_JS,
+        invoker = invoker,
+        proxy = proxy,
     );
 
     runtime
@@ -1770,7 +2315,7 @@ fn run_code_mode_runner() -> Result<(), String> {
     // proxy ends with `var` declarations (no completion value), so the trailing
     // IIFE remains the `eval` completion value (the awaited promise). An empty
     // proxy (search path / legacy Start) leaves `codemode` undefined as before.
-    let wrapped = format!("{proxy}\n(async () => {{\n{invoker}}})()");
+    let wrapped = format!("{CODE_MODE_VALUE_CODEC_JS}\n{proxy}\n(async () => {{\n{invoker}}})()");
     let value = context
         .eval(Source::from_bytes(wrapped.as_bytes()))
         .map_err(js_error_message)?;
@@ -2105,6 +2650,7 @@ fn js_value_message(value: &JsValue, context: &mut Context) -> String {
 #[cfg(test)]
 mod tests {
     use boa_engine::{Context, Source};
+    use rmcp::model::{CallToolResult, Content};
     use serde_json::json;
 
     use super::{
@@ -2159,6 +2705,18 @@ mod tests {
     }
 
     #[test]
+    fn capability_filter_allows_only_selected_upstreams_and_tools() {
+        let filter = super::CodeModeCapabilityFilter::new(
+            vec!["github".to_string()],
+            vec!["upstream::github::search_issues".to_string()],
+        );
+
+        assert!(filter.allows("github", "search_issues"));
+        assert!(!filter.allows("github", "delete_repo"));
+        assert!(!filter.allows("docker", "search_issues"));
+    }
+
+    #[test]
     fn upstream_error_info_preserves_user_error_kinds() {
         let text = json!({
             "error": {
@@ -2174,6 +2732,128 @@ mod tests {
         assert_eq!(kind, "missing_param");
         assert_eq!(message, "query is required");
         assert!(!counts_as_failure);
+    }
+
+    #[test]
+    fn unwrap_upstream_tool_result_prefers_structured_content() {
+        let result = CallToolResult::structured(json!({
+            "items": [{"id": 1}],
+            "total": 1
+        }));
+
+        let unwrapped = super::unwrap_code_mode_upstream_result(result);
+
+        assert_eq!(
+            unwrapped,
+            json!({
+                "items": [{"id": 1}],
+                "total": 1
+            })
+        );
+        assert!(unwrapped.get("content").is_none());
+        assert!(unwrapped.get("structuredContent").is_none());
+        assert!(unwrapped.get("isError").is_none());
+    }
+
+    #[test]
+    fn unwrap_upstream_tool_result_parses_or_returns_text_content() {
+        let parsed =
+            super::unwrap_code_mode_upstream_result(CallToolResult::success(vec![Content::text(
+                r#"{"ok":true}"#,
+            )]));
+        assert_eq!(parsed, json!({"ok": true}));
+
+        let raw =
+            super::unwrap_code_mode_upstream_result(CallToolResult::success(vec![Content::text(
+                "plain text",
+            )]));
+        assert_eq!(raw, json!("plain text"));
+    }
+
+    #[test]
+    fn unwrap_upstream_tool_result_joins_all_text_and_preserves_mixed_content() {
+        let joined = super::unwrap_code_mode_upstream_result(CallToolResult::success(vec![
+            Content::text("{\"a\":"),
+            Content::text("1}"),
+        ]));
+        assert_eq!(joined, json!({"a": 1}));
+
+        let mixed = super::unwrap_code_mode_upstream_result(CallToolResult::success(vec![
+            Content::text("caption"),
+            Content::image("AQID", "image/png"),
+        ]));
+        assert!(mixed.get("content").is_some(), "{mixed}");
+    }
+
+    #[test]
+    fn validates_code_mode_params_against_input_schema() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["query"]
+        });
+
+        super::validate_code_mode_params_against_schema(
+            &json!({"query": "rust", "limit": 10}),
+            Some(&schema),
+        )
+        .expect("valid params pass");
+
+        let missing = super::validate_code_mode_params_against_schema(&json!({}), Some(&schema))
+            .expect_err("missing required field fails");
+        assert_eq!(missing.kind(), "missing_param");
+
+        let invalid =
+            super::validate_code_mode_params_against_schema(&json!({"query": 42}), Some(&schema))
+                .expect_err("wrong field type fails");
+        assert_eq!(invalid.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn validates_code_mode_params_recursively_against_schema() {
+        let schema = json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "state": { "enum": ["open", "closed"] },
+                "limit": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 },
+                "labels": { "type": "array", "items": { "type": "string" } },
+                "owner": {
+                    "type": "object",
+                    "properties": { "login": { "type": "string" } },
+                    "required": ["login"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["state", "owner"]
+        });
+
+        super::validate_code_mode_params_against_schema(
+            &json!({
+                "state": "open",
+                "limit": null,
+                "labels": ["bug"],
+                "owner": {"login": "octo"}
+            }),
+            Some(&schema),
+        )
+        .expect("valid nested params pass");
+
+        for params in [
+            json!({"state": "merged", "owner": {"login": "octo"}}),
+            json!({"state": "open", "owner": {"login": "octo", "extra": true}}),
+            json!({"state": "open", "owner": {}, "labels": ["bug"]}),
+            json!({"state": "open", "owner": {"login": "octo"}, "labels": [1]}),
+            json!({"state": "open", "owner": {"login": "octo"}, "limit": 0}),
+            json!({"state": "open", "owner": {"login": "octo"}, "extra": true}),
+        ] {
+            let err = super::validate_code_mode_params_against_schema(&params, Some(&schema))
+                .expect_err("invalid nested params fail");
+            assert_eq!(err.kind(), "invalid_param", "{params}");
+        }
     }
 
     #[tokio::test]
@@ -2204,11 +2884,13 @@ mod tests {
                 "search_issues",
                 "search issues",
                 None,
+                None,
             ),
             super::CodeModeCatalogEntry::upstream_tool(
                 "docker",
                 "container_logs",
                 "tail container logs",
+                None,
                 None,
             ),
         ];
@@ -2243,6 +2925,7 @@ mod tests {
                 json!({"query": "Matrix"}),
                 super::CodeModeCaller::TrustedLocal,
                 super::CodeModeSurface::Cli,
+                &super::CodeModeCapabilityFilter::default(),
             )
             .await
             .expect_err("lab:: callTool id should return unknown_tool");
@@ -2326,12 +3009,67 @@ mod tests {
             "github",
             "search_issues",
             "Search issues",
-            Some(json!({"type": "object"})),
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "q": {
+                        "type": "string",
+                        "description": "Search query"
+                    }
+                },
+                "required": ["q"]
+            })),
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            })),
         );
         assert_eq!(candidate.id, "upstream::github::search_issues");
         assert_eq!(candidate.upstream, "github");
         assert_eq!(candidate.name, "search_issues");
-        assert_eq!(candidate.schema, Some(json!({"type": "object"})));
+        assert_eq!(
+            candidate.output_schema,
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }))
+        );
+        assert!(
+            candidate
+                .signature
+                .contains("codemode.github.search_issues")
+        );
+        assert!(candidate.signature.contains("GithubSearchIssuesInput"));
+        assert!(candidate.signature.contains("GithubSearchIssuesOutput"));
+        assert!(candidate.dts.contains("type GithubSearchIssuesInput"));
+        assert!(candidate.dts.contains("/** Search query */"));
+        assert!(candidate.dts.contains("q: string;"));
+        assert!(candidate.dts.contains("title?: string;"));
+        assert!(
+            candidate
+                .dts
+                .contains("declare function callTool(id: \"upstream::github::search_issues\"")
+        );
     }
 
     #[test]
@@ -2522,6 +3260,35 @@ mod tests {
 
     #[cfg(feature = "code_mode_wasm")]
     #[test]
+    fn wasm_runner_reuses_cached_modules() {
+        let wat = r#"
+            (module
+              (func (export "run") (result i32)
+                i32.const 7))
+            "#;
+        super::wasm_runner::run_wasm_i32_export_for_smoke(
+            wat,
+            "run",
+            super::wasm_runner::DEFAULT_SEARCH_FUEL,
+        )
+        .expect("first wasm smoke runs");
+        let after_first = super::wasm_runner::cached_module_count_for_tests();
+        super::wasm_runner::run_wasm_i32_export_for_smoke(
+            wat,
+            "run",
+            super::wasm_runner::DEFAULT_SEARCH_FUEL,
+        )
+        .expect("second wasm smoke runs");
+        let after_second = super::wasm_runner::cached_module_count_for_tests();
+
+        assert_eq!(
+            after_second, after_first,
+            "same WAT should reuse cached module"
+        );
+    }
+
+    #[cfg(feature = "code_mode_wasm")]
+    #[test]
     fn wasm_runner_reports_fuel_exhaustion_kind() {
         let err = super::wasm_runner::run_wasm_i32_export_for_smoke(
             r#"
@@ -2550,7 +3317,7 @@ mod tests {
 
         // PRESENCE: inner code preserved
         assert!(
-            result.contains("console.log('hi');"),
+            result.contains("console.log"),
             "inner code must survive fence stripping"
         );
         // ABSENCE: fences removed
@@ -2568,104 +3335,99 @@ mod tests {
     fn normalize_user_code_strips_typescript_fences() {
         let fenced = "```typescript\nconst x: number = 1;\n```";
         let result = super::normalize_user_code(fenced);
-        assert!(result.contains("const x: number = 1;"));
+        assert!(result.contains("const x: number = 1"));
         assert!(!result.contains("```"));
         assert!(!result.contains("typescript"));
     }
 
     #[test]
-    fn normalize_user_code_parenthesizes_bare_async_main_into_expression() {
+    fn normalize_user_code_wraps_and_calls_bare_async_main() {
         let bare = "async function main() { return 42; }";
         let result = super::normalize_user_code(bare);
 
-        // PRESENCE: wrapped as a parenthesized function EXPRESSION
-        assert!(
-            result.starts_with("(async function main()"),
-            "must parenthesize into a function expression, got: {result}"
-        );
-        assert!(
-            result.ends_with("})"),
-            "expression must be closed, got: {result}"
-        );
-        // ABSENCE: no trailing self-invocation (the execute wrapper invokes it)
-        assert!(
-            !result.contains("main();"),
-            "must NOT append a main() call — wrapper invokes the expression, got: {result}"
-        );
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("async function main()"), "got: {result}");
+        assert!(result.contains("return main();"), "got: {result}");
     }
 
     #[test]
-    fn normalize_user_code_parenthesizes_bare_sync_main_into_expression() {
+    fn normalize_user_code_wraps_and_calls_bare_sync_main() {
         let bare = "function main() { return 42; }";
         let result = super::normalize_user_code(bare);
-        assert!(
-            result.starts_with("(function main()"),
-            "must parenthesize sync main into an expression, got: {result}"
-        );
-        assert!(
-            result.ends_with("})"),
-            "expression must be closed, got: {result}"
-        );
-        assert!(
-            !result.contains("main();"),
-            "must NOT append a main() call, got: {result}"
-        );
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("function main()"), "got: {result}");
+        assert!(result.contains("return main();"), "got: {result}");
     }
 
     #[test]
-    fn normalize_user_code_does_not_touch_non_main_decl_code() {
-        // Code that does not start with a main declaration must pass through
-        // unchanged — no main() injected, no parenthesization.
+    fn normalize_user_code_wraps_loose_statement_block() {
         let already_called = "const x = 1;\nmain();";
         let result = super::normalize_user_code(already_called);
-        assert_eq!(
-            result, already_called,
-            "non-main-decl code must pass through unchanged, got: {result}"
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("const x = 1;"));
+        assert!(result.contains("return (main())"));
+    }
+
+    #[test]
+    fn normalize_user_code_returns_trailing_expression() {
+        let loose = "const x = await callTool('upstream::github::search_issues', {});\nx.items";
+        let result = super::normalize_user_code(loose);
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("const x = await callTool"));
+        assert!(result.contains("return (x.items)"), "got: {result}");
+    }
+
+    #[test]
+    fn normalize_user_code_handles_cloudflare_ast_cases() {
+        let assigned_arrow = super::normalize_user_code("const f = () => 1; f()");
+        assert!(
+            assigned_arrow.starts_with("async () => {"),
+            "{assigned_arrow}"
+        );
+        assert!(assigned_arrow.contains("return (f())"), "{assigned_arrow}");
+
+        let export_arrow = super::normalize_user_code("export default async () => 42");
+        assert_eq!(export_arrow, "async () => 42");
+
+        let named = super::normalize_user_code("async function doStuff() { return 42; }");
+        assert!(named.contains("return doStuff();"), "{named}");
+
+        let iife = super::normalize_user_code("(async () => 42)()");
+        assert!(
+            iife.contains("return ((") && iife.contains(")())"),
+            "{iife}"
         );
     }
 
     #[test]
-    fn normalize_user_code_unwraps_export_default_async_into_expression() {
+    fn normalize_user_code_wraps_export_default_async_function_as_iife() {
         let exported = "export default async function() { return 42; }";
         let result = super::normalize_user_code(exported);
 
-        // ABSENCE: export default removed
-        assert!(
-            !result.contains("export default"),
-            "export default must be removed, got: {result}"
-        );
-        // PRESENCE: parenthesized async function EXPRESSION
-        assert!(
-            result.starts_with("(async function"),
-            "must wrap as a parenthesized function expression, got: {result}"
-        );
-        // ABSENCE: no IIFE self-invocation (the execute wrapper invokes it)
-        assert!(
-            result.ends_with("})") && !result.ends_with("()"),
-            "must NOT be a self-invoking IIFE, got: {result}"
-        );
+        assert!(!result.contains("export default"));
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("return (async function"), "got: {result}");
+        assert!(result.contains("})();"), "got: {result}");
     }
 
     #[test]
-    fn normalize_user_code_unwraps_export_default_sync_into_expression() {
+    fn normalize_user_code_wraps_export_default_sync_function_as_iife() {
         let exported = "export default function() { return 42; }";
         let result = super::normalize_user_code(exported);
         assert!(!result.contains("export default"));
-        assert!(result.starts_with("(function"));
-        assert!(
-            result.ends_with("})") && !result.ends_with("()"),
-            "must NOT be a self-invoking IIFE, got: {result}"
-        );
+        assert!(result.starts_with("async () => {"), "got: {result}");
+        assert!(result.contains("return (function"), "got: {result}");
+        assert!(result.contains("})();"), "got: {result}");
     }
 
     #[test]
     fn normalize_user_code_passthrough_for_plain_expressions() {
-        let plain = "const result = await callTool('lab::test', {});";
+        let plain = "async () => callTool('lab::test', {})";
         let result = super::normalize_user_code(plain);
         // PRESENCE: no transformation applied
         assert_eq!(
             result, plain,
-            "plain expressions must pass through unchanged"
+            "async arrow expressions must pass through unchanged"
         );
     }
 

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -189,7 +189,7 @@ fn normalize_script_code(source: &str) -> Option<String> {
                         boa_ast::Expression::ArrowFunction(_)
                             | boa_ast::Expression::AsyncArrowFunction(_)
                     ) {
-                        return Some(source.to_string());
+                        return Some(strip_trailing_statement_semicolon(source));
                     }
                     return Some(format!(
                         "async () => {{\nreturn ({})\n}}",
@@ -231,6 +231,14 @@ fn normalize_script_code(source: &str) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n");
     Some(format!("async () => {{\n{body}\n}}"))
+}
+
+fn strip_trailing_statement_semicolon(source: &str) -> String {
+    let trimmed = source.trim();
+    trimmed.strip_suffix(';').map_or_else(
+        || source.to_string(),
+        |without| without.trim_end().to_string(),
+    )
 }
 
 fn function_declaration_name(
@@ -996,9 +1004,19 @@ impl<'a> CodeModeBroker<'a> {
         // proxy rather than aborting execute — `callTool` is always available as
         // the documented escape hatch, so the run can still proceed without the
         // typed namespace.
-        let proxy = self
+        let proxy = match self
             .build_code_mode_proxy(&caller, surface, &capability_filter)
-            .await?;
+            .await
+        {
+            Ok(proxy) => proxy,
+            Err(err) => {
+                tracing::warn!(
+                    kind = err.kind(),
+                    "code_mode.proxy_generation_failed; continuing with callTool only"
+                );
+                String::new()
+            }
+        };
 
         write_runner_input(
             &mut stdin,
@@ -2456,7 +2474,7 @@ fn run_code_mode_runner() -> Result<(), String> {
 
     context
         .register_global_builtin_callable(
-            js_string!("callTool"),
+            js_string!("__labCallToolNative"),
             2,
             NativeFunction::from_copy_closure(code_mode_call_tool_native),
         )
@@ -2471,7 +2489,23 @@ fn run_code_mode_runner() -> Result<(), String> {
     // proxy ends with `var` declarations (no completion value), so the trailing
     // IIFE remains the `eval` completion value (the awaited promise). An empty
     // proxy (search path / legacy Start) leaves `codemode` undefined as before.
-    let wrapped = format!("{CODE_MODE_VALUE_CODEC_JS}\n{proxy}\n(async () => {{\n{invoker}}})()");
+    let wrapped = format!(
+        r#"
+{CODE_MODE_VALUE_CODEC_JS}
+globalThis.callTool = (id, params = {{}}) => {{
+  if (typeof id !== "string" || id.trim() === "") {{
+    throw new TypeError("callTool id must be a non-empty string");
+  }}
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {{
+    throw new TypeError("callTool params must be a JSON object");
+  }}
+  return globalThis.__labCallToolNative(id, __labEncodeResult(params));
+}};
+{proxy}
+(async () => {{
+{invoker}}})()
+"#
+    );
     let value = context
         .eval(Source::from_bytes(wrapped.as_bytes()))
         .map_err(js_error_message)?;
@@ -3878,6 +3912,16 @@ mod tests {
         assert_eq!(
             result, plain,
             "async arrow expressions must pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn normalize_user_code_strips_arrow_expression_trailing_semicolon() {
+        let result = super::normalize_user_code("async () => 42;");
+        assert!(result.starts_with("async () =>"), "got: {result}");
+        assert!(
+            !result.trim_end().ends_with(';'),
+            "normalized arrow must not keep the source trailing semicolon: {result}"
         );
     }
 

--- a/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
@@ -187,6 +187,7 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> Result
     // upstreams that snake-collide merge into one namespace object (tools are not
     // dropped); a per-tool snake collision is last-wins inside the object literal.
     let mut by_snake_upstream: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut final_proxy_keys: BTreeMap<(String, String), (String, String)> = BTreeMap::new();
     for (upstream_name, upstream_tools) in &by_upstream {
         let upstream_snake = tool_name_to_snake(upstream_name);
 
@@ -209,8 +210,16 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> Result
             snake_to_dotted.insert(snake, tool.tool.name.to_string());
         }
 
-        let method_defs = by_snake_upstream.entry(upstream_snake).or_default();
+        let method_defs = by_snake_upstream.entry(upstream_snake.clone()).or_default();
         for (snake, dotted) in &snake_to_dotted {
+            if let Some((existing_upstream, existing_tool)) = final_proxy_keys.insert(
+                (upstream_snake.clone(), snake.clone()),
+                (upstream_name.to_string(), dotted.clone()),
+            ) {
+                return Err(format!(
+                    "Tools \"{existing_upstream}::{existing_tool}\" and \"{upstream_name}::{dotted}\" both sanitize to \"{upstream_snake}.{snake}\""
+                ));
+            }
             // callTool id uses the RAW upstream + RAW tool name.
             let tool_id = format!("upstream::{upstream_name}::{dotted}");
             let tool_id_json =
@@ -431,5 +440,34 @@ mod tests {
             .expect_err("sanitized collisions must not be last-wins");
 
         assert!(err.contains("both sanitize to"));
+    }
+
+    #[test]
+    fn generate_js_proxy_rejects_final_proxy_collisions_across_raw_upstreams() {
+        let schema = Arc::new(serde_json::Map::new());
+        let hyphenated = UpstreamTool {
+            upstream_name: Arc::from("foo-bar"),
+            tool: Tool::new("ping", "Ping", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+            output_schema: None,
+        };
+        let dotted = UpstreamTool {
+            upstream_name: Arc::from("foo.bar"),
+            tool: Tool::new("ping", "Ping", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+            output_schema: None,
+        };
+
+        let err = generate_js_proxy(
+            &[hyphenated, dotted],
+            &["foo-bar".to_string(), "foo.bar".to_string()],
+        )
+        .expect_err("final proxy collisions must not generate duplicate keys");
+
+        assert!(err.contains("both sanitize to"));
+        assert!(err.contains("foo_bar"));
+        assert!(err.contains("ping"));
     }
 }

--- a/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_preamble.rs
@@ -23,9 +23,15 @@ use crate::dispatch::upstream::types::UpstreamTool;
 
 /// JavaScript reserved words that need an underscore suffix.
 const JS_RESERVED: &[&str] = &[
+    "abstract",
+    "arguments",
+    "await",
+    "boolean",
     "break",
+    "byte",
     "case",
     "catch",
+    "char",
     "class",
     "const",
     "continue",
@@ -33,31 +39,52 @@ const JS_RESERVED: &[&str] = &[
     "default",
     "delete",
     "do",
+    "double",
     "else",
+    "enum",
+    "eval",
     "export",
     "extends",
     "false",
+    "final",
     "finally",
+    "float",
     "for",
     "function",
+    "goto",
     "if",
+    "implements",
     "import",
     "in",
     "instanceof",
+    "int",
+    "interface",
     "let",
+    "long",
+    "native",
     "new",
     "null",
+    "package",
+    "private",
+    "protected",
+    "public",
     "return",
+    "short",
     "static",
     "super",
     "switch",
+    "synchronized",
     "this",
     "throw",
+    "throws",
+    "transient",
     "true",
     "try",
     "typeof",
+    "undefined",
     "var",
     "void",
+    "volatile",
     "while",
     "with",
     "yield",
@@ -68,8 +95,8 @@ const JS_RESERVED: &[&str] = &[
 /// Examples (Cloudflare parity):
 /// - `movie.search` → `movie_search`
 /// - `tv-show.get` → `tv_show_get`
-/// - `create/issue` → `create_issue`
-/// - `list:repos` → `list_repos`
+/// - `create/issue` → `createissue`
+/// - `list:repos` → `listrepos`
 /// - `delete` → `delete_` (reserved word)
 /// - `2fa_setup` → `_2fa_setup` (leading digit prefixed with `_`)
 ///
@@ -77,13 +104,33 @@ const JS_RESERVED: &[&str] = &[
 /// — last insert wins when building the namespace. A `tracing::debug!` is emitted
 /// when a collision is detected.
 pub fn tool_name_to_snake(name: &str) -> String {
-    // Split on dots, hyphens, forward-slashes, and colons; rejoin with `_`.
-    // Underscores already in segments are preserved.
-    let snake: String = name
-        .split(['.', '-', '/', ':'])
-        .filter(|seg| !seg.is_empty())
-        .collect::<Vec<_>>()
-        .join("_");
+    if name.is_empty() {
+        return "_".to_string();
+    }
+
+    // Cloudflare parity: replace common separators with underscores, then strip
+    // any remaining characters that are invalid in JavaScript identifiers.
+    let mut snake = String::new();
+    let mut previous_was_separator = false;
+    for ch in name.chars() {
+        if ch == '-' || ch == '.' || ch.is_whitespace() {
+            if !previous_was_separator {
+                snake.push('_');
+            }
+            previous_was_separator = true;
+        } else if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+            snake.push(ch);
+            previous_was_separator = false;
+        } else {
+            previous_was_separator = false;
+        }
+    }
+    let snake = snake.trim_matches('_').to_string();
+    let snake = if snake.is_empty() {
+        "_".to_string()
+    } else {
+        snake
+    };
 
     // Prefix with `_` if the result starts with a digit (invalid JS identifier start).
     let snake = if snake.starts_with(|c: char| c.is_ascii_digit()) {
@@ -117,7 +164,7 @@ pub fn tool_name_to_snake(name: &str) -> String {
 ///
 /// `tools` — the upstream tools to expose
 /// `upstreams` — sorted, deduplicated list of upstream names
-pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String {
+pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> Result<String, String> {
     use std::collections::BTreeMap;
     use std::fmt::Write as _;
 
@@ -150,12 +197,14 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String
         for tool in &sorted_tools {
             let snake = tool_name_to_snake(tool.tool.name.as_ref());
             if snake_to_dotted.contains_key(&snake) {
-                tracing::debug!(
-                    upstream = *upstream_name,
-                    tool_name = tool.tool.name.as_ref(),
-                    snake_name = %snake,
-                    "Code Mode proxy: tool name collision detected, last registration wins"
-                );
+                let existing = snake_to_dotted
+                    .get(&snake)
+                    .map(String::as_str)
+                    .unwrap_or("<unknown>");
+                return Err(format!(
+                    "Tool names \"{existing}\" and \"{}\" both sanitize to \"{snake}\" in upstream \"{upstream_name}\"",
+                    tool.tool.name.as_ref()
+                ));
             }
             snake_to_dotted.insert(snake, tool.tool.name.to_string());
         }
@@ -192,13 +241,13 @@ pub fn generate_js_proxy(tools: &[UpstreamTool], upstreams: &[String]) -> String
     // Emit __meta__.upstreams value.
     let upstreams_json = serde_json::to_string(upstreams).unwrap_or_else(|_| "[]".to_string());
 
-    format!(
+    Ok(format!(
         "// Code Mode proxy — auto-generated\n\
          var codemode = {{}};\n\
          {parts}\
          codemode.__meta__ = {{ upstreams: function() {{ return Promise.resolve({upstreams_json}); }} }};\n\
          var __upstreams__ = {upstreams_json};\n"
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -228,11 +277,11 @@ mod tests {
     #[test]
     fn tool_name_to_snake_handles_slashes_and_colons() {
         // PRESENCE: forward-slashes and colons join with underscore
-        assert_eq!(tool_name_to_snake("create/issue"), "create_issue");
-        assert_eq!(tool_name_to_snake("list:repos"), "list_repos");
+        assert_eq!(tool_name_to_snake("create/issue"), "createissue");
+        assert_eq!(tool_name_to_snake("list:repos"), "listrepos");
         assert_eq!(
             tool_name_to_snake("repos/create/branch"),
-            "repos_create_branch"
+            "reposcreatebranch"
         );
         // PRESENCE: already-snake input is preserved
         assert_eq!(tool_name_to_snake("create_issue"), "create_issue");
@@ -241,6 +290,14 @@ mod tests {
         // ABSENCE: separators must not appear in output (would break JS syntax)
         assert!(!tool_name_to_snake("create/issue").contains('/'));
         assert!(!tool_name_to_snake("list:repos").contains(':'));
+    }
+
+    #[test]
+    fn tool_name_to_snake_matches_cloudflare_identifier_sanitization() {
+        assert_eq!(tool_name_to_snake("list tags"), "list_tags");
+        assert_eq!(tool_name_to_snake("create#issue!"), "createissue");
+        assert_eq!(tool_name_to_snake("await"), "await_");
+        assert_eq!(tool_name_to_snake(""), "_");
     }
 
     // ── generate_js_proxy ─────────────────────────────────────────────────────
@@ -260,8 +317,9 @@ mod tests {
             tool: Tool::new("create/issue", "Create an issue", Arc::clone(&schema)),
             destructive: false,
             input_schema: None,
+            output_schema: None,
         };
-        let js = generate_js_proxy(&[tool], &["github".to_string()]);
+        let js = generate_js_proxy(&[tool], &["github".to_string()]).expect("proxy");
 
         // PRESENCE: the upstream object must be present
         assert!(
@@ -270,8 +328,8 @@ mod tests {
         );
         // PRESENCE: the tool key must appear as a quoted string (not unquoted)
         assert!(
-            js.contains("\"create_issue\""),
-            "snake_case key must be quoted"
+            js.contains("\"createissue\""),
+            "sanitized key must be quoted"
         );
         // ABSENCE: no unquoted slash-containing key that would break JS syntax
         assert!(
@@ -293,8 +351,9 @@ mod tests {
             tool: Tool::new("movie.search", "Search for movies", Arc::clone(&schema)),
             destructive: false,
             input_schema: None,
+            output_schema: None,
         };
-        let js = generate_js_proxy(&[tool], &["radarr".to_string()]);
+        let js = generate_js_proxy(&[tool], &["radarr".to_string()]).expect("proxy");
 
         // PRESENCE: declares the script-global `var codemode`
         assert!(js.contains("var codemode = {}"), "must declare codemode");
@@ -329,8 +388,9 @@ mod tests {
             tool: Tool::new("arcane", "Docker management", Arc::clone(&schema)),
             destructive: false,
             input_schema: None,
+            output_schema: None,
         };
-        let js = generate_js_proxy(&[tool], &["arcane-mcp".to_string()]);
+        let js = generate_js_proxy(&[tool], &["arcane-mcp".to_string()]).expect("proxy");
 
         // PRESENCE: namespace key is snake_cased (dot-accessible)
         assert!(
@@ -347,5 +407,29 @@ mod tests {
             js.contains("upstream::arcane-mcp::arcane"),
             "callTool id must keep the raw upstream name: {js}"
         );
+    }
+
+    #[test]
+    fn generate_js_proxy_rejects_sanitized_tool_collisions() {
+        let schema = Arc::new(serde_json::Map::new());
+        let dotted = UpstreamTool {
+            upstream_name: Arc::from("demo"),
+            tool: Tool::new("movie.search", "Search", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+            output_schema: None,
+        };
+        let underscored = UpstreamTool {
+            upstream_name: Arc::from("demo"),
+            tool: Tool::new("movie_search", "Search", Arc::clone(&schema)),
+            destructive: false,
+            input_schema: None,
+            output_schema: None,
+        };
+
+        let err = generate_js_proxy(&[dotted, underscored], &["demo".to_string()])
+            .expect_err("sanitized collisions must not be last-wins");
+
+        assert!(err.contains("both sanitize to"));
     }
 }

--- a/crates/lab/src/dispatch/gateway/code_mode_types.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_types.rs
@@ -25,6 +25,7 @@ pub fn generate_tool_types(
     );
     let input_name = format!("{base}Input");
     let output_name = format!("{base}Output");
+    let upstream_interface = format!("Codemode{}Tools", to_pascal_identifier(upstream));
     let upstream_method = tool_name_to_snake(upstream);
     let tool_method = tool_name_to_snake(tool);
     let tool_id = upstream_tool_id(upstream, tool);
@@ -38,16 +39,18 @@ pub fn generate_tool_types(
     let mut dts = String::new();
     dts.push_str(&format!("type {input_name} = {input_type};\n"));
     dts.push_str(&format!("type {output_name} = {output_type};\n"));
-    dts.push_str("declare const codemode: {\n");
-    dts.push_str(&format!("  {upstream_method}: {{\n"));
+    dts.push_str(&format!("interface {upstream_interface} {{\n"));
     if let Some(comment) = jsdoc_block(description, 4) {
         dts.push_str(&comment);
     }
     dts.push_str(&format!(
-        "    {tool_method}(params: {input_name}): Promise<{output_name}>;\n"
+        "  {tool_method}(params: {input_name}): Promise<{output_name}>;\n"
     ));
-    dts.push_str("  };\n");
-    dts.push_str("};\n");
+    dts.push_str("}\n");
+    dts.push_str("interface CodemodeTools {\n");
+    dts.push_str(&format!("  {upstream_method}: {upstream_interface};\n"));
+    dts.push_str("}\n");
+    dts.push_str("declare var codemode: CodemodeTools;\n");
     dts.push_str(&format!(
         "declare function callTool(id: {tool_id_literal}, params: {input_name}): Promise<{output_name}>;\n"
     ));
@@ -158,6 +161,9 @@ fn schema_type_to_type(
     match kind {
         "object" => object_type(schema, root, depth, seen_refs),
         "array" => array_type(schema, root, depth, seen_refs),
+        "string" if schema.get("format").and_then(Value::as_str) == Some("binary") => {
+            "Uint8Array | ArrayBuffer".to_string()
+        }
         "string" => "string".to_string(),
         "integer" | "number" => "number".to_string(),
         "boolean" => "boolean".to_string(),
@@ -188,31 +194,48 @@ fn object_type(
         .unwrap_or_default();
 
     let mut lines = Vec::new();
+    let mut property_index_types = Vec::new();
     if let Some(properties) = object.get("properties").and_then(Value::as_object) {
         for key in properties.keys() {
             let property = &properties[key];
             if let Some(comment) = property_jsdoc(property, 2) {
                 lines.push(comment.trim_end().to_string());
             }
-            let optional = if required.contains(key.as_str()) {
-                ""
-            } else {
-                "?"
-            };
+            let property_type = schema_to_type(property, root, depth + 1, seen_refs);
+            let is_required = required.contains(key.as_str());
+            let optional = if is_required { "" } else { "?" };
+            push_union_parts(&mut property_index_types, &property_type);
+            if !is_required {
+                property_index_types.push("undefined".to_string());
+            }
             lines.push(format!(
                 "  {}{}: {};",
                 quote_prop(key),
                 optional,
-                schema_to_type(property, root, depth + 1, seen_refs)
+                property_type
             ));
         }
     }
 
     match object.get("additionalProperties") {
-        Some(Value::Object(_)) => lines.push(format!(
-            "  [key: string]: {};",
-            schema_to_type(&object["additionalProperties"], root, depth + 1, seen_refs)
-        )),
+        Some(Value::Object(_)) => {
+            let additional_type =
+                schema_to_type(&object["additionalProperties"], root, depth + 1, seen_refs);
+            if property_index_types.is_empty() {
+                lines.push(format!("  [key: string]: {additional_type};"));
+            } else {
+                lines.push(format!(
+                    "  /** Additional properties match: {additional_type} */"
+                ));
+                let mut index_types = Vec::new();
+                push_union_parts(&mut index_types, &additional_type);
+                index_types.extend(property_index_types);
+                lines.push(format!(
+                    "  [key: string]: {};",
+                    union(index_types.into_iter())
+                ));
+            }
+        }
         Some(Value::Bool(true)) => lines.push("  [key: string]: unknown;".to_string()),
         Some(Value::Bool(false)) => {}
         _ => {}
@@ -220,7 +243,7 @@ fn object_type(
 
     if lines.is_empty() {
         if object.get("additionalProperties").and_then(Value::as_bool) == Some(false) {
-            return "{}".to_string();
+            return "Record<string, never>".to_string();
         }
         return "Record<string, unknown>".to_string();
     }
@@ -238,17 +261,13 @@ fn array_type(
         return "unknown[]".to_string();
     };
 
-    if let Some(items) = object.get("prefixItems").and_then(Value::as_array) {
-        let items = items
-            .iter()
-            .map(|item| schema_to_type(item, root, depth + 1, seen_refs))
-            .collect::<Vec<_>>()
-            .join(", ");
-        return format!("[{items}]");
-    }
-
-    if let Some(items) = object.get("items").and_then(Value::as_array) {
-        let items = items
+    // Tuple form: `prefixItems` (draft 2020-12) or a legacy array-valued `items`.
+    if let Some(tuple) = object
+        .get("prefixItems")
+        .or_else(|| object.get("items"))
+        .and_then(Value::as_array)
+    {
+        let items = tuple
             .iter()
             .map(|item| schema_to_type(item, root, depth + 1, seen_refs))
             .collect::<Vec<_>>()
@@ -288,6 +307,15 @@ fn intersection(types: impl Iterator<Item = String>) -> String {
     } else {
         types.join(" & ")
     }
+}
+
+fn push_union_parts(types: &mut Vec<String>, ty: &str) {
+    types.extend(
+        ty.split('|')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(ToString::to_string),
+    );
 }
 
 fn literal_type(value: &Value) -> String {
@@ -444,11 +472,81 @@ mod tests {
         let ts = super::json_schema_to_type(Some(&schema));
 
         assert!(ts.contains("tuple?: [string, number];"), "{ts}");
-        assert!(ts.contains("exact?: {};"), "{ts}");
+        assert!(ts.contains("exact?: Record<string, never>;"), "{ts}");
         assert!(ts.contains("* Timestamp"), "{ts}");
         assert!(ts.contains("* @format date-time"), "{ts}");
         assert!(ts.contains("anything?: unknown;"), "{ts}");
         assert!(ts.contains("nothing?: never;"), "{ts}");
+    }
+
+    #[test]
+    fn json_schema_to_type_maps_binary_strings_to_runtime_buffer_types() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "string",
+                    "format": "binary"
+                }
+            },
+            "required": ["payload"]
+        });
+
+        let ts = super::json_schema_to_type(Some(&schema));
+
+        assert!(ts.contains("payload: Uint8Array | ArrayBuffer;"), "{ts}");
+    }
+
+    #[test]
+    fn json_schema_to_type_does_not_emit_conflicting_index_signatures() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["id"],
+            "additionalProperties": { "type": "number" }
+        });
+
+        let ts = super::json_schema_to_type(Some(&schema));
+
+        assert!(ts.contains("id: string;"), "{ts}");
+        assert!(ts.contains("count?: number;"), "{ts}");
+        assert!(
+            ts.contains("* Additional properties match: number"),
+            "additional properties should preserve the schema type in documentation: {ts}"
+        );
+        assert!(
+            ts.contains("[key: string]: number | string | undefined;"),
+            "additional properties should be widened to avoid conflicting with explicit properties: {ts}"
+        );
+        assert!(!ts.contains("[key: string]: number;"), "{ts}");
+    }
+
+    #[test]
+    fn generate_tool_types_emits_composable_codemode_declarations() {
+        let first = super::generate_tool_types(
+            "github",
+            "list_tags",
+            "List tags",
+            Some(&json!({"type": "object"})),
+            None,
+        );
+        let second = super::generate_tool_types(
+            "github",
+            "create_issue",
+            "Create issue",
+            Some(&json!({"type": "object"})),
+            None,
+        );
+        let combined = format!("{}\n{}", first.dts, second.dts);
+
+        assert!(!combined.contains("declare const codemode"), "{combined}");
+        assert_eq!(combined.matches("declare var codemode").count(), 2);
+        assert!(combined.contains("interface CodemodeGithubTools"));
+        assert!(combined.contains("list_tags(params:"), "{combined}");
+        assert!(combined.contains("create_issue(params:"), "{combined}");
     }
 
     #[test]
@@ -469,5 +567,44 @@ mod tests {
         assert!(types.dts.contains("list_tags(params:"), "{types:?}");
         assert!(!types.dts.contains("github chat: {"), "{types:?}");
         assert!(!types.dts.contains("list tags(params:"), "{types:?}");
+    }
+
+    #[test]
+    fn generate_tool_types_sanitizes_reserved_digits_empty_dollar_and_collision_adjacent_names() {
+        let cases = [
+            ("await", "delete", "codemode.await_.delete_"),
+            ("9lives", "2fa setup", "codemode._9lives._2fa_setup"),
+            ("", "", "codemode._._"),
+            ("cash$box", "$charge", "codemode.cash$box.$charge"),
+            (
+                "movie.search",
+                "list-tags",
+                "codemode.movie_search.list_tags",
+            ),
+            (
+                "movie_search",
+                "list.tags",
+                "codemode.movie_search.list_tags",
+            ),
+        ];
+
+        for (upstream, tool, expected) in cases {
+            let types = super::generate_tool_types(
+                upstream,
+                tool,
+                "Description",
+                Some(&json!({"type": "object"})),
+                None,
+            );
+
+            assert!(
+                types.signature.contains(expected),
+                "expected {expected} in {:?}",
+                types.signature
+            );
+            assert!(!types.dts.contains(".."), "{types:?}");
+            assert!(!types.dts.contains("  : {"), "{types:?}");
+            assert!(!types.dts.contains(" (params:"), "{types:?}");
+        }
     }
 }

--- a/crates/lab/src/dispatch/gateway/code_mode_types.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode_types.rs
@@ -1,0 +1,473 @@
+use std::collections::{BTreeSet, HashSet};
+
+use serde_json::Value;
+
+use super::code_mode::upstream_tool_id;
+use super::code_mode_preamble::tool_name_to_snake;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolTypes {
+    pub signature: String,
+    pub dts: String,
+}
+
+pub fn generate_tool_types(
+    upstream: &str,
+    tool: &str,
+    description: &str,
+    input_schema: Option<&Value>,
+    output_schema: Option<&Value>,
+) -> ToolTypes {
+    let base = format!(
+        "{}{}",
+        to_pascal_identifier(upstream),
+        to_pascal_identifier(tool)
+    );
+    let input_name = format!("{base}Input");
+    let output_name = format!("{base}Output");
+    let upstream_method = tool_name_to_snake(upstream);
+    let tool_method = tool_name_to_snake(tool);
+    let tool_id = upstream_tool_id(upstream, tool);
+    let tool_id_literal = serde_json::to_string(&tool_id).unwrap_or_else(|_| "\"\"".to_string());
+    let input_type = json_schema_to_type(input_schema);
+    let output_type = json_schema_to_type(output_schema);
+    let signature = format!(
+        "codemode.{upstream_method}.{tool_method}(params: {input_name}): Promise<{output_name}>"
+    );
+
+    let mut dts = String::new();
+    dts.push_str(&format!("type {input_name} = {input_type};\n"));
+    dts.push_str(&format!("type {output_name} = {output_type};\n"));
+    dts.push_str("declare const codemode: {\n");
+    dts.push_str(&format!("  {upstream_method}: {{\n"));
+    if let Some(comment) = jsdoc_block(description, 4) {
+        dts.push_str(&comment);
+    }
+    dts.push_str(&format!(
+        "    {tool_method}(params: {input_name}): Promise<{output_name}>;\n"
+    ));
+    dts.push_str("  };\n");
+    dts.push_str("};\n");
+    dts.push_str(&format!(
+        "declare function callTool(id: {tool_id_literal}, params: {input_name}): Promise<{output_name}>;\n"
+    ));
+
+    ToolTypes { signature, dts }
+}
+
+pub fn json_schema_to_type(schema: Option<&Value>) -> String {
+    let Some(schema) = schema else {
+        return "unknown".to_string();
+    };
+    let mut seen_refs = HashSet::new();
+    schema_to_type(schema, schema, 0, &mut seen_refs)
+}
+
+fn schema_to_type(
+    schema: &Value,
+    root: &Value,
+    depth: usize,
+    seen_refs: &mut HashSet<String>,
+) -> String {
+    if let Some(value) = schema.as_bool() {
+        return if value { "unknown" } else { "never" }.to_string();
+    }
+    if depth > 20 {
+        return "unknown".to_string();
+    }
+    let Some(object) = schema.as_object() else {
+        return "unknown".to_string();
+    };
+
+    if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+        if !seen_refs.insert(reference.to_string()) {
+            return "unknown".to_string();
+        }
+        let resolved = resolve_ref(root, reference)
+            .map(|schema| schema_to_type(schema, root, depth + 1, seen_refs))
+            .unwrap_or_else(|| "unknown".to_string());
+        seen_refs.remove(reference);
+        return resolved;
+    }
+
+    if let Some(values) = object.get("anyOf").and_then(Value::as_array) {
+        return union(
+            values
+                .iter()
+                .map(|v| schema_to_type(v, root, depth + 1, seen_refs)),
+        );
+    }
+    if let Some(values) = object.get("oneOf").and_then(Value::as_array) {
+        return union(
+            values
+                .iter()
+                .map(|v| schema_to_type(v, root, depth + 1, seen_refs)),
+        );
+    }
+    if let Some(values) = object.get("allOf").and_then(Value::as_array) {
+        return intersection(
+            values
+                .iter()
+                .map(|v| schema_to_type(v, root, depth + 1, seen_refs)),
+        );
+    }
+
+    if let Some(value) = object.get("const") {
+        return literal_type(value);
+    }
+    if let Some(values) = object.get("enum").and_then(Value::as_array) {
+        return union(values.iter().map(literal_type));
+    }
+
+    let mut rendered = match object.get("type") {
+        Some(Value::Array(types)) => union(types.iter().map(|value| {
+            value
+                .as_str()
+                .map(|kind| schema_type_to_type(kind, schema, root, depth, seen_refs))
+                .unwrap_or_else(|| "unknown".to_string())
+        })),
+        Some(Value::String(kind)) => schema_type_to_type(kind, schema, root, depth, seen_refs),
+        _ if object.contains_key("properties") || object.contains_key("additionalProperties") => {
+            object_type(schema, root, depth, seen_refs)
+        }
+        _ if object.contains_key("items") || object.contains_key("prefixItems") => {
+            array_type(schema, root, depth, seen_refs)
+        }
+        _ => "unknown".to_string(),
+    };
+
+    if object
+        .get("nullable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        && !rendered.split('|').any(|part| part.trim() == "null")
+    {
+        rendered.push_str(" | null");
+    }
+
+    rendered
+}
+
+fn schema_type_to_type(
+    kind: &str,
+    schema: &Value,
+    root: &Value,
+    depth: usize,
+    seen_refs: &mut HashSet<String>,
+) -> String {
+    match kind {
+        "object" => object_type(schema, root, depth, seen_refs),
+        "array" => array_type(schema, root, depth, seen_refs),
+        "string" => "string".to_string(),
+        "integer" | "number" => "number".to_string(),
+        "boolean" => "boolean".to_string(),
+        "null" => "null".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn object_type(
+    schema: &Value,
+    root: &Value,
+    depth: usize,
+    seen_refs: &mut HashSet<String>,
+) -> String {
+    let Some(object) = schema.as_object() else {
+        return "Record<string, unknown>".to_string();
+    };
+
+    let required = object
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut lines = Vec::new();
+    if let Some(properties) = object.get("properties").and_then(Value::as_object) {
+        for key in properties.keys() {
+            let property = &properties[key];
+            if let Some(comment) = property_jsdoc(property, 2) {
+                lines.push(comment.trim_end().to_string());
+            }
+            let optional = if required.contains(key.as_str()) {
+                ""
+            } else {
+                "?"
+            };
+            lines.push(format!(
+                "  {}{}: {};",
+                quote_prop(key),
+                optional,
+                schema_to_type(property, root, depth + 1, seen_refs)
+            ));
+        }
+    }
+
+    match object.get("additionalProperties") {
+        Some(Value::Object(_)) => lines.push(format!(
+            "  [key: string]: {};",
+            schema_to_type(&object["additionalProperties"], root, depth + 1, seen_refs)
+        )),
+        Some(Value::Bool(true)) => lines.push("  [key: string]: unknown;".to_string()),
+        Some(Value::Bool(false)) => {}
+        _ => {}
+    }
+
+    if lines.is_empty() {
+        if object.get("additionalProperties").and_then(Value::as_bool) == Some(false) {
+            return "{}".to_string();
+        }
+        return "Record<string, unknown>".to_string();
+    }
+
+    format!("{{\n{}\n}}", lines.join("\n"))
+}
+
+fn array_type(
+    schema: &Value,
+    root: &Value,
+    depth: usize,
+    seen_refs: &mut HashSet<String>,
+) -> String {
+    let Some(object) = schema.as_object() else {
+        return "unknown[]".to_string();
+    };
+
+    if let Some(items) = object.get("prefixItems").and_then(Value::as_array) {
+        let items = items
+            .iter()
+            .map(|item| schema_to_type(item, root, depth + 1, seen_refs))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("[{items}]");
+    }
+
+    if let Some(items) = object.get("items").and_then(Value::as_array) {
+        let items = items
+            .iter()
+            .map(|item| schema_to_type(item, root, depth + 1, seen_refs))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("[{items}]");
+    }
+
+    let item_type = object
+        .get("items")
+        .map(|items| schema_to_type(items, root, depth + 1, seen_refs))
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("Array<{item_type}>")
+}
+
+fn resolve_ref<'a>(root: &'a Value, reference: &str) -> Option<&'a Value> {
+    reference
+        .strip_prefix('#')
+        .and_then(|pointer| root.pointer(pointer))
+}
+
+fn union(types: impl Iterator<Item = String>) -> String {
+    let mut seen = BTreeSet::new();
+    let types = types
+        .filter(|ty| seen.insert(ty.clone()))
+        .collect::<Vec<_>>();
+    if types.is_empty() {
+        "unknown".to_string()
+    } else {
+        types.join(" | ")
+    }
+}
+
+fn intersection(types: impl Iterator<Item = String>) -> String {
+    let types = types.collect::<Vec<_>>();
+    if types.is_empty() {
+        "unknown".to_string()
+    } else {
+        types.join(" & ")
+    }
+}
+
+fn literal_type(value: &Value) -> String {
+    match value {
+        Value::String(text) => serde_json::to_string(text).unwrap_or_else(|_| "string".to_string()),
+        Value::Number(number) => number.to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(_) | Value::Object(_) => {
+            serde_json::to_string(value).unwrap_or_else(|_| "unknown".to_string())
+        }
+    }
+}
+
+fn quote_prop(key: &str) -> String {
+    if is_identifier(key) {
+        key.to_string()
+    } else {
+        serde_json::to_string(key).unwrap_or_else(|_| "\"\"".to_string())
+    }
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first == '$' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+fn jsdoc_block(text: &str, indent: usize) -> Option<String> {
+    let text = escape_jsdoc(text.trim());
+    if text.is_empty() {
+        return None;
+    }
+    let pad = " ".repeat(indent);
+    Some(format!("{pad}/** {text} */\n"))
+}
+
+fn property_jsdoc(schema: &Value, indent: usize) -> Option<String> {
+    let object = schema.as_object()?;
+    let description = object.get("description").and_then(Value::as_str);
+    let format = object.get("format").and_then(Value::as_str);
+    if description.is_none() && format.is_none() {
+        return None;
+    }
+    if let (Some(description), None) = (description, format) {
+        return jsdoc_block(description, indent);
+    }
+    let pad = " ".repeat(indent);
+    let mut lines = Vec::new();
+    lines.push(format!("{pad}/**"));
+    if let Some(description) = description {
+        lines.push(format!("{pad} * {}", escape_jsdoc(description.trim())));
+    }
+    if let Some(format) = format {
+        lines.push(format!("{pad} * @format {}", escape_jsdoc(format.trim())));
+    }
+    lines.push(format!("{pad} */\n"));
+    Some(lines.join("\n"))
+}
+
+fn escape_jsdoc(text: &str) -> String {
+    text.replace("*/", "* /").replace('\n', " ")
+}
+
+fn to_pascal_identifier(value: &str) -> String {
+    let mut out = String::new();
+    for segment in value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|segment| !segment.is_empty())
+    {
+        let mut chars = segment.chars();
+        if let Some(first) = chars.next() {
+            out.push(first.to_ascii_uppercase());
+            out.extend(chars.map(|ch| ch.to_ascii_lowercase()));
+        }
+    }
+    if out.is_empty() {
+        "Tool".to_string()
+    } else if out.starts_with(|ch: char| ch.is_ascii_digit()) {
+        format!("_{out}")
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn json_schema_to_type_handles_refs_unions_arrays_and_required_properties() {
+        let schema = json!({
+            "$defs": {
+                "Issue": {
+                    "type": "object",
+                    "properties": {
+                        "title": { "type": "string" },
+                        "number": { "type": "integer" }
+                    },
+                    "required": ["title"]
+                }
+            },
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Issue" }
+                },
+                "state": {
+                    "enum": ["open", "closed"]
+                },
+                "cursor": {
+                    "anyOf": [{ "type": "string" }, { "type": "null" }]
+                }
+            },
+            "required": ["items"]
+        });
+
+        let ts = super::json_schema_to_type(Some(&schema));
+
+        assert!(ts.contains("items: Array<{"));
+        assert!(ts.contains("title: string;"));
+        assert!(ts.contains("number?: number;"));
+        assert!(ts.contains("state?: \"open\" | \"closed\";"));
+        assert!(ts.contains("cursor?: string | null;"));
+    }
+
+    #[test]
+    fn json_schema_to_type_matches_cloudflare_edge_cases() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tuple": {
+                    "type": "array",
+                    "items": [{ "type": "string" }, { "type": "integer" }]
+                },
+                "exact": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "when": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timestamp"
+                },
+                "anything": true,
+                "nothing": false
+            }
+        });
+
+        let ts = super::json_schema_to_type(Some(&schema));
+
+        assert!(ts.contains("tuple?: [string, number];"), "{ts}");
+        assert!(ts.contains("exact?: {};"), "{ts}");
+        assert!(ts.contains("* Timestamp"), "{ts}");
+        assert!(ts.contains("* @format date-time"), "{ts}");
+        assert!(ts.contains("anything?: unknown;"), "{ts}");
+        assert!(ts.contains("nothing?: never;"), "{ts}");
+    }
+
+    #[test]
+    fn generate_tool_types_quotes_sanitized_namespace_and_method_names() {
+        let types = super::generate_tool_types(
+            "github chat",
+            "list tags",
+            "List tags",
+            Some(&json!({"type": "object"})),
+            None,
+        );
+
+        assert!(
+            types.signature.contains("codemode.github_chat.list_tags"),
+            "{types:?}"
+        );
+        assert!(types.dts.contains("github_chat"), "{types:?}");
+        assert!(types.dts.contains("list_tags(params:"), "{types:?}");
+        assert!(!types.dts.contains("github chat: {"), "{types:?}");
+        assert!(!types.dts.contains("list tags(params:"), "{types:?}");
+    }
+}

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -1163,6 +1163,7 @@ mod tests {
                 crate::dispatch::upstream::types::UpstreamTool {
                     tool,
                     input_schema: None,
+                    output_schema: None,
                     upstream_name: std::sync::Arc::clone(&upstream_name),
                     destructive: false,
                 },

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -2983,6 +2983,7 @@ mod tests {
         let upstream_tool = UpstreamTool {
             tool,
             input_schema: None,
+            output_schema: None,
             upstream_name: Arc::clone(&upstream_name),
             destructive: false,
         };
@@ -4541,6 +4542,48 @@ mod tests {
         assert!(view.warnings.is_empty());
         assert_eq!(view.exposed_resource_count, 2);
         assert_eq!(view.exposed_prompt_count, 4);
+    }
+
+    #[tokio::test]
+    async fn lazily_seeded_healthy_upstream_reports_connected_before_first_use() {
+        // Regression: with lazy discovery the catalog is empty (0 tools) until an
+        // upstream's first use. A seeded-but-healthy upstream must not render as
+        // "Disconnected" just because no tools are exposed yet.
+        let pool = UpstreamPool::new();
+        let upstream = fixture_http_upstream("lazy-upstream");
+        pool.seed_lazy_upstreams(std::slice::from_ref(&upstream))
+            .await;
+
+        let view = server_view_from_upstream(Some(&pool), &upstream).await;
+        assert!(
+            view.connected,
+            "seeded healthy upstream should be connected"
+        );
+        assert!(view.surfaces.mcp.connected);
+        assert_eq!(view.discovered_tool_count, 0);
+        assert!(view.warnings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn errored_upstream_reports_disconnected_even_when_circuit_closed() {
+        // An upstream with a recorded operator-visible error must surface as down
+        // regardless of the optimistic seeded health default.
+        let pool = UpstreamPool::new();
+        let mut entry = fixture_upstream_entry("broken-upstream", HashMap::new());
+        entry.tool_health = UpstreamHealth::Unhealthy {
+            consecutive_failures: 1,
+        };
+        entry.tool_last_error = Some("auth required: 401 Unauthorized".to_string());
+        pool.insert_entry_for_tests("broken-upstream", entry).await;
+
+        let upstream = fixture_http_upstream("broken-upstream");
+        let view = server_view_from_upstream(Some(&pool), &upstream).await;
+        assert!(!view.connected, "errored upstream should be disconnected");
+        assert!(!view.surfaces.mcp.connected);
+        assert_eq!(
+            view.warnings.first().map(|warning| warning.code.as_str()),
+            Some("auth_failed")
+        );
     }
 
     #[tokio::test]

--- a/crates/lab/src/dispatch/gateway/projection.rs
+++ b/crates/lab/src/dispatch/gateway/projection.rs
@@ -247,9 +247,22 @@ pub(super) async fn server_view_from_upstream(
         Some(pool) => pool.upstream_last_error(&upstream.name).await,
         None => None,
     });
-    let connected = summary.exposed_tool_count > 0
+    let health = match pool {
+        Some(pool) => pool.upstream_tool_health(&upstream.name).await,
+        None => None,
+    };
+    // Health-aware connectivity (mirrors `server_view_from_virtual_server`): an
+    // upstream counts as connected when it is actively exposing capabilities OR
+    // it is healthy with no recorded error. The health term keeps lazily
+    // discovered upstreams — whose catalog stays empty until their first use —
+    // from rendering as "Disconnected" at rest, while upstreams with a recorded
+    // error or an open circuit breaker still surface as down.
+    let exposing_capabilities = summary.exposed_tool_count > 0
         || summary.exposed_resource_count > 0
         || summary.exposed_prompt_count > 0;
+    let health_ok =
+        last_error.is_none() && health.map(|health| health.is_routable()).unwrap_or(false);
+    let connected = exposing_capabilities || health_ok;
     let enabled = upstream.enabled;
     let pid = match pool {
         Some(pool) => pool

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -563,6 +563,11 @@ fn cached_upstream_tool(
         UpstreamTool {
             input_schema: (!tool.input_schema.is_empty())
                 .then(|| Value::Object((*tool.input_schema).clone())),
+            output_schema: tool
+                .output_schema
+                .as_ref()
+                .filter(|schema| !schema.is_empty())
+                .map(|schema| Value::Object((**schema).clone())),
             tool,
             upstream_name: Arc::clone(upstream_name),
             destructive,
@@ -4060,6 +4065,7 @@ mod tests {
         UpstreamTool {
             tool,
             input_schema: None,
+            output_schema: None,
             upstream_name: Arc::clone(upstream_name),
             destructive: false,
         }
@@ -5402,6 +5408,7 @@ mod tests {
                     Arc::new(serde_json::Map::new()),
                 ),
                 input_schema: Some(serde_json::json!({"type": "object"})),
+                output_schema: None,
                 upstream_name: Arc::from("alpha"),
                 destructive: false,
             },
@@ -5434,6 +5441,7 @@ mod tests {
         let make_tool = |name: &'static str| UpstreamTool {
             tool: rmcp::model::Tool::new(name, "desc", Arc::new(serde_json::Map::new())),
             input_schema: Some(serde_json::json!({"type": "object"})),
+            output_schema: None,
             upstream_name: Arc::from("alpha"),
             destructive: false,
         };

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -20,6 +20,8 @@ pub struct UpstreamTool {
     pub tool: Tool,
     /// Cached input schema as a JSON value for `schema` action proxying.
     pub input_schema: Option<Value>,
+    /// Cached output schema as a JSON value for typed Code Mode returns.
+    pub output_schema: Option<Value>,
     /// Name of the upstream server this tool belongs to.
     pub upstream_name: Arc<str>,
     /// Whether this tool has been marked as destructive via MCP annotations.destructiveHint.

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -129,17 +129,29 @@ fn action_schema() -> serde_json::Map<String, Value> {
         .expect("schema literal is always an object")
 }
 
-fn string_array_arg(args: &serde_json::Map<String, Value>, key: &str) -> Vec<String> {
-    args.get(key)
-        .and_then(Value::as_array)
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(Value::as_str)
+fn string_array_arg(
+    args: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Vec<String>, DispatchToolError> {
+    let Some(value) = args.get(key) else {
+        return Ok(Vec::new());
+    };
+    let values = value.as_array().ok_or_else(|| DispatchToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("`{key}` must be an array of strings when provided"),
+    })?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
                 .map(ToOwned::to_owned)
-                .collect()
+                .ok_or_else(|| DispatchToolError::Sdk {
+                    sdk_kind: "invalid_param".to_string(),
+                    message: format!("`{key}` entries must be strings"),
+                })
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 fn completion_info(values: Vec<String>) -> CompletionInfo {
@@ -1507,10 +1519,16 @@ impl ServerHandler for LabMcpServer {
                 .min(config.max_tool_calls.max(1));
             let allow_destructive_actions =
                 args.get("confirm").and_then(Value::as_bool) == Some(true);
-            let capability_filter = CodeModeCapabilityFilter::new(
+            let capability_filter = match (
                 string_array_arg(&args, "upstreams"),
                 string_array_arg(&args, "tools"),
-            );
+            ) {
+                (Ok(upstreams), Ok(tools)) => CodeModeCapabilityFilter::new(upstreams, tools),
+                (Err(err), _) | (_, Err(err)) => {
+                    let env = tool_error_envelope(&service, "call_tool", &err);
+                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                }
+            };
             let code_hash = hash_arguments(&Value::String(code.to_string()));
             tracing::info!(
                 surface = "mcp",
@@ -2794,6 +2812,40 @@ mod tests {
         assert_eq!(
             envelope.pointer("/error/param"),
             Some(&Value::from("query"))
+        );
+    }
+
+    #[test]
+    fn code_mode_filter_arg_rejects_malformed_values() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "tools".to_string(),
+            Value::String("upstream::github::search_issues".to_string()),
+        );
+        let err = super::string_array_arg(&args, "tools")
+            .expect_err("string filter must not be treated as allow-all");
+        assert_eq!(err.kind(), "invalid_param");
+
+        let mut args = serde_json::Map::new();
+        args.insert("upstreams".to_string(), serde_json::json!(["github", 42]));
+        let err = super::string_array_arg(&args, "upstreams")
+            .expect_err("non-string filter entries must not be dropped");
+        assert_eq!(err.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn code_mode_filter_arg_accepts_absent_and_string_arrays() {
+        let args = serde_json::Map::new();
+        assert_eq!(
+            super::string_array_arg(&args, "tools").expect("absent ok"),
+            Vec::<String>::new()
+        );
+
+        let mut args = serde_json::Map::new();
+        args.insert("tools".to_string(), serde_json::json!(["a", "b"]));
+        assert_eq!(
+            super::string_array_arg(&args, "tools").expect("array ok"),
+            vec!["a".to_string(), "b".to_string()]
         );
     }
 

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -25,7 +25,9 @@ use tokio::sync::RwLock;
 use crate::config::NodeRole;
 use crate::dispatch::error::ToolError as DispatchToolError;
 use crate::dispatch::gateway::SHARED_GATEWAY_OAUTH_SUBJECT;
-use crate::dispatch::gateway::code_mode::{CodeModeBroker, CodeModeCaller, CodeModeSurface};
+use crate::dispatch::gateway::code_mode::{
+    CodeModeBroker, CodeModeCaller, CodeModeCapabilityFilter, CodeModeSurface,
+};
 use crate::dispatch::gateway::manager::GatewayManager;
 use crate::dispatch::upstream::types::UpstreamRuntimeOwner;
 use crate::mcp::catalog::{TOOL_EXECUTE_TOOL_NAME, TOOL_SEARCH_TOOL_NAME};
@@ -43,8 +45,8 @@ const CODE_MODE_MAX_CODE_BYTES: usize = 20_000;
 const CODE_EXECUTE_DESCRIPTION: &str = "\
 Execute a JavaScript async arrow function in the Code Mode sandbox. Pass `code` as \
 `async () => { ... }` — the sandbox awaits its return value (same shape as search). \
-Discover tool ids and their parameter schemas with `search` FIRST — schemas are not \
-injected into this sandbox, so `search` is how you learn what arguments a tool takes. \
+Discover tool ids and TypeScript signatures with `search` FIRST — search entries include \
+`schema`, `output_schema`, `signature`, and `dts`. \
 Every upstream MCP tool is then callable two ways: `callTool(id, params)`, or the \
 auto-generated `codemode.<upstream>.<tool>(params)` helper (a thin wrapper over the \
 same callTool, named from the live catalog — handy once `search` has told you the id).
@@ -62,9 +64,8 @@ reads instead of awaiting serially.
 
 ```ts
 // codemode.<upstream>.<tool>() helpers are auto-generated from the live catalog and
-// are callable, but UNTYPED — there is no schema in this sandbox to introspect. Run
-// `search` first to learn each tool's params. callTool is the direct form and the
-// escape hatch for dynamic ids or truncated catalogs.
+// match the signatures returned by search.dts. callTool is the direct form and the
+// escape hatch for dynamic ids.
 declare function callTool<T = unknown>(
   id: `upstream::${string}::${string}`,
   params: Record<string, unknown>
@@ -125,7 +126,20 @@ fn action_schema() -> serde_json::Map<String, Value> {
     })
     .as_object()
     .cloned()
-    .expect("schema literal is always an object")
+        .expect("schema literal is always an object")
+}
+
+fn string_array_arg(args: &serde_json::Map<String, Value>, key: &str) -> Vec<String> {
+    args.get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn completion_info(values: Vec<String>) -> CompletionInfo {
@@ -1160,9 +1174,9 @@ impl ServerHandler for LabMcpServer {
                         "type": "string",
                         "description": "JavaScript async arrow function to search the upstream MCP tool catalog. \
                             The sandbox injects `const tools = [...]` where each entry has id, upstream, \
-                            name, description, and schema. Return JSON-serializable results. \
+                            name, description, schema, output_schema, signature, and dts. Return JSON-serializable results. \
                             Examples: \
-                            `async () => tools.filter(t => /container.*log/i.test(t.description)).map(t => ({id:t.id, schema:t.schema}))`; \
+                            `async () => tools.filter(t => /container.*log/i.test(t.description)).map(t => ({id:t.id, signature:t.signature, dts:t.dts}))`; \
                             `async () => tools.find(t => t.id === \"upstream::github::search_issues\")`; \
                             `async () => tools.filter(t => t.upstream === \"github\").slice(0, 20)`."
                     }
@@ -1175,7 +1189,7 @@ impl ServerHandler for LabMcpServer {
             tools.push(Tool::new(
                 TOOL_SEARCH_TOOL_NAME,
                 "Filter the upstream MCP tool catalog with JavaScript. Write an async arrow function \
-                that filters `const tools = [...]` (each entry: id, upstream, name, description, schema) \
+                that filters `const tools = [...]` (each entry: id, upstream, name, description, schema, output_schema, signature, dts) \
                 and returns what you need. No embedding model, no vector DB — the agent writes the filter. \
                 Use before execute() to discover the right tool id.",
                 search_schema,
@@ -1187,6 +1201,16 @@ impl ServerHandler for LabMcpServer {
                     "code": {
                         "type": "string",
                         "description": "JavaScript async arrow function to execute. Use await callTool(id, params) with JSON-serializable params."
+                    },
+                    "upstreams": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional upstream allowlist for this execution."
+                    },
+                    "tools": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional tool allowlist for this execution. Accepts raw tool names or upstream::<name>::<tool> ids."
                     }
                 },
                 "required": ["code"]
@@ -1483,6 +1507,10 @@ impl ServerHandler for LabMcpServer {
                 .min(config.max_tool_calls.max(1));
             let allow_destructive_actions =
                 args.get("confirm").and_then(Value::as_bool) == Some(true);
+            let capability_filter = CodeModeCapabilityFilter::new(
+                string_array_arg(&args, "upstreams"),
+                string_array_arg(&args, "tools"),
+            );
             let code_hash = hash_arguments(&Value::String(code.to_string()));
             tracing::info!(
                 surface = "mcp",
@@ -1509,6 +1537,7 @@ impl ServerHandler for LabMcpServer {
                     caller,
                     self.code_mode_surface(allow_destructive_actions),
                     config,
+                    capability_filter,
                 )
                 .await
             {
@@ -3397,8 +3426,7 @@ mod tests {
     }
 
     #[test]
-    fn gateway_search_and_execute_input_schemas_are_code_only() {
-        // Cloudflare-parity: both gateway meta-tools take exactly { code: string }.
+    fn gateway_search_input_schema_is_code_only() {
         for schema in [serde_json::json!({
             "type": "object",
             "properties": { "code": { "type": "string" } },

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -157,6 +157,44 @@ fn code_mode_runner_tags_typed_array_results_as_base64() {
 }
 
 #[test]
+fn code_mode_runner_rejects_non_json_serializable_results() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "type": "start",
+            "code": "async () => BigInt(1)"
+        })
+    )
+    .expect("write start");
+
+    let error = read_protocol_line(&mut stdout);
+    assert_eq!(error["type"], "error", "expected error, got: {error}");
+    assert_eq!(error["kind"], "invalid_param");
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("JSON-serializable")),
+        "unexpected error message: {error}"
+    );
+
+    let status = child.wait().expect("wait for runner");
+    assert!(!status.success(), "runner must exit non-zero after error");
+}
+
+#[test]
 fn code_mode_runner_preserves_binary_tool_args_and_results() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
         .args(["internal", "code-mode-runner"])
@@ -630,18 +668,18 @@ fn codemode_proxy_routes_through_call_tool() {
 
 /// FIX 1 (bead lab-vkwfa): an `export default async function` form, after
 /// `normalize_user_code`, must execute end-to-end. Non-vacuous: the raw form
-/// would be an IIFE (a Promise, not a function) and fail the wrapper's typeof
-/// check; normalize now emits a bare function expression instead.
+/// would fail because `export default` is not valid in a script wrapper;
+/// normalize now emits an async wrapper that invokes the exported function.
 #[test]
 fn normalized_export_default_form_executes_end_to_end() {
     let body =
         "export default async function() { return await callTool(\"upstream::test::ping\", {}); }";
     let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
     assert!(
-        normalized.starts_with("(async function")
-            && normalized.ends_with("})")
-            && !normalized.ends_with("()"),
-        "normalize must emit a bare function expression (no IIFE), got: {normalized}"
+        normalized.starts_with("async () =>")
+            && normalized.contains("async function")
+            && !normalized.contains("export default"),
+        "normalize must emit executable script code without export syntax, got: {normalized}"
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -27,8 +27,17 @@ fn code_mode_runner_evaluates_js_in_a_minimal_host_environment() {
     let code = r#"async () => {
         if (typeof process !== "undefined" || typeof require !== "undefined" ||
             typeof fetch !== "undefined" || typeof Deno !== "undefined" ||
-            typeof Bun !== "undefined") {
+            typeof Bun !== "undefined" || typeof XMLHttpRequest !== "undefined" ||
+            typeof connect !== "undefined") {
           throw new Error("ambient host API exposed");
+        }
+        let dynamicImportWorked = false;
+        try {
+          await Function("return import('fs')")();
+          dynamicImportWorked = true;
+        } catch (_e) {}
+        if (dynamicImportWorked) {
+          throw new Error("dynamic import exposed host modules");
         }
         console.log("runner console check");
         const first = await callTool("lab::gateway.first", {"x": 1});
@@ -107,6 +116,104 @@ fn code_mode_runner_evaluates_js_in_a_minimal_host_environment() {
     // Boa path defers console capture to Bead 3 (boa_runtime integration).
     #[cfg(feature = "code_mode_wasm")]
     assert!(stderr_text.contains("runner console check"));
+}
+
+#[test]
+fn code_mode_runner_tags_typed_array_results_as_base64() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "type": "start",
+            "code": "async () => ({ bytes: new Uint8Array([1, 2, 255]) })"
+        })
+    )
+    .expect("write start");
+
+    let done = read_protocol_line(&mut stdout);
+    assert_eq!(done["type"], "done");
+    assert_eq!(
+        done["result"]["bytes"],
+        json!({
+            "__labBinary": "base64",
+            "type": "Uint8Array",
+            "data": "AQL/"
+        })
+    );
+    let status = child.wait().expect("wait for runner");
+    assert!(status.success(), "runner exited with {status}");
+}
+
+#[test]
+fn code_mode_runner_preserves_binary_tool_args_and_results() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_labby"))
+        .args(["internal", "code-mode-runner"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn code mode runner");
+
+    let mut stdin = child.stdin.take().expect("runner stdin");
+    let stdout = child.stdout.take().expect("runner stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "type": "start",
+            "code": "async () => { const bytes = await callTool('upstream::test::echo', { bytes: new Uint8Array([1, 2, 3]) }); return { isBytes: bytes instanceof Uint8Array, values: Array.from(bytes) }; }"
+        })
+    )
+    .expect("write start");
+
+    let call = read_protocol_line(&mut stdout);
+    assert_eq!(call["type"], "tool_call");
+    assert_eq!(
+        call["params"]["bytes"],
+        json!({
+            "__labBinary": "base64",
+            "type": "Uint8Array",
+            "data": "AQID"
+        })
+    );
+    let seq = call["seq"].as_u64().expect("seq");
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "type": "tool_result",
+            "seq": seq,
+            "result": {
+                "__labBinary": "base64",
+                "type": "Uint8Array",
+                "data": "BAUG"
+            }
+        })
+    )
+    .expect("write result");
+
+    let done = read_protocol_line(&mut stdout);
+    assert_eq!(done["type"], "done");
+    assert_eq!(
+        done["result"],
+        json!({"isBytes": true, "values": [4, 5, 6]})
+    );
+    let status = child.wait().expect("wait for runner");
+    assert!(status.success(), "runner exited with {status}");
 }
 
 #[test]
@@ -439,17 +546,17 @@ fn assert_single_call_round_trip(code: &str, expected_result: Value) {
 
 /// FIX 1 (bead lab-vkwfa): a `function main` BODY form, after `normalize_user_code`,
 /// must execute end-to-end through the runner's arrow-function wrapper. This is
-/// non-vacuous: the raw body form is normalized to a parenthesized function
-/// EXPRESSION before being piped to the runner, exactly as the broker does.
+/// non-vacuous: the raw body form is normalized to a wrapper that calls the
+/// named function before being piped to the runner, exactly as the broker does.
 #[test]
 fn normalized_function_main_form_executes_end_to_end() {
     let body = "async function main() { return await callTool(\"upstream::test::ping\", {}); }";
     let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
-    // Guard: normalize must produce a parenthesized expression with no self-call,
+    // Guard: normalize must produce a wrapper that invokes the named function,
     // otherwise this test would be vacuous (the raw form happens to wrap too).
     assert!(
-        normalized.starts_with("(async function main()") && !normalized.contains("main();"),
-        "normalize must emit a bare function expression, got: {normalized}"
+        normalized.starts_with("async () => {") && normalized.contains("return main();"),
+        "normalize must emit a named-function wrapper, got: {normalized}"
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }

--- a/crates/lab/tests/gateway_schema_resources.rs
+++ b/crates/lab/tests/gateway_schema_resources.rs
@@ -18,6 +18,7 @@ fn make_tool(name: &'static str, upstream: &str) -> UpstreamTool {
     UpstreamTool {
         tool: rmcp::model::Tool::new(name, "desc", Arc::new(serde_json::Map::new())),
         input_schema: Some(json!({"type": "object", "properties": {}})),
+        output_schema: None,
         upstream_name: Arc::from(upstream),
         destructive: false,
     }

--- a/docs/code-mode-cloudflare-enhancements.md
+++ b/docs/code-mode-cloudflare-enhancements.md
@@ -14,11 +14,38 @@ truth for what CF actually ships today. Key correction to any blog-based reading
 **`packages/agents/src/codemode/ai.ts` is now a 5-line throwing stub** — the real
 implementation is the standalone `@cloudflare/codemode` package.
 
+## PR 85 follow-up status
+
+The current implementation has moved several items in this comparison from
+"recommended" to "present":
+
+- `search` entries now include `output_schema`, `signature`, and `dts`, so typed
+  discovery is delivered progressively through `search` rather than injected as a
+  monolithic execute preamble. Missing or unsupported schemas degrade to
+  `unknown`.
+- Successful upstream calls are unwrapped before they reach sandbox JavaScript:
+  `structuredContent` wins, all-text content is parsed as JSON when possible, and
+  mixed/non-text content keeps its MCP JSON shape.
+- `execute` supports `upstreams` and `tools` capability filters. When present,
+  they must be JSON string arrays; non-array values are ignored as absent filters,
+  and empty strings are dropped.
+- Destructive upstream calls are host-gated. MCP `execute` can confirm the run
+  with top-level `confirm: true`. Execute-capable scopes (`lab` or `lab:admin`)
+  authorize Code Mode execution, but do not implicitly confirm destructive
+  upstream effects. Unconfirmed MCP destructive calls receive
+  `confirmation_required`. CLI execution permits destructive upstream calls.
+- The runner has a tagged base64 codec for JavaScript `ArrayBuffer` and typed
+  array values crossing the parent/runner boundary. Mixed or binary MCP content
+  blocks that are not unwrapped as structured/all-text content still remain JSON
+  MCP content.
+
 ## The single most important finding
 
-We **deliberately removed typed signatures** from Code Mode in the search+execute
-pivot, citing "Cloudflare parity" — but Cloudflare *keeps* typing in **every** one
-of its paths. Our `execute_sandboxed` (code_mode.rs:611) literally says:
+Before PR 85, we **deliberately removed typed signatures** from Code Mode in the
+search+execute pivot, citing "Cloudflare parity" — but Cloudflare *keeps* typing
+in **every** one of its paths. The implementation now restores typed discovery
+through `search` (`signature`/`dts`) while keeping the execute sandbox runtime-only.
+The older `execute_sandboxed` comment said:
 
 > `// Cloudflare-parity: no typed TypeScript preamble is injected.`
 
@@ -37,53 +64,49 @@ Cloudflare ships three entry points, all typed:
 | `codeMcpServer` (wraps an MCP server) | `mcp.ts:135` | single `code` tool | `generateTypesFromJsonSchema` → `{{types}}` in description |
 | `openApiMcpServer` | `mcp.ts:408` | `search` + `execute` | `OpenApiSpec` TS interface + `codemode.spec()` returns the spec |
 
-Lab's `search` returns the raw JSON `schema` per tool but **no TypeScript**, and
-`execute` injects only a runtime JS proxy (`generate_js_proxy`) with **no types and
-no JSDoc**. We are the only one of the four designs that gives the model zero typed
-surface.
+Lab's current `search` returns raw JSON schemas plus TypeScript signatures and
+focused DTS for each tool. `execute` still injects only the runtime JS proxy
+(`generate_js_proxy`) and expects callers to discover types with `search` first.
+That keeps progressive disclosure while avoiding a giant typed preamble.
 
 **Current `main` is internally honest about this** — the `CODE_EXECUTE_DESCRIPTION`
-constant (`crates/lab/src/mcp/server.rs:43`) tells the agent the truth: *"schemas are not
-injected into this sandbox, so `search` is how you learn what arguments a tool takes,"* and
-the `codemode.<upstream>.<tool>()` helpers are *"callable, but UNTYPED — there is no schema
-in this sandbox to introspect"* (server.rs:64-66). So this is a capability gap, not a
-broken contract: the design correctly works around the missing types by routing the agent
-through `search` for raw schema. Enhancement #1 closes the gap — once `search` emits real
-TypeScript, that "UNTYPED / run search first" caveat can be replaced with delivered types,
-and the agent gets IDE-grade signatures instead of having to read raw JSON Schema.
+constant tells the agent to discover tool ids and TypeScript signatures with `search`
+first, and states that the runtime helpers match the signatures returned by
+`search.dts`. The execute sandbox still has no TypeScript typechecker or schema
+introspection API; typing is a discovery-time contract for agents.
 
-(Note: an *older deployed* build's execute description claimed tools were "pre-declared as
-a typed TypeScript helper — read the types" — which *was* untrue. Current `main` already
-fixed the wording to match reality. #1 makes the stronger, typed version true.)
+(Note: an *older deployed* build's execute description claimed tools were
+"pre-declared as a typed TypeScript helper — read the types" before that was true.
+The current wording now matches the implemented search-delivered type surface.)
 
 **Why our base is still the right one:** CF's MCP path loads the *entire* tool API
 into one tool description. At our scale (many upstreams, hundreds of tools, a 256KB
 catalog soft-cap that already truncates — code_mode.rs:538) that doesn't fit. Our
 `search` is the progressive-disclosure mechanism CF's blog calls future work. So the
-fix is **not** "go back to a typed monolith" — it's **make `search` emit types**,
-keeping progressive disclosure. That puts us ahead of CF's described state instead of
-behind it.
+fix was **not** "go back to a typed monolith" — it was **make `search` emit
+types**, keeping progressive disclosure. That puts us ahead of CF's described
+state instead of behind it.
 
 ---
 
-## Ranked enhancements
+## Ranked Enhancements And Status
 
-| # | Enhancement | Impact | Effort | Confidence |
-|---|---|---|---|---|
-| 1 | Emit TypeScript signatures + JSDoc from `search` (port `jsonSchemaToType`) | ★★★ | M | High — input data already preserved |
-| 2 | Unwrap the MCP result envelope (parity with `unwrapMcpResult`) | ★★★ | S | High — confirmed contradicts our own contract |
-| 3 | Thread `outputSchema` → typed returns | ★★ | M | High |
-| 4 | AST-based code normalization (splice `return`, wrap loose statements) | ★★ | M | High |
-| 5 | In-sandbox arg validation against inputSchema before dispatch | ★★ | M | Med |
-| 6 | Binary-safe value codec across the sandbox boundary | ★ | M | Med |
-| 7 | Explicit, tested network/fs/require deny invariant | ★★ | S | High |
-| 8 | Per-execution capability narrowing (`upstreams`/`tools` filter) | ★★ | M | Med |
-| 9 | Latency: cache/pool the wasmtime module + instances | ★ | M | Med |
-| 10 | Fix stale `docs/dev/CODE_MODE.md` (documents removed design) | ★★ | S | High |
+| # | Enhancement | Status | Notes |
+|---|---|---|---|
+| 1 | Emit TypeScript signatures + JSDoc from `search` | Present | `signature` and `dts` are emitted per catalog entry |
+| 2 | Unwrap the MCP result envelope | Present | Sandbox receives payload values, not raw successful `CallToolResult` envelopes |
+| 3 | Thread `outputSchema` → typed returns | Present | `output_schema` feeds generated output types, falling back to `unknown` |
+| 4 | AST-based code normalization | Present | Boa parsing handles exports, function declarations, and trailing expressions |
+| 5 | Arg validation against inputSchema before dispatch | Present | Host-side validation returns `missing_param` / `invalid_param` before upstream dispatch |
+| 6 | Binary-safe value codec across the sandbox boundary | Present | JavaScript `ArrayBuffer` and typed-array values use tagged base64 |
+| 7 | Explicit, tested network/fs/require deny invariant | Pending | Still worth keeping as a verification target |
+| 8 | Per-execution capability narrowing (`upstreams`/`tools` filter) | Present | Filters narrow proxy generation and direct `callTool` resolution |
+| 9 | Latency: cache/pool the wasmtime module + instances | Pending | Optimization, not a correctness blocker |
+| 10 | Fix stale `docs/dev/CODE_MODE.md` | Present | Root Code Mode docs now describe search+execute and search-delivered typing |
 
 ---
 
-### 1. Emit TypeScript signatures + JSDoc from `search` — the headline
+### 1. Emit TypeScript signatures + JSDoc from `search` — present
 
 **CF reference (ready to port):** `json-schema-types.ts` is a complete, dependency-free
 JSON-Schema→TypeScript emitter. `generateTypesFromJsonSchema(tools)` (line 334) produces:
@@ -125,12 +148,10 @@ emit step. Two caveats to handle in the emitter: (a) a schema dropped for exceed
 arrives as `None` → emit `unknown` (CF's exact fallback); (b) long `description`s are
 truncated to 2048 chars before they reach JSDoc — acceptable, but note it.
 
-**Proposal:** port `jsonSchemaToType` to Rust (a focused ~250-line module). Add a
-`signature: String` and/or `dts: String` field to `CodeModeCatalogEntry`
-(code_mode.rs:198) so a `search` filter can return real signatures, not just raw
-schema. Optionally also prepend the generated `declare const codemode` block into the
-`execute` proxy preamble (`generate_js_proxy`) as comments, so an agent that goes
-straight to `execute` still sees signatures.
+**Status:** implemented through Rust-side schema-to-TypeScript generation.
+`CodeModeCatalogEntry` carries `signature` and `dts` alongside `schema` and
+`output_schema`. The execute proxy remains runtime JavaScript; callers should use
+`search` first to retrieve the focused declaration block they need.
 
 **Constraint-aware (heterogeneous MCP vs CF's owned tools):** CF's `try/catch`
 fallback (line 380) degrades a bad schema to `type X = unknown` — copy that exactly.
@@ -138,45 +159,31 @@ Our `tool_name_to_snake` already matches CF's `sanitizeToolName` semantics (veri
 hyphen/dot/slash/colon→`_`, leading-digit prefix, reserved-word suffix), so generated
 method names will line up with the runtime proxy.
 
-### 2. Unwrap the MCP result envelope — confirmed correctness gap
+### 2. Unwrap the MCP result envelope — present
 
-**Lab today:** `call_upstream_tool` (code_mode.rs:1017) returns the **entire**
-`CallToolResult` via `serde_json::to_value(result)`. Sandbox code therefore receives
-`{ content: [{type:"text", text:"..."}], structuredContent, isError }` and has to
-dig the payload out itself.
+**Lab today:** `call_upstream_tool` unwraps successful `CallToolResult` values before
+returning to sandbox JavaScript. `structuredContent` wins; all-text content is joined
+and parsed as JSON when possible; empty content returns `null`; mixed/non-text content
+keeps its JSON MCP representation.
 
 **CF:** `unwrapMcpResult` (mcp.ts:70) gives the sandbox a **plain value**, in priority
 order: compat `toolResult` → **throw** on `isError` → `structuredContent` (authoritative
 typed value) → all-text content `JSON.parse`'d (or raw) → mixed/binary returned as-is.
 
-**This contradicts our own shipped tool description, verbatim.**
-`TOOL_EXECUTE_DESCRIPTION` (`crates/lab/src/mcp/server.rs:73-74`) tells every agent:
-*"Successful return: the upstream tool's structuredContent if present, else the parsed
-text of the first content[0] block. **Never the raw MCP envelope.**"* Our code returns
-the raw envelope. There is even a test asserting that description string is present
-(server.rs:3011) — so we test that we *promise* the behavior, but not that we *do* it.
-CF's `unwrapMcpResult` (mcp.ts:70) is the exact target: implement the same unwrap in
-`call_upstream_tool` before `serde_json::to_value`. (We already throw on `is_error` via
-`code_mode_upstream_error_info` at line 998 — that half matches the contract; the
-success-path unwrap is the missing half.) This is a clean correctness fix: make code
-match the contract two other parts of the codebase already assert.
+This now matches the shipped tool description that promises successful returns are
+payloads, not raw MCP envelopes. Upstream `isError` results still become structured
+ToolErrors before reaching sandbox code.
 
-### 3. Thread `outputSchema` → typed returns
+### 3. Thread `outputSchema` → typed returns — present
 
-`CodeModeCatalogEntry` only carries the input `schema` (code_mode.rs:204) and
-`code_search_catalog` only passes `tool.input_schema` (line 516). MCP now supports
-`outputSchema`; CF's emitter already generates `${Type}Output` from it
-(json-schema-types.ts:347) and falls back to `unknown`. Thread `output_schema` through
-the catalog and into #1's emitter so agents can chain `r.map(x => x.field)` against a
-real type instead of `unknown`. Compounds with #1 and #2 (a typed return is only
-useful once the envelope is unwrapped).
+`CodeModeCatalogEntry` carries `output_schema`, and the TypeScript emitter generates
+`${Type}Output` from it when available. Missing output schemas fall back to `unknown`.
 
-### 4. AST-based code normalization
+### 4. AST-based code normalization — present
 
-**Lab:** `normalize_user_code` (code_mode.rs:73) is string-prefix based: strips
-markdown fences, parenthesizes `function main`/`export default function`, passes arrows
-through. Anything else must already be a bare async-arrow expression or it fails the
-`typeof __codeModeMain === 'function'` check (CODE_MODE_MAIN_SHAPE_ERROR).
+**Lab:** `normalize_user_code` strips markdown fences, parses module/script forms
+with Boa, unwraps default exports, wraps named function declarations, and returns a
+trailing expression from loose multi-statement snippets.
 
 **CF:** `normalizeCode` (normalize.ts) parses with **acorn** and is far more forgiving:
 arrow passthrough; `export default` expression/anonymous-fn/anonymous-class unwrap;
@@ -184,29 +191,25 @@ named function declaration → wrap + call; **trailing expression statement → 
 `return`**; any other multi-statement body → wrap in `async () => { ... }`; empty →
 `async () => {}`; parse failure → wrap-and-hope.
 
-The practical gap: an LLM emitting `const x = await codemode.foo(); x.items` (no
-explicit `return`, multi-statement) **works in CF, fails for us.** That's a recurrent
-real-world LLM output shape. Porting equivalent logic (a small JS-statement classifier;
-we don't need full acorn — even a "if it doesn't start with `async (`/`(` , wrap it and
-splice a return into the last statement" heuristic captures most cases) materially cuts
-spurious `code_execute` contract errors.
+The practical gap called out in the original review is closed: an LLM emitting
+`const x = await codemode.foo(); x.items` is normalized into an async function that
+returns the trailing expression.
 
-### 5. In-sandbox arg validation before dispatch
+### 5. Input schema arg validation before dispatch — present
 
 CF validates tool args against the input schema before invoking
-(`tool.ts:extractFns` → `asSchema(...).validate`, throwing on failure). Lab passes
-`params` straight to the upstream (code_mode.rs:991-995). Validating against the
-already-preserved input schema in `call_upstream_tool` would surface a precise
-`invalid_param` to the agent's `try/catch` instead of a generic upstream rejection —
-better fan-out ergonomics. Lower priority than #1–#4.
+(`tool.ts:extractFns` → `asSchema(...).validate`, throwing on failure). Lab now
+validates host-side against the preserved input schema before upstream dispatch,
+surfacing precise `missing_param` or `invalid_param` errors to the agent's
+`try/catch` instead of a generic upstream rejection.
 
-### 6. Binary-safe value codec
+### 6. Binary-safe value codec — present
 
 CF base64-wraps `Uint8Array`/`ArrayBuffer`/views across the sandbox boundary with a
-tagged codec (`executor.ts` `BINARY_TAG`/`SANDBOX_CODEC`). Our boundary is
-JSON-over-stdio, so non-UTF8/binary tool results round-trip only as far as JSON allows.
-MCP already base64-encodes binary content blocks in-spec, so this is **lower impact for
-us than for CF** — but worth a note for tools returning raw bytes in `structuredContent`.
+tagged codec (`executor.ts` `BINARY_TAG`/`SANDBOX_CODEC`). Lab now uses a tagged
+base64 codec for JavaScript `ArrayBuffer` and typed-array values crossing the runner
+boundary. MCP binary content blocks still follow their JSON MCP representation unless
+an upstream exposes bytes through structured content that the codec can carry.
 
 ### 7. Explicit, tested network/fs/require deny invariant
 
@@ -218,15 +221,13 @@ invariant: assert in the runner test suite that `fetch`, `connect`, `XMLHttpRequ
 `require`, dynamic `import`, and fs globals are `undefined` in both the Boa and Javy
 paths. Cheap, and it turns a claim into a guarantee.
 
-### 8. Per-execution capability narrowing
+### 8. Per-execution capability narrowing — present
 
 CF's capability set per run = the providers/bindings handed to that execution
-(executor.ts `ResolvedProvider[]`, namespaced). Lab's `build_code_mode_proxy`
-(code_mode.rs:576) exposes the **entire** readable catalog every time. Add optional
-`execute` params — `upstreams: [...]` / `tools: [...]` — that narrow the injected proxy
-**and** `callTool` resolution for that run. Wins: least-privilege, clearer agent intent,
-and a smaller injected type surface (directly shrinks #1's context cost). The capability
-model to enforce it (`CodeModeCaller`, `destructive_permitted`) is already in place.
+(executor.ts `ResolvedProvider[]`, namespaced). Lab now accepts optional `execute`
+params `upstreams: [...]` and `tools: [...]` that narrow both injected proxy generation
+and direct `callTool` resolution for that run. Valid filters are JSON arrays of strings;
+non-array values reject as `invalid_param`.
 
 ### 9. Latency — cache/pool the wasmtime path
 
@@ -237,16 +238,11 @@ stronger isolation, slower start. The wasmtime engine skeleton already exists
 + instance pool on the wasm path would cut per-call latency while keeping per-call state
 isolation. Optimization, not correctness — do last.
 
-### 10. Fix stale `docs/dev/CODE_MODE.md`
+### 10. Fix stale `docs/dev/CODE_MODE.md` — present
 
-The doc describes the **removed** design: "exposes a **single** MCP tool — `code`",
-"`[code_mode] enabled = true`", "mutually exclusive with Tool Search mode", and a typed
-`codemode.*` "TypeScript preamble" that "declares `__catalog__` as `string | undefined`."
-All of that was deleted (`780c67d3`, `da593edc`). Today the surface is search+execute
-with a runtime-only proxy. Rewrite the doc to match — and once #1 lands, document the
-restored (search-delivered) typing. Ironically the stale doc proves the typed-preamble
-machinery already existed once; #1 is partly a *re-introduction* through the better
-delivery channel.
+The root Code Mode doc now describes the current search+execute surface, focused
+TypeScript delivered through `search`, capability filters, result unwrapping, binary
+codec behavior, and destructive upstream confirmation semantics.
 
 ---
 
@@ -267,11 +263,11 @@ delivery channel.
 
 ## Where Lab is already ahead of Cloudflare
 
-- **`search` = progressive type disclosure.** Once #1 ships, we expose typed tools
-  on-demand at a scale CF's "whole-API-in-one-description" can't reach.
-- **Per-`sub` OAuth attribution + scope-gated destructive actions** (`CodeModeCaller`,
-  `oauth_subject`, `destructive_permitted`) — finer-grained authz than CF's
-  `filterTools`/`needsApproval` static drop.
+- **`search` = progressive type disclosure.** Lab exposes typed tools on-demand at
+  a scale CF's "whole-API-in-one-description" can't reach.
+- **Per-`sub` OAuth attribution + explicit destructive confirmation**
+  (`CodeModeCaller`, `oauth_subject`, `destructive_permitted`) — finer-grained
+  authz than CF's `filterTools`/`needsApproval` static drop.
 - **Machine-actionable envelope** — `calls[]` metadata + token-budget truncation
   (`truncate_execution_response`) + canonical error taxonomy
   (`code_mode_canonical_error_kind`) beats CF's `console.log` capture.
@@ -291,12 +287,9 @@ delivery channel.
 - **Durable-Object / `ctx.exports` RPC plumbing** — platform-specific; our gateway
   manager + OAuth-subject attribution is the equivalent.
 
-## Suggested sequencing
+## Remaining sequencing
 
-1. **#10 + #2** — fix the stale doc and the envelope-unwrap bug (both are
-   correctness/truth fixes, small, and #2 unblocks the value of typed returns).
-2. **#1 + #3** — port the JSON-Schema→TS emitter, wire `dts`/`signature` into `search`,
-   thread `outputSchema`. The headline; compounds with #2.
-3. **#4 + #7** — robust normalization + the tested isolation invariant.
-4. **#5 + #8** — arg validation and capability narrowing.
-5. **#6 + #9** — binary codec and wasmtime pooling, last.
+Most original correctness/truth items are implemented. The remaining follow-ups are:
+
+1. **#7** — add explicit runner tests for denied network/fs/module globals.
+2. **#9** — tune wasmtime compile/module reuse if execution latency becomes material.

--- a/docs/code-mode-cloudflare-enhancements.md
+++ b/docs/code-mode-cloudflare-enhancements.md
@@ -1,0 +1,302 @@
+# Code Mode — Lab vs Cloudflare: Enhancement Analysis
+
+> Session 2026-05-31. Compares Lab's Code Mode
+> (`crates/lab/src/dispatch/gateway/code_mode.rs`, `code_mode_preamble.rs`,
+> `projection.rs`) against Cloudflare's **current** Code Mode source — the
+> `cloudflare/agents` monorepo `packages/codemode/` package (git `fac4463`),
+> which has evolved well past the `blog.cloudflare.com/code-mode` post.
+
+## Evidence basis
+
+Everything below was read from source on both sides (file:line cited inline).
+The Cloudflare blog describes an earlier state; the cloned repo is the source of
+truth for what CF actually ships today. Key correction to any blog-based reading:
+**`packages/agents/src/codemode/ai.ts` is now a 5-line throwing stub** — the real
+implementation is the standalone `@cloudflare/codemode` package.
+
+## The single most important finding
+
+We **deliberately removed typed signatures** from Code Mode in the search+execute
+pivot, citing "Cloudflare parity" — but Cloudflare *keeps* typing in **every** one
+of its paths. Our `execute_sandboxed` (code_mode.rs:611) literally says:
+
+> `// Cloudflare-parity: no typed TypeScript preamble is injected.`
+
+That comment is now **factually behind Cloudflare's own code.** Git history:
+`82832562` added `{{types}}` injection → `780c67d3` "restore Cloudflare-parity
+search+execute; remove code tool" deleted it → `da593edc` removed the
+`code_mode.enabled` flag. We modeled ourselves on CF's *OpenAPI* server shape
+(search+execute) while dropping the typing that CF's OpenAPI **and** MCP servers
+both retain.
+
+Cloudflare ships three entry points, all typed:
+
+| CF entry point | File | Shape | How types reach the model |
+|---|---|---|---|
+| `createCodeTool` (AI SDK) | `tool.ts` | single `code` tool | `generateTypes` (Zod/AI-SDK) → `{{types}}` in description |
+| `codeMcpServer` (wraps an MCP server) | `mcp.ts:135` | single `code` tool | `generateTypesFromJsonSchema` → `{{types}}` in description |
+| `openApiMcpServer` | `mcp.ts:408` | `search` + `execute` | `OpenApiSpec` TS interface + `codemode.spec()` returns the spec |
+
+Lab's `search` returns the raw JSON `schema` per tool but **no TypeScript**, and
+`execute` injects only a runtime JS proxy (`generate_js_proxy`) with **no types and
+no JSDoc**. We are the only one of the four designs that gives the model zero typed
+surface.
+
+**Current `main` is internally honest about this** — the `CODE_EXECUTE_DESCRIPTION`
+constant (`crates/lab/src/mcp/server.rs:43`) tells the agent the truth: *"schemas are not
+injected into this sandbox, so `search` is how you learn what arguments a tool takes,"* and
+the `codemode.<upstream>.<tool>()` helpers are *"callable, but UNTYPED — there is no schema
+in this sandbox to introspect"* (server.rs:64-66). So this is a capability gap, not a
+broken contract: the design correctly works around the missing types by routing the agent
+through `search` for raw schema. Enhancement #1 closes the gap — once `search` emits real
+TypeScript, that "UNTYPED / run search first" caveat can be replaced with delivered types,
+and the agent gets IDE-grade signatures instead of having to read raw JSON Schema.
+
+(Note: an *older deployed* build's execute description claimed tools were "pre-declared as
+a typed TypeScript helper — read the types" — which *was* untrue. Current `main` already
+fixed the wording to match reality. #1 makes the stronger, typed version true.)
+
+**Why our base is still the right one:** CF's MCP path loads the *entire* tool API
+into one tool description. At our scale (many upstreams, hundreds of tools, a 256KB
+catalog soft-cap that already truncates — code_mode.rs:538) that doesn't fit. Our
+`search` is the progressive-disclosure mechanism CF's blog calls future work. So the
+fix is **not** "go back to a typed monolith" — it's **make `search` emit types**,
+keeping progressive disclosure. That puts us ahead of CF's described state instead of
+behind it.
+
+---
+
+## Ranked enhancements
+
+| # | Enhancement | Impact | Effort | Confidence |
+|---|---|---|---|---|
+| 1 | Emit TypeScript signatures + JSDoc from `search` (port `jsonSchemaToType`) | ★★★ | M | High — input data already preserved |
+| 2 | Unwrap the MCP result envelope (parity with `unwrapMcpResult`) | ★★★ | S | High — confirmed contradicts our own contract |
+| 3 | Thread `outputSchema` → typed returns | ★★ | M | High |
+| 4 | AST-based code normalization (splice `return`, wrap loose statements) | ★★ | M | High |
+| 5 | In-sandbox arg validation against inputSchema before dispatch | ★★ | M | Med |
+| 6 | Binary-safe value codec across the sandbox boundary | ★ | M | Med |
+| 7 | Explicit, tested network/fs/require deny invariant | ★★ | S | High |
+| 8 | Per-execution capability narrowing (`upstreams`/`tools` filter) | ★★ | M | Med |
+| 9 | Latency: cache/pool the wasmtime module + instances | ★ | M | Med |
+| 10 | Fix stale `docs/dev/CODE_MODE.md` (documents removed design) | ★★ | S | High |
+
+---
+
+### 1. Emit TypeScript signatures + JSDoc from `search` — the headline
+
+**CF reference (ready to port):** `json-schema-types.ts` is a complete, dependency-free
+JSON-Schema→TypeScript emitter. `generateTypesFromJsonSchema(tools)` (line 334) produces:
+
+```ts
+type MovieSearchInput = {
+  /** Search query */
+  query: string;
+  /** Release year filter */
+  year?: number;
+};
+type MovieSearchOutput = unknown;
+declare const codemode: {
+  /**
+   * Search the catalog for movies.
+   * @param input.query - Search query
+   */
+  movie_search: (input: MovieSearchInput) => Promise<MovieSearchOutput>;
+};
+```
+
+`jsonSchemaToTypeString` (line 66) already handles everything messy MCP schemas throw
+at it: `$ref` (internal JSON-pointer resolve), `anyOf`/`oneOf` (unions),
+`allOf` (intersection), `enum`/`const`, tuples (`prefixItems` + draft-07 array
+`items`), `additionalProperties` (index signatures), OpenAPI `nullable`, type arrays
+(`["string","null"]`), a **maxDepth=20 guard** and a **circular-ref guard** (line 80).
+`utils.ts` supplies `sanitizeToolName`, `toPascalCase`, `quoteProp`, `escapeJsDoc`,
+`escapeStringLiteral`.
+
+**Why it's low-risk for us:** the data is already there. `sanitize_schema`
+(projection.rs:117) is **permissive** — it does NOT drop schema fields. It recurses the
+JSON value, redacting secret-looking strings and truncating string values to 2048 chars
+(projection.rs:120-122), and drops a whole schema only if it serializes over
+`MAX_SCHEMA_BYTES = 16_384` (line 139). Every codegen-relevant field —
+`type, properties, required, items, enum, const, description, format, default,
+additionalProperties, anyOf, oneOf, allOf` — survives untouched. So each
+`CodeModeCatalogEntry.schema` already carries enough to type from; we just never run an
+emit step. Two caveats to handle in the emitter: (a) a schema dropped for exceeding 16KB
+arrives as `None` → emit `unknown` (CF's exact fallback); (b) long `description`s are
+truncated to 2048 chars before they reach JSDoc — acceptable, but note it.
+
+**Proposal:** port `jsonSchemaToType` to Rust (a focused ~250-line module). Add a
+`signature: String` and/or `dts: String` field to `CodeModeCatalogEntry`
+(code_mode.rs:198) so a `search` filter can return real signatures, not just raw
+schema. Optionally also prepend the generated `declare const codemode` block into the
+`execute` proxy preamble (`generate_js_proxy`) as comments, so an agent that goes
+straight to `execute` still sees signatures.
+
+**Constraint-aware (heterogeneous MCP vs CF's owned tools):** CF's `try/catch`
+fallback (line 380) degrades a bad schema to `type X = unknown` — copy that exactly.
+Our `tool_name_to_snake` already matches CF's `sanitizeToolName` semantics (verified:
+hyphen/dot/slash/colon→`_`, leading-digit prefix, reserved-word suffix), so generated
+method names will line up with the runtime proxy.
+
+### 2. Unwrap the MCP result envelope — confirmed correctness gap
+
+**Lab today:** `call_upstream_tool` (code_mode.rs:1017) returns the **entire**
+`CallToolResult` via `serde_json::to_value(result)`. Sandbox code therefore receives
+`{ content: [{type:"text", text:"..."}], structuredContent, isError }` and has to
+dig the payload out itself.
+
+**CF:** `unwrapMcpResult` (mcp.ts:70) gives the sandbox a **plain value**, in priority
+order: compat `toolResult` → **throw** on `isError` → `structuredContent` (authoritative
+typed value) → all-text content `JSON.parse`'d (or raw) → mixed/binary returned as-is.
+
+**This contradicts our own shipped tool description, verbatim.**
+`TOOL_EXECUTE_DESCRIPTION` (`crates/lab/src/mcp/server.rs:73-74`) tells every agent:
+*"Successful return: the upstream tool's structuredContent if present, else the parsed
+text of the first content[0] block. **Never the raw MCP envelope.**"* Our code returns
+the raw envelope. There is even a test asserting that description string is present
+(server.rs:3011) — so we test that we *promise* the behavior, but not that we *do* it.
+CF's `unwrapMcpResult` (mcp.ts:70) is the exact target: implement the same unwrap in
+`call_upstream_tool` before `serde_json::to_value`. (We already throw on `is_error` via
+`code_mode_upstream_error_info` at line 998 — that half matches the contract; the
+success-path unwrap is the missing half.) This is a clean correctness fix: make code
+match the contract two other parts of the codebase already assert.
+
+### 3. Thread `outputSchema` → typed returns
+
+`CodeModeCatalogEntry` only carries the input `schema` (code_mode.rs:204) and
+`code_search_catalog` only passes `tool.input_schema` (line 516). MCP now supports
+`outputSchema`; CF's emitter already generates `${Type}Output` from it
+(json-schema-types.ts:347) and falls back to `unknown`. Thread `output_schema` through
+the catalog and into #1's emitter so agents can chain `r.map(x => x.field)` against a
+real type instead of `unknown`. Compounds with #1 and #2 (a typed return is only
+useful once the envelope is unwrapped).
+
+### 4. AST-based code normalization
+
+**Lab:** `normalize_user_code` (code_mode.rs:73) is string-prefix based: strips
+markdown fences, parenthesizes `function main`/`export default function`, passes arrows
+through. Anything else must already be a bare async-arrow expression or it fails the
+`typeof __codeModeMain === 'function'` check (CODE_MODE_MAIN_SHAPE_ERROR).
+
+**CF:** `normalizeCode` (normalize.ts) parses with **acorn** and is far more forgiving:
+arrow passthrough; `export default` expression/anonymous-fn/anonymous-class unwrap;
+named function declaration → wrap + call; **trailing expression statement → splice in
+`return`**; any other multi-statement body → wrap in `async () => { ... }`; empty →
+`async () => {}`; parse failure → wrap-and-hope.
+
+The practical gap: an LLM emitting `const x = await codemode.foo(); x.items` (no
+explicit `return`, multi-statement) **works in CF, fails for us.** That's a recurrent
+real-world LLM output shape. Porting equivalent logic (a small JS-statement classifier;
+we don't need full acorn — even a "if it doesn't start with `async (`/`(` , wrap it and
+splice a return into the last statement" heuristic captures most cases) materially cuts
+spurious `code_execute` contract errors.
+
+### 5. In-sandbox arg validation before dispatch
+
+CF validates tool args against the input schema before invoking
+(`tool.ts:extractFns` → `asSchema(...).validate`, throwing on failure). Lab passes
+`params` straight to the upstream (code_mode.rs:991-995). Validating against the
+already-preserved input schema in `call_upstream_tool` would surface a precise
+`invalid_param` to the agent's `try/catch` instead of a generic upstream rejection —
+better fan-out ergonomics. Lower priority than #1–#4.
+
+### 6. Binary-safe value codec
+
+CF base64-wraps `Uint8Array`/`ArrayBuffer`/views across the sandbox boundary with a
+tagged codec (`executor.ts` `BINARY_TAG`/`SANDBOX_CODEC`). Our boundary is
+JSON-over-stdio, so non-UTF8/binary tool results round-trip only as far as JSON allows.
+MCP already base64-encodes binary content blocks in-spec, so this is **lower impact for
+us than for CF** — but worth a note for tools returning raw bytes in `structuredContent`.
+
+### 7. Explicit, tested network/fs/require deny invariant
+
+`docs/dev/CODE_MODE.md` claims the Javy runner has "no Node, Deno, Bun, fetch, or
+require globals," and we `env_clear()` + run in a temp dir (code_mode.rs:627). CF makes
+isolation a **runtime-enforced, documented guarantee** (`globalOutbound: null` →
+`fetch`/`connect` throw; executor.ts:233). Convert our incidental absence into a tested
+invariant: assert in the runner test suite that `fetch`, `connect`, `XMLHttpRequest`,
+`require`, dynamic `import`, and fs globals are `undefined` in both the Boa and Javy
+paths. Cheap, and it turns a claim into a guarantee.
+
+### 8. Per-execution capability narrowing
+
+CF's capability set per run = the providers/bindings handed to that execution
+(executor.ts `ResolvedProvider[]`, namespaced). Lab's `build_code_mode_proxy`
+(code_mode.rs:576) exposes the **entire** readable catalog every time. Add optional
+`execute` params — `upstreams: [...]` / `tools: [...]` — that narrow the injected proxy
+**and** `callTool` resolution for that run. Wins: least-privilege, clearer agent intent,
+and a smaller injected type surface (directly shrinks #1's context cost). The capability
+model to enforce it (`CodeModeCaller`, `destructive_permitted`) is already in place.
+
+### 9. Latency — cache/pool the wasmtime path
+
+CF: fresh V8 isolate per call, ms startup, no pooling (cheap on workerd). Lab spawns a
+**subprocess** per `execute` (`labby internal code-mode-runner`, code_mode.rs:625) —
+stronger isolation, slower start. The wasmtime engine skeleton already exists
+(`wasm_runner`, code_mode.rs:1202, fuel + epoch interruption). A compiled-module cache
++ instance pool on the wasm path would cut per-call latency while keeping per-call state
+isolation. Optimization, not correctness — do last.
+
+### 10. Fix stale `docs/dev/CODE_MODE.md`
+
+The doc describes the **removed** design: "exposes a **single** MCP tool — `code`",
+"`[code_mode] enabled = true`", "mutually exclusive with Tool Search mode", and a typed
+`codemode.*` "TypeScript preamble" that "declares `__catalog__` as `string | undefined`."
+All of that was deleted (`780c67d3`, `da593edc`). Today the surface is search+execute
+with a runtime-only proxy. Rewrite the doc to match — and once #1 lands, document the
+restored (search-delivered) typing. Ironically the stale doc proves the typed-preamble
+machinery already existed once; #1 is partly a *re-introduction* through the better
+delivery channel.
+
+---
+
+## Parity already achieved — do not re-fix
+
+- **snake_case tool naming** — `tool_name_to_snake` (code_mode_preamble.rs:79) matches
+  CF's `sanitizeToolName` (separators→`_`, leading-digit prefix, reserved-word suffix).
+- **Sandbox reaches MCP only via the host bridge; secrets never enter the sandbox** —
+  `callTool`/proxy is the only channel, same posture as CF bindings, different mechanism.
+- **Intermediate results stay local; only the return value comes back** — inherent to
+  running one arrow function per sandbox pass; matches CF's core efficiency claim.
+- **Catchable structured errors** — `settle_code_mode_tool_promise` (code_mode.rs:1994)
+  rejects with a JSON-encoded `{kind,message}` so `JSON.parse(String(e.message))` works;
+  fixed in both Boa and Javy paths (commit `8f4032bb`). This is parity-plus.
+- **Computed-only runs allowed** — no minimum `callTool` requirement (code_mode.rs:786).
+- **Markdown-fence / `export default` / `function main` normalization** exists (the
+  *coverage* is narrower than CF's — see #4 — but the intent is matched).
+
+## Where Lab is already ahead of Cloudflare
+
+- **`search` = progressive type disclosure.** Once #1 ships, we expose typed tools
+  on-demand at a scale CF's "whole-API-in-one-description" can't reach.
+- **Per-`sub` OAuth attribution + scope-gated destructive actions** (`CodeModeCaller`,
+  `oauth_subject`, `destructive_permitted`) — finer-grained authz than CF's
+  `filterTools`/`needsApproval` static drop.
+- **Machine-actionable envelope** — `calls[]` metadata + token-budget truncation
+  (`truncate_execution_response`) + canonical error taxonomy
+  (`code_mode_canonical_error_kind`) beats CF's `console.log` capture.
+- **Multi-engine portability** (Boa in-process / Javy subprocess / wasmtime) + a wasm
+  build, vs CF's workerd-only substrate.
+- **Process-group kill + stderr-drain anti-deadlock** (code_mode.rs:632, 660) —
+  production hardening CF gets "for free" from the platform and we implement explicitly.
+
+## Cloudflare ideas that do NOT port (and why)
+
+- **Worker Loader API / V8-isolate-per-call** — different substrate; our subprocess +
+  wasmtime already give per-call isolation. Don't chase it.
+- **"Load the entire API into one tool description"** — anti-pattern at our scale;
+  adopt the *typing* (#1), not the delivery.
+- **`iframe-executor.ts` browser sandbox** — CF added a browser execution path; n/a to a
+  Rust gateway.
+- **Durable-Object / `ctx.exports` RPC plumbing** — platform-specific; our gateway
+  manager + OAuth-subject attribution is the equivalent.
+
+## Suggested sequencing
+
+1. **#10 + #2** — fix the stale doc and the envelope-unwrap bug (both are
+   correctness/truth fixes, small, and #2 unblocks the value of typed returns).
+2. **#1 + #3** — port the JSON-Schema→TS emitter, wire `dts`/`signature` into `search`,
+   thread `outputSchema`. The headline; compounds with #2.
+3. **#4 + #7** — robust normalization + the tested isolation invariant.
+4. **#5 + #8** — arg validation and capability narrowing.
+5. **#6 + #9** — binary codec and wasmtime pooling, last.

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -64,11 +64,15 @@ Search entries include both raw JSON Schemas and generated TypeScript:
 
 The execute proxy is runtime JavaScript; the TypeScript surface is delivered by
 `search` so agents can request only the declarations they need instead of loading
-the entire upstream catalog into one tool description.
+the entire upstream catalog into one tool description. When a schema is missing or
+too complex for the TypeScript emitter, the generated declaration falls back to
+`unknown`.
 
 `execute` accepts optional `upstreams` and `tools` arrays to narrow the per-run
-capability set. The injected proxy only includes allowed tools, and direct
-`callTool` IDs outside the allowlist reject as `unknown_tool`.
+capability set. When present, each filter must be a JSON array of strings; other
+shapes reject with `invalid_param`. Empty strings are ignored. The injected proxy only
+includes allowed tools, and direct `callTool` IDs outside the allowlist reject as
+`unknown_tool`.
 
 ## Result Contract
 
@@ -86,12 +90,18 @@ Successful upstream tool calls resolve to the payload, never the raw MCP
   `error_kind` on failure.
 - `logs[]` — sandbox console output when available.
 
-Binary-like JavaScript return values (`ArrayBuffer` and typed-array views) are
-encoded as tagged base64 JSON:
+Binary-like JavaScript values crossing the runner boundary use a tagged base64
+codec. JavaScript return values (`ArrayBuffer` and typed-array views) are encoded
+as JSON:
 
 ```json
 { "__labBinary": "base64", "type": "Uint8Array", "data": "AQL/" }
 ```
+
+Tagged binary values received from the parent bridge are decoded back to
+`ArrayBuffer` or `Uint8Array` inside the sandbox. Mixed or binary MCP content
+blocks that are not unwrapped as `structuredContent` or all-text content remain in
+their JSON MCP representation.
 
 Defaults:
 
@@ -123,8 +133,13 @@ Canonical recovery buckets:
 - Terminal: `unknown_tool`, `unknown_action`, `auth_failed`, `server_error`,
   `internal_error`
 
-Destructive upstream tools are blocked unless the surface or caller scope permits
-destructive actions.
+Destructive upstream tools are gated by host-side metadata before dispatch. In
+the MCP `execute` surface, callers can explicitly confirm the whole Code Mode run
+with top-level `confirm: true`. Execute-capable scopes (`lab` or `lab:admin`)
+authorize Code Mode execution, but do not implicitly confirm destructive upstream
+effects. Unconfirmed MCP destructive calls fail as `confirmation_required`. CLI
+Code Mode execution permits destructive upstream calls because it is
+operator-driven.
 
 ## Scope
 

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -1,70 +1,166 @@
 # Code Mode
 
-Code Mode exposes a **single** MCP tool — `code` — when `[code_mode] enabled = true` in
-`config.toml`. This is mutually exclusive with Tool Search mode (`search` + `execute`).
+Code Mode is the JavaScript execution surface behind the MCP `search` and `execute`
+tools. It lets an agent discover upstream MCP tools with a small catalog query, then
+run one async JavaScript function in a sandbox that can call those upstream tools.
 
-The `code` tool accepts a single required field:
+Lab actions are intentionally not exposed through Code Mode. For Lab built-in actions,
+use the normal Tool Search `execute` shape with `name=<service>` and
+`arguments={ action, params }`.
 
-```json
-{ "code": "<JavaScript async arrow function body>" }
+## Surface
+
+Code Mode has two MCP tools:
+
+- `search` — runs a JavaScript async arrow function over a projected catalog:
+  `const tools = [...]`. Use it to find upstream tool IDs and inspect their input
+  schemas.
+- `execute` — runs a JavaScript async arrow function in the Code Mode sandbox.
+  The sandbox can call upstream tools with `callTool(id, params)` or with the
+  generated `codemode.<upstream>.<tool>(params)` helper.
+
+Example search:
+
+```ts
+async () => tools
+  .filter(t => /issue/i.test(t.description))
+  .map(t => ({ id: t.id, schema: t.schema }))
 ```
 
-The sandbox injects the typed `codemode.*` namespace (built from the upstream catalog)
-before your function runs. Each `codemode.<server>.<helper>(params)` call dispatches to the
-real upstream server via `callTool` under the hood. You can also call `callTool` directly
-using `upstream::<server>::<tool>` IDs.
+Example execute:
 
-Required scope: `lab:read` to access the catalog; `lab` or `lab:admin` to execute code.
+```ts
+async () => {
+  const issues = await callTool("upstream::github::search_issues", { q: "bug" });
+  return issues.items.length;
+}
+```
 
-Lab actions are intentionally not exposed through Code Mode. Use the normal
-`execute` (Tool Search mode) or CLI surface for Lab service actions.
+`Promise.all([...])` and `Promise.allSettled([...])` fan out independent upstream
+calls. A failed `callTool` rejects only that promise; catch locally when partial
+success is useful.
 
-## Catalog Budget
+## Tool IDs and Helpers
 
-The inline catalog has a 256KB soft cap. Over the soft cap, the catalog is stably
-pruned and two overflow signals are emitted:
+Upstream tool IDs use:
 
-- A `__truncated__` sentinel entry is appended to the catalog array (id and name both
-  `"__truncated__"`, upstream `"__catalog__"`), indicating how many tools were dropped.
-- The TypeScript preamble declares `__catalog__` as `string | undefined` (instead of
-  `undefined`) so sandbox code can detect the truncation and fall back to `callTool`.
+```text
+upstream::<upstream-name>::<tool-name>
+```
 
-Use `callTool("upstream::<server>::<tool>", params)` as the escape hatch when tools are
-not listed in the catalog due to overflow.
+`execute` injects a runtime proxy generated from the live readable catalog, so
+`codemode.github.search_issues(params)` calls the same bridge as:
 
-## Execute Response Budget
+```ts
+callTool("upstream::github::search_issues", params)
+```
 
-`code(execute)` returns a capped envelope. Defaults:
+Search entries include both raw JSON Schemas and generated TypeScript:
+
+- `schema` — input JSON Schema.
+- `output_schema` — output JSON Schema when the upstream tool declares one.
+- `signature` — one-line TypeScript call signature.
+- `dts` — focused TypeScript declarations with JSDoc for that tool.
+
+The execute proxy is runtime JavaScript; the TypeScript surface is delivered by
+`search` so agents can request only the declarations they need instead of loading
+the entire upstream catalog into one tool description.
+
+`execute` accepts optional `upstreams` and `tools` arrays to narrow the per-run
+capability set. The injected proxy only includes allowed tools, and direct
+`callTool` IDs outside the allowlist reject as `unknown_tool`.
+
+## Result Contract
+
+Successful upstream tool calls resolve to the payload, never the raw MCP
+`CallToolResult` envelope:
+
+1. `structuredContent` when present.
+2. Otherwise the first text content block, parsed as JSON when possible.
+3. Otherwise raw text, `null`, or non-text content blocks as JSON.
+
+`execute` itself returns a capped envelope with:
+
+- `result` — the JavaScript function return value.
+- `calls[]` — lightweight per-call metadata: `id`, `ok`, `elapsed_ms`, and
+  `error_kind` on failure.
+- `logs[]` — sandbox console output when available.
+
+Binary-like JavaScript return values (`ArrayBuffer` and typed-array views) are
+encoded as tagged base64 JSON:
+
+```json
+{ "__labBinary": "base64", "type": "Uint8Array", "data": "AQL/" }
+```
+
+Defaults:
 
 - `max_response_bytes = 24576`
 - `max_response_tokens = 6000`
 
-`calls[]` carries lightweight per-call metadata only (`id`, `ok`, `elapsed_ms`,
-and `error_kind` on failure) — never the per-call result payload. When the
-envelope is too large, the final `result` is replaced with a truncation marker
-containing `truncated`, `original_size`, `original_tokens`, `preview`, and
-`next_action`.
+When the envelope is too large, the final `result` is replaced with a truncation
+marker containing `truncated`, `original_size`, `original_tokens`, `preview`, and
+`next_action`. Logs are trimmed after result truncation if needed.
+
+## Error Contract
+
+Tool errors reject with a JSON-encoded string that can be decoded in the sandbox:
+
+```ts
+try {
+  await callTool("upstream::github::search_issues", {});
+} catch (e) {
+  const env = JSON.parse(String(e.message));
+  return env.kind;
+}
+```
+
+Canonical recovery buckets:
+
+- Retry-safe: `rate_limited`, `timeout`, `network_error`
+- Fix-and-retry: `missing_param`, `invalid_param`, `validation_failed`,
+  `confirmation_required`
+- Terminal: `unknown_tool`, `unknown_action`, `auth_failed`, `server_error`,
+  `internal_error`
+
+Destructive upstream tools are blocked unless the surface or caller scope permits
+destructive actions.
+
+## Scope
+
+- `lab:read` can use `search`.
+- `lab` or `lab:admin` can use `execute`.
+
+OAuth callers retain their subject attribution when Code Mode calls upstream tools.
+Trusted local callers use the shared gateway subject.
 
 ## Runner Architecture
 
-The stdio parent-broker protocol is unchanged:
+The stdio parent-broker protocol is:
 
 1. Parent starts `labby internal code-mode-runner`.
-2. Child emits `tool_call` lines for `callTool` requests.
-3. Parent dispatches through the gateway broker and replies with `tool_result`.
-4. Child emits `done` after all promises settle.
+2. Child evaluates the normalized async function.
+3. Child emits `tool_call` lines for `callTool` requests.
+4. Parent dispatches through the gateway broker and replies with `tool_result` or
+   `tool_error`.
+5. Child settles pending promises and emits `done`.
 
 With `code_mode_wasm` enabled, the child runner uses Javy/QuickJS for snippet
-execution. `callTool` returns a real JavaScript promise, so `Promise.all`
-fan-out emits independent tool calls before awaiting results. `console.log` and
-`console.error` are routed to stderr, and the runner process starts with an
-empty environment in a temporary directory with no Node, Deno, Bun, fetch, or
-require globals.
-
-Without `code_mode_wasm`, the runner keeps the Boa fallback implementation for
+execution. Without it, the runner keeps the Boa fallback implementation for
 development builds that do not include the Javy/Wasmtime dependencies.
 
-The same feature also initializes the Wasmtime engine skeleton with fuel and
-epoch interruption enabled. Fuel and timeout traps are normalized to
-`code_mode_fuel_exhausted` and `code_mode_timeout` so callers can recover
-programmatically as the Wasmtime path grows.
+The runner starts with an empty environment in a temporary directory. It does not
+provide Node, Deno, Bun, `fetch`, `connect`, `XMLHttpRequest`, `require`, or host
+module `import()` access. `callTool` is the only host bridge exposed to user code.
+
+The Wasmtime engine skeleton uses fuel and epoch interruption. Fuel and timeout
+traps are normalized to `code_mode_fuel_exhausted` and `code_mode_timeout` so
+callers can recover programmatically as the Wasmtime path grows. The Wasmtime path
+shares one configured engine and caches compiled modules by source to avoid paying
+compile cost on repeated executions while keeping per-call stores and instances
+isolated.
+
+Loose JavaScript snippets are normalized before execution. Already-formed
+function expressions pass through, while statement blocks such as
+`const x = await callTool(...); x.items` are wrapped as `async () => { ... }` and
+the trailing expression is returned.

--- a/docs/sessions/2026-05-31-code-mode-cloudflare-parity.md
+++ b/docs/sessions/2026-05-31-code-mode-cloudflare-parity.md
@@ -1,0 +1,111 @@
+---
+date: 2026-05-31 10:45:52 EDT
+repo: git@github.com:jmagar/lab.git
+branch: fix/code-mode-cloudflare-parity-gaps
+head: 41fdde2c
+agent: Codex
+session id: 5b9c01b9-03b1-439e-b166-ac898d2bbd0f
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-lab/5b9c01b9-03b1-439e-b166-ac898d2bbd0f.jsonl
+working directory: /home/jmagar/workspace/lab
+worktree: /home/jmagar/workspace/lab 41fdde2c [fix/code-mode-cloudflare-parity-gaps]
+---
+
+# Code Mode Cloudflare Parity
+
+## User Request
+
+Implement all listed Cloudflare Code Mode parity gaps, then quick-push the result.
+
+## Session Overview
+
+- Reworked Code Mode normalization, typing, schema validation, MCP result unwrap, binary codec handling, and sanitized proxy generation.
+- Added focused unit and runner tests for the parity cases.
+- Validated the deployed dev container with live `mcporter` calls.
+- Bumped the workspace and gateway admin versions from `0.20.0` to `0.21.0`, updated `CHANGELOG.md`, committed, and pushed `fix/code-mode-cloudflare-parity-gaps`.
+
+## Sequence of Events
+
+- Reviewed the requested Cloudflare comparison findings and existing Lab Code Mode implementation.
+- Added failing tests around normalization, binary handling, recursive validation, unwrap behavior, identifier sanitization, collision rejection, and JSON Schema to TypeScript generation.
+- Implemented the Code Mode parity changes in the gateway dispatch code.
+- Ran formatting and focused Code Mode tests.
+- Rebuilt and restarted the dev container with `just dev-debug`.
+- Exercised the live container through `mcporter`.
+- Ran `cargo check --workspace --all-features`, bumped versions, updated the changelog, committed, and pushed.
+
+## Key Findings
+
+- The old normalization path was heuristic and failed Cloudflare cases like `const f = () => 1; f()`.
+- The old binary codec only tagged final sandbox results and did not preserve binary values across tool-call boundaries.
+- The old input-schema validation covered only shallow object and primitive checks.
+- MCP result unwrap and tool identifier sanitization differed from Cloudflare in observable edge cases.
+- Sanitized method collisions were previously last-wins behavior instead of an execution error.
+
+## Technical Decisions
+
+- Added Boa parser dependencies to implement structural JavaScript normalization in Rust.
+- Kept validation local to the Code Mode dispatch boundary so upstream tools receive checked params before execution.
+- Rejected sanitized collisions during proxy generation to avoid silently routing a helper to the wrong upstream tool.
+- Bumped minor version because the change adds materially broader Code Mode capability and compatibility.
+
+## Files Modified
+
+- `crates/lab/src/dispatch/gateway/code_mode.rs` - parser-backed normalization, recursive schema validation, MCP unwrap, binary codec paths, and tests.
+- `crates/lab/src/dispatch/gateway/code_mode_preamble.rs` - sanitizer parity and collision rejection.
+- `crates/lab/src/dispatch/gateway/code_mode_types.rs` - generated TypeScript from JSON Schema.
+- `crates/lab/tests/code_mode_runner.rs` - sandbox runner coverage for normalization and binary values.
+- `crates/lab/Cargo.toml`, `Cargo.lock` - Boa parser dependencies and workspace version lock updates.
+- `Cargo.toml`, `apps/gateway-admin/package.json`, `CHANGELOG.md` - release version and changelog updates.
+- `docs/code-mode-cloudflare-enhancements.md`, `docs/dev/CODE_MODE.md` - Code Mode parity documentation.
+- Gateway dispatch, MCP server, and upstream support files - plumbing for typed catalog and gateway behavior.
+- `plugins/vibin/skills/aurora-design-system/*` - pre-existing staged plugin skill changes included by quick-push.
+
+## Commands Executed
+
+- `cargo fmt --all` - formatted the Rust workspace.
+- `cargo test --manifest-path crates/lab/Cargo.toml --all-features code_mode` - focused Code Mode tests passed.
+- `just dev-debug` - rebuilt and restarted the dev container.
+- `curl -sSI http://localhost:8765/health` - confirmed the restarted container returned `HTTP/1.1 200 OK`.
+- `pnpm exec tsx src/cli.ts ...` from `/home/jmagar/workspace/mcporter` - exercised live Code Mode behavior against the deployed container.
+- `cargo check --workspace --all-features` - passed before commit.
+- `git commit -m "feat: close code mode cloudflare parity gaps"` - created commit `41fdde2c`.
+- `git push -u origin fix/code-mode-cloudflare-parity-gaps` - pushed the branch.
+
+## Errors Encountered
+
+- The first health check after `just dev-debug` saw a connection reset while the container was still starting. A retry returned `HTTP/1.1 200 OK`.
+- `mcporter` was not on `PATH`; the local checkout at `/home/jmagar/workspace/mcporter` was used with `pnpm exec tsx src/cli.ts`.
+
+## Behavior Changes (Before/After)
+
+- Before: Code Mode normalization could feed invalid parenthesized statement blocks to the invoker. After: parser-backed normalization handles Cloudflare AST cases and fallbacks.
+- Before: binary values were only encoded for final sandbox results. After: binary tool params, upstream results, and final results preserve tagged values on the Javy path.
+- Before: schema checks were shallow. After: nested objects, arrays, tuples, enums, constants, combinators, numeric bounds, and `additionalProperties: false` are validated.
+- Before: mixed MCP content and multiple text chunks unwrapped differently. After: unwrap behavior follows Cloudflare semantics more closely.
+- Before: sanitized helper collisions were silent last-wins. After: collision detection returns an error.
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+| --- | --- | --- | --- |
+| `cargo test --manifest-path crates/lab/Cargo.toml --all-features code_mode` | Code Mode tests pass | 61 lib tests and 7 runner tests passed | Pass |
+| `cargo check --workspace --all-features` | Workspace compiles | Finished dev profile successfully | Pass |
+| `just dev-debug` | Dev container rebuilt and restarted | `Container labby Started` | Pass |
+| `curl -sSI http://localhost:8765/health` | HTTP 200 | `HTTP/1.1 200 OK` on retry | Pass |
+| `mcporter execute` with `const f = () => 1; f()` | Result `1` | `{"result":1,"calls":[],"logs":[]}` | Pass |
+| `mcporter execute` with `Uint8Array([1,2,255])` | Binary tag preserved | `{"__labBinary":"base64","type":"Uint8Array","data":"AQL/"}` | Pass |
+| `mcporter execute` with `page: 0` where minimum is `1` | `invalid_param` | `callTool params params.page is below minimum` | Pass |
+
+## Risks and Rollback
+
+- The new parser dependencies increase Code Mode implementation surface area. Rollback path is reverting commit `41fdde2c`.
+- The post-push session document is intentionally saved after the pushed commit and is not part of `41fdde2c`.
+
+## Open Questions
+
+- Full `cargo nextest run --workspace --all-features` was not run in this session; focused tests and full compile check passed.
+
+## Next Steps
+
+- Open a pull request for `fix/code-mode-cloudflare-parity-gaps`.
+- Run the full nextest suite if release gating requires more than the focused Code Mode tests plus all-features compile check.

--- a/docs/sessions/2026-05-31-code-mode-simplify-cleanup.md
+++ b/docs/sessions/2026-05-31-code-mode-simplify-cleanup.md
@@ -1,0 +1,209 @@
+---
+date: 2026-05-31 11:39:09 EST
+repo: git@github.com:jmagar/lab.git
+branch: fix/code-mode-cloudflare-parity-gaps
+head: 41fdde2c
+session id: 5b9c01b9-03b1-439e-b166-ac898d2bbd0f
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-lab/5b9c01b9-03b1-439e-b166-ac898d2bbd0f.jsonl
+working directory: /home/jmagar/workspace/lab
+worktree: /home/jmagar/workspace/lab
+pr: #85 feat: close Code Mode Cloudflare parity gaps (https://github.com/jmagar/lab/pull/85)
+beads: No bead activity observed
+---
+
+# Code Mode parity diff — `/simplify` cleanup pass
+
+## User Request
+
+Run `/simplify`: dispatch 4 cleanup review agents in parallel over the changed code
+(reuse, simplification, efficiency, altitude), then apply the safe fixes. Quality
+only — no correctness bug hunting (that is `/code-review`'s job).
+
+## Session Overview
+
+`/simplify` reviewed the Code Mode Cloudflare-parity diff (commit `41fdde2c`, PR #85)
+with four independent review agents. Agents returned findings across reuse,
+simplification, efficiency, and altitude axes. After dedup and triage, **four
+behavior-preserving cleanups were applied** to `code_mode.rs` and `code_mode_types.rs`.
+Six larger findings were deliberately skipped as out of cleanup scope (behavior change,
+new dependency, or changes outside the reviewed diff). Build, the 68 code-mode tests,
+and clippy all passed after the edits.
+
+## Sequence of Events
+
+1. Phase 0 — gathered the review scope. `git diff @{upstream}...HEAD` was empty (branch
+   pushed), so captured `git diff main...HEAD -- crates/` to `/tmp/simplify_code.diff`
+   (2606 lines). At this point `git status` showed only the untracked session doc — the
+   working tree was otherwise clean.
+2. Read the full diff to orient: `normalize_user_code` rewritten with boa AST parsing,
+   new `CodeModeCapabilityFilter`, hand-rolled JSON-schema validator, JS base64 value
+   codec, wasm module cache, and a new 473-line `code_mode_types.rs` (.d.ts generation).
+3. Phase 1 — dispatched 4 `general-purpose` review agents concurrently (reuse,
+   simplification, efficiency, altitude), each given the diff path and targeted
+   scrutiny points.
+4. Phase 2 — deduped findings and applied four safe simplifications; skipped six with
+   recorded reasons.
+5. Verified: `cargo build --all-features` (clean), `cargo nextest ... code_mode`
+   (68/68 pass), `cargo clippy --all-features --lib` (no warnings).
+
+## Key Findings
+
+- **Dead threaded parameter** (`code_mode.rs` `validate_json_schema_value`): the
+  `required_missing_is_missing_param: bool` was threaded through every recursion, but the
+  invariant `flag == (path == "params")` holds at every call site, so the use-site guard
+  `flag && path == "params"` reduces to `path == "params"`. The boolean carried no
+  information the path didn't already carry.
+- **Self-inflicted string hack** (`code_mode.rs` `normalize_module_code`): the two
+  function-export arms wrote `({} )()` with a deliberate space, then scrubbed it with
+  `.replace("} )", "})")` — re-deriving what the sibling class arm already wrote cleanly,
+  and risking corruption of any interior `} )` in a function body.
+- **Duplicate tuple blocks** (`code_mode_types.rs` `array_type`): `prefixItems` and
+  array-valued `items` had byte-identical tuple-rendering blocks.
+- **Copy-paste pipeline** (`code_mode.rs` `CodeModeCapabilityFilter::new`): the
+  `upstreams` and `tools` fields ran identical trim/filter/collect chains.
+- **Agreement across agents**: the simplification agent confirmed the
+  `looks_like_returnable_expression` keyword heuristic is the intentional boa-parse-failure
+  (TypeScript) fallback and should be kept; the altitude agent flagged it but agreed it
+  only fires on parse failure. Left unchanged.
+
+## Technical Decisions
+
+- Applied only behavior-preserving cleanups. The `.replace` removal produces byte-identical
+  output for the common case (function render ends in `}`, so `({fn})()` ≡ post-replace),
+  and is strictly safer for interior `} )`. Test assertions (`})();`) already match.
+- Skipped findings whose fix would change behavior, add a dependency, or touch code outside
+  the reviewed diff (see Repository Maintenance / Decisions Not Taken).
+
+## Files Changed
+
+This session authored edits to two files. The working tree also contains additional
+uncommitted changes (`code_mode_preamble.rs`, both docs, and the bulk of the
+`code_mode_types.rs` additions) that were modified externally/concurrently during the
+session — these were not authored by this `/simplify` pass and were left untouched.
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `crates/lab/src/dispatch/gateway/code_mode.rs` | — | Dropped dead validator param; added `wrap_default_fn_as_iife` + `clean_set` helpers; removed `.replace` hack | `grep -c "wrap_default_fn_as_iife\|fn clean_set"` → 4 |
+| modified | `crates/lab/src/dispatch/gateway/code_mode_types.rs` | — | Merged `prefixItems`/`items` tuple blocks in `array_type` (this session's only edit here) | `grep -c "Tuple form: \`prefixItems\`"` → 1 |
+| created | `docs/sessions/2026-05-31-code-mode-simplify-cleanup.md` | — | This session log | written by save-to-md |
+
+Not authored by this session (external/concurrent dirty state, left as-is):
+`crates/lab/src/dispatch/gateway/code_mode_preamble.rs` (+29), `docs/code-mode-cloudflare-enhancements.md` (+47), `docs/dev/CODE_MODE.md` (+28), and additions to `code_mode_types.rs` beyond the tuple merge.
+
+## Beads Activity
+
+No bead activity observed. The session never invoked `bd`; the injected beads data is
+prior repository history, not actions taken this session.
+
+## Repository Maintenance
+
+- **Plans**: `docs/plans/` holds `fleet-ws-plan-lab-n07n.md` and
+  `mcp-streamable-http-oauth-proxy.md`. Neither relates to this session and neither is
+  clearly complete, so nothing was moved. `docs/plans/complete/` does not exist and was not
+  created (no completed plan to move). Evidence: `ls docs/plans/`.
+- **Beads**: no session bead activity, so no tracker state was changed. The Code Mode parity
+  work is already tracked by PR #85.
+- **Worktrees/branches**: single worktree at `/home/jmagar/workspace/lab` on
+  `fix/code-mode-cloudflare-parity-gaps` (the active PR #85 branch). `main` is behind it.
+  No stale or merged branches to remove; the active branch must stay. Evidence:
+  `git worktree list`, branch list in injected context.
+- **Stale docs**: `docs/dev/CODE_MODE.md` and `docs/code-mode-cloudflare-enhancements.md`
+  are already modified in the working tree (external to this session). This session did not
+  update docs and made no code change that contradicts them, so no doc edits were performed.
+- **Transparency**: this session's only repo mutations are the two source edits above plus
+  this session file. All other dirty files were left untouched intentionally.
+
+## Tools and Skills Used
+
+- **Shell (Bash)**: `git diff`/`git status`/`git worktree` for scope and state;
+  `cargo build`, `cargo nextest`, `cargo clippy` for verification; `grep` to confirm
+  authored edits. No failures.
+- **File tools**: Read (diff + source regions), Edit (4 simplification fixes), Write (this
+  log). One Edit initially failed on `code_mode_types.rs` ("File has not been read yet")
+  because the file had only been seen via the diff, not Read directly — resolved by reading
+  the region first, then editing.
+- **Subagents**: 4 `general-purpose` review agents via the Agent tool (reuse,
+  simplification, efficiency, altitude), run concurrently. All returned findings. The
+  efficiency and altitude agents noted the `advisor` was rate-limited and proceeded without
+  it; no impact on output.
+- **Skills**: `/simplify` (this workflow), `/vibin:save-to-md` (this log).
+- No MCP servers, browser tools, or external CLIs beyond cargo/git were used.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git diff main...HEAD -- crates/ > /tmp/simplify_code.diff` | 2606 lines captured |
+| `cargo build --manifest-path crates/lab/Cargo.toml --all-features` | `Finished dev profile` in 7m13s, clean |
+| `cargo nextest run --manifest-path crates/lab/Cargo.toml --all-features code_mode` | 68 passed, 0 failed, 1366 skipped |
+| `cargo clippy --manifest-path crates/lab/Cargo.toml --all-features --lib` | no warnings/errors (empty grep, exit 0) |
+
+## Errors Encountered
+
+- **Edit on `code_mode_types.rs` rejected**: "File has not been read yet." Root cause: the
+  file was only viewed through the unified diff, not Read directly, so the harness had no
+  current-state snapshot. Resolved by Reading the `array_type` region first, then re-applying
+  the edit.
+- **`cargo build -p lab --all-features`**: "cannot specify features for packages outside of
+  workspace." Root cause: `lab` is a member but `-p` with `--all-features` is rejected here.
+  Resolved by switching to `--manifest-path crates/lab/Cargo.toml`.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| `validate_json_schema_value` signature | 4 params incl. dead `required_missing_is_missing_param` | 3 params; missing-required gated on `path == "params"` alone (same outcomes) |
+| `export default` function normalization | built `({} )()` then string-replaced the space out | builds `({})()` directly via `wrap_default_fn_as_iife`; identical output, no interior-`} )` corruption risk |
+
+No user-visible runtime behavior changed; these are internal refactors with identical
+observable results (confirmed by unchanged passing tests).
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo build --all-features` (lab) | compiles clean | `Finished dev profile`, no errors | pass |
+| `cargo nextest ... code_mode` | all code-mode tests pass | 68/68 passed | pass |
+| `cargo clippy --all-features --lib` | no new warnings | empty output, exit 0 | pass |
+
+## Risks and Rollback
+
+- Low risk: all four edits are local refactors with no behavior change, covered by the
+  passing code-mode test suite. Rollback: `git checkout -- crates/lab/src/dispatch/gateway/code_mode.rs crates/lab/src/dispatch/gateway/code_mode_types.rs` (note this would also discard the unrelated external `code_mode_types.rs` additions, so revert selectively if needed).
+
+## Decisions Not Taken
+
+- **Move `CodeModeCapabilityFilter` onto the broker struct** (altitude finding): `execute(&self)`
+  can't store per-execution state without an invasive API change. Skipped.
+- **Shared `connected` predicate helper in `projection.rs`** (altitude): would modify
+  `server_view_from_virtual_server`, outside the reviewed diff; the two predicates also use
+  genuinely different health notions. Skipped.
+- **Remove `looks_like_returnable_expression` keyword sniffing** (altitude): it is the
+  intentional boa-parse-failure (TS) fallback; removing it changes behavior. Kept.
+- **Replace hand-rolled schema validator / fix `$ref` coverage** (altitude + reuse): a
+  correctness concern for `/code-review`, and no JSON-schema crate exists in-tree (would be a
+  new dependency). Skipped.
+- **Cache `ToolTypes` at the pool / fix O(N²) truncation re-serialization** (efficiency):
+  real hot-path win but requires pool-layer changes outside the diff. Deferred as follow-up.
+- **JS codec binary pre-scan guard** (efficiency): adds code for a bounded in-sandbox cost.
+  Skipped.
+
+## References
+
+- PR #85: feat: close Code Mode Cloudflare parity gaps —
+  https://github.com/jmagar/lab/pull/85
+
+## Open Questions
+
+- The working tree's external changes to `code_mode_preamble.rs`,
+  `docs/code-mode-cloudflare-enhancements.md`, and `docs/dev/CODE_MODE.md` were not authored
+  by this session. Their provenance and intended commit are unclear; they were left untouched.
+
+## Next Steps
+
+- Commit the four `/simplify` edits to `code_mode.rs` and `code_mode_types.rs` (alongside or
+  separate from the external dirty changes, as the author intends) onto PR #85.
+- Consider the deferred efficiency follow-up: cache `ToolTypes` at the upstream pool and
+  avoid re-serializing the now-heavier catalog entries in the search truncation loop.
+- Recommended immediate command to review the session's source changes before committing:
+  `git diff crates/lab/src/dispatch/gateway/code_mode.rs crates/lab/src/dispatch/gateway/code_mode_types.rs`.

--- a/plugins/vibin/skills/agent-os/README.md
+++ b/plugins/vibin/skills/agent-os/README.md
@@ -1,10 +1,10 @@
 # agent-os (Windows sandbox VM)
 
-Drive Claude's dedicated sandboxed Windows 11 VM, the **`agent-os`** VM (container name `agent-os-win11`, image `dockur/windows`) on host `dookie`, historically nicknamed "winbox", through the **Windows-MCP** server installed inside it. The skill name is now `agent-os`; both `agent-os` and legacy `winbox` work as trigger phrases.
+Drive Claude's dedicated sandboxed Windows 11 VM, the **`agent-os`** VM (container name `agent-os-win11`, image `dockur/windows`) on host `tootie`, historically nicknamed "winbox", through the **Windows-MCP** server installed inside it. The skill name is now `agent-os`; both `agent-os` and legacy `winbox` work as trigger phrases.
 
 ## What changed
 
-This skill used to drive the VM over noVNC at `http://dookie:8006` via `agent-browser`, dispatching `MouseEvent`s on the canvas and typing one keystroke at a time. That path worked but was slow and had a known `Shift+<digit>` bug.
+This skill used to drive the VM over noVNC at `http://tootie:8006` via `agent-browser`, dispatching `MouseEvent`s on the canvas and typing one keystroke at a time. That path worked but was slow and had a known `Shift+<digit>` bug.
 
 Windows-MCP ([CursorTouch/Windows-MCP](https://github.com/CursorTouch/Windows-MCP)) replaces it. The MCP server runs inside the agent-os VM and exposes native Windows automation as `mcp__windows-mcp__*` tools. You get a real keyboard, a real accessibility tree (`Snapshot`), and direct PowerShell (`Shell`).
 
@@ -18,7 +18,7 @@ Windows-MCP ([CursorTouch/Windows-MCP](https://github.com/CursorTouch/Windows-MC
 
 ## When to invoke
 
-Sandbox-specific triggers only: `agent-os`, `the agent-os VM`, `winbox`, `the windows sandbox`, `the dookie windows`, `drive the windows VM`, `spin up agent-os`, `open the noVNC`, or any "run X / screenshot agent-os" prompt. Does **not** fire on the user's personal Windows machine (steamy-wsl) - that target uses the `nircmd` skill.
+Sandbox-specific triggers only: `agent-os`, `the agent-os VM`, `winbox`, `the windows sandbox`, `the tootie windows`, `drive the windows VM`, `spin up agent-os`, `open the noVNC`, or any "run X / screenshot agent-os" prompt. Does **not** fire on the user's personal Windows machine (steamy-wsl) - that target uses the `nircmd` skill.
 
 ## Web-dev browser priority
 
@@ -36,12 +36,12 @@ Use Windows-MCP for desktop/OS state, native dialogs, installed Windows software
 
 Configured as an HTTP MCP server in `~/.claude.json` under `mcpServers.windows-mcp` (Tailscale address + Bearer token). Claude Code reaches it automatically. Nothing to start.
 
-If unreachable: `ssh dookie "docker ps --format '{{.Names}}' | grep agent-os"` to confirm the container (`agent-os-win11`) is up.
+If unreachable: `ssh tootie "docker ps --format '{{.Names}}' | grep agent-os"` to confirm the container (`agent-os-win11`) is up.
 
 Side-channels exposed by the container, in case Windows-MCP is wedged:
-- noVNC at `http://dookie:8006` (visual debug)
-- RDP at `dookie:33890` (needs an agent-side RDP client)
-- SSH at `dookie:2222` → guest port 22 (sshd inside the guest must be running; if it is, this is the cleanest scripted bypass)
+- noVNC at `http://tootie:8006` (visual debug)
+- RDP at `tootie:33890` (needs an agent-side RDP client)
+- SSH at `tootie:2222` → guest port 22 (sshd inside the guest must be running; if it is, this is the cleanest scripted bypass)
 
 ## Key advantages over the legacy noVNC path
 
@@ -52,7 +52,7 @@ Side-channels exposed by the container, in case Windows-MCP is wedged:
 
 ## Visual debugging fallback
 
-noVNC at `http://dookie:8006/vnc.html?autoconnect=1&resize=remote` still works for eyeballing the desktop visually, but isn't the primary interaction surface anymore. See git history of `SKILL.md` for the legacy `agent-browser` helpers if you ever need them.
+noVNC at `http://tootie:8006/vnc.html?autoconnect=1&resize=remote` still works for eyeballing the desktop visually, but isn't the primary interaction surface anymore. See git history of `SKILL.md` for the legacy `agent-browser` helpers if you ever need them.
 
 ## Files
 

--- a/plugins/vibin/skills/agent-os/SKILL.md
+++ b/plugins/vibin/skills/agent-os/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: agent-os
-description: 'Use to drive Claude''s sandboxed Windows 11 VM, the `agent-os` VM, container `agent-os-win11` (`dockur/windows`) on host `dookie`, historically nicknamed "winbox", via the Windows-MCP server installed inside it. Triggers: "agent-os", "the agent-os VM", "winbox", "the windows sandbox", "the dookie windows", "drive the windows VM", "spin up agent-os", "run X on agent-os", "screenshot agent-os", "PowerShell on agent-os", or explicit noVNC at http://dookie:8006. For web-dev/browser verification prefer: CDP on agent-os, agent-browser, claude-in-chrome on agent-os, agent-os Windows-MCP, then claude-in-chrome on steamy. Prefer `mcp__windows-mcp__*` for desktop/OS work. Does NOT fire on the user''s personal Windows on steamy-wsl; that target uses the `nircmd` skill. The sandbox is Claude''s alone: install software, change settings, run shells freely without confirmation.'
+description: 'Use to drive Claude''s sandboxed Windows 11 VM, the `agent-os` VM, container `agent-os-win11` (`dockur/windows`) on host `tootie`, historically nicknamed "winbox", via the Windows-MCP server installed inside it. Triggers: "agent-os", "the agent-os VM", "winbox", "the windows sandbox", "the tootie windows", "drive the windows VM", "spin up agent-os", "run X on agent-os", "screenshot agent-os", "PowerShell on agent-os", or explicit noVNC at http://tootie:8006. For web-dev/browser verification prefer: CDP on agent-os, agent-browser, claude-in-chrome on agent-os, agent-os Windows-MCP, then claude-in-chrome on steamy. Prefer `mcp__windows-mcp__*` for desktop/OS work. Does NOT fire on the user''s personal Windows on steamy-wsl; that target uses the `nircmd` skill. The sandbox is Claude''s alone: install software, change settings, run shells freely without confirmation.'
 ---
 
 # agent-os (Windows sandbox VM)
 
-A real Windows 11 desktop reserved for Claude, running on host `dookie` as the **`agent-os`** VM (container name `agent-os-win11`, image `dockur/windows`). "Winbox" is only the historical nickname; the skill name and official name are **agent-os**. Both `agent-os` and `winbox` remain trigger phrases for compatibility.
+A real Windows 11 desktop reserved for Claude, running on host `tootie` as the **`agent-os`** VM (container name `agent-os-win11`, image `dockur/windows`). "Winbox" is only the historical nickname; the skill name and official name are **agent-os**. Both `agent-os` and `winbox` remain trigger phrases for compatibility.
 
 Drive it through **Windows-MCP** ([CursorTouch/Windows-MCP](https://github.com/CursorTouch/Windows-MCP)) — an MCP server installed inside the VM that exposes native click/type/shell/clipboard/filesystem/registry tools as `mcp__windows-mcp__*`.
 
-The sandbox is Claude's. Install software, write to the registry, kill processes — don't ask first. Only think twice about actions that escape into host `dookie` (Docker daemon, mounted volumes, host network).
+The sandbox is Claude's. Install software, write to the registry, kill processes — don't ask first. Only think twice about actions that escape into host `tootie` (Docker daemon, mounted volumes, host network).
 
 ## Why Windows-MCP, not noVNC
 
-The previous version of this skill drove the VM through `agent-browser` against `http://dookie:8006`'s noVNC canvas. That path still works as a visual fallback, but Windows-MCP is the new primary surface because:
+The previous version of this skill drove the VM through `agent-browser` against `http://tootie:8006`'s noVNC canvas. That path still works as a visual fallback, but Windows-MCP is the new primary surface because:
 
 - **Real keyboard.** `Type` reliably handles full strings including shifted symbols (`!@#$%^&*()`, `:`, `"`, etc.). The noVNC `Shift+<digit>` bug is gone.
 - **Real accessibility tree.** `Snapshot` returns interactive elements with ids — Claude can target controls by name, not by reasoning about pixels.
 - **Native shell.** `Shell` runs PowerShell directly; no `Win+R`, no canvas focus juggling.
 - **Faster.** No browser, no canvas event dispatch, no per-character `press` loop.
 
-Reach for noVNC at `http://dookie:8006` only when you need to *see* the desktop visually for debugging (e.g. confirming a screenshot that Windows-MCP returned), or if Windows-MCP is unreachable.
+Reach for noVNC at `http://tootie:8006` only when you need to *see* the desktop visually for debugging (e.g. confirming a screenshot that Windows-MCP returned), or if Windows-MCP is unreachable.
 
 ## Browser/web-dev priority
 
@@ -38,7 +38,7 @@ Do not use Windows-MCP just because it is available when `agent-browser` can do 
 
 Windows-MCP is exposed inside agent-os over HTTP + Bearer token and registered in `~/.claude.json` as the `windows-mcp` server (Tailscale address; the bearer token lives in that config, not in this skill). Claude Code reaches it automatically — there is nothing to start.
 
-If the server is unreachable: SSH into `dookie`, confirm the VM container is up (`docker ps --format '{{.Names}}' | grep agent-os`; the container name is `agent-os-win11`), and that the MCP service inside is listening. The container persists `/storage` across restarts so installed software survives.
+If the server is unreachable: SSH into `tootie`, confirm the VM container is up (`docker ps --format '{{.Names}}' | grep agent-os`; the container name is `agent-os-win11`), and that the MCP service inside is listening. The container persists `/storage` across restarts so installed software survives.
 
 ## Tool surface
 
@@ -167,7 +167,7 @@ Registry {"action": "write", "path": "HKCU\\Software\\YourApp", "name": "Setting
 
 When something looks wrong and you need eyeballs, the old path still works:
 
-- URL: `http://dookie:8006/vnc.html?autoconnect=1&resize=remote`
+- URL: `http://tootie:8006/vnc.html?autoconnect=1&resize=remote`
 - Drive with `agent-browser` (see git history of this file for the canvas/dispatch helpers).
 
 Treat this strictly as a visual debugger. Once you've identified the problem, fix it through Windows-MCP — don't fall back into the per-char `press` loop just because noVNC is open.
@@ -177,8 +177,8 @@ Treat this strictly as a visual debugger. Once you've identified the problem, fi
 These predate Windows-MCP but remain useful where the MCP path is awkward:
 
 - **`/oem` install-time drop folder.** Host path `/home/jmagar/compose/windows/oem` is mounted as `\\host.lan\Data` *only during initial Windows install/OOBE*. Once setup completes, the SMB share is gone. Use only for first-boot provisioning.
-- **RDP on `dookie:33890`.** Exposed by the `agent-os-win11` container in addition to noVNC. No agent-side RDP client installed today; install `freerdp` if a real interactive session is ever needed (now that Windows-MCP exists, the case for this is weaker).
-- **SSH to the guest on `dookie:2222`.** The container forwards host port `2222` → guest port `22`. Confirmed exposed on the running container; whether sshd is actually running and configured inside the guest depends on first-boot provisioning. If it answers, this is the cleanest scripted side-channel — no `Shell` round-trip through the MCP server.
+- **RDP on `tootie:33890`.** Exposed by the `agent-os-win11` container in addition to noVNC. No agent-side RDP client installed today; install `freerdp` if a real interactive session is ever needed (now that Windows-MCP exists, the case for this is weaker).
+- **SSH to the guest on `tootie:2222`.** The container forwards host port `2222` → guest port `22`. Confirmed exposed on the running container; whether sshd is actually running and configured inside the guest depends on first-boot provisioning. If it answers, this is the cleanest scripted side-channel — no `Shell` round-trip through the MCP server.
 
 ## Operating notes
 

--- a/plugins/vibin/skills/aurora-design-system/CHANGELOG.md
+++ b/plugins/vibin/skills/aurora-design-system/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this skill are recorded here. Format roughly follows [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-05-30
+
+### Added
+- `references/editor-cli-tokens.md` — non-web Aurora palettes: the Zed "Aurora Neon" theme + icon theme, the Claude Code CLI palette, shell tools, and the terminal ANSI foundation, with a three-tier divergence map (web canonical `#29b6f6` vs CLI-brightened `#36c9ff` vs Zed Neon `#38d2ff`).
+- SKILL.md pointers to the new reference (token section + reference list) so non-web theme work doesn't cross-contaminate the web canonical palette.
+
 ## 2026-05-17
 
 ### Added

--- a/plugins/vibin/skills/aurora-design-system/CHANGELOG.md
+++ b/plugins/vibin/skills/aurora-design-system/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this skill are recorded here. Format roughly follows [Kee
 ## 2026-05-30
 
 ### Added
+
 - `references/editor-cli-tokens.md` — non-web Aurora palettes: the Zed "Aurora Neon" theme + icon theme, the Claude Code CLI palette, shell tools, and the terminal ANSI foundation, with a three-tier divergence map (web canonical `#29b6f6` vs CLI-brightened `#36c9ff` vs Zed Neon `#38d2ff`).
 - SKILL.md pointers to the new reference (token section + reference list) so non-web theme work doesn't cross-contaminate the web canonical palette.
 

--- a/plugins/vibin/skills/aurora-design-system/SKILL.md
+++ b/plugins/vibin/skills/aurora-design-system/SKILL.md
@@ -89,6 +89,8 @@ For slides, mocks, throwaway prototypes, design reviews, and other non-productio
 
 Reach for semantic Aurora vars, or `color-mix(in srgb, var(--aurora-accent-primary) 14%, transparent)` for tinted fills. Full list and light/dark values in `references/tokens.md`; headline shape:
 
+> For non-web surfaces (Zed, Claude Code CLI, terminals, shell tools) the cyan/rose diverge into separate brighter tiers — see `references/editor-cli-tokens.md`. The values below are the **web canonical** palette; don't paste them into a `.tmTheme`/Zed theme or vice-versa.
+
 ### Surfaces
 
 | Token | Purpose |
@@ -298,6 +300,7 @@ Install URL for end users: `https://aurora.tootie.tv` (root) or `https://aurora.
 ## Reference files
 
 - `references/tokens.md` — full token list with values for both dark and light modes, plus the shadcn token bridge.
+- `references/editor-cli-tokens.md` — non-web palettes: Zed "Aurora Neon", Claude Code CLI, shell tools, and the terminal ANSI foundation. Read this before touching `editors/` or `shell/` themes — it maps the three diverging cyan/rose tiers so you don't cross-contaminate.
 - `references/components.md` — every UI primitive and block with import path and the props that matter.
 - `references/recipes.md` — copy-pasteable patterns: page shell, two-pane layout, stat grid, command palette trigger, prompt input with model selector, data table with filter bar.
 

--- a/plugins/vibin/skills/aurora-design-system/references/editor-cli-tokens.md
+++ b/plugins/vibin/skills/aurora-design-system/references/editor-cli-tokens.md
@@ -1,0 +1,149 @@
+# Editor & CLI tokens — terminal, shell, and Zed Neon palettes
+
+Aurora theming extends past the web registry into editors, terminals, and CLI
+tools. These live in `~/workspace/aurora-design-system/editors/` and `/shell/`
+(hand-authored per-tool native formats, excluded from the Next/TS/eslint build).
+They are **canonical there**; `~/.config/...`, `~/.claude/themes/`, etc. are
+deployed copies kept in sync.
+
+## ⚠️ Three palette tiers — do not cross-contaminate
+
+The Aurora cyan/rose deliberately diverge by surface. Know which tier you're in
+before copying a hex:
+
+| Tier | Cyan primary | Rose | Background | Where |
+|---|---|---|---|---|
+| **Web canonical** | `#29b6f6` | `#f9a8c4` | `#07131c` | `registry/aurora/styles/aurora.css`, all React UI, Android. The source of truth — see `references/tokens.md`. |
+| **CLI / Claude Code** | `#36c9ff` | `#ff7eb6` | `#07131c` | `editors/claude-code/*.json`, Claude Code statusline. Brightened so accents survive a dark terminal + low-gamut emulators. |
+| **Zed Neon** | `#38d2ff` | `#ff9ec9` | `#102a3e` | `editors/zed/` only. A lifted-canvas neon variant. **Most divergent.** |
+| Shell tools | `#29b6f6` | `#f9a8c4` | `#07131c` | `shell/*` (p10k, bat, mc, nano, zsh) — mirror the web canonical palette. |
+
+**Rule:** never sync one tier's cyan/rose into another without an explicit
+decision to re-base the whole system. When in doubt for web/React work, use the
+canonical `--aurora-*` vars from `references/tokens.md`.
+
+---
+
+## Zed — "Aurora Neon" (`editors/zed/`)
+
+A Zed extension (`id = aurora-neon`) shipping two UI themes + two icon themes:
+**Aurora Neon** / **Aurora Neon Light**, **Aurora Neon Icons** / **… Light**.
+Validated against `https://zed.dev/schema/themes/v0.2.0.json`. The **dark** variant
+is the brightened neon palette; the **light** variant uses the canonical light hues.
+
+### Aurora Neon — dark surfaces & chrome
+
+| Role | Hex | Zed key |
+|---|---|---|
+| canvas / editor bg | `#102a3e` | `background`, `editor.background` |
+| surface (panels/tabs) | `#14334a` | `surface.background` |
+| elevated surface | `#1a3d56` | `elevated_surface.background` |
+| hover / active line | `#26507a` | `element.hover` |
+| border | `#356b8c` | `border` |
+| border focused / accent | `#38d2ff` | `border.focused`, `text.accent` |
+| text | `#ffffff` | `text`, `editor.foreground` |
+| text muted | `#cfe0ea` | `text.muted` |
+| active line number / indent guide | `#38d2ff` | `editor.active_line_number`, `editor.indent_guide_active` |
+
+### Aurora Neon — syntax (neon tier)
+
+| Token | Hex | Role |
+|---|---|---|
+| function / tag | `#38d2ff` | electric cyan |
+| type / title / enum | `#6fdcff` | light cyan |
+| property | `#5ed0ff` | sky |
+| keyword | `#c4a5ff` | violet |
+| string | `#5ef0d8` | mint |
+| number / attribute | `#ffcf6b` | gold |
+| constant / boolean | `#ff9ec9` | rose |
+| comment | `#93b8c8` | muted (italic) |
+| operator / punctuation | `#cfe0ea` | bright muted |
+
+`accents` cycle: `#38d2ff` `#c4a5ff` `#ff9ec9` `#5ef0d8` `#ffcf6b` `#6fdcff`.
+**Light** variant: cyan primary `#0288d1` on `#ffffff` (canonical light hues).
+
+Icon theme: 60 generated glyph-tile SVGs (`editors/zed/icons/*.svg`) covering 98
+file suffixes + 22 stems, category-tinted (cyan=web, gold=systems, mint=scripting,
+violet=jvm/config, light-cyan=data, rose=docs/media). Regenerate via
+`python3 editors/zed/generate-icons.py`. Icon themes load **only** from an
+installed extension, not a drop-in `themes/` file.
+
+---
+
+## CLI / Claude Code (`editors/claude-code/`)
+
+Canonical CLI terminal palette — brightened cyan/rose. Full key set in the repo's
+`editors/claude-code/TOKENS.md` (every Claude Code theme key + value).
+
+| Role | Hex | Notes |
+|---|---|---|
+| cyan primary (`claude`, `permission`, `suggestion`) | `#36c9ff` | web uses `#29b6f6` |
+| cyan shimmer | `#7ee0ff` | |
+| ide / secondary blue | `#4dc8fa` | |
+| deep cyan (borders) | `#1c7fac` | |
+| rose (`remember`) | `#ff7eb6` | web uses `#f9a8c4` |
+| violet (`merged`, `effortUltra`) | `#a78bfa` | |
+| success teal | `#7dd3c7` | |
+| warn amber | `#c6a36b` | |
+| error rose | `#c78490` | |
+| text primary | `#e6f4fb` | |
+| inactive text | `#cfe0ec` | brightened from `#a7bcc9` for menu legibility |
+| page bg | `#07131c` | |
+
+Diff uses the Aurora rose scheme (removals are rose `#2e151c`/`#5e2a38`, not red;
+additions stay teal `#0f2a24`/`#1d5448`). Subagent wheel + `rainbow_*` ramps are
+fully defined in `TOKENS.md`. Light variant keeps web hues (cyan `#0288d1`).
+
+Deploy: `cp editors/claude-code/aurora.json ~/.claude/themes/aurora.json` then
+re-run `/theme`.
+
+---
+
+## Shell tools (`shell/`) — mirror the web canonical palette
+
+Themes for tools that run *inside* any terminal. These use the **canonical**
+`#29b6f6`/`#f9a8c4` palette (not the brightened CLI tier).
+
+| Token | Hex | 24-bit | Role |
+|---|---|---|---|
+| navy (bg) | `#07131c` | `7;19;28` | background |
+| panel | `#102330` | `16;35;48` | surfaces |
+| white | `#e6f4fb` | `230;244;251` | values / typed text |
+| muted | `#a7bcc9` | `167;188;201` | labels |
+| dim | `#3d6070` | `61;96;112` | line numbers / suggestions |
+| cyan | `#29b6f6` | `41;182;246` | identity / commands |
+| cyan+ | `#67cbfa` | `103;203;250` | accents |
+| deep-blue | `#1c7fac` | `28;127;172` | separators |
+| rose | `#f9a8c4` | `249;168;196` | git branch |
+| rose-deep | `#e879a0` | `232;121;160` | git dirty |
+| violet | `#a78bfa` | `167;139;250` | python / consts |
+| teal | `#7dd3c7` | `125;211;199` | success / strings |
+| amber | `#c6a36b` | `198;163;107` | numbers / timing |
+| error | `#c78490` | `199;132;144` | errors |
+
+Per-tool files: `shell/p10k/aurora-p10k.zsh` (Powerlevel10k, 24-bit), `shell/bat/Aurora.tmTheme`,
+`shell/mc/aurora.ini` (Midnight Commander), `shell/nano/nanorc` (named colors only),
+`shell/zsh/aurora-{fzf,fsh,eza}.zsh` + `aurora.dircolors`, `shell/statusline/statusline-aurora.sh`.
+
+### Terminal ANSI foundation (`editors/warp/themes/aurora.yaml`)
+
+`bat --theme=ansi` and `nano`'s named colors resolve through the terminal's 16
+ANSI colors, so the emulator palette is the highest-leverage surface. Aurora's
+ANSI mapping (Warp `terminal_colors`):
+
+| | black | red | green | yellow | blue | magenta | cyan | white |
+|---|---|---|---|---|---|---|---|---|
+| normal | `#14304a` | `#e090a0` | `#8fe6d8` | `#e0bc7a` | `#4dc8fa` | `#ffb0d0` | `#67d4ff` | `#c4d8e4` |
+| bright | `#3a92c0` | `#f9a8c4` | `#b0f0e6` | `#f2d090` | `#8ad8ff` | `#c4b5fd` | `#d0f0ff` | `#f4fafe` |
+
+---
+
+## Source-of-truth files (in the repo)
+
+- `editors/zed/themes/aurora.json` + `editors/zed/icon_themes/aurora.json` — Zed Neon
+- `editors/claude-code/TOKENS.md` — exhaustive Claude Code CLI token reference
+- `editors/warp/themes/aurora.yaml` — Warp + the ANSI foundation
+- `shell/README.md` — shell palette + per-tool inventory
+
+When palette values change, the deployed copies (`~/.config/zed/`, `~/.claude/themes/`,
+`public/{zed,warp}/`) must be re-synced; see each tool's README.

--- a/plugins/vibin/skills/desktop-app-testing/SKILL.md
+++ b/plugins/vibin/skills/desktop-app-testing/SKILL.md
@@ -44,7 +44,7 @@ gateway predates the fix; rebuild + redeploy (see `references/windows-mcp-calls.
      gate is open; if `confirmation_required`, fix the gateway first.
    - Create run dir `~/.agents/docs/sessions/<app>-desktop-test/run_<id>/`.
 2. **Transfer the build** into the VM (see `references/windows-mcp-calls.md`): HTTP-pull via
-   PowerShell `Invoke-WebRequest` (verified reachable) or SCP to `dookie:2222`. `Unblock-File` the
+   PowerShell `Invoke-WebRequest` (verified reachable) or SCP to the agent-os guest (`scp ... agent-os:` / host forward `tootie:2222`). `Unblock-File` the
    copied binary; pre-create a firewall allow rule if it binds a port.
 3. **Launch.** Prefer `PowerShell {command:"Start-Process 'C:\\...\\app.exe'; ...return PID"}`
    (Start-menu `App {name}` is unreliable for arbitrary binaries). Confirm a PID came back.

--- a/plugins/vibin/skills/desktop-app-testing/references/windows-mcp-calls.md
+++ b/plugins/vibin/skills/desktop-app-testing/references/windows-mcp-calls.md
@@ -1,7 +1,7 @@
 # Windows-MCP call patterns (agent-os VM via the Lab gateway)
 
 Verified live 2026-05-29 after the destructive-gate fix. The desktop target is the **agent-os**
-Windows 11 VM (container `agent-os-win11`, `dockur/windows` on host `dookie`), driven through the
+Windows 11 VM (container `agent-os-win11`, `dockur/windows` on host `tootie`), driven through the
 `agent-os_windows-mcp` upstream on the Lab gateway.
 
 ## Invocation surface

--- a/plugins/vibin/skills/homelab-map/SKILL.md
+++ b/plugins/vibin/skills/homelab-map/SKILL.md
@@ -12,7 +12,7 @@ Quick map of Jacob's homelab. **Full runtime inventory lives at `~/.homelab/home
 | Name | Role | LAN IP | OS | Notes |
 |---|---|---|---|---|
 | **tootie** | Primary NAS / app server | 10.1.0.2 | Unraid 7.2.4 (i7-13700K, 128GB) | 49 containers. Web: `:6969`. SSH port `29229`. Also runs dookie as a KVM guest. **⚠ no parity disk currently.** |
-| **dookie** | Dev / AI / MCP hub | 10.1.0.6 | Linux KVM guest on tootie | Axon RAG stack, syslog-mcp (1514/3100), arcane-mcp (44332), unraid-mcp (40010), Lab (8765), MCP bridge containers (40020-40060). The Windows 11 sandbox container (`agent-os-win11`) at `:8006` also lives here. |
+| **dookie** | Dev / AI / MCP hub | 10.1.0.6 | Linux KVM guest on tootie | Axon RAG stack, syslog-mcp (1514/3100), arcane-mcp (44332), unraid-mcp (40010), Lab (8765), MCP bridge containers (40020-40060). |
 | **squirts** | Edge services | 10.1.0.8 | Ubuntu (4 cores, 15GB) | SWAG (149 active configs), Authelia, AdGuard, Gotify, MCP gateway, Vaultwarden, Paperless, etc. RAM sample 10GiB/14GiB used. |
 | **shart** | ZFS backup target | 10.1.0.3 | Unraid | ZFS `backup` pool 7.27TB / 1.80TB used. Also has old link-local `169.254.80.235` on `shim-br0`. Receives Syncoid streams from tootie + squirts. |
 | **steamy** | GPU workloads (RTX 4070) | 10.1.0.65 | Win11 + WSL2 | `crawl4r-qdrant` (GPU qdrant). Arcane marks this env disabled/offline, but `ssh steamy-wsl` works and remains the default target for the `screenshots`, `clipboard`, `nircmd` skills. |
@@ -31,7 +31,7 @@ All nodes joined to **Tailscale** mesh (`100.x.y.z`). Router is a UniFi UCG-Max 
 | Sanoid / Syncoid backups, ZFS receive | shart |
 | Portainer, Glances, Scrutiny, Vnstat, MinIO, Loggifly, Notifiarr, Apprise API, Olivetin, Crontab UI, Zipline | tootie |
 | **MCP servers** — syslog, arcane, unraid, swag, unifi, gotify, tailscale, apprise, rmcp-template/example | mostly **dookie + squirts** — see `~/.homelab/homelab.md` §"MCP Server Ecosystem" for exact host |
-| Windows sandbox (dookie:8006 noVNC), agent-os skill target | dookie (`agent-os-win11` / dockurr/windows container) |
+| Windows sandbox (tootie:8006 noVNC), agent-os skill target | tootie (`agent-os-win11` / dockurr/windows container) |
 
 ## Conventions
 

--- a/plugins/vibin/skills/homelab-map/scripts/generate-homelab-report.py
+++ b/plugins/vibin/skills/homelab-map/scripts/generate-homelab-report.py
@@ -83,12 +83,12 @@ SERVICE_HINTS = {
     "tootie": [
         "plex", "sonarr", "radarr", "bazarr", "prowlarr", "qbittorrent", "sabnzbd",
         "tautulli", "immich", "audiobookshelf", "kavita", "navidrome", "minio",
-        "loggifly", "notifiarr", "apprise-api", "olivetin", "zipline",
+        "loggifly", "notifiarr", "apprise-api", "olivetin", "zipline", "agent-os-win11",
     ],
     "dookie": [
         "axon", "axon-qdrant", "axon-tei", "axon-chrome", "syslog-mcp",
         "arcane-mcp", "unraid-mcp", "gotify-mcp", "unifi-mcp", "tailscale-mcp",
-        "apprise-mcp", "labby", "agent-os-win11",
+        "apprise-mcp", "labby",
     ],
     "squirts": [
         "swag", "authelia", "adguard", "gotify", "vaultwarden", "paperless",
@@ -398,8 +398,8 @@ def report_payload(snapshots: dict[str, HostSnapshot], generated_at: dt.datetime
             {"service": "Arcane MCP", "url": "http://dookie:44332"},
             {"service": "Unraid MCP", "url": "http://dookie:40010"},
             {"service": "Plex", "url": "http://10.1.0.2:32400"},
-            {"service": "Windows sandbox noVNC", "url": "http://dookie:8006"},
-            {"service": "Windows sandbox RDP", "url": "dookie:33890"},
+            {"service": "Windows sandbox noVNC", "url": "http://tootie:8006"},
+            {"service": "Windows sandbox RDP", "url": "tootie:33890"},
         ],
     }
 
@@ -592,8 +592,8 @@ SWAG is expected on `squirts`. Active proxy config count is generated from `/mnt
     ["Arcane MCP", "http://dookie:44332"],
     ["Unraid MCP", "http://dookie:40010"],
     ["Plex", "http://10.1.0.2:32400"],
-    ["Windows sandbox noVNC", "http://dookie:8006"],
-    ["Windows sandbox RDP", "dookie:33890"],
+    ["Windows sandbox noVNC", "http://tootie:8006"],
+    ["Windows sandbox RDP", "tootie:33890"],
 ])}
 """
 


### PR DESCRIPTION
## Summary
- port Code Mode normalization to a parser-backed path for Cloudflare-style snippets
- preserve binary values across sandbox/tool boundaries and improve MCP result unwrap behavior
- add recursive schema validation, safer identifier sanitization, collision rejection, and fuller JSON Schema-to-TypeScript generation
- bump workspace and gateway admin versions to 0.21.0

## Verification
- cargo fmt --all
- cargo test --manifest-path crates/lab/Cargo.toml --all-features code_mode
- just dev-debug
- live mcporter checks for normalization, binary results, typed search, and schema validation
- cargo check --workspace --all-features

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes remaining Code Mode parity gaps with Cloudflare by adding AST-based snippet normalization, typed returns with output schemas, capability filtering, and aligned runtime behavior. Follow-up fixes add a safe callTool fallback, binary param encoding, safer arrow normalization, and the workspace bumps to 0.21.0.

- New Features
  - Parser-backed normalization for Cloudflare-style snippets with consistent wrapping and safe fallbacks.
  - Typed Code Mode: generate tool signatures and `.d.ts`; output schema returns; improved JSON Schema→TypeScript; safer identifier sanitization and method collision rejection; caches input/output schemas.
  - Runtime parity and scoping: Cloudflare-like result unwrapping, recursive schema validation before dispatch, binary preservation across sandbox/tool calls, and capability-based tool filtering.

- Bug Fixes
  - Health-aware connectivity: lazily seeded but healthy upstreams show as connected before first use.
  - Sandbox hardening: block dynamic import of host modules and extra globals (e.g., `XMLHttpRequest`, `connect`).
  - Review follow-ups: preserve direct `callTool` execution if proxy generation fails; encode `callTool` binary params via the shared JS codec; strip unsafe trailing semicolons from arrow snippets.

<sup>Written for commit a9e43b760fac6ca713cd9b5fb0ae2850729a5a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.21.0

* **New Features**
  * Enhanced Code Mode with TypeScript type generation and JSDoc documentation for tools
  * Implemented capability-based filtering to control Code Mode execution scope
  * Added output schema support and parameter validation for tools

* **Bug Fixes**
  * Fixed binary data preservation through tool execution pipelines
  * Improved handling of structured tool results

* **Documentation**
  * Updated Code Mode execution documentation with sandbox and safety details
  * Added design token references for non-web contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->