### PR TITLE
feat(cli): Aurora-themed clap help + root catalog shim

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -3,3 +3,4 @@
 *.env
 *.env.*
 config.toml
+apps/gateway-admin/out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "lab-apis"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "base64",
  "futures",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "lab-auth"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "axum",
  "base64",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "labby"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = ["crates/lab-apis", "crates/lab", "crates/lab-auth"]
 agent-client-protocol = { path = "crates/vendor/agent-client-protocol" }
 
 [workspace.package]
-version = "0.21.3"
+version = "0.21.4"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -63,7 +63,7 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 
 # cli / output
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "color"] }
 clap_complete = "4"
 owo-colors = "4"
 is-terminal = "0.4"

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -22,6 +22,7 @@ pub mod params;
 pub mod serve;
 pub mod setup;
 pub mod stash;
+pub mod style;
 
 #[cfg(feature = "deploy")]
 pub mod deploy;
@@ -37,7 +38,7 @@ use crate::output::{ColorPolicy, OutputFormat, RenderEnv};
 
 /// `lab` — pluggable homelab CLI + MCP server SDK.
 #[derive(Debug, Parser)]
-#[command(name = "labby", version, about, long_about = None, disable_help_subcommand = true)]
+#[command(name = "labby", version, about, long_about = None, styles = style::AURORA_STYLES)]
 pub struct Cli {
     /// Emit JSON instead of human-readable tables.
     #[arg(long, global = true)]
@@ -78,8 +79,6 @@ pub enum Command {
     Health,
     /// Open the web-based first-run wizard (or settings) — lab-bg3e.3.
     Setup(setup::SetupArgs),
-    /// Print the service + action catalog.
-    Help(help::HelpArgs),
     /// Generate shell completions.
     Completions(completions::CompletionsArgs),
     /// Manage proxied upstream MCP gateways.
@@ -115,7 +114,6 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
         Command::Nodes(args) => nodes::run(args, format, &config).await,
         Command::Health => health::run(format).await,
         Command::Setup(args) => setup::run(args, format).await,
-        Command::Help(args) => help::run(args, format),
         Command::Completions(args) => completions::run(&args),
         Command::Gateway(args) => gateway::run(args, format, &config).await,
         Command::Oauth(args) => oauth::run(args, &config).await,

--- a/crates/lab/src/cli/gateway.rs
+++ b/crates/lab/src/cli/gateway.rs
@@ -27,16 +27,27 @@ pub struct GatewayArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayCommand {
+    /// List configured gateways and their runtime status.
     List,
+    /// Get one configured gateway.
     Get(GatewayGetArgs),
+    /// Test a configured or proposed gateway without saving it.
     Test(GatewayTestArgs),
+    /// Add a gateway and reconcile runtime state.
     Add(GatewayAddArgs),
+    /// Update a gateway and reconcile runtime state.
     Update(GatewayUpdateArgs),
+    /// Remove a gateway and reconcile runtime state.
     Remove(GatewayRemoveArgs),
+    /// Manage Lab-backed virtual servers quarantined during config migration.
     Quarantine(GatewayQuarantineArgs),
+    /// Manage public MCP routes protected by Lab OAuth.
     ProtectedRoute(GatewayProtectedRouteArgs),
+    /// Configure gateway-wide tool_search/tool_execute mode.
     ToolSearch(GatewayToolSearchArgs),
+    /// Reload gateways from config and reconcile runtime state.
     Reload,
+    /// Manage upstream MCP server lifecycle and OAuth.
     Mcp(GatewayMcpArgs),
     /// Scan the machine for MCP server configs from known editors and tools (read-only)
     Discover(GatewayDiscoverArgs),
@@ -186,7 +197,9 @@ pub struct GatewayQuarantineArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayQuarantineCommand {
+    /// List Lab-backed virtual servers quarantined during config migration.
     List,
+    /// Restore a quarantined Lab-backed virtual server into the active gateway list.
     Restore(GatewayQuarantineRestoreArgs),
 }
 
@@ -203,11 +216,17 @@ pub struct GatewayProtectedRouteArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayProtectedRouteCommand {
+    /// List Gateway-managed public MCP routes protected by Lab OAuth.
     List,
+    /// Get one Gateway-managed protected MCP route.
     Get(GatewayProtectedRouteNameArgs),
+    /// Add a Gateway-managed protected MCP route.
     Add(GatewayProtectedRouteUpsertArgs),
+    /// Replace a Gateway-managed protected MCP route.
     Update(GatewayProtectedRouteUpdateArgs),
+    /// Remove a Gateway-managed protected MCP route.
     Remove(GatewayProtectedRouteNameArgs),
+    /// Validate a proposed protected MCP route without saving it.
     Test(GatewayProtectedRouteUpsertArgs),
 }
 
@@ -269,8 +288,11 @@ pub struct GatewayToolSearchArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayToolSearchCommand {
+    /// Read the gateway-wide tool_search settings.
     Status,
+    /// Enable gateway-wide tool_search/tool_execute mode for all exposed upstream tools.
     Enable(GatewayToolSearchSetArgs),
+    /// Disable gateway-wide tool_search/tool_execute mode.
     Disable,
 }
 
@@ -290,10 +312,15 @@ pub struct GatewayMcpArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayMcpCommand {
+    /// Manage upstream MCP server OAuth credentials.
     Auth(GatewayMcpAuthArgs),
+    /// List upstream MCP runtime state, discovery counts, and likely stale process counts.
     List,
+    /// Enable an upstream MCP server so new sessions discover and proxy it again.
     Enable(GatewayMcpLifecycleArgs),
+    /// Disable an upstream MCP server and optionally clean up running processes.
     Disable(GatewayMcpLifecycleArgs),
+    /// Kill or preview running processes associated with one upstream MCP server.
     Cleanup(GatewayMcpCleanupArgs),
 }
 
@@ -305,9 +332,13 @@ pub struct GatewayMcpAuthArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum GatewayMcpAuthCommand {
+    /// Start the upstream OAuth flow and print the browser authorization URL.
     Start(GatewayOauthUpstreamArgs),
+    /// Start the upstream OAuth flow and open the authorization URL in a browser.
     Open(GatewayOauthUpstreamArgs),
+    /// Read upstream OAuth status for the shared gateway credential.
     Status(GatewayOauthUpstreamArgs),
+    /// Clear stored upstream OAuth credentials for the shared gateway credential.
     Clear(GatewayOauthUpstreamArgs),
 }
 
@@ -1027,37 +1058,13 @@ fn render_gateway_list_human(
         } else if s.connected {
             let mut parts = Vec::new();
             if s.exposed_tool_count > 0 {
-                parts.push(format!(
-                    "🔧 {} {}",
-                    s.exposed_tool_count,
-                    if s.exposed_tool_count == 1 {
-                        "tool"
-                    } else {
-                        "tools"
-                    }
-                ));
+                parts.push(format!("🔧 {}", s.exposed_tool_count));
             }
             if s.exposed_prompt_count > 0 {
-                parts.push(format!(
-                    "💬 {} {}",
-                    s.exposed_prompt_count,
-                    if s.exposed_prompt_count == 1 {
-                        "prompt"
-                    } else {
-                        "prompts"
-                    }
-                ));
+                parts.push(format!("💬 {}", s.exposed_prompt_count));
             }
             if s.exposed_resource_count > 0 {
-                parts.push(format!(
-                    "📦 {} {}",
-                    s.exposed_resource_count,
-                    if s.exposed_resource_count == 1 {
-                        "resource"
-                    } else {
-                        "resources"
-                    }
-                ));
+                parts.push(format!("📦 {}", s.exposed_resource_count));
             }
             let joined = if parts.is_empty() {
                 "connected".to_string()

--- a/crates/lab/src/cli/oauth.rs
+++ b/crates/lab/src/cli/oauth.rs
@@ -17,6 +17,7 @@ pub struct OauthArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum OauthCommand {
+    /// Run a local OAuth callback relay that forwards to a machine or explicit target.
     RelayLocal(RelayLocalArgs),
 }
 

--- a/crates/lab/src/cli/style.rs
+++ b/crates/lab/src/cli/style.rs
@@ -1,0 +1,32 @@
+//! Aurora-themed clap help/error styling.
+//!
+//! A single `AURORA_STYLES` applied at the root `#[command(...)]` propagates
+//! to every subcommand, so `labby gateway --help`, `labby gateway help`, and
+//! deeper subcommands all render with the Aurora palette. The ANSI-256 indices
+//! come from `crate::output::theme::aurora` so clap help stays in sync with the
+//! catalog and table renderers.
+//!
+//! Note: clap only emits these escapes when its `color` feature is enabled AND
+//! the resolved `clap::ColorChoice` is not `Never`. `crates/lab/src/main.rs`
+//! maps the resolved `ColorPolicy` onto `ColorChoice`, so `--color plain` /
+//! `NO_COLOR` strip the styling. `render_long_help().to_string()` (used by the
+//! docs generator) stays plain regardless, keeping `cli-help.md` ANSI-free.
+
+use clap::builder::styling::{Ansi256Color, Styles};
+
+use crate::output::theme::aurora;
+
+/// Aurora-themed styling for clap help and error output.
+pub const AURORA_STYLES: Styles = Styles::styled()
+    // Section headers (`Usage:`, `Options:`, `Commands:`) and the usage line —
+    // primary cyan, bold.
+    .header(Ansi256Color(aurora::ACCENT_PRIMARY).on_default().bold())
+    .usage(Ansi256Color(aurora::ACCENT_PRIMARY).on_default().bold())
+    // Literals: subcommand names and flag spellings — strong cyan.
+    .literal(Ansi256Color(aurora::ACCENT_STRONG).on_default())
+    // Placeholders: `<COMMAND>`, value names — violet (AI/automation identity).
+    .placeholder(Ansi256Color(aurora::VIOLET).on_default())
+    // Validation/error accents — muted status triad.
+    .valid(Ansi256Color(aurora::SUCCESS).on_default())
+    .invalid(Ansi256Color(aurora::WARN).on_default())
+    .error(Ansi256Color(aurora::ERROR).on_default());

--- a/crates/lab/src/dispatch/upstream/pool/testsupport.rs
+++ b/crates/lab/src/dispatch/upstream/pool/testsupport.rs
@@ -305,20 +305,16 @@ impl UpstreamPool {
             tools: Arc<tokio::sync::RwLock<Vec<String>>>,
         }
 
-        impl rmcp::ServerHandler for MutableToolCatalogServer {
-            fn get_info(&self) -> rmcp::model::ServerInfo {
-                rmcp::model::ServerInfo::new(
-                    rmcp::model::ServerCapabilities::builder()
-                        .enable_tools()
-                        .build(),
-                )
+        impl ServerHandler for MutableToolCatalogServer {
+            fn get_info(&self) -> ServerInfo {
+                ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             }
 
             async fn list_tools(
                 &self,
-                _request: Option<rmcp::model::PaginatedRequestParams>,
-                _context: rmcp::service::RequestContext<rmcp::RoleServer>,
-            ) -> Result<rmcp::model::ListToolsResult, rmcp::model::ErrorData> {
+                _request: Option<PaginatedRequestParams>,
+                _context: RequestContext<RoleServer>,
+            ) -> Result<ListToolsResult, ErrorData> {
                 let tools = self
                     .tools
                     .read()
@@ -332,7 +328,7 @@ impl UpstreamPool {
                         )
                     })
                     .collect::<Vec<_>>();
-                Ok(rmcp::model::ListToolsResult::with_all_items(tools))
+                Ok(ListToolsResult::with_all_items(tools))
             }
         }
 

--- a/crates/lab/src/main.rs
+++ b/crates/lab/src/main.rs
@@ -203,8 +203,14 @@ const fn color_choice_for(policy: ColorPolicy) -> ColorChoice {
 ///
 /// Returns `Some` only when, after skipping leading global flags, the first
 /// positional token is:
-/// - bare `help` (optionally followed by exactly `--all`), or
+/// - bare `help`, optionally followed by any mix of global flags (`--json`,
+///   `--color`) and `--all`, or
 /// - `-h` / `--help` at the root (no preceding subcommand).
+///
+/// Global flags are accepted on *both* sides of the trigger because they are
+/// `global = true` on [`Cli`] — `labby help --json` and `labby --json help` must
+/// both reach the catalog (scripts consume `help --json`). Their values are
+/// folded into the returned flags regardless of position.
 ///
 /// `help <subcommand>` (e.g. `help gateway`) returns `None` and falls through to
 /// clap's native, now-themed `help` subcommand.
@@ -247,24 +253,57 @@ where
     let first = first.as_ref().to_string_lossy().into_owned();
     match first.as_str() {
         "-h" | "--help" => {
-            // Root `-h`/`--help` with no preceding subcommand → catalog.
+            // Root `-h`/`--help` with no preceding subcommand → catalog. Fold any
+            // trailing global flags (`-h --json`) into the captured flags; a
+            // foreign token after a terminal help flag is ignored, mirroring
+            // clap's treatment of `--help` as short-circuiting.
+            trailing_globals_only(&mut iter, &mut flags);
             Some(flags)
         }
         "help" => {
-            // Only bare `help` or `help --all` is the catalog; `help <cmd>`
-            // falls through to clap's native help subcommand.
-            match iter.next() {
-                None => Some(flags),
-                Some(next)
-                    if next.as_ref().to_string_lossy() == "--all" && iter.next().is_none() =>
-                {
-                    Some(flags)
-                }
-                _ => None,
+            // Bare `help` plus any trailing global flags / `--all` is the root
+            // catalog; `help <subcommand>` (a foreign trailing token) falls
+            // through to clap's native help subcommand.
+            if trailing_globals_only(&mut iter, &mut flags) {
+                Some(flags)
+            } else {
+                None
             }
         }
         _ => None,
     }
+}
+
+/// Consume the tokens trailing a root help trigger, folding recognized global
+/// flag values (`--json`, `--color VALUE`, `--color=VALUE`) into `flags` and
+/// tolerating `--all`. Returns `true` if every remaining token was a global
+/// flag or `--all`, or `false` on the first foreign token (e.g. a subcommand
+/// name) — which marks the invocation as `help <subcommand>`.
+fn trailing_globals_only<I, T>(iter: &mut I, flags: &mut GlobalFlags) -> bool
+where
+    I: Iterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    while let Some(arg) = iter.next() {
+        let arg = arg.as_ref().to_string_lossy().into_owned();
+        if arg == "--all" || global_flags::BOOLEAN.contains(&arg.as_str()) {
+            if arg == "--json" {
+                flags.json = true;
+            }
+        } else if let Some(rest) = arg.strip_prefix("--color=") {
+            flags.color = Some(parse_color_value(rest));
+        } else if global_flags::VALUED.contains(&arg.as_str()) {
+            // `--color VALUE` — the value (if present) is the next token.
+            if let Some(value) = iter.next() {
+                if arg == "--color" {
+                    flags.color = Some(parse_color_value(&value.as_ref().to_string_lossy()));
+                }
+            }
+        } else {
+            return false;
+        }
+    }
+    true
 }
 
 /// Whether the (already-skipped) help invocation requested `--all`.
@@ -312,7 +351,11 @@ fn run_root_catalog(flags: &GlobalFlags) -> ExitCode {
     match cli::help::run(cli::help::HelpArgs { all }, format) {
         Ok(code) => code,
         Err(err) => {
-            tracing::error!("{err:#}");
+            // This runs before `init_tracing`, so `tracing::error!` would have no
+            // subscriber and the failure (e.g. a malformed config.toml) would be
+            // invisible. Use stderr directly, matching the pre-tracing error path
+            // in `main`. (`clippy::print_stderr` is `allow` workspace-wide.)
+            eprintln!("error: {err:#}");
             ExitCode::from(1)
         }
     }

--- a/crates/lab/src/main.rs
+++ b/crates/lab/src/main.rs
@@ -29,16 +29,17 @@ mod test_support;
 #[cfg(feature = "fs")]
 mod workspace;
 
+use std::ffi::OsStr;
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{ColorChoice, CommandFactory, FromArgMatches};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{EnvFilter, filter::filter_fn, fmt, prelude::*};
 
 use crate::cli::Cli;
 use crate::dispatch::logs::ingest::LogIngestLayer;
 use crate::log_fmt::formatter::PremiumEventFormatter;
-use crate::output::{ColorPolicy, RenderEnv, human_output_styling_enabled};
+use crate::output::{ColorPolicy, OutputFormat, RenderEnv, human_output_styling_enabled};
 
 fn human_console_target_enabled(target: &str) -> bool {
     target == "labby"
@@ -128,9 +129,216 @@ fn init_tracing(
     _log_guard
 }
 
+/// Global flags that may appear *before* a subcommand and must be skipped when
+/// the pre-parse shim scans for the root `help` / `-h` / `--help` tokens.
+///
+/// These mirror the `#[arg(global = true)]` flags on [`Cli`]. **If you add a new
+/// global flag to `Cli`, add it here too** — otherwise the catalog shim will
+/// mistake its value for a subcommand. A missed flag degrades to clap's own
+/// help (it never crashes), but the root catalog would stop firing.
+mod global_flags {
+    /// Boolean global flags (no value follows).
+    pub const BOOLEAN: &[&str] = &["--json"];
+    /// Value-taking global flags in `--flag VALUE` form. The `--flag=VALUE`
+    /// form is handled separately by prefix match.
+    pub const VALUED: &[&str] = &["--color"];
+}
+
+/// A global flag's captured value, used by the catalog shim.
+#[derive(Default)]
+struct GlobalFlags {
+    json: bool,
+    color: Option<ColorPolicy>,
+}
+
+/// Parse a `--color` value string (`auto`/`plain`/`color`) into a [`ColorPolicy`].
+///
+/// Styling is cosmetic, so an unrecognized value falls back to `Auto` rather
+/// than erroring — the real validation happens later in clap's parse pass.
+fn parse_color_value(value: &str) -> ColorPolicy {
+    match value.to_ascii_lowercase().as_str() {
+        "plain" => ColorPolicy::Plain,
+        "color" => ColorPolicy::Color,
+        _ => ColorPolicy::Auto,
+    }
+}
+
+/// Resolve the effective color policy.
+///
+/// The CLI `--color` flag wins when set explicitly; when it is `Auto`, the
+/// `LAB_LOG_COLOR` env var can force or disable color (e.g. inside Docker where
+/// there is no TTY). This is the single source of truth shared by the catalog
+/// shim, the clap parser's `ColorChoice`, and `init_tracing` so help color and
+/// log color never drift.
+fn resolve_color_policy(cli_color: ColorPolicy) -> ColorPolicy {
+    if cli_color == ColorPolicy::Auto {
+        match std::env::var("LAB_LOG_COLOR")
+            .ok()
+            .as_deref()
+            .map(str::to_lowercase)
+            .as_deref()
+        {
+            Some("force" | "always" | "1") => ColorPolicy::Color,
+            Some("plain" | "never" | "0") => ColorPolicy::Plain,
+            _ => ColorPolicy::Auto,
+        }
+    } else {
+        cli_color
+    }
+}
+
+/// Map a resolved [`ColorPolicy`] onto clap's [`ColorChoice`] so themed clap
+/// help obeys `--color` / `NO_COLOR` / `LAB_LOG_COLOR`. `Auto` defers to clap's
+/// own TTY + `NO_COLOR` detection.
+const fn color_choice_for(policy: ColorPolicy) -> ColorChoice {
+    match policy {
+        ColorPolicy::Plain => ColorChoice::Never,
+        ColorPolicy::Color => ColorChoice::Always,
+        ColorPolicy::Auto => ColorChoice::Auto,
+    }
+}
+
+/// If the invocation is a *root-level* help request, return the captured global
+/// flags so the caller can render the Aurora catalog instead of clap help.
+///
+/// Returns `Some` only when, after skipping leading global flags, the first
+/// positional token is:
+/// - bare `help` (optionally followed by exactly `--all`), or
+/// - `-h` / `--help` at the root (no preceding subcommand).
+///
+/// `help <subcommand>` (e.g. `help gateway`) returns `None` and falls through to
+/// clap's native, now-themed `help` subcommand.
+fn root_help_request<I, T>(args: I) -> Option<GlobalFlags>
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    let mut flags = GlobalFlags::default();
+    let mut iter = args.into_iter();
+    // Skip argv[0] (program name).
+    iter.next();
+
+    let mut iter = iter.peekable();
+    while let Some(arg) = iter.peek() {
+        let arg = arg.as_ref().to_string_lossy().into_owned();
+        if global_flags::BOOLEAN.contains(&arg.as_str()) {
+            if arg == "--json" {
+                flags.json = true;
+            }
+            iter.next();
+        } else if let Some(rest) = arg.strip_prefix("--color=") {
+            flags.color = Some(parse_color_value(rest));
+            iter.next();
+        } else if global_flags::VALUED.contains(&arg.as_str()) {
+            // `--color VALUE` — consume the flag, then its value (if present).
+            iter.next();
+            if let Some(value) = iter.next() {
+                if arg == "--color" {
+                    flags.color = Some(parse_color_value(&value.as_ref().to_string_lossy()));
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    // First non-global token must be the help trigger.
+    let first = iter.next()?;
+    let first = first.as_ref().to_string_lossy().into_owned();
+    match first.as_str() {
+        "-h" | "--help" => {
+            // Root `-h`/`--help` with no preceding subcommand → catalog.
+            Some(flags)
+        }
+        "help" => {
+            // Only bare `help` or `help --all` is the catalog; `help <cmd>`
+            // falls through to clap's native help subcommand.
+            match iter.next() {
+                None => Some(flags),
+                Some(next)
+                    if next.as_ref().to_string_lossy() == "--all" && iter.next().is_none() =>
+                {
+                    Some(flags)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Whether the (already-skipped) help invocation requested `--all`.
+fn help_wants_all<I, T>(args: I) -> bool
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    args.into_iter()
+        .any(|a| a.as_ref().to_string_lossy() == "--all")
+}
+
+/// Scan the whole argv for a `--color` value (the flag is `global = true`, so
+/// it may appear before or after the subcommand). Returns the last occurrence's
+/// policy, or `None` if `--color` is absent. Used only to pick clap's
+/// `ColorChoice`; clap itself still performs full validation afterwards.
+fn scan_color_flag<I, T>(args: I) -> Option<ColorPolicy>
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    let mut found = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        let arg = arg.as_ref().to_string_lossy().into_owned();
+        if let Some(rest) = arg.strip_prefix("--color=") {
+            found = Some(parse_color_value(rest));
+        } else if arg == "--color" {
+            if let Some(value) = iter.next() {
+                found = Some(parse_color_value(&value.as_ref().to_string_lossy()));
+            }
+        }
+    }
+    found
+}
+
+/// Render the Aurora service + action catalog for the root help path.
+fn run_root_catalog(flags: &GlobalFlags) -> ExitCode {
+    // The env-filtered catalog needs config + .env (unlike the metadata-only
+    // Docs fast-path). Failures are non-fatal — fall back to defaults.
+    config::load_dotenv().ok();
+    let policy = resolve_color_policy(flags.color.unwrap_or_default());
+    let format = OutputFormat::from_json_flag(flags.json, policy, RenderEnv::stdout());
+    let all = help_wants_all(std::env::args_os());
+    match cli::help::run(cli::help::HelpArgs { all }, format) {
+        Ok(code) => code,
+        Err(err) => {
+            tracing::error!("{err:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
-    let cli = Cli::parse();
+    // Pre-parse shim: root `help` / `--help` / `-h` renders the Aurora catalog,
+    // which clap cannot express via derive (it would auto-handle `--help` and
+    // panics on a duplicate `help`). Every *non-root* help path (`gateway help`,
+    // `gateway --help`, `help gateway`) falls through to clap's themed output.
+    if let Some(flags) = root_help_request(std::env::args_os()) {
+        return run_root_catalog(&flags);
+    }
+
+    // Build the parser with an explicit ColorChoice so themed clap help obeys
+    // our `--color` policy (clap's `color` feature otherwise ignores it). We
+    // scan argv for `--color` directly rather than doing a clap pre-parse: a
+    // pre-parse `get_matches()` would itself auto-exit (rendering unthemed help)
+    // the moment it saw `--help`, before the real themed parse could run.
+    let cli = {
+        let pre = scan_color_flag(std::env::args_os()).unwrap_or_default();
+        let choice = color_choice_for(resolve_color_policy(pre));
+        let matches = Cli::command().color(choice).get_matches();
+        Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit())
+    };
 
     if matches!(
         cli.command,
@@ -187,21 +395,9 @@ async fn main() -> ExitCode {
     // LAB_LOG_COLOR overrides the CLI default when running without a TTY (e.g.
     // inside Docker). The CLI --color flag wins when the user sets it explicitly,
     // but since clap cannot distinguish "user passed --color auto" from "defaulted
-    // to auto", the env var only activates when the policy is Auto.
-    let color_policy = if cli.color == ColorPolicy::Auto {
-        match std::env::var("LAB_LOG_COLOR")
-            .ok()
-            .as_deref()
-            .map(str::to_lowercase)
-            .as_deref()
-        {
-            Some("force" | "always" | "1") => ColorPolicy::Color,
-            Some("plain" | "never" | "0") => ColorPolicy::Plain,
-            _ => ColorPolicy::Auto,
-        }
-    } else {
-        cli.color
-    };
+    // to auto", the env var only activates when the policy is Auto. Shared with
+    // the catalog shim and clap's ColorChoice so help and log color stay in sync.
+    let color_policy = resolve_color_policy(cli.color);
 
     // _log_guard MUST live for the entire process — dropping it stops file logging.
     let _log_guard = init_tracing(&config.log, color_policy, log_filter_override.as_deref());

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -17,7 +17,6 @@ Commands:
   nodes        Query nodes from the configured controller
   health       Quick reachability check for configured services
   setup        Open the web-based first-run wizard (or settings) — lab-bg3e.3
-  help         Print the service + action catalog
   completions  Generate shell completions
   gateway      Manage proxied upstream MCP gateways
   oauth        Run local OAuth callback relay helpers
@@ -26,6 +25,7 @@ Commands:
   registry     MCP Registry — look up and install servers from registry.modelcontextprotocol.io
   stash        Component versioning and deployment
   deploy       Deploy the local lab release binary to SSH targets
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -52,7 +52,8 @@ Start the MCP server (stdio or HTTP transport)
 Usage: serve [OPTIONS] [COMMAND]
 
 Commands:
-  mcp  Run the MCP server over stdio instead of the default HTTP transport
+  mcp   Run the MCP server over stdio instead of the default HTTP transport
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -109,6 +110,18 @@ Options:
           Print help
 ```
 
+## `labby serve help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby mcp`
 
 ```text
@@ -149,6 +162,7 @@ Commands:
   system    Run local system checks (env vars, Docker, disk, toolchain)
   service   Probe a single configured service
   services  Probe all configured services
+  help      Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -285,6 +299,18 @@ Options:
           Print help
 ```
 
+## `labby doctor help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby docs`
 
 ```text
@@ -295,6 +321,7 @@ Usage: docs [OPTIONS] <COMMAND>
 Commands:
   generate  Regenerate every tracked generated-docs artifact
   check     Verify generated-docs artifacts are fresh
+  help      Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -352,6 +379,18 @@ Options:
           Print help
 ```
 
+## `labby docs help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby nodes`
 
 ```text
@@ -364,6 +403,7 @@ Commands:
   get          Get details for a specific node by `node_id`
   update       Build and roll out the local release binary to selected nodes
   enrollments  Manage pending, approved, and denied node enrollments
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -464,6 +504,7 @@ Commands:
   list     List pending, approved, and denied enrollments
   approve  Approve a pending enrollment
   deny     Deny a pending or approved enrollment
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -556,6 +597,30 @@ Options:
           Print help
 ```
 
+## `labby nodes enrollments help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
+## `labby nodes help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby health`
 
 ```text
@@ -596,6 +661,7 @@ Commands:
   install              Copy the labby binary into ~/.local/bin so it is callable in your own terminal
   install-plugin       Install the Claude Code plugin for a configured service
   uninstall-plugin     Uninstall the Claude Code plugin for a service
+  help                 Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -892,28 +958,16 @@ Options:
           Print help
 ```
 
-## `labby help`
+## `labby setup help`
 
 ```text
-Print the service + action catalog
+Print this message or the help of the given subcommand(s)
 
-Usage: help [OPTIONS]
+Usage: help [COMMAND]...
 
-Options:
-      --all
-          Show every compiled-in service, even if required env vars are missing
-
-      --json
-          Emit JSON instead of human-readable tables
-
-      --color <COLOR>
-          Control human-readable CLI styling
-
-          [default: auto]
-          [possible values: auto, plain, color]
-
-  -h, --help
-          Print help
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
 ```
 
 ## `labby completions`
@@ -951,22 +1005,23 @@ Manage proxied upstream MCP gateways
 Usage: gateway [OPTIONS] <COMMAND>
 
 Commands:
-  list
-  get
-  test
-  add
-  update
-  remove
-  quarantine
-  protected-route
-  tool-search
-  reload
-  mcp
+  list             List configured gateways and their runtime status
+  get              Get one configured gateway
+  test             Test a configured or proposed gateway without saving it
+  add              Add a gateway and reconcile runtime state
+  update           Update a gateway and reconcile runtime state
+  remove           Remove a gateway and reconcile runtime state
+  quarantine       Manage Lab-backed virtual servers quarantined during config migration
+  protected-route  Manage public MCP routes protected by Lab OAuth
+  tool-search      Configure gateway-wide tool_search/tool_execute mode
+  reload           Reload gateways from config and reconcile runtime state
+  mcp              Manage upstream MCP server lifecycle and OAuth
   discover         Scan the machine for MCP server configs from known editors and tools (read-only)
   import           Import discovered MCP servers into the gateway (disabled by default)
   pending          Manage pending discovered servers waiting for approval
   public-urls      Show resolved public URL configuration (app and MCP gateway)
   code             Search, inspect, and execute Code Mode snippets through dispatch
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -985,6 +1040,8 @@ Options:
 ## `labby gateway list`
 
 ```text
+List configured gateways and their runtime status
+
 Usage: list [OPTIONS]
 
 Options:
@@ -1004,6 +1061,8 @@ Options:
 ## `labby gateway get`
 
 ```text
+Get one configured gateway
+
 Usage: get [OPTIONS] <NAME>
 
 Arguments:
@@ -1027,6 +1086,8 @@ Options:
 ## `labby gateway test`
 
 ```text
+Test a configured or proposed gateway without saving it
+
 Usage: test [OPTIONS]
 
 Options:
@@ -1052,6 +1113,8 @@ Options:
 ## `labby gateway add`
 
 ```text
+Add a gateway and reconcile runtime state
+
 Usage: add [OPTIONS] --name <NAME>
 
 Options:
@@ -1092,6 +1155,8 @@ Options:
 ## `labby gateway update`
 
 ```text
+Update a gateway and reconcile runtime state
+
 Usage: update [OPTIONS] <NAME>
 
 Arguments:
@@ -1136,6 +1201,8 @@ Options:
 ## `labby gateway remove`
 
 ```text
+Remove a gateway and reconcile runtime state
+
 Usage: remove [OPTIONS] <NAME>
 
 Arguments:
@@ -1159,11 +1226,14 @@ Options:
 ## `labby gateway quarantine`
 
 ```text
+Manage Lab-backed virtual servers quarantined during config migration
+
 Usage: quarantine [OPTIONS] <COMMAND>
 
 Commands:
-  list
-  restore
+  list     List Lab-backed virtual servers quarantined during config migration
+  restore  Restore a quarantined Lab-backed virtual server into the active gateway list
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -1182,6 +1252,8 @@ Options:
 ## `labby gateway quarantine list`
 
 ```text
+List Lab-backed virtual servers quarantined during config migration
+
 Usage: list [OPTIONS]
 
 Options:
@@ -1201,6 +1273,8 @@ Options:
 ## `labby gateway quarantine restore`
 
 ```text
+Restore a quarantined Lab-backed virtual server into the active gateway list
+
 Usage: restore [OPTIONS] <ID>
 
 Arguments:
@@ -1221,18 +1295,33 @@ Options:
           Print help
 ```
 
+## `labby gateway quarantine help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby gateway protected-route`
 
 ```text
+Manage public MCP routes protected by Lab OAuth
+
 Usage: protected-route [OPTIONS] <COMMAND>
 
 Commands:
-  list
-  get
-  add
-  update
-  remove
-  test
+  list    List Gateway-managed public MCP routes protected by Lab OAuth
+  get     Get one Gateway-managed protected MCP route
+  add     Add a Gateway-managed protected MCP route
+  update  Replace a Gateway-managed protected MCP route
+  remove  Remove a Gateway-managed protected MCP route
+  test    Validate a proposed protected MCP route without saving it
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -1251,6 +1340,8 @@ Options:
 ## `labby gateway protected-route list`
 
 ```text
+List Gateway-managed public MCP routes protected by Lab OAuth
+
 Usage: list [OPTIONS]
 
 Options:
@@ -1270,6 +1361,8 @@ Options:
 ## `labby gateway protected-route get`
 
 ```text
+Get one Gateway-managed protected MCP route
+
 Usage: get [OPTIONS] <NAME>
 
 Arguments:
@@ -1293,6 +1386,8 @@ Options:
 ## `labby gateway protected-route add`
 
 ```text
+Add a Gateway-managed protected MCP route
+
 Usage: add [OPTIONS] --name <NAME> --public-host <PUBLIC_HOST> --public-path <PUBLIC_PATH>
 
 Options:
@@ -1336,6 +1431,8 @@ Options:
 ## `labby gateway protected-route update`
 
 ```text
+Replace a Gateway-managed protected MCP route
+
 Usage: update [OPTIONS] --public-host <PUBLIC_HOST> --public-path <PUBLIC_PATH> <NAME>
 
 Arguments:
@@ -1383,6 +1480,8 @@ Options:
 ## `labby gateway protected-route remove`
 
 ```text
+Remove a Gateway-managed protected MCP route
+
 Usage: remove [OPTIONS] <NAME>
 
 Arguments:
@@ -1406,6 +1505,8 @@ Options:
 ## `labby gateway protected-route test`
 
 ```text
+Validate a proposed protected MCP route without saving it
+
 Usage: test [OPTIONS] --name <NAME> --public-host <PUBLIC_HOST> --public-path <PUBLIC_PATH>
 
 Options:
@@ -1446,15 +1547,30 @@ Options:
           Print help
 ```
 
+## `labby gateway protected-route help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby gateway tool-search`
 
 ```text
+Configure gateway-wide tool_search/tool_execute mode
+
 Usage: tool-search [OPTIONS] <COMMAND>
 
 Commands:
-  status
-  enable
-  disable
+  status   Read the gateway-wide tool_search settings
+  enable   Enable gateway-wide tool_search/tool_execute mode for all exposed upstream tools
+  disable  Disable gateway-wide tool_search/tool_execute mode
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -1473,6 +1589,8 @@ Options:
 ## `labby gateway tool-search status`
 
 ```text
+Read the gateway-wide tool_search settings
+
 Usage: status [OPTIONS]
 
 Options:
@@ -1492,6 +1610,8 @@ Options:
 ## `labby gateway tool-search enable`
 
 ```text
+Enable gateway-wide tool_search/tool_execute mode for all exposed upstream tools
+
 Usage: enable [OPTIONS]
 
 Options:
@@ -1517,6 +1637,8 @@ Options:
 ## `labby gateway tool-search disable`
 
 ```text
+Disable gateway-wide tool_search/tool_execute mode
+
 Usage: disable [OPTIONS]
 
 Options:
@@ -1533,9 +1655,23 @@ Options:
           Print help
 ```
 
+## `labby gateway tool-search help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby gateway reload`
 
 ```text
+Reload gateways from config and reconcile runtime state
+
 Usage: reload [OPTIONS]
 
 Options:
@@ -1555,14 +1691,17 @@ Options:
 ## `labby gateway mcp`
 
 ```text
+Manage upstream MCP server lifecycle and OAuth
+
 Usage: mcp [OPTIONS] <COMMAND>
 
 Commands:
-  auth
-  list
-  enable
-  disable
-  cleanup
+  auth     Manage upstream MCP server OAuth credentials
+  list     List upstream MCP runtime state, discovery counts, and likely stale process counts
+  enable   Enable an upstream MCP server so new sessions discover and proxy it again
+  disable  Disable an upstream MCP server and optionally clean up running processes
+  cleanup  Kill or preview running processes associated with one upstream MCP server
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -1581,13 +1720,16 @@ Options:
 ## `labby gateway mcp auth`
 
 ```text
+Manage upstream MCP server OAuth credentials
+
 Usage: auth [OPTIONS] <COMMAND>
 
 Commands:
-  start
-  open
-  status
-  clear
+  start   Start the upstream OAuth flow and print the browser authorization URL
+  open    Start the upstream OAuth flow and open the authorization URL in a browser
+  status  Read upstream OAuth status for the shared gateway credential
+  clear   Clear stored upstream OAuth credentials for the shared gateway credential
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -1606,6 +1748,8 @@ Options:
 ## `labby gateway mcp auth start`
 
 ```text
+Start the upstream OAuth flow and print the browser authorization URL
+
 Usage: start [OPTIONS] <NAME>
 
 Arguments:
@@ -1641,6 +1785,8 @@ Options:
 ## `labby gateway mcp auth open`
 
 ```text
+Start the upstream OAuth flow and open the authorization URL in a browser
+
 Usage: open [OPTIONS] <NAME>
 
 Arguments:
@@ -1676,6 +1822,8 @@ Options:
 ## `labby gateway mcp auth status`
 
 ```text
+Read upstream OAuth status for the shared gateway credential
+
 Usage: status [OPTIONS] <NAME>
 
 Arguments:
@@ -1711,6 +1859,8 @@ Options:
 ## `labby gateway mcp auth clear`
 
 ```text
+Clear stored upstream OAuth credentials for the shared gateway credential
+
 Usage: clear [OPTIONS] <NAME>
 
 Arguments:
@@ -1743,9 +1893,23 @@ Options:
           Print help
 ```
 
+## `labby gateway mcp auth help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby gateway mcp list`
 
 ```text
+List upstream MCP runtime state, discovery counts, and likely stale process counts
+
 Usage: list [OPTIONS]
 
 Options:
@@ -1765,6 +1929,8 @@ Options:
 ## `labby gateway mcp enable`
 
 ```text
+Enable an upstream MCP server so new sessions discover and proxy it again
+
 Usage: enable [OPTIONS] <NAME>
 
 Arguments:
@@ -1797,6 +1963,8 @@ Options:
 ## `labby gateway mcp disable`
 
 ```text
+Disable an upstream MCP server and optionally clean up running processes
+
 Usage: disable [OPTIONS] <NAME>
 
 Arguments:
@@ -1829,6 +1997,8 @@ Options:
 ## `labby gateway mcp cleanup`
 
 ```text
+Kill or preview running processes associated with one upstream MCP server
+
 Usage: cleanup [OPTIONS] <NAME>
 
 Arguments:
@@ -1853,6 +2023,18 @@ Options:
 
   -h, --help
           Print help
+```
+
+## `labby gateway mcp help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
 ```
 
 ## `labby gateway discover`
@@ -1926,6 +2108,7 @@ Commands:
   list     List discovered servers waiting for approval
   approve  Approve a pending server and add it to the gateway (disabled by default)
   reject   Reject a pending server and tombstone it so it never re-appears
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2024,6 +2207,18 @@ Options:
           Print help
 ```
 
+## `labby gateway pending help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby gateway public-urls`
 
 ```text
@@ -2054,6 +2249,7 @@ Usage: code [OPTIONS] <COMMAND>
 
 Commands:
   exec  Execute a sandboxed JavaScript snippet that calls the typed `codemode.<upstream>.<tool>` helpers (or `callTool` directly). Cloudflare-parity: the `code` MCP tool takes only `{ code }`, so the CLI mirrors that — no separate `search` subcommand
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2096,6 +2292,30 @@ Options:
           Print help
 ```
 
+## `labby gateway code help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
+## `labby gateway help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby oauth`
 
 ```text
@@ -2104,7 +2324,8 @@ Run local OAuth callback relay helpers
 Usage: oauth [OPTIONS] <COMMAND>
 
 Commands:
-  relay-local
+  relay-local  Run a local OAuth callback relay that forwards to a machine or explicit target
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2123,6 +2344,8 @@ Options:
 ## `labby oauth relay-local`
 
 ```text
+Run a local OAuth callback relay that forwards to a machine or explicit target
+
 Usage: relay-local [OPTIONS] --port <PORT> <--machine <MACHINE>|--forward-base <FORWARD_BASE>>
 
 Options:
@@ -2148,6 +2371,18 @@ Options:
           Print help
 ```
 
+## `labby oauth help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby logs`
 
 ```text
@@ -2159,6 +2394,7 @@ Commands:
   search   Search fleet logs for a device from the master control plane
   local    Search or inspect the local-master runtime log store
   forward  Forward this node's syslog to the master log store (peer mode)
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2214,6 +2450,7 @@ Commands:
   tail    Read a bounded follow-up window from the persistent local log store
   stats   Inspect local retention and drop counters
   stream  Live push is HTTP SSE only in v1; this command fails with guidance
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2355,6 +2592,18 @@ Options:
           Print help
 ```
 
+## `labby logs local help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby logs forward`
 
 ```text
@@ -2399,6 +2648,18 @@ Options:
           Print help
 ```
 
+## `labby logs help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby marketplace`
 
 ```text
@@ -2408,6 +2669,7 @@ Usage: marketplace [OPTIONS] [ACTION] [COMMAND]
 
 Commands:
   generate  Generate a Claude Code marketplace tree from compiled-in PluginMeta
+  help      Print this message or the help of the given subcommand(s)
 
 Arguments:
   [ACTION]
@@ -2470,6 +2732,18 @@ Options:
           Print help
 ```
 
+## `labby marketplace help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby registry`
 
 ```text
@@ -2479,6 +2753,7 @@ Usage: registry [OPTIONS] <COMMAND>
 
 Commands:
   install  Fetch a server from the MCP registry and add it to the local gateway
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2533,6 +2808,18 @@ Options:
           Print help (see a summary with '-h')
 ```
 
+## `labby registry help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
 ## `labby stash`
 
 ```text
@@ -2582,6 +2869,7 @@ Commands:
   run          Destructive: build, transfer, install, restart, verify
   rollback     Destructive: restore the most recent backup on each target
   monitor      Watch SSH hosts and emit JSON events when they go online or offline
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --json
@@ -2750,4 +3038,28 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+```
+
+## `labby deploy help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
+## `labby help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
 ```


### PR DESCRIPTION
## What

Themes `labby`'s clap help and error output with the Aurora palette, and keeps the custom service+action catalog as the root help screen.

- **`crates/lab/src/cli/style.rs`** (new) — `AURORA_STYLES` built from `output::theme::aurora` ANSI-256 indices, applied once at the root `#[command]` so it propagates to every subcommand. Headers/usage = primary cyan; literals = strong cyan; placeholders = violet; valid/invalid/error = status triad.
- **`crates/lab/src/main.rs`** — pre-parse shim: root `help` / `--help` / `-h` renders the Aurora catalog (which clap can't express via derive); every non-root help path (`gateway --help`, `help gateway`) falls through to clap's now-themed output. `ColorChoice` is derived from the resolved `ColorPolicy`, so `--color` / `NO_COLOR` / `LAB_LOG_COLOR` govern help color and log color identically (single source of truth shared with `init_tracing`).
- **`crates/lab/src/cli.rs`** — wires `styles`, removes the now-dead `Help` subcommand variant/arm, drops `disable_help_subcommand` so `help <sub>` works.
- **`gateway.rs` / `oauth.rs`** — doc comments on subcommand variants (now surfaced in themed help) + minor gateway-list rendering tweak.
- `Cargo.toml` — adds clap `color` feature; bumps workspace to `0.21.4`.
- `docs/generated/cli-help.md` regenerated (stays ANSI-free via `render_long_help`).

## Verification

- `cargo build --workspace --all-features` ✓
- `cargo clippy --workspace --all-features -- -D warnings` ✓ / `cargo fmt --check` ✓
- `cargo nextest run --workspace --all-features` → 1615 passed (1 pre-existing flaky: `gateway_mcp_cleanup_dispatch_returns_cleanup_payload`, passes on retry, unrelated to these changes)
- `labby docs check` → 15 artifacts fresh

Manual smoke: `help` / `--help` / `-h` render the colored catalog; `gateway --help` and `help gateway` render themed clap help; `--color plain`, `NO_COLOR=1`, and piped/non-TTY output are all ANSI-free.

> Note: builds must run locally (`CARGO_BUILD_RUSTC_WRAPPER=""`) — `boa_engine` (pulled by code_mode) is non-distributable and breaks under sccache-dist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aurora-themed `clap` help and errors across `labby`, with a root help shim that shows the service+action catalog. Global flags around `help` are honored, and help/log colors stay in sync via one policy.

- **Bug Fixes**
  - Root help now captures global flags before/after the trigger and `--all` (e.g., `labby help --json`, `labby -h --json`), while `help <sub>` still falls through to themed `clap`.
  - Themed help respects `--color` even when `--help` short-circuits by pre-setting `clap::ColorChoice`; root-catalog errors print to stderr before tracing initialization.
  - Fix test build: drop unnecessary `rmcp` qualifications in upstream testsupport to satisfy `unused_qualifications` in CI; no behavior change.

<sup>Written for commit 256688cdf582fb7b48b99d449b7fa2a9584ed891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aurora-themed styling for CLI help and error messages with ANSI colors
  * Root-level help requests now display a catalog view instead of standard help text
  * Improved gateway server status display with updated emoji formatting

* **Documentation**
  * Enhanced documentation for CLI commands and subcommands

* **Chores**
  * Workspace version updated to 0.21.4
  * Added color feature support to CLI dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->