### PR TITLE
fix(code_mode): normalize export-default arrow with a prologue

### DIFF
--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -45,7 +45,47 @@ pub fn normalize_user_code(code: &str) -> String {
         }
         return normalize_user_code(inner);
     }
+    // `{prologue} export default <value>` — a `export default` after prologue
+    // statements. Boa's AST path either drops the prologue (its
+    // DefaultAssignmentExpression / function / class arms render only the export
+    // declaration) or cannot parse the form at all (an *arrow* in default-export
+    // position). Handle it textually instead: re-derive the no-prologue entry
+    // (reusing the start-anchored handling above), then run the prologue first and
+    // invoke that entry inside one wrapper so the entry closes over the prologue's
+    // bindings. The start-anchored case returned earlier, so this only fires when
+    // a real prologue precedes the export.
+    if let Some((prologue, value)) = split_prologue_export_default(code) {
+        let value = value.trim().trim_end_matches(';').trim();
+        if !value.is_empty() {
+            let entry = normalize_user_code(&format!("export default {value}"));
+            return format!("async () => {{\n{prologue}\nreturn await ({entry})();\n}}");
+        }
+    }
     normalize_user_code_parsed(code).unwrap_or_else(|| wrap_loose_code_as_async_arrow(code))
+}
+
+/// Split `{prologue} export default {value}` into the prologue and the
+/// default-export value, but only when `export default` appears at a statement
+/// boundary after a non-empty prologue (the prologue ends at a `;` or `}`).
+///
+/// This is a conservative textual fallback used only after the AST-based
+/// normalizers fail — which happens for an arrow function in default-export
+/// position, since Boa's `parse_module` cannot parse that form. The boundary
+/// check keeps it from firing on an `export default` substring inside an
+/// expression. The start-anchored `export default` case is handled earlier in
+/// `normalize_user_code`, so this only fires when a real prologue is present.
+fn split_prologue_export_default(code: &str) -> Option<(&str, &str)> {
+    const NEEDLE: &str = "export default ";
+    let mut from = 0;
+    while let Some(rel) = code[from..].find(NEEDLE) {
+        let idx = from + rel;
+        let before = code[..idx].trim_end();
+        if !before.is_empty() && (before.ends_with(';') || before.ends_with('}')) {
+            return Some((before, &code[idx + NEEDLE.len()..]));
+        }
+        from = idx + NEEDLE.len();
+    }
+    None
 }
 
 fn wrap_loose_code_as_async_arrow(code: &str) -> String {

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -45,15 +45,18 @@ pub fn normalize_user_code(code: &str) -> String {
         }
         return normalize_user_code(inner);
     }
-    // `{prologue} export default <value>` — a `export default` after prologue
-    // statements. Boa's AST path either drops the prologue (its
-    // DefaultAssignmentExpression / function / class arms render only the export
-    // declaration) or cannot parse the form at all (an *arrow* in default-export
-    // position). Handle it textually instead: re-derive the no-prologue entry
-    // (reusing the start-anchored handling above), then run the prologue first and
-    // invoke that entry inside one wrapper so the entry closes over the prologue's
-    // bindings. The start-anchored case returned earlier, so this only fires when
-    // a real prologue precedes the export.
+    if let Some(normalized) = normalize_user_code_parsed(code) {
+        return normalized;
+    }
+    // Reached only when the code parses as neither a module nor a script — i.e.
+    // an *arrow* function in `export default` position after a prologue
+    // (`const x = 1; export default async () => x`): Boa's parse_module cannot
+    // parse an arrow default export, and `export` is invalid in a script, so both
+    // parses above returned `None`. Recover textually here. This is safe against
+    // false positives: valid script code that merely contains the literal
+    // "; export default " (e.g. inside a string) parses as a script above and
+    // never reaches this point. Run the prologue first and invoke the no-prologue
+    // entry inside one wrapper so it closes over the prologue's bindings.
     if let Some((prologue, value)) = split_prologue_export_default(code) {
         let value = value.trim().trim_end_matches(';').trim();
         if !value.is_empty() {
@@ -61,7 +64,7 @@ pub fn normalize_user_code(code: &str) -> String {
             return format!("async () => {{\n{prologue}\nreturn await ({entry})();\n}}");
         }
     }
-    normalize_user_code_parsed(code).unwrap_or_else(|| wrap_loose_code_as_async_arrow(code))
+    wrap_loose_code_as_async_arrow(code)
 }
 
 /// Split `{prologue} export default {value}` into the prologue and the
@@ -80,7 +83,11 @@ fn split_prologue_export_default(code: &str) -> Option<(&str, &str)> {
     while let Some(rel) = code[from..].find(NEEDLE) {
         let idx = from + rel;
         let before = code[..idx].trim_end();
-        if !before.is_empty() && (before.ends_with(';') || before.ends_with('}')) {
+        // Skip a trailing line/block comment when checking the statement boundary
+        // so `const x = 1; // note\nexport default ...` still splits. The comment
+        // is kept in the returned prologue (harmless — it precedes the `return`).
+        let boundary = strip_trailing_comment(before).trim_end();
+        if !boundary.is_empty() && (boundary.ends_with(';') || boundary.ends_with('}')) {
             return Some((before, &code[idx + NEEDLE.len()..]));
         }
         from = idx + NEEDLE.len();
@@ -132,32 +139,44 @@ fn normalize_module_code(source: &str) -> Option<String> {
     let module = parser
         .parse_module(&boa_ast::scope::Scope::new_global(), &mut interner)
         .ok()?;
-    // Find the `export default` declaration among the module items, ignoring any
-    // import/other prologue items. Requiring exactly one item made a module with
-    // a prologue (e.g. `const x = 1; export default async () => x`) fall through
-    // to the loose-wrap path and produce invalid wrapper JS.
-    let export = module.items().items().iter().find_map(|item| {
-        if let boa_ast::ModuleItem::ExportDeclaration(export) = item {
-            Some(export)
-        } else {
-            None
+    // Separate the `export default` declaration from any prologue statements, so a
+    // module with leading statements (`const x = 1; export default <X>`) keeps
+    // those bindings. Rendering only the export left the default's free variables
+    // undefined at runtime. Imports are skipped — the sandbox has no module loader.
+    let mut prologue: Vec<String> = Vec::new();
+    let mut export = None;
+    for item in module.items().items() {
+        match item {
+            boa_ast::ModuleItem::ExportDeclaration(decl) => export = Some(decl),
+            boa_ast::ModuleItem::ImportDeclaration(_) => {}
+            boa_ast::ModuleItem::StatementListItem(stmt) => {
+                prologue.push(stmt.to_indented_string(&interner, 0));
+            }
         }
-    })?;
-    match export.as_ref() {
+    }
+    let entry = match export?.as_ref() {
         boa_ast::declaration::ExportDeclaration::DefaultAssignmentExpression(expr) => {
-            Some(normalize_user_code(&expr.to_interned_string(&interner)))
+            normalize_user_code(&expr.to_interned_string(&interner))
         }
-        boa_ast::declaration::ExportDeclaration::DefaultFunctionDeclaration(function) => Some(
-            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0)),
-        ),
-        boa_ast::declaration::ExportDeclaration::DefaultAsyncFunctionDeclaration(function) => Some(
-            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0)),
-        ),
-        boa_ast::declaration::ExportDeclaration::DefaultClassDeclaration(class) => Some(format!(
+        boa_ast::declaration::ExportDeclaration::DefaultFunctionDeclaration(function) => {
+            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0))
+        }
+        boa_ast::declaration::ExportDeclaration::DefaultAsyncFunctionDeclaration(function) => {
+            wrap_default_fn_as_iife(&function.to_indented_string(&interner, 0))
+        }
+        boa_ast::declaration::ExportDeclaration::DefaultClassDeclaration(class) => format!(
             "async () => {{\nreturn ({});\n}}",
             class.to_indented_string(&interner, 0)
-        )),
-        _ => None,
+        ),
+        _ => return None,
+    };
+    if prologue.is_empty() {
+        Some(entry)
+    } else {
+        let prologue = prologue.join("\n");
+        Some(format!(
+            "async () => {{\n{prologue}\nreturn await ({entry})();\n}}"
+        ))
     }
 }
 

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -269,14 +269,17 @@ fn strip_prologue_exports(prologue: &str) -> String {
     else {
         return prologue.to_string();
     };
-    // Only rewrite when the prologue actually carries a named export; otherwise
-    // keep the verbatim text so re-rendering never perturbs the common case.
-    let has_named_export = module
+    // Only rewrite when the prologue carries a non-statement item — a named
+    // export whose `export` keyword must be stripped, or an `import` that must be
+    // dropped (no loader in the sandbox; left verbatim it is a syntax error inside
+    // the wrapper). A pure-statement prologue is kept verbatim so re-rendering
+    // never perturbs the common case.
+    let needs_rewrite = module
         .items()
         .items()
         .iter()
-        .any(|item| matches!(item, boa_ast::ModuleItem::ExportDeclaration(_)));
-    if !has_named_export {
+        .any(|item| !matches!(item, boa_ast::ModuleItem::StatementListItem(_)));
+    if !needs_rewrite {
         return prologue.to_string();
     }
     module

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -76,23 +76,29 @@ pub fn normalize_user_code(code: &str) -> String {
 /// default-export value, but only when `export default` appears at a statement
 /// boundary after a non-empty prologue (the prologue ends at a `;` or `}`).
 ///
-/// This is a conservative textual fallback used only after the AST-based
-/// normalizers fail — which happens for an arrow function in default-export
-/// position, since Boa's `parse_module` cannot parse that form. The boundary
-/// check keeps it from firing on an `export default` substring inside an
-/// expression. The start-anchored `export default` case is handled earlier in
-/// `normalize_user_code`, so this only fires when a real prologue is present.
+/// This is a conservative textual fallback. String-literal safety does NOT come
+/// from this function — it comes from the caller: this runs only after both the
+/// module and script parses fail, so any valid script that merely contains
+/// `; export default` inside a string parses as a script first and never reaches
+/// here (see `normalize_user_code` and the `..._inside_a_string` test). The
+/// start-anchored `export default` case is also handled earlier, so this only
+/// fires when a real prologue precedes an otherwise-unparseable arrow default.
 fn split_prologue_export_default(code: &str) -> Option<(&str, &str)> {
     const NEEDLE: &str = "export default ";
     let mut from = 0;
     while let Some(rel) = code[from..].find(NEEDLE) {
         let idx = from + rel;
         let before = code[..idx].trim_end();
-        // Skip a trailing line/block comment when checking the statement boundary
-        // so `const x = 1; // note\nexport default ...` still splits. The comment
-        // is kept in the returned prologue (harmless — it precedes the `return`).
-        let boundary = strip_trailing_comment(before).trim_end();
-        if !boundary.is_empty() && (boundary.ends_with(';') || boundary.ends_with('}')) {
+        // A real statement terminator wins as-is. Only when `before` does not
+        // already end at a boundary do we retry after stripping a trailing
+        // comment, so `const x = 1; // note\nexport default ...` still splits —
+        // without letting a `//` *inside* a prologue string (e.g. a "http://"
+        // URL) corrupt an otherwise-terminated prologue.
+        let ends_at_boundary = |s: &str| s.ends_with(';') || s.ends_with('}');
+        let comment_stripped = strip_trailing_comment(before).trim_end();
+        if (!before.is_empty() && ends_at_boundary(before))
+            || (!comment_stripped.is_empty() && ends_at_boundary(comment_stripped))
+        {
             return Some((before, &code[idx + NEEDLE.len()..]));
         }
         from = idx + NEEDLE.len();
@@ -187,7 +193,17 @@ fn normalize_module_code(source: &str) -> Option<String> {
 
 /// Wrap a rendered `export default` function declaration as an immediately
 /// invoked expression inside an async arrow wrapper.
+///
+/// Boa renders an *anonymous* `export default [async] function() {...}` with the
+/// synthesized name `default` (`async function default() {...}`). `default` is a
+/// reserved word, so that is a syntax error when used as an expression in the
+/// IIFE. Drop the synthesized name to recover a valid anonymous function
+/// expression. (A genuinely named `export default function foo() {}` keeps `foo`
+/// and is untouched.)
 fn wrap_default_fn_as_iife(rendered: &str) -> String {
+    let rendered = rendered
+        .replacen("function default(", "function(", 1)
+        .replacen("function default (", "function (", 1);
     format!("async () => {{\nreturn ({rendered})();\n}}")
 }
 

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -22,6 +22,11 @@ use boa_parser::{Parser, Source as ParserSource};
 ///    function expression).
 /// 5. Loose statements / trailing expressions are wrapped in `async () => { ... }`;
 ///    if the trailing statement looks like an expression, it is returned.
+/// 6. `export default <X>` preceded by prologue statements
+///    (`const x = 1; export default async () => x`) keeps the prologue and
+///    invokes the default-export entry so it closes over those bindings —
+///    handled via the AST when Boa can parse it, and via a textual fallback for
+///    the one form it cannot (an arrow in default-export position).
 ///
 /// Only `execute` normalizes the caller's code through this before handing it to
 /// the Javy runner. `search` passes its code to the runner *raw* (no

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -144,6 +144,21 @@ fn normalize_user_code_parsed(source: &str) -> Option<String> {
     normalize_module_code(source).or_else(|| normalize_script_code(source))
 }
 
+/// Whether an export declaration is an `export default ...` form (vs a named
+/// export, `export { ... }`, or a re-export).
+fn is_default_export(decl: &boa_ast::declaration::ExportDeclaration) -> bool {
+    use boa_ast::declaration::ExportDeclaration as E;
+    matches!(
+        decl,
+        E::DefaultFunctionDeclaration(_)
+            | E::DefaultGeneratorDeclaration(_)
+            | E::DefaultAsyncFunctionDeclaration(_)
+            | E::DefaultAsyncGeneratorDeclaration(_)
+            | E::DefaultClassDeclaration(_)
+            | E::DefaultAssignmentExpression(_)
+    )
+}
+
 fn normalize_module_code(source: &str) -> Option<String> {
     let mut interner = Interner::default();
     let mut parser = Parser::new(ParserSource::from_bytes(source.as_bytes()));
@@ -158,11 +173,19 @@ fn normalize_module_code(source: &str) -> Option<String> {
     let mut export = None;
     for item in module.items().items() {
         match item {
-            boa_ast::ModuleItem::ExportDeclaration(decl) => export = Some(decl),
-            boa_ast::ModuleItem::ImportDeclaration(_) => {}
+            // Capture the `export default` declaration specifically — not just any
+            // export. A *named* export (`export const y = 1`, `export { ... }`, a
+            // re-export) after `export default` must not shadow the default and
+            // cause normalization to bail. Named exports have no entry/runtime
+            // role in the sandbox, so they (and imports) are skipped.
+            boa_ast::ModuleItem::ExportDeclaration(decl) if is_default_export(decl) => {
+                export = Some(decl);
+            }
             boa_ast::ModuleItem::StatementListItem(stmt) => {
                 prologue.push(stmt.to_indented_string(&interner, 0));
             }
+            boa_ast::ModuleItem::ExportDeclaration(_)
+            | boa_ast::ModuleItem::ImportDeclaration(_) => {}
         }
     }
     let entry = match export?.as_ref() {

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -68,6 +68,9 @@ pub fn normalize_user_code(code: &str) -> String {
     if let Some((prologue, value)) = split_prologue_export_default(code) {
         let value = value.trim().trim_end_matches(';').trim();
         if !value.is_empty() {
+            // The prologue is kept verbatim except for named exports, whose
+            // `export` keyword would be a syntax error inside the wrapper.
+            let prologue = strip_prologue_exports(prologue);
             let entry = normalize_user_code(&format!("export default {value}"));
             return format!("async () => {{\n{prologue}\nreturn await ({entry})();\n}}");
         }
@@ -98,9 +101,19 @@ fn split_prologue_export_default(code: &str) -> Option<(&str, &str)> {
         // without letting a `//` *inside* a prologue string (e.g. a "http://"
         // URL) corrupt an otherwise-terminated prologue.
         let ends_at_boundary = |s: &str| s.ends_with(';') || s.ends_with('}');
+        // `strip_trailing_comment` bails on any earlier `//` (it can't tell a
+        // string-internal `//` from a comment). That defeats a prologue whose
+        // tail holds both a "http://" URL string and a real trailing comment.
+        // `strip_suffix_line_comment` inspects only the last `//` on the final
+        // line, so it strips the genuine trailing comment regardless. A spurious
+        // strip can only split here if the text before that `//` already ends at
+        // a `;`/`}` — gated by `ends_at_boundary` and by this running only after
+        // both real parses failed.
         let comment_stripped = strip_trailing_comment(before).trim_end();
+        let suffix_stripped = strip_suffix_line_comment(before);
         if (!before.is_empty() && ends_at_boundary(before))
             || (!comment_stripped.is_empty() && ends_at_boundary(comment_stripped))
+            || (!suffix_stripped.is_empty() && ends_at_boundary(suffix_stripped))
         {
             return Some((before, &code[idx + NEEDLE.len()..]));
         }
@@ -175,20 +188,20 @@ fn normalize_module_code(source: &str) -> Option<String> {
     let mut prologue: Vec<String> = Vec::new();
     let mut export = None;
     for item in module.items().items() {
-        match item {
-            // Capture the `export default` declaration specifically — not just any
-            // export. A *named* export (`export const y = 1`, `export { ... }`, a
-            // re-export) after `export default` must not shadow the default and
-            // cause normalization to bail. Named exports have no entry/runtime
-            // role in the sandbox, so they (and imports) are skipped.
-            boa_ast::ModuleItem::ExportDeclaration(decl) if is_default_export(decl) => {
-                export = Some(decl);
-            }
-            boa_ast::ModuleItem::StatementListItem(stmt) => {
-                prologue.push(stmt.to_indented_string(&interner, 0));
-            }
-            boa_ast::ModuleItem::ExportDeclaration(_)
-            | boa_ast::ModuleItem::ImportDeclaration(_) => {}
+        // Capture the `export default` declaration specifically — not just any
+        // export. A *named* export (`export const y = 1`, `export { ... }`, a
+        // re-export) must not shadow the default and cause normalization to bail.
+        if let boa_ast::ModuleItem::ExportDeclaration(decl) = item
+            && is_default_export(decl)
+        {
+            export = Some(decl);
+            continue;
+        }
+        // Everything else: statements and binding-carrying named exports become
+        // prologue (with `export` stripped); imports / `export {}` lists / re-exports
+        // have no sandbox-runtime role and render to nothing.
+        if let Some(rendered) = render_prologue_item(item, &interner) {
+            prologue.push(rendered);
         }
     }
     let entry = match export?.as_ref() {
@@ -215,6 +228,64 @@ fn normalize_module_code(source: &str) -> Option<String> {
             "async () => {{\n{prologue}\nreturn await ({entry})();\n}}"
         ))
     }
+}
+
+/// Render a non-default module item as prologue source, with any `export` keyword
+/// stripped. Returns `None` for items with no sandbox-runtime role: `export default`
+/// (handled by the caller), `export { a, b }` lists, re-exports, and imports (the
+/// sandbox has no module loader). Binding-carrying named exports (`export const`,
+/// `export var`, `export function`, `export class`) keep their binding so a default
+/// that references them resolves at runtime.
+fn render_prologue_item(item: &boa_ast::ModuleItem, interner: &Interner) -> Option<String> {
+    match item {
+        boa_ast::ModuleItem::StatementListItem(stmt) => Some(stmt.to_indented_string(interner, 0)),
+        boa_ast::ModuleItem::ExportDeclaration(decl) => match decl.as_ref() {
+            boa_ast::declaration::ExportDeclaration::VarStatement(var) => {
+                Some(var.to_interned_string(interner))
+            }
+            boa_ast::declaration::ExportDeclaration::Declaration(d) => {
+                Some(d.to_indented_string(interner, 0))
+            }
+            _ => None,
+        },
+        boa_ast::ModuleItem::ImportDeclaration(_) => None,
+    }
+}
+
+/// Strip `export` keywords from a textual-fallback prologue by reparsing it.
+///
+/// The async-arrow `export default` fallback keeps the prologue verbatim, but a
+/// prologue may carry named exports (`export const helper = ...`) whose `export`
+/// keyword is a syntax error inside the generated `async () => { ... }` wrapper.
+/// Unlike the full input, the prologue alone has no async-arrow default and so
+/// parses cleanly as a module — reparse it and re-render statements and
+/// binding-carrying named exports without `export`. Returns the prologue unchanged
+/// if it does not parse as a module (e.g. a plain script prologue), preserving the
+/// prior behavior for the common no-named-export case.
+fn strip_prologue_exports(prologue: &str) -> String {
+    let mut interner = Interner::default();
+    let mut parser = Parser::new(ParserSource::from_bytes(prologue.as_bytes()));
+    let Ok(module) = parser.parse_module(&boa_ast::scope::Scope::new_global(), &mut interner)
+    else {
+        return prologue.to_string();
+    };
+    // Only rewrite when the prologue actually carries a named export; otherwise
+    // keep the verbatim text so re-rendering never perturbs the common case.
+    let has_named_export = module
+        .items()
+        .items()
+        .iter()
+        .any(|item| matches!(item, boa_ast::ModuleItem::ExportDeclaration(_)));
+    if !has_named_export {
+        return prologue.to_string();
+    }
+    module
+        .items()
+        .items()
+        .iter()
+        .filter_map(|item| render_prologue_item(item, &interner))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Wrap a rendered `export default` function declaration as an immediately
@@ -324,6 +395,23 @@ fn strip_trailing_statement_semicolon(source: &str) -> String {
         || trimmed.to_string(),
         |without| without.trim_end().to_string(),
     )
+}
+
+/// Strip a trailing `// ...` line comment, inspecting only the last `//` on the
+/// final line. Unlike [`strip_trailing_comment`], this tolerates an earlier `//`
+/// elsewhere in `source` (e.g. inside a `"http://..."` URL string in a prologue).
+///
+/// Only [`split_prologue_export_default`] uses this, where the result feeds a
+/// `;`/`}` boundary check — a string-internal last `//` produces a non-boundary
+/// remainder and is rejected there, so this loose strip is safe in that context
+/// but is NOT a general-purpose comment stripper.
+fn strip_suffix_line_comment(source: &str) -> &str {
+    let trimmed = source.trim_end();
+    let line_start = trimmed.rfind('\n').map_or(0, |i| i + 1);
+    match trimmed[line_start..].rfind("//") {
+        Some(rel) => trimmed[..line_start + rel].trim_end(),
+        None => trimmed,
+    }
 }
 
 /// Remove a single trailing `// ...` line comment or `/* ... */` block comment

--- a/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/normalize.rs
@@ -26,7 +26,8 @@ use boa_parser::{Parser, Source as ParserSource};
 ///    (`const x = 1; export default async () => x`) keeps the prologue and
 ///    invokes the default-export entry so it closes over those bindings —
 ///    handled via the AST when Boa can parse it, and via a textual fallback for
-///    the one form it cannot (an arrow in default-export position).
+///    the one form it cannot (an *async* arrow in default-export position; a
+///    plain arrow parses as a DefaultAssignmentExpression and uses the AST).
 ///
 /// Only `execute` normalizes the caller's code through this before handing it to
 /// the Javy runner. `search` passes its code to the runner *raw* (no
@@ -54,10 +55,12 @@ pub fn normalize_user_code(code: &str) -> String {
         return normalized;
     }
     // Reached only when the code parses as neither a module nor a script — i.e.
-    // an *arrow* function in `export default` position after a prologue
+    // an *async arrow* function in `export default` position after a prologue
     // (`const x = 1; export default async () => x`): Boa's parse_module cannot
-    // parse an arrow default export, and `export` is invalid in a script, so both
-    // parses above returned `None`. Recover textually here. This is safe against
+    // parse an *async* arrow default export (a plain arrow parses fine as a
+    // DefaultAssignmentExpression and takes the AST path), and `export` is invalid
+    // in a script, so both parses above returned `None`. Recover textually here.
+    // This is safe against
     // false positives: valid script code that merely contains the literal
     // "; export default " (e.g. inside a string) parses as a script above and
     // never reaches this point. Run the prologue first and invoke the no-prologue
@@ -224,10 +227,27 @@ fn normalize_module_code(source: &str) -> Option<String> {
 /// expression. (A genuinely named `export default function foo() {}` keeps `foo`
 /// and is untouched.)
 fn wrap_default_fn_as_iife(rendered: &str) -> String {
-    let rendered = rendered
-        .replacen("function default(", "function(", 1)
-        .replacen("function default (", "function (", 1);
+    let rendered = strip_synthesized_default_name(rendered);
     format!("async () => {{\nreturn ({rendered})();\n}}")
+}
+
+/// Remove Boa's synthesized `default` name from an anonymous default-export
+/// function (`[async] function default(...)`), anchored at the leading function
+/// keyword. Anchoring matters: an unanchored replace would also rewrite a
+/// `function default(` substring appearing *inside* the body (e.g. in a string
+/// literal of a genuinely-named default export), silently corrupting it.
+fn strip_synthesized_default_name(rendered: &str) -> String {
+    for (synthesized, anonymous) in [
+        ("async function default(", "async function("),
+        ("async function default (", "async function ("),
+        ("function default(", "function("),
+        ("function default (", "function ("),
+    ] {
+        if let Some(rest) = rendered.strip_prefix(synthesized) {
+            return format!("{anonymous}{rest}");
+        }
+    }
+    rendered.to_string()
 }
 
 fn normalize_script_code(source: &str) -> Option<String> {

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -144,7 +144,10 @@ fn normalize_user_code_wraps_export_default_plain_arrow_with_prologue() {
     let result = super::normalize_user_code("const n = 7;\nexport default () => n;");
     assert!(!result.contains("export default"), "got: {result}");
     assert!(result.starts_with("async () => {"), "got: {result}");
-    assert!(result.contains("const n = 7"), "prologue must be kept: {result}");
+    assert!(
+        result.contains("const n = 7"),
+        "prologue must be kept: {result}"
+    );
     // Boa reformats the arrow body (`() => n` → `() => { return n; }`), so assert
     // behavior, not exact shape: the prologue runs and the arrow (which returns n)
     // is invoked, not returned uncalled.
@@ -152,7 +155,10 @@ fn normalize_user_code_wraps_export_default_plain_arrow_with_prologue() {
         result.contains("return await ("),
         "the entry must be invoked: {result}"
     );
-    assert!(result.contains("return n"), "arrow body must reference n: {result}");
+    assert!(
+        result.contains("return n"),
+        "arrow body must reference n: {result}"
+    );
 }
 
 #[test]
@@ -182,6 +188,35 @@ fn normalize_user_code_export_default_arrow_with_trailing_comment_prologue() {
     assert!(result.starts_with("async () => {"), "got: {result}");
     assert!(result.contains("const x = 1"), "got: {result}");
     assert!(result.contains("(async () => x)()"), "got: {result}");
+}
+
+#[test]
+fn normalize_user_code_export_default_arrow_after_url_string_prologue() {
+    // Regression: a `//` inside a prologue string (e.g. a URL) must not corrupt
+    // the statement-boundary check. The prologue already ends at `;`, so the
+    // textual fallback must split rather than loose-wrap into invalid JS.
+    let result = super::normalize_user_code("const u = \"http://x\"; export default async () => u");
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(
+        result.contains("http://x"),
+        "prologue string must be kept: {result}"
+    );
+    assert!(result.contains("(async () => u)()"), "got: {result}");
+}
+
+#[test]
+fn normalize_user_code_export_default_class_with_prologue() {
+    // The DefaultClassDeclaration AST arm is only reachable with a prologue (a
+    // bare class default is caught by the start-anchored strip). Prologue kept.
+    let result = super::normalize_user_code("const base = 1;\nexport default class Foo {}");
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(
+        result.contains("base = 1"),
+        "prologue must be kept: {result}"
+    );
+    assert!(result.contains("class Foo"), "got: {result}");
 }
 
 #[test]
@@ -226,6 +261,14 @@ fn normalize_user_code_finds_export_default_after_prologue() {
         assert!(
             result.contains("base + 1"),
             "the default-export body must be preserved, got: {result}"
+        );
+        // Non-vacuous on the PR's core mechanism: the prologue `const base = 41`
+        // must survive (otherwise `base` is undefined at runtime). `base + 1`
+        // alone lives in the export body and would pass even if the prologue were
+        // dropped — this is the assertion that actually guards prologue scoping.
+        assert!(
+            result.contains("base = 41"),
+            "the prologue binding must be preserved, got: {result}"
         );
         assert!(
             result.trim_start().starts_with("async () =>") || result.trim_start().starts_with('('),

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -209,6 +209,64 @@ fn normalize_user_code_export_default_arrow_after_url_string_prologue() {
 }
 
 #[test]
+fn normalize_user_code_export_default_arrow_url_string_and_trailing_comment_prologue() {
+    // Regression (CodeRabbit): a prologue tail with BOTH a `//` inside a URL
+    // string AND a real trailing line comment. `strip_trailing_comment` bails
+    // (it sees two `//` and can't tell string from comment), so the suffix-only
+    // strip must carry the `;` boundary check and split rather than loose-wrap.
+    let result = super::normalize_user_code(
+        "const u = \"http://x\"; const x = 1; // note\nexport default async () => x",
+    );
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(
+        result.contains("http://x"),
+        "URL string must be kept whole, not corrupted by the strip: {result}"
+    );
+    assert!(result.contains("const x = 1"), "got: {result}");
+    assert!(result.contains("(async () => x)()"), "got: {result}");
+}
+
+#[test]
+fn normalize_user_code_keeps_named_export_binding_referenced_by_default() {
+    // Regression (cubic): a named export the default references must keep its
+    // binding in the prologue. Previously every named export was dropped, leaving
+    // the default's free variable undefined (ReferenceError) at runtime.
+    let result = super::normalize_user_code(
+        "export const helper = (n) => n * 2;\nexport default async () => helper(21)",
+    );
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(
+        !result.contains("export const"),
+        "the `export` keyword must be stripped from the named export: {result}"
+    );
+    assert!(
+        result.contains("helper"),
+        "the named-export binding must be kept in the prologue: {result}"
+    );
+    assert!(result.starts_with("async () => {"), "got: {result}");
+}
+
+#[test]
+fn normalize_user_code_keeps_export_var_and_export_function_bindings() {
+    // Both binding-carrying named-export forms reach the prologue: `export var`
+    // (VarStatement arm) and `export function` (Declaration arm).
+    let result = super::normalize_user_code(
+        "export var base = 40;\nexport function bump() { return base + 2; }\nexport default async () => bump()",
+    );
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(
+        !result.contains("export var") && !result.contains("export function"),
+        "the `export` keyword must be stripped from both named exports: {result}"
+    );
+    assert!(result.contains("base"), "export var binding kept: {result}");
+    assert!(
+        result.contains("function bump"),
+        "export function binding kept: {result}"
+    );
+}
+
+#[test]
 fn normalize_user_code_export_default_class_with_prologue() {
     // The DefaultClassDeclaration AST arm is only reachable with a prologue (a
     // bare class default is caught by the start-anchored strip). Prologue kept.

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -267,6 +267,23 @@ fn normalize_user_code_keeps_export_var_and_export_function_bindings() {
 }
 
 #[test]
+fn normalize_user_code_drops_import_in_async_arrow_default_prologue() {
+    // Regression (cubic, follow-up): a textual-fallback prologue containing only
+    // an `import` (no named export) must still be rewritten — the sandbox has no
+    // module loader, and a verbatim `import` inside the wrapper is a syntax error.
+    // Drop it (matching the module path), leaving at most a runtime ReferenceError
+    // rather than a parse failure that kills the whole script.
+    let result =
+        super::normalize_user_code("import { x } from \"y\";\nexport default async () => 1");
+    assert!(
+        !result.contains("import"),
+        "import must be dropped: {result}"
+    );
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+}
+
+#[test]
 fn normalize_user_code_export_default_class_with_prologue() {
     // The DefaultClassDeclaration AST arm is only reachable with a prologue (a
     // bare class default is caught by the start-anchored strip). Prologue kept.

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -220,6 +220,26 @@ fn normalize_user_code_export_default_class_with_prologue() {
 }
 
 #[test]
+fn normalize_user_code_export_default_with_trailing_named_export() {
+    // A named export *after* `export default` must not shadow the default in the
+    // module-item scan. This needs a prologue so the input does not start with
+    // `export default` (which would take the start-anchored strip) and instead
+    // goes through normalize_module_code. Pre-fix the scan captured the trailing
+    // `export const y` and bailed to an invalid loose-wrap.
+    let result = super::normalize_user_code("const x = 1;\nexport default x;\nexport const y = 2;");
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(
+        !result.contains("export const"),
+        "the trailing named export must not leak into the wrapper: {result}"
+    );
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(
+        result.contains("const x = 1"),
+        "prologue must be kept: {result}"
+    );
+}
+
+#[test]
 fn normalize_user_code_passthrough_for_plain_expressions() {
     let plain = "async () => callTool('lab::test', {})";
     let result = super::normalize_user_code(plain);

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -144,8 +144,44 @@ fn normalize_user_code_wraps_export_default_plain_arrow_with_prologue() {
     let result = super::normalize_user_code("const n = 7;\nexport default () => n;");
     assert!(!result.contains("export default"), "got: {result}");
     assert!(result.starts_with("async () => {"), "got: {result}");
-    assert!(result.contains("const n = 7"), "got: {result}");
-    assert!(result.contains("(() => n)()"), "got: {result}");
+    assert!(result.contains("const n = 7"), "prologue must be kept: {result}");
+    // Boa reformats the arrow body (`() => n` → `() => { return n; }`), so assert
+    // behavior, not exact shape: the prologue runs and the arrow (which returns n)
+    // is invoked, not returned uncalled.
+    assert!(
+        result.contains("return await ("),
+        "the entry must be invoked: {result}"
+    );
+    assert!(result.contains("return n"), "arrow body must reference n: {result}");
+}
+
+#[test]
+fn normalize_user_code_does_not_split_export_default_inside_a_string() {
+    // A valid script whose string literal merely contains "; export default "
+    // must parse as a script (returning the trailing expression `s`), not be
+    // split textually into a broken module wrapper. The textual fallback only
+    // runs after both parses fail, so this never reaches it.
+    let result = super::normalize_user_code("const s = \"; export default \"; s");
+    assert!(
+        !result.contains("return await ("),
+        "a string literal must not be IIFE-wrapped as an export default: {result}"
+    );
+    assert!(result.contains("const s ="), "prologue kept: {result}");
+    assert!(
+        result.contains("return (s)"),
+        "the trailing expression must be returned: {result}"
+    );
+}
+
+#[test]
+fn normalize_user_code_export_default_arrow_with_trailing_comment_prologue() {
+    // A trailing line comment after the prologue's `;` must not defeat the
+    // statement-boundary check for the textual arrow-default fallback.
+    let result = super::normalize_user_code("const x = 1; // note\nexport default async () => x");
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(result.contains("const x = 1"), "got: {result}");
+    assert!(result.contains("(async () => x)()"), "got: {result}");
 }
 
 #[test]

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -140,7 +140,10 @@ fn normalize_user_code_wraps_export_default_arrow_with_prologue() {
 
 #[test]
 fn normalize_user_code_wraps_export_default_plain_arrow_with_prologue() {
-    // Non-async arrow default export after a prologue — same parse limitation.
+    // A *plain* (non-async) arrow default export parses fine as a
+    // DefaultAssignmentExpression, so unlike the async arrow it goes through the
+    // AST path (normalize_module_code), not the textual fallback. The prologue
+    // must still be preserved and the arrow invoked.
     let result = super::normalize_user_code("const n = 7;\nexport default () => n;");
     assert!(!result.contains("export default"), "got: {result}");
     assert!(result.starts_with("async () => {"), "got: {result}");
@@ -236,6 +239,28 @@ fn normalize_user_code_export_default_with_trailing_named_export() {
     assert!(
         result.contains("const x = 1"),
         "prologue must be kept: {result}"
+    );
+}
+
+#[test]
+fn normalize_user_code_named_default_function_body_literal_not_corrupted() {
+    // wrap_default_fn_as_iife strips only Boa's synthesized leading `default`
+    // name. A genuinely-named default export whose body contains the literal
+    // `function default(` (here inside a string) must survive verbatim — an
+    // unanchored replace would corrupt it to `function(`. Needs a NAMED fn plus a
+    // prologue to route through the AST (a bare default takes the start-anchored
+    // strip path).
+    let result = super::normalize_user_code(
+        "const x = 1;\nexport default function named() { return \"function default(\"; }",
+    );
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(
+        result.contains("function named"),
+        "named function kept: {result}"
+    );
+    assert!(
+        result.contains("function default("),
+        "the string-literal body must survive verbatim, not be corrupted: {result}"
     );
 }
 

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_normalize.rs
@@ -112,6 +112,43 @@ fn normalize_user_code_wraps_export_default_sync_function_as_iife() {
 }
 
 #[test]
+fn normalize_user_code_wraps_export_default_arrow_with_prologue() {
+    // Boa's parse_module cannot parse an arrow in default-export position, so a
+    // module with a prologue (`const x = 1; export default async () => x`) used
+    // to fall through to loose-wrapping, which left `export default` inside the
+    // wrapper body and produced invalid JS. The prologue-aware fallback must turn
+    // it into a single valid function expression that runs the prologue and
+    // invokes the arrow (which closes over the prologue binding).
+    let result = super::normalize_user_code("const x = 1; export default async () => x");
+    assert!(
+        !result.contains("export default"),
+        "export default must be removed: {result}"
+    );
+    assert!(
+        result.starts_with("async () => {"),
+        "must be a bare async function expression: {result}"
+    );
+    assert!(
+        result.contains("const x = 1"),
+        "prologue must be kept: {result}"
+    );
+    assert!(
+        result.contains("(async () => x)()"),
+        "the arrow must be invoked so its result is returned: {result}"
+    );
+}
+
+#[test]
+fn normalize_user_code_wraps_export_default_plain_arrow_with_prologue() {
+    // Non-async arrow default export after a prologue — same parse limitation.
+    let result = super::normalize_user_code("const n = 7;\nexport default () => n;");
+    assert!(!result.contains("export default"), "got: {result}");
+    assert!(result.starts_with("async () => {"), "got: {result}");
+    assert!(result.contains("const n = 7"), "got: {result}");
+    assert!(result.contains("(() => n)()"), "got: {result}");
+}
+
+#[test]
 fn normalize_user_code_passthrough_for_plain_expressions() {
     let plain = "async () => callTool('lab::test', {})";
     let result = super::normalize_user_code(plain);

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -940,3 +940,22 @@ fn normalized_export_default_function_with_prologue_executes_end_to_end() {
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
+
+/// Multiple prologue statements — a function declaration the default closes over
+/// plus a `const` computed from it — must all land in runtime scope. Routes
+/// through the AST path (plain-arrow default → DefaultAssignmentExpression),
+/// exercising the `prologue.join("\n")` rendering rather than the single-`const`
+/// shape the other e2e tests use. Non-vacuous: a dropped prologue leaves `mk`/
+/// `tool` undefined, so no tool_call fires.
+#[test]
+fn normalized_export_default_multi_statement_prologue_executes_end_to_end() {
+    let body = "function mk() { return \"upstream::test::ping\"; }\n\
+                const tool = mk();\n\
+                export default () => callTool(tool, {});";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("async () =>") && !normalized.contains("export default"),
+        "normalize must emit executable script code without export syntax, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -903,3 +903,22 @@ fn normalized_export_default_arrow_with_prologue_executes_end_to_end() {
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
+
+/// The same prologue-preservation must hold for the *AST* path (a plain — non
+/// async — arrow in `export default` position parses as a DefaultAssignmentExpression,
+/// so it goes through `normalize_module_code`, not the textual fallback). Boa
+/// re-renders the arrow on round-trip, so string assertions can't prove the
+/// prologue binding is actually in runtime scope — this runs it. Non-vacuous: the
+/// arrow references the prologue `const tool`, so a dropped prologue would leave
+/// `tool` undefined and emit no tool_call.
+#[test]
+fn normalized_export_default_plain_arrow_with_prologue_executes_end_to_end() {
+    let body = "const tool = \"upstream::test::ping\";\n\
+                export default () => callTool(tool, {});";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("async () =>") && !normalized.contains("export default"),
+        "normalize must emit executable script code without export syntax, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -941,6 +941,25 @@ fn normalized_export_default_function_with_prologue_executes_end_to_end() {
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
 
+/// A *named* export the default references, with an async-arrow default — the
+/// textual fallback path (boa can't parse an async-arrow `export default`, so the
+/// whole module fails to parse and the prologue is recovered textually). The
+/// named export's `export` keyword must be stripped, otherwise it is a syntax
+/// error inside the wrapper and nothing runs. Non-vacuous: the default calls the
+/// `tool` binding from `export const`, so a dropped/un-stripped export emits no
+/// tool_call.
+#[test]
+fn normalized_async_arrow_default_with_named_export_executes_end_to_end() {
+    let body = "export const tool = \"upstream::test::ping\";\n\
+                export default async () => await callTool(tool, {});";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("async () =>") && !normalized.contains("export "),
+        "normalize must strip every `export` keyword, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}
+
 /// Multiple prologue statements — a function declaration the default closes over
 /// plus a `const` computed from it — must all land in runtime scope. Routes
 /// through the AST path (plain-arrow default → DefaultAssignmentExpression),

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -884,3 +884,22 @@ fn normalized_export_default_form_executes_end_to_end() {
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
+
+/// An arrow function in `export default` position *with a prologue*
+/// (`const tool = "..."; export default async () => callTool(tool, {})`) must
+/// execute end-to-end. Boa's parse_module cannot parse an arrow default export,
+/// and its AST arms drop the prologue, so this used to loose-wrap into invalid JS
+/// (or lose `tool`). Non-vacuous: the arrow references the prologue binding
+/// `tool`, so if the prologue were dropped, `tool` would be undefined and no
+/// tool_call would fire (the round-trip helper would fail waiting for one).
+#[test]
+fn normalized_export_default_arrow_with_prologue_executes_end_to_end() {
+    let body = "const tool = \"upstream::test::ping\";\n\
+                export default async () => await callTool(tool, {});";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("async () =>") && !normalized.contains("export default"),
+        "normalize must emit executable script code without export syntax, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -922,3 +922,21 @@ fn normalized_export_default_plain_arrow_with_prologue_executes_end_to_end() {
     );
     assert_single_call_round_trip(&normalized, json!({"pong": true}));
 }
+
+/// The AST *function* arm with a prologue (`const tool = "...";
+/// export default async function() { ... }`) goes through `normalize_module_code`
+/// → `wrap_default_fn_as_iife` nested inside the prologue wrapper — a different
+/// shape (double IIFE) than the arrow arms. Run it to prove the prologue binding
+/// is in runtime scope for the exported function too. Non-vacuous: the function
+/// references the prologue `const tool`.
+#[test]
+fn normalized_export_default_function_with_prologue_executes_end_to_end() {
+    let body = "const tool = \"upstream::test::ping\";\n\
+                export default async function() { return await callTool(tool, {}); }";
+    let normalized = labby::dispatch::gateway::code_mode::normalize_user_code(body);
+    assert!(
+        normalized.starts_with("async () =>") && !normalized.contains("export default"),
+        "normalize must emit executable script code without export syntax, got: {normalized}"
+    );
+    assert_single_call_round_trip(&normalized, json!({"pong": true}));
+}


### PR DESCRIPTION
## Why

Follow-up to #90. Code Mode normalization mishandled an **arrow function in `export default` position when preceded by a prologue**, e.g.:

```js
const x = 1;
export default async () => x;
```

Two failure modes:
- **async arrow** → Boa's `parse_module` cannot parse an arrow in default-export position (`expected token 'function', got '('`), so both the module and script parses failed and the input **loose-wrapped into invalid JS** (left `export default` inside the wrapper body).
- **plain/expr/function defaults with a prologue** → Boa *does* parse these, but its AST arms (`DefaultAssignmentExpression` / function / class) render only the export declaration and **drop the prologue**, emitting valid-but-broken JS (the default's free variables are `undefined` at runtime).

This was disclosed as a known limitation on #90.

## What

Handle `{prologue} export default <value>` **textually, before the AST path**: split off the default-export value at a statement boundary, re-derive the no-prologue entry (reusing the existing start-anchored `export default` handling), then run the prologue first and invoke that entry inside one wrapper so it **closes over the prologue's bindings**:

```js
// const x = 1; export default async () => x   ⇒
async () => {
  const x = 1;
  return await (async () => x)();
}
```

Conservative: the split only fires when a real prologue ends at a `;`/`}` boundary; the start-anchored (no-prologue) case is unchanged.

## Tests

- `normalize_user_code_wraps_export_default_arrow_with_prologue` (async)
- `normalize_user_code_wraps_export_default_plain_arrow_with_prologue` (non-async)
- `normalized_export_default_arrow_with_prologue_executes_end_to_end` — **non-vacuous**: the arrow references a prologue `const`, so a dropped prologue would surface no `tool_call` and the round-trip helper would fail.

The existing 10a test (`normalize_user_code_finds_export_default_after_prologue`) still passes — and now actually preserves the prologue rather than emitting valid-but-broken JS.

Verified: 44 code_mode/normalize tests pass; clippy `-D warnings` + fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes normalization for `export default` arrows and functions that follow a prologue. Emits valid JS, preserves prologue bindings (including named exports), drops imports inside the wrapper, and avoids regressions with trailing exports and comments.

- **Bug Fixes**
  - Async arrow default fallback: runs only after both module and script parses fail; splits at a real `;`/`}` boundary; tolerates trailing comments and `//` inside strings via a suffix-only strip.
  - AST path keeps the prologue: render non-export statements; keep binding-carrying named exports with `export` stripped; skip imports; select only the default export so later named exports don’t shadow it.
  - Textual fallback reparses the prologue to strip `export` from named exports and now drops `import` declarations too.
  - Anonymous default functions: drop Boa’s synthesized `default` name when IIFE-wrapping, anchored at the leading `function`.
  - Tests: URL+trailing-comment boundary, export var/function bindings, async-arrow + named-export e2e, import-only prologue e2e, and multi-statement prologue e2e.

<sup>Written for commit 909ee6141e0297919e0fc8e9271d6e93b3cf9be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved normalization for scripts with a leading prologue followed by a default export: preserves prologue bindings and produces a single async wrapper that invokes the export, with a conservative textual fallback when parsing fails.

* **Refactor**
  * Reworked module normalization to reliably extract and wrap default-export entries while preserving leading bindings and avoiding synthesized-name issues.

* **Tests**
  * Added unit and end-to-end tests for prologue+default-export scenarios and edge cases (exports in strings, trailing comments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->