### PR TITLE
fix(gateway): configurable level for forwarded upstream stderr + UTF-8-safe truncation

### DIFF
--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -105,10 +105,11 @@ pub(super) async fn connect_stdio_upstream(
 
     // A stdio MCP server logs to stderr (stdout is the JSON-RPC channel), so the
     // child's stderr is the ONLY place its server-side diagnostics go. Capture
-    // it by default and forward into the gateway log; opt out per `LAB_GW_UPSTREAM_STDERR`.
-    let capture_stderr = upstream_stderr_capture_enabled();
+    // it by default and forward into the gateway log at the level resolved from
+    // `LAB_GW_UPSTREAM_STDERR` (default DEBUG; `off` discards).
+    let stderr_level = upstream_stderr_log_level();
     let stderr_cfg = || {
-        if capture_stderr {
+        if stderr_level.is_some() {
             Stdio::piped()
         } else {
             Stdio::null()
@@ -132,7 +133,9 @@ pub(super) async fn connect_stdio_upstream(
     // upstream (e.g. axon at INFO) fills the ~64 KB pipe buffer and then blocks
     // on its next stderr write, hanging the upstream. The drain task reads to
     // EOF so failures are recoverable from the gateway log instead of lost.
-    forward_upstream_stderr(child_stderr, config.name.clone());
+    if let Some(level) = stderr_level {
+        forward_upstream_stderr(child_stderr, config.name.clone(), level);
+    }
 
     let pid = process.id();
     tracing::info!(
@@ -190,17 +193,48 @@ pub(super) async fn connect_stdio_upstream(
     Ok((conn, tools))
 }
 
-/// Whether to capture spawned-upstream stderr and forward it into the gateway
-/// log. Default: enabled. Set `LAB_GW_UPSTREAM_STDERR` to `null`/`off`/`0` to
-/// discard it (the pre-capture behavior) for an extremely chatty upstream.
-fn upstream_stderr_capture_enabled() -> bool {
-    match std::env::var("LAB_GW_UPSTREAM_STDERR") {
-        Ok(value) => !matches!(
-            value.trim().to_ascii_lowercase().as_str(),
-            "null" | "off" | "0" | "none" | "discard" | "false"
-        ),
-        Err(_) => true,
+/// Resolve the log level for forwarded upstream stderr from
+/// `LAB_GW_UPSTREAM_STDERR`.
+///
+/// - unset / `on` / `1` / `true` / unknown values → `Some(DEBUG)` (the
+///   reviewed default: a chatty upstream must not pollute the INFO stream)
+/// - `trace` / `debug` / `info` / `warn` → that level (e.g. `info` restores
+///   the pre-hardening visibility for an upstream being actively debugged)
+/// - `null` / `off` / `0` / `none` / `discard` / `false` → `None` — stderr is
+///   discarded entirely (the pre-capture behavior)
+fn upstream_stderr_log_level() -> Option<tracing::Level> {
+    parse_stderr_level(std::env::var("LAB_GW_UPSTREAM_STDERR").ok().as_deref())
+}
+
+fn parse_stderr_level(raw: Option<&str>) -> Option<tracing::Level> {
+    let Some(raw) = raw else {
+        return Some(tracing::Level::DEBUG);
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "null" | "off" | "0" | "none" | "discard" | "false" => None,
+        "trace" => Some(tracing::Level::TRACE),
+        "info" => Some(tracing::Level::INFO),
+        "warn" | "warning" => Some(tracing::Level::WARN),
+        // "debug", enable-flavored values, and anything unrecognized fall back
+        // to the default level.
+        _ => Some(tracing::Level::DEBUG),
     }
+}
+
+/// Truncate `line` to at most `max` bytes without splitting a UTF-8 codepoint.
+///
+/// A plain `&line[..max]` panics when byte `max` lands inside a multi-byte
+/// character — and stderr content is upstream-controlled, so that slice was a
+/// remotely triggerable panic in the drain task.
+fn cap_line_bytes(line: &str, max: usize) -> &str {
+    if line.len() <= max {
+        return line;
+    }
+    let mut cut = max;
+    while cut > 0 && !line.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    &line[..cut]
 }
 
 /// Maximum number of bytes forwarded per line from a child's stderr.
@@ -216,11 +250,14 @@ const STDERR_LINE_MAX_BYTES: usize = 1024;
 const STDERR_RATE_CAP_PER_SEC: u32 = 50;
 
 /// Drain a piped child stderr to EOF, forwarding each non-empty line into the
-/// gateway log under the `labby::upstream_stderr` target at **DEBUG** level
-/// (silence just this stream with `LAB_LOG=labby::upstream_stderr=warn`).
+/// gateway log under the `labby::upstream_stderr` target at `level`
+/// (default **DEBUG**; tune per `LAB_GW_UPSTREAM_STDERR`, or silence just this
+/// stream with `LAB_LOG=labby::upstream_stderr=warn`).
 ///
 /// Security / observability invariants (O-M2 / P-L5):
-/// - Lines are emitted at DEBUG so a chatty upstream does not pollute the INFO stream.
+/// - Default level is DEBUG so a chatty upstream does not pollute the INFO
+///   stream; the operator can raise it per `LAB_GW_UPSTREAM_STDERR=info` while
+///   actively debugging an upstream.
 /// - Each line is capped at `STDERR_LINE_MAX_BYTES` before logging.
 /// - Lines are rate-limited to `STDERR_RATE_CAP_PER_SEC`; bursts above the cap
 ///   are dropped with a single warning rather than forwarded verbatim.
@@ -229,8 +266,21 @@ const STDERR_RATE_CAP_PER_SEC: u32 = 50;
 ///
 /// Draining is mandatory: an unread pipe buffer fills and blocks the child's
 /// next stderr write, hanging the upstream.
-fn forward_upstream_stderr(stderr: Option<tokio::process::ChildStderr>, upstream: String) {
-    let Some(stderr) = stderr else { return };
+fn forward_upstream_stderr(
+    stderr: Option<tokio::process::ChildStderr>,
+    upstream: String,
+    level: tracing::Level,
+) {
+    let Some(stderr) = stderr else {
+        // Capture was requested (level resolved) but the spawn returned no
+        // stderr handle — diagnostics for this upstream are being lost.
+        tracing::warn!(
+            target: "labby::upstream_stderr",
+            upstream = %upstream,
+            "stderr capture enabled but child returned no stderr handle; upstream diagnostics will be lost"
+        );
+        return;
+    };
     tokio::spawn(async move {
         use crate::dispatch::redact::redact_stdio_value;
         use tokio::io::{AsyncBufReadExt, BufReader};
@@ -269,24 +319,38 @@ fn forward_upstream_stderr(stderr: Option<tokio::process::ChildStderr>, upstream
                     }
                     lines_this_window += 1;
 
-                    // Truncate long lines before redaction/emission.
-                    let truncated = if line.len() > STDERR_LINE_MAX_BYTES {
-                        format!("{}…[truncated]", &line[..STDERR_LINE_MAX_BYTES])
+                    // Truncate long lines (UTF-8-boundary-safe) before
+                    // redaction/emission.
+                    let capped = cap_line_bytes(&line, STDERR_LINE_MAX_BYTES);
+                    let truncated = if capped.len() < line.len() {
+                        format!("{capped}…[truncated]")
                     } else {
-                        line
+                        line.clone()
                     };
 
                     // Redact credential-shaped tokens before forwarding.
                     let redacted = redact_stdio_value(&truncated);
 
-                    tracing::debug!(
-                        target: "labby::upstream_stderr",
-                        surface = "dispatch",
-                        service = "upstream.pool",
-                        upstream = %upstream,
-                        stream = "stderr",
-                        "{redacted}",
-                    );
+                    // `tracing` macros require a const level — dispatch on the
+                    // configured level explicitly.
+                    macro_rules! emit {
+                        ($macro:ident) => {
+                            tracing::$macro!(
+                                target: "labby::upstream_stderr",
+                                surface = "dispatch",
+                                service = "upstream.pool",
+                                upstream = %upstream,
+                                stream = "stderr",
+                                "{redacted}",
+                            )
+                        };
+                    }
+                    match level {
+                        tracing::Level::TRACE => emit!(trace),
+                        tracing::Level::INFO => emit!(info),
+                        tracing::Level::WARN | tracing::Level::ERROR => emit!(warn),
+                        _ => emit!(debug),
+                    }
                 }
                 Ok(None) => break,
                 Err(error) => {
@@ -301,4 +365,75 @@ fn forward_upstream_stderr(stderr: Option<tokio::process::ChildStderr>, upstream
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cap_line_bytes, parse_stderr_level};
+
+    #[test]
+    fn stderr_level_unset_defaults_to_debug() {
+        assert_eq!(parse_stderr_level(None), Some(tracing::Level::DEBUG));
+    }
+
+    #[test]
+    fn stderr_level_named_levels_parse() {
+        assert_eq!(
+            parse_stderr_level(Some("trace")),
+            Some(tracing::Level::TRACE)
+        );
+        assert_eq!(
+            parse_stderr_level(Some("debug")),
+            Some(tracing::Level::DEBUG)
+        );
+        assert_eq!(parse_stderr_level(Some("INFO")), Some(tracing::Level::INFO));
+        assert_eq!(
+            parse_stderr_level(Some(" warn ")),
+            Some(tracing::Level::WARN)
+        );
+        assert_eq!(
+            parse_stderr_level(Some("warning")),
+            Some(tracing::Level::WARN)
+        );
+    }
+
+    #[test]
+    fn stderr_level_disable_values_discard() {
+        for raw in ["null", "off", "0", "none", "discard", "FALSE"] {
+            assert_eq!(parse_stderr_level(Some(raw)), None, "{raw}");
+        }
+    }
+
+    #[test]
+    fn stderr_level_enable_flavored_and_unknown_fall_back_to_debug() {
+        for raw in ["", "on", "1", "true", "verbose", "garbage"] {
+            assert_eq!(
+                parse_stderr_level(Some(raw)),
+                Some(tracing::Level::DEBUG),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn cap_line_bytes_is_utf8_boundary_safe() {
+        // 'é' is 2 bytes; a cut at byte 3 lands mid-codepoint and must back up.
+        let line = "aéé";
+        assert_eq!(cap_line_bytes(line, 3), "aé");
+        // ASCII passes through untouched below the cap.
+        assert_eq!(cap_line_bytes("abc", 8), "abc");
+        // Exact-cap multi-byte input is not truncated.
+        assert_eq!(cap_line_bytes("éé", 4), "éé");
+        // A pathological all-multibyte line cut at byte 1 yields empty, not a panic.
+        assert_eq!(cap_line_bytes("ééé", 1), "");
+    }
+
+    #[test]
+    fn cap_line_bytes_never_panics_on_any_boundary() {
+        let line = "x😀y漢字é";
+        for max in 0..=line.len() + 2 {
+            let capped = cap_line_bytes(line, max.min(line.len()));
+            assert!(line.starts_with(capped));
+        }
+    }
 }


### PR DESCRIPTION
## Context

The original version of this PR introduced stderr capture for stdio upstreams. That capability has since landed on main and was hardened by the gateway comprehensive review (PR #106, finding O-M2): DEBUG default level, 1024-byte line cap, 50 lines/s rate cap, and credential redaction.

This PR is now rebased onto main and reduced to the delta that was still missing:

## Changes

- **Configurable level**: `LAB_GW_UPSTREAM_STDERR` accepts `trace` / `debug` / `info` / `warn` in addition to the existing disable values (`off`/`0`/`null`/…). Default stays **DEBUG** (the reviewed O-M2 posture — a chatty upstream must not pollute the INFO stream); set `info` per-deployment when actively debugging an upstream.
- **Lost-diagnostics warning**: WARN when capture is enabled but the spawn returns no stderr handle.
- **Panic fix**: line truncation previously sliced at a fixed byte offset — a multi-byte UTF-8 character straddling byte 1024 in upstream-controlled stderr panicked the drain task. Truncation is now codepoint-boundary-safe.
- Unit tests for level parsing and boundary-safe truncation.

All O-M2 hardening (caps, rate limit, redaction, mandatory drain) is preserved.

## Validation

`cargo clippy --workspace --all-features -- -D warnings` exit 0; `cargo nextest run -p labby --all-features` — 1643 passed.

Closes lab-tp4d3.