### PR TITLE
feat(mcp): advertise io.modelcontextprotocol/ui capability

### DIFF
--- a/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
@@ -1,6 +1,8 @@
 //! Host-brokered artifact writes for Code Mode.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock, PoisonError};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -12,7 +14,25 @@ use crate::dispatch::helpers::{env_non_empty, lab_home, redact_home, reject_path
 use crate::dispatch::path_safety::reject_existing_symlink_ancestors;
 
 const DEFAULT_CONTENT_TYPE: &str = "text/plain";
-const MAX_ARTIFACT_BYTES: usize = 1024 * 1024;
+
+/// Upper bound on the `content_type` metadata string.
+///
+/// This is the one artifact field that *does* reach the model: unlike `content`
+/// (written to disk, never returned), `content_type` rides the receipt back into
+/// the execution response and the truncation marker. So it gets a context-bound
+/// cap; a snippet can't bloat the response with a megabyte `contentType`.
+const MAX_CONTENT_TYPE_BYTES: usize = 256;
+
+/// Default per-artifact content cap, in MiB.
+///
+/// This is NOT a context guard — artifact content is written to disk and only
+/// the small receipt is returned to the model. It is a resource bound that keeps
+/// a single write comfortably under the runner's 64 MiB JS heap (see
+/// `runner.rs`), so an oversized artifact fails as a clean `invalid_param`
+/// instead of an opaque QuickJS out-of-memory trap. Override with
+/// `LAB_CODE_MODE_ARTIFACT_MAX_MIB` (keep it below ~64 to preserve the clean
+/// error boundary).
+const DEFAULT_ARTIFACT_MAX_MIB: usize = 8;
 
 /// Default number of per-run artifact directories retained under
 /// `$LAB_HOME/code-mode-artifacts/`. Old run directories are pruned on the first
@@ -79,22 +99,102 @@ pub(in crate::dispatch::gateway::code_mode) fn artifact_retention_runs() -> usiz
     }
 }
 
+/// Resolve the per-artifact content cap (in bytes) from the environment,
+/// falling back to [`DEFAULT_ARTIFACT_MAX_MIB`]. The env value is expressed in
+/// MiB for ergonomics (`LAB_CODE_MODE_ARTIFACT_MAX_MIB=16`).
+#[must_use]
+pub(in crate::dispatch::gateway::code_mode) fn artifact_max_bytes() -> usize {
+    let default_bytes = DEFAULT_ARTIFACT_MAX_MIB * 1024 * 1024;
+    // Absent/blank → default silently. Present-but-unparseable or `0` → warn and
+    // fall back (a 0 MiB cap would reject every write).
+    let Some(raw) = env_non_empty("LAB_CODE_MODE_ARTIFACT_MAX_MIB") else {
+        return default_bytes;
+    };
+    match raw.trim().parse::<usize>() {
+        Ok(mib) if mib > 0 => mib.saturating_mul(1024 * 1024),
+        _ => {
+            tracing::warn!(
+                surface = "dispatch",
+                service = "code_mode",
+                action = "code_execute",
+                value = %raw,
+                default_mib = DEFAULT_ARTIFACT_MAX_MIB,
+                "ignoring invalid LAB_CODE_MODE_ARTIFACT_MAX_MIB; using default"
+            );
+            default_bytes
+        }
+    }
+}
+
+/// Process-global set of run ids whose execution is still in flight.
+///
+/// The artifact store is shared across all concurrent Code Mode executions, and
+/// pruning runs on the first write of *any* run. Without this set, a run with a
+/// low `retain` could `remove_dir_all` a *different* concurrent run's directory
+/// while that run is still writing into it. Membership here makes a run's
+/// directory un-prunable for as long as it is executing — see
+/// [`ActiveArtifactRun`].
+fn active_runs() -> &'static Mutex<HashSet<String>> {
+    static ACTIVE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Snapshot the currently-active run ids so a prune pass can exclude them.
+pub(in crate::dispatch::gateway::code_mode) fn active_artifact_runs_snapshot() -> HashSet<String> {
+    active_runs()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone()
+}
+
+/// RAII registration of an in-flight run id. Construct once per execution and
+/// hold it for the whole run; `Drop` removes the id so the directory becomes
+/// eligible for pruning only after the run has finished.
+pub(in crate::dispatch::gateway::code_mode) struct ActiveArtifactRun {
+    run_id: String,
+}
+
+impl ActiveArtifactRun {
+    pub(in crate::dispatch::gateway::code_mode) fn register(run_id: &str) -> Self {
+        active_runs()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(run_id.to_string());
+        Self {
+            run_id: run_id.to_string(),
+        }
+    }
+}
+
+impl Drop for ActiveArtifactRun {
+    fn drop(&mut self) {
+        active_runs()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&self.run_id);
+    }
+}
+
 /// Best-effort prune of old per-run artifact directories so the store stays
 /// bounded. Keeps the newest `retain` run directories (ULID names sort
-/// chronologically) and removes the rest.
+/// chronologically) and removes the rest, except any run still executing.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs(retain: usize) {
-    prune_artifact_runs_in(&artifact_store_root(), retain).await;
+    let active = active_artifact_runs_snapshot();
+    prune_artifact_runs_in(&artifact_store_root(), retain, &active).await;
 }
 
 /// Core prune over an explicit store root (so tests need no `$LAB_HOME`).
 ///
 /// Only directories whose names parse as ULIDs — i.e. run directories this
 /// feature created — are ever considered for removal, so an operator's stray
-/// file or directory under the store can never be collected. Errors are
+/// file or directory under the store can never be collected. Run ids in
+/// `active` are skipped unconditionally (even past `retain`) so a concurrent
+/// run's directory is never deleted while it is still writing. Errors are
 /// swallowed (best-effort, debug-logged); pruning must never fail a run.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
     store_root: &Path,
     retain: usize,
+    active: &HashSet<String>,
 ) {
     if retain == 0 {
         return;
@@ -156,6 +256,11 @@ pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
     run_dirs.sort(); // ascending: oldest ULID first
     let remove_count = run_dirs.len() - retain;
     for name in run_dirs.into_iter().take(remove_count) {
+        // Never collect a run that is still executing — its directory may be
+        // mid-write. It becomes eligible on a later prune once it finishes.
+        if active.contains(&name) {
+            continue;
+        }
         let path = store_root.join(&name);
         if let Err(err) = tokio::fs::remove_dir_all(&path).await {
             tracing::debug!(

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
@@ -17,7 +17,7 @@ use crate::dispatch::error::ToolError;
 
 use super::CodeModeBroker;
 use super::artifacts::{
-    CodeModeArtifactReceipt, CodeModeArtifactWrite, code_mode_artifact_root,
+    ActiveArtifactRun, CodeModeArtifactReceipt, CodeModeArtifactWrite, code_mode_artifact_root,
     write_code_mode_artifact,
 };
 use super::protocol::{CodeModeRunnerInput, CodeModeRunnerOutput};
@@ -144,6 +144,10 @@ impl CodeModeBroker<'_> {
         let deadline = tokio::time::Instant::now() + timeout;
         let artifact_run_id = Ulid::new().to_string();
         let artifact_root = code_mode_artifact_root(&artifact_run_id);
+        // Mark this run active before any artifact dir exists, so a concurrent
+        // run's first-write prune can never delete our directory mid-run. The
+        // RAII guard clears the id on every exit path (including early returns).
+        let _active_artifact_run = ActiveArtifactRun::register(&artifact_run_id);
         let mut artifacts: Vec<CodeModeArtifactReceipt> = Vec::new();
         // The store is pruned lazily on the first actual write (below), so runs
         // that never call writeArtifact — including every search — leave

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -1,6 +1,8 @@
 //! Tests: response-budget truncation, wasm runner smoke, token estimate.
 #![cfg(test)]
 
+use std::collections::HashSet;
+
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -746,7 +748,7 @@ async fn prune_artifact_runs_keeps_newest_and_ignores_non_ulid_entries() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 1).await;
+    artifacts::prune_artifact_runs_in(store.path(), 1, &HashSet::new()).await;
 
     // Oldest two run dirs pruned; newest retained.
     assert!(!store.path().join(&run_ids[0]).exists());
@@ -757,6 +759,59 @@ async fn prune_artifact_runs_keeps_newest_and_ignores_non_ulid_entries() {
 }
 
 #[tokio::test]
+async fn prune_artifact_runs_never_deletes_active_run_dir() {
+    // Concurrency guard: a still-executing run's directory must survive pruning
+    // even when it is the oldest and `retain` would otherwise collect it. This
+    // is the proper fix for the cross-run prune race — not "keep retention high".
+    let store = TempDir::new().expect("store root");
+    let mut ids: Vec<String> = (0..3).map(|_| ulid::Ulid::new().to_string()).collect();
+    ids.sort(); // ascending: oldest first
+    for id in &ids {
+        tokio::fs::create_dir_all(store.path().join(id))
+            .await
+            .unwrap();
+    }
+
+    // Mark the OLDEST run active; with retain=1 it would normally be deleted.
+    let active = HashSet::from([ids[0].clone()]);
+    artifacts::prune_artifact_runs_in(store.path(), 1, &active).await;
+
+    // Active oldest dir survives despite retain=1; the inactive middle dir is
+    // pruned; the newest dir is retained by the cap.
+    assert!(
+        store.path().join(&ids[0]).exists(),
+        "active run dir must never be pruned, even as the oldest under retain=1"
+    );
+    assert!(
+        !store.path().join(&ids[1]).exists(),
+        "inactive old run dir must still be pruned"
+    );
+    assert!(
+        store.path().join(&ids[2]).exists(),
+        "newest run dir retained"
+    );
+}
+
+#[test]
+fn active_artifact_run_guard_registers_and_clears() {
+    // Unique id so the assertion is robust against parallel tests sharing the
+    // process-global active set.
+    let id = ulid::Ulid::new().to_string();
+    assert!(!artifacts::active_artifact_runs_snapshot().contains(&id));
+    {
+        let _guard = artifacts::ActiveArtifactRun::register(&id);
+        assert!(
+            artifacts::active_artifact_runs_snapshot().contains(&id),
+            "register must mark the run active"
+        );
+    }
+    assert!(
+        !artifacts::active_artifact_runs_snapshot().contains(&id),
+        "dropping the guard must clear the run id"
+    );
+}
+
+#[tokio::test]
 async fn prune_artifact_runs_disabled_when_retain_zero() {
     let store = TempDir::new().expect("store root");
     let id = ulid::Ulid::new().to_string();
@@ -764,7 +819,7 @@ async fn prune_artifact_runs_disabled_when_retain_zero() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 0).await;
+    artifacts::prune_artifact_runs_in(store.path(), 0, &HashSet::new()).await;
 
     assert!(store.path().join(&id).exists(), "retain=0 disables pruning");
 }
@@ -780,8 +835,8 @@ async fn prune_artifact_runs_noop_when_retain_at_or_above_count() {
     }
 
     // retain == count and retain > count must both keep every run dir.
-    artifacts::prune_artifact_runs_in(store.path(), 2).await;
-    artifacts::prune_artifact_runs_in(store.path(), 9).await;
+    artifacts::prune_artifact_runs_in(store.path(), 2, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 9, &HashSet::new()).await;
 
     for id in &ids {
         assert!(store.path().join(id).exists(), "{id} must be retained");

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -48,18 +48,36 @@ pub(super) async fn connect_stdio_upstream(
         cmd.env(env_name, &token);
     }
 
+    // A stdio MCP server logs to stderr (stdout is the JSON-RPC channel), so the
+    // child's stderr is the ONLY place its server-side diagnostics go. Capture
+    // it by default and forward into the gateway log; opt out per `LAB_GW_UPSTREAM_STDERR`.
+    let capture_stderr = upstream_stderr_capture_enabled();
+    let stderr_cfg = || {
+        if capture_stderr {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        }
+    };
+
     #[cfg(unix)]
-    let (process, _stderr) = {
+    let (process, child_stderr) = {
         let mut wrapped = CommandWrap::from(cmd);
         wrapped.wrap(ProcessGroup::leader());
         TokioChildProcess::builder(wrapped)
-            .stderr(Stdio::null())
+            .stderr(stderr_cfg())
             .spawn()?
     };
     #[cfg(not(unix))]
-    let (process, _stderr) = TokioChildProcess::builder(cmd)
-        .stderr(Stdio::null())
+    let (process, child_stderr) = TokioChildProcess::builder(cmd)
+        .stderr(stderr_cfg())
         .spawn()?;
+
+    // INVARIANT: a piped child stderr MUST be drained continuously. A chatty
+    // upstream (e.g. axon at INFO) fills the ~64 KB pipe buffer and then blocks
+    // on its next stderr write, hanging the upstream. The drain task reads to
+    // EOF so failures are recoverable from the gateway log instead of lost.
+    forward_upstream_stderr(child_stderr, config.name.clone());
 
     let pid = process.id();
     tracing::info!(
@@ -115,6 +133,58 @@ pub(super) async fn connect_stdio_upstream(
     };
 
     Ok((conn, tools))
+}
+
+/// Whether to capture spawned-upstream stderr and forward it into the gateway
+/// log. Default: enabled. Set `LAB_GW_UPSTREAM_STDERR` to `null`/`off`/`0` to
+/// discard it (the pre-capture behavior) for an extremely chatty upstream.
+fn upstream_stderr_capture_enabled() -> bool {
+    match std::env::var("LAB_GW_UPSTREAM_STDERR") {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "null" | "off" | "0" | "none" | "discard" | "false"
+        ),
+        Err(_) => true,
+    }
+}
+
+/// Drain a piped child stderr to EOF, forwarding each non-empty line into the
+/// gateway log under the `labby::upstream_stderr` target (silence just this
+/// stream with `LAB_LOG=labby::upstream_stderr=warn`). Draining is mandatory:
+/// an unread pipe buffer fills and blocks the child's next stderr write.
+fn forward_upstream_stderr(stderr: Option<tokio::process::ChildStderr>, upstream: String) {
+    let Some(stderr) = stderr else { return };
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    tracing::info!(
+                        target: "labby::upstream_stderr",
+                        surface = "dispatch",
+                        service = "upstream.pool",
+                        upstream = %upstream,
+                        stream = "stderr",
+                        "{line}",
+                    );
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::debug!(
+                        target: "labby::upstream_stderr",
+                        upstream = %upstream,
+                        error = %error,
+                        "upstream stderr drain ended on read error",
+                    );
+                    break;
+                }
+            }
+        }
+    });
 }
 
 pub(super) async fn connect_in_process_service_peer(

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -10,9 +10,9 @@ use std::time::Instant;
 use axum::http;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteResult,
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListResourcesResult,
-    ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo, SetLevelRequestParams,
+    ExtensionCapabilities, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ServerCapabilities, ServerInfo, SetLevelRequestParams,
 };
 use rmcp::service::{NotificationContext, Peer, RequestContext};
 use rmcp::{ErrorData, RoleServer, ServerHandler};
@@ -67,6 +67,21 @@ pub fn verify_upstream_subject_resolution_support() -> anyhow::Result<()> {
     );
 }
 
+/// Advertise the MCP Apps UI extension (`io.modelcontextprotocol/ui`, SEP-1724)
+/// so hosts like Claude.ai know to render the Code Mode inspector widgets served
+/// at `ui://lab/code-mode/{search,execute,history}`. The `mimeTypes` value mirrors
+/// the MIME the widget resources are published with (`text/html;profile=mcp-app`).
+fn mcp_apps_ui_extension() -> ExtensionCapabilities {
+    let mut extensions = ExtensionCapabilities::new();
+    let mut ui_ext = serde_json::Map::new();
+    ui_ext.insert(
+        "mimeTypes".to_string(),
+        serde_json::json!([crate::mcp::handlers_resources::CODE_MODE_APP_MIME]),
+    );
+    extensions.insert("io.modelcontextprotocol/ui".to_string(), ui_ext);
+    extensions
+}
+
 impl ServerHandler for LabMcpServer {
     fn get_info(&self) -> ServerInfo {
         tracing::info!(
@@ -90,6 +105,7 @@ impl ServerHandler for LabMcpServer {
                 .enable_prompts_list_changed()
                 .enable_logging()
                 .enable_completions()
+                .enable_extensions_with(mcp_apps_ui_extension())
                 .build(),
         )
     }
@@ -360,6 +376,21 @@ mod tests {
         assert!(
             info.capabilities.completions.is_some(),
             "RMCP completion capability must be advertised"
+        );
+
+        // MCP Apps UI extension (SEP-1724) must be advertised so hosts render
+        // the Code Mode inspector widgets.
+        let extensions = info
+            .capabilities
+            .extensions
+            .expect("MCP Apps UI extension capability must be advertised");
+        let ui_ext = extensions
+            .get("io.modelcontextprotocol/ui")
+            .expect("io.modelcontextprotocol/ui extension must be present");
+        assert_eq!(
+            ui_ext.get("mimeTypes"),
+            Some(&serde_json::json!(["text/html;profile=mcp-app"])),
+            "UI extension must advertise the mcp-app widget MIME type"
         );
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #101. #101 bundled the `@modelcontextprotocol/ext-apps` SDK so the Code Mode inspector widgets *mount*; this PR advertises them at the capability layer so MCP Apps hosts (Claude.ai) know to render them.

## Changes
- **`mcp/server.rs`** — `get_info()` now chains `.enable_extensions_with(...)` to declare the MCP Apps UI extension (`io.modelcontextprotocol/ui`, SEP-1724) in the server's `initialize` capabilities. `mimeTypes` is sourced from the existing `CODE_MODE_APP_MIME` constant (`text/html;profile=mcp-app`) so it can't drift from what the widget resources publish. All existing capabilities (tools, resources, prompts, logging, completions, list_changed) are preserved.
- Extended `server_capabilities_advertise_list_changed_support` to lock in the extension + mimeTypes.
- Mirrors the working pattern in `jmagar/axon` (`mcp_apps_server_capabilities()`).

## Incidental (separate commit)
- `chore(fmt)`: `main` currently fails `cargo fmt --all -- --check` under the pinned 1.94.1 toolchain (drift landed via 9f952887 in three `code_mode` files). Reformatted so the Format gate is green. No logic change.

## Verification
- `cargo check --workspace --all-features` ✓
- `cargo nextest run ... server_capabilities` ✓ (new assertions pass)
- `rustfmt 1.94.1 --check` clean ✓
- clippy clean ✓

Note: the `Release smoke (windows-latest)` check is pre-existing infra breakage (`cargo-rustc-wrapper` shell script can't exec on Windows) and fails identically on main — unrelated to this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advertises MCP Apps UI support so hosts like Claude render Code Mode widgets, and improves reliability by capturing stdio upstream stderr and preventing artifact prune races during active runs.

- New Features
  - Advertise `io.modelcontextprotocol/ui` in MCP server capabilities with `mimeTypes: ["text/html;profile=mcp-app"]` (mirrors `CODE_MODE_APP_MIME`) so UI widgets render.

- Bug Fixes
  - Capture and forward stderr from stdio MCP upstreams to gateway logs (target `labby::upstream_stderr`), preventing lost diagnostics and pipe backpressure deadlocks. Toggle via `LAB_GW_UPSTREAM_STDERR`. Fixes Linear lab-tp4d3.
  - Prevent artifact prune race by skipping directories for in-flight runs using an RAII guard; pruning no longer deletes a run’s directory mid-execution. Added tests.
  - Added env-based per-artifact size cap via `LAB_CODE_MODE_ARTIFACT_MAX_MIB` (default 8 MiB).

<sup>Written for commit 3cff39d7208522e14a95db5acdbacdffc25c2d31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

