### PR TITLE
fix(code-mode): rework artifact write caps, retention, and prune safety

### DIFF
--- a/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
@@ -38,8 +38,15 @@ const DEFAULT_ARTIFACT_MAX_MIB: usize = 8;
 /// `$LAB_HOME/code-mode-artifacts/`. Old run directories are pruned on the first
 /// artifact write of a run (never on search / no-write runs) so the on-disk
 /// store stays bounded. Override with `LAB_CODE_MODE_ARTIFACT_RETENTION_RUNS`;
-/// set it to `0` to disable pruning (unbounded growth).
+/// set it to `0` to disable *count* pruning.
 const DEFAULT_ARTIFACT_RETENTION_RUNS: usize = 200;
+
+/// Default total-store byte budget, in MiB. Now that a single artifact can be
+/// several MiB, the run-count cap alone no longer bounds disk usage, so pruning
+/// also drops the oldest inactive run directories until the whole store fits
+/// this budget. Override with `LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB`; set it to
+/// `0` to disable *byte* pruning.
+const DEFAULT_ARTIFACT_MAX_STORE_MIB: u64 = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(in crate::dispatch::gateway::code_mode) struct CodeModeArtifactWrite {
@@ -126,6 +133,59 @@ pub(in crate::dispatch::gateway::code_mode) fn artifact_max_bytes() -> usize {
     }
 }
 
+/// Resolve the total-store byte budget from the environment, falling back to
+/// [`DEFAULT_ARTIFACT_MAX_STORE_MIB`]. The env value is in MiB
+/// (`LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB=8192`); `0` disables byte pruning.
+#[must_use]
+pub(in crate::dispatch::gateway::code_mode) fn artifact_max_store_bytes() -> u64 {
+    let default_bytes = DEFAULT_ARTIFACT_MAX_STORE_MIB * 1024 * 1024;
+    let Some(raw) = env_non_empty("LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB") else {
+        return default_bytes;
+    };
+    match raw.trim().parse::<u64>() {
+        // `0` is meaningful here (disable byte pruning), unlike the per-artifact
+        // cap where 0 is nonsense.
+        Ok(mib) => mib.saturating_mul(1024 * 1024),
+        Err(_) => {
+            tracing::warn!(
+                surface = "dispatch",
+                service = "code_mode",
+                action = "code_execute",
+                value = %raw,
+                default_mib = DEFAULT_ARTIFACT_MAX_STORE_MIB,
+                "ignoring unparseable LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB; using default"
+            );
+            default_bytes
+        }
+    }
+}
+
+/// Best-effort recursive byte size of a directory. Symlinks are not followed
+/// (`file_type()` does not traverse them), so the count can never wander outside
+/// the store. Unreadable entries are skipped — this only feeds a retention
+/// heuristic, never a correctness decision.
+async fn dir_size_bytes(path: PathBuf) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![path];
+    while let Some(dir) = stack.pop() {
+        let Ok(mut entries) = tokio::fs::read_dir(&dir).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            match entry.file_type().await {
+                Ok(ft) if ft.is_dir() => stack.push(entry.path()),
+                Ok(ft) if ft.is_file() => {
+                    if let Ok(meta) = entry.metadata().await {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    total
+}
+
 /// Process-global set of run ids whose execution is still in flight.
 ///
 /// The artifact store is shared across all concurrent Code Mode executions, and
@@ -176,27 +236,42 @@ impl Drop for ActiveArtifactRun {
 }
 
 /// Best-effort prune of old per-run artifact directories so the store stays
-/// bounded. Keeps the newest `retain` run directories (ULID names sort
-/// chronologically) and removes the rest, except any run still executing.
+/// bounded by both a run-count cap and a total-byte budget. Keeps the newest
+/// runs (ULID names sort chronologically) and removes older ones, except any run
+/// still executing.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs(retain: usize) {
     let active = active_artifact_runs_snapshot();
-    prune_artifact_runs_in(&artifact_store_root(), retain, &active).await;
+    prune_artifact_runs_in(
+        &artifact_store_root(),
+        retain,
+        artifact_max_store_bytes(),
+        &active,
+    )
+    .await;
 }
 
 /// Core prune over an explicit store root (so tests need no `$LAB_HOME`).
 ///
+/// Removes the oldest run directories that fall outside *either* the run-count
+/// cap (`retain`, newest-N) *or* the total-byte budget (`max_store_bytes`,
+/// newest-fits-first). `retain == 0` disables the count rule and
+/// `max_store_bytes == 0` disables the byte rule; with both off this is a no-op.
+///
 /// Only directories whose names parse as ULIDs — i.e. run directories this
 /// feature created — are ever considered for removal, so an operator's stray
 /// file or directory under the store can never be collected. Run ids in
-/// `active` are skipped unconditionally (even past `retain`) so a concurrent
+/// `active` are skipped unconditionally (even past either limit) so a concurrent
 /// run's directory is never deleted while it is still writing. Errors are
 /// swallowed (best-effort, debug-logged); pruning must never fail a run.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
     store_root: &Path,
     retain: usize,
+    max_store_bytes: u64,
     active: &HashSet<String>,
 ) {
-    if retain == 0 {
+    let count_pruning = retain > 0;
+    let byte_pruning = max_store_bytes > 0;
+    if !count_pruning && !byte_pruning {
         return;
     }
     let mut entries = match tokio::fs::read_dir(store_root).await {
@@ -250,17 +325,47 @@ pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
             run_dirs.push(name);
         }
     }
-    if run_dirs.len() <= retain {
-        return;
-    }
     run_dirs.sort(); // ascending: oldest ULID first
-    let remove_count = run_dirs.len() - retain;
-    for name in run_dirs.into_iter().take(remove_count) {
-        // Never collect a run that is still executing — its directory may be
-        // mid-write. It becomes eligible on a later prune once it finishes.
-        if active.contains(&name) {
+    let newest_first: Vec<&String> = run_dirs.iter().rev().collect();
+
+    // When byte-pruning is on, size every run directory concurrently up front —
+    // the walks are independent — instead of serializing them inside the
+    // decision loop below.
+    let sizes: Vec<u64> = if byte_pruning {
+        futures::future::join_all(
+            newest_first
+                .iter()
+                .map(|name| dir_size_bytes(store_root.join(name))),
+        )
+        .await
+    } else {
+        Vec::new()
+    };
+
+    // Walk newest-first, keeping a run while it sits inside BOTH the count window
+    // and the running byte budget; everything past either limit is a removal
+    // candidate. Active runs still count toward the byte total (they're on disk)
+    // but are never themselves removed.
+    let mut cumulative: u64 = 0;
+    let mut to_remove: Vec<String> = Vec::new();
+    for (idx, name) in newest_first.iter().enumerate() {
+        if byte_pruning {
+            cumulative = cumulative.saturating_add(sizes[idx]);
+        }
+        let within_count = !count_pruning || idx < retain;
+        let within_bytes = !byte_pruning || cumulative <= max_store_bytes;
+        if within_count && within_bytes {
             continue;
         }
+        // Never collect a run that is still executing — its directory may be
+        // mid-write. It becomes eligible on a later prune once it finishes.
+        if active.contains(*name) {
+            continue;
+        }
+        to_remove.push((*name).clone());
+    }
+
+    for name in to_remove {
         let path = store_root.join(&name);
         if let Err(err) = tokio::fs::remove_dir_all(&path).await {
             tracing::debug!(
@@ -277,15 +382,16 @@ pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
 pub(in crate::dispatch::gateway::code_mode) async fn write_code_mode_artifact(
     root: &Path,
     request: &CodeModeArtifactWrite,
+    max_bytes: usize,
 ) -> Result<CodeModeArtifactReceipt, ToolError> {
     let rel_path = normalize_artifact_path(&request.path)?;
+    reject_oversized_content_type(request.content_type.as_deref())?;
     let bytes = request.content.as_bytes();
-    if bytes.len() > MAX_ARTIFACT_BYTES {
+    if bytes.len() > max_bytes {
         return Err(ToolError::InvalidParam {
             message: format!(
-                "artifact content is {} bytes; maximum is {} bytes",
+                "artifact content is {} bytes; maximum is {max_bytes} bytes",
                 bytes.len(),
-                MAX_ARTIFACT_BYTES
             ),
             param: "content".to_string(),
         });
@@ -338,6 +444,24 @@ pub(in crate::dispatch::gateway::code_mode) async fn write_code_mode_artifact(
         bytes: bytes.len(),
         sha256: hex::encode(sha256),
     })
+}
+
+/// Reject a `content_type` that would bloat the response. The receipt (and the
+/// truncation marker) carry this string into the model's context, so unlike the
+/// on-disk content it needs a small, fixed cap.
+fn reject_oversized_content_type(content_type: Option<&str>) -> Result<(), ToolError> {
+    if let Some(value) = content_type
+        && value.len() > MAX_CONTENT_TYPE_BYTES
+    {
+        return Err(ToolError::InvalidParam {
+            message: format!(
+                "artifact content_type is {} bytes; maximum is {MAX_CONTENT_TYPE_BYTES} bytes",
+                value.len(),
+            ),
+            param: "content_type".to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn normalize_artifact_path(raw: &str) -> Result<String, ToolError> {

--- a/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
@@ -1,6 +1,8 @@
 //! Host-brokered artifact writes for Code Mode.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock, PoisonError};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -12,7 +14,25 @@ use crate::dispatch::helpers::{env_non_empty, lab_home, redact_home, reject_path
 use crate::dispatch::path_safety::reject_existing_symlink_ancestors;
 
 const DEFAULT_CONTENT_TYPE: &str = "text/plain";
-const MAX_ARTIFACT_BYTES: usize = 1024 * 1024;
+
+/// Upper bound on the `content_type` metadata string.
+///
+/// This is the one artifact field that *does* reach the model: unlike `content`
+/// (written to disk, never returned), `content_type` rides the receipt back into
+/// the execution response and the truncation marker. So it gets a context-bound
+/// cap; a snippet can't bloat the response with a megabyte `contentType`.
+const MAX_CONTENT_TYPE_BYTES: usize = 256;
+
+/// Default per-artifact content cap, in MiB.
+///
+/// This is NOT a context guard — artifact content is written to disk and only
+/// the small receipt is returned to the model. It is a resource bound that keeps
+/// a single write comfortably under the runner's 64 MiB JS heap (see
+/// `runner.rs`), so an oversized artifact fails as a clean `invalid_param`
+/// instead of an opaque QuickJS out-of-memory trap. Override with
+/// `LAB_CODE_MODE_ARTIFACT_MAX_MIB` (keep it below ~64 to preserve the clean
+/// error boundary).
+const DEFAULT_ARTIFACT_MAX_MIB: usize = 8;
 
 /// Default number of per-run artifact directories retained under
 /// `$LAB_HOME/code-mode-artifacts/`. Old run directories are pruned on the first
@@ -79,22 +99,102 @@ pub(in crate::dispatch::gateway::code_mode) fn artifact_retention_runs() -> usiz
     }
 }
 
+/// Resolve the per-artifact content cap (in bytes) from the environment,
+/// falling back to [`DEFAULT_ARTIFACT_MAX_MIB`]. The env value is expressed in
+/// MiB for ergonomics (`LAB_CODE_MODE_ARTIFACT_MAX_MIB=16`).
+#[must_use]
+pub(in crate::dispatch::gateway::code_mode) fn artifact_max_bytes() -> usize {
+    let default_bytes = DEFAULT_ARTIFACT_MAX_MIB * 1024 * 1024;
+    // Absent/blank → default silently. Present-but-unparseable or `0` → warn and
+    // fall back (a 0 MiB cap would reject every write).
+    let Some(raw) = env_non_empty("LAB_CODE_MODE_ARTIFACT_MAX_MIB") else {
+        return default_bytes;
+    };
+    match raw.trim().parse::<usize>() {
+        Ok(mib) if mib > 0 => mib.saturating_mul(1024 * 1024),
+        _ => {
+            tracing::warn!(
+                surface = "dispatch",
+                service = "code_mode",
+                action = "code_execute",
+                value = %raw,
+                default_mib = DEFAULT_ARTIFACT_MAX_MIB,
+                "ignoring invalid LAB_CODE_MODE_ARTIFACT_MAX_MIB; using default"
+            );
+            default_bytes
+        }
+    }
+}
+
+/// Process-global set of run ids whose execution is still in flight.
+///
+/// The artifact store is shared across all concurrent Code Mode executions, and
+/// pruning runs on the first write of *any* run. Without this set, a run with a
+/// low `retain` could `remove_dir_all` a *different* concurrent run's directory
+/// while that run is still writing into it. Membership here makes a run's
+/// directory un-prunable for as long as it is executing — see
+/// [`ActiveArtifactRun`].
+fn active_runs() -> &'static Mutex<HashSet<String>> {
+    static ACTIVE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Snapshot the currently-active run ids so a prune pass can exclude them.
+pub(in crate::dispatch::gateway::code_mode) fn active_artifact_runs_snapshot() -> HashSet<String> {
+    active_runs()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone()
+}
+
+/// RAII registration of an in-flight run id. Construct once per execution and
+/// hold it for the whole run; `Drop` removes the id so the directory becomes
+/// eligible for pruning only after the run has finished.
+pub(in crate::dispatch::gateway::code_mode) struct ActiveArtifactRun {
+    run_id: String,
+}
+
+impl ActiveArtifactRun {
+    pub(in crate::dispatch::gateway::code_mode) fn register(run_id: &str) -> Self {
+        active_runs()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(run_id.to_string());
+        Self {
+            run_id: run_id.to_string(),
+        }
+    }
+}
+
+impl Drop for ActiveArtifactRun {
+    fn drop(&mut self) {
+        active_runs()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&self.run_id);
+    }
+}
+
 /// Best-effort prune of old per-run artifact directories so the store stays
 /// bounded. Keeps the newest `retain` run directories (ULID names sort
-/// chronologically) and removes the rest.
+/// chronologically) and removes the rest, except any run still executing.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs(retain: usize) {
-    prune_artifact_runs_in(&artifact_store_root(), retain).await;
+    let active = active_artifact_runs_snapshot();
+    prune_artifact_runs_in(&artifact_store_root(), retain, &active).await;
 }
 
 /// Core prune over an explicit store root (so tests need no `$LAB_HOME`).
 ///
 /// Only directories whose names parse as ULIDs — i.e. run directories this
 /// feature created — are ever considered for removal, so an operator's stray
-/// file or directory under the store can never be collected. Errors are
+/// file or directory under the store can never be collected. Run ids in
+/// `active` are skipped unconditionally (even past `retain`) so a concurrent
+/// run's directory is never deleted while it is still writing. Errors are
 /// swallowed (best-effort, debug-logged); pruning must never fail a run.
 pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
     store_root: &Path,
     retain: usize,
+    active: &HashSet<String>,
 ) {
     if retain == 0 {
         return;
@@ -156,6 +256,11 @@ pub(in crate::dispatch::gateway::code_mode) async fn prune_artifact_runs_in(
     run_dirs.sort(); // ascending: oldest ULID first
     let remove_count = run_dirs.len() - retain;
     for name in run_dirs.into_iter().take(remove_count) {
+        // Never collect a run that is still executing — its directory may be
+        // mid-write. It becomes eligible on a later prune once it finishes.
+        if active.contains(&name) {
+            continue;
+        }
         let path = store_root.join(&name);
         if let Err(err) = tokio::fs::remove_dir_all(&path).await {
             tracing::debug!(

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
@@ -17,7 +17,7 @@ use crate::dispatch::error::ToolError;
 
 use super::CodeModeBroker;
 use super::artifacts::{
-    CodeModeArtifactReceipt, CodeModeArtifactWrite, code_mode_artifact_root,
+    ActiveArtifactRun, CodeModeArtifactReceipt, CodeModeArtifactWrite, code_mode_artifact_root,
     write_code_mode_artifact,
 };
 use super::protocol::{CodeModeRunnerInput, CodeModeRunnerOutput};
@@ -144,6 +144,10 @@ impl CodeModeBroker<'_> {
         let deadline = tokio::time::Instant::now() + timeout;
         let artifact_run_id = Ulid::new().to_string();
         let artifact_root = code_mode_artifact_root(&artifact_run_id);
+        // Mark this run active before any artifact dir exists, so a concurrent
+        // run's first-write prune can never delete our directory mid-run. The
+        // RAII guard clears the id on every exit path (including early returns).
+        let _active_artifact_run = ActiveArtifactRun::register(&artifact_run_id);
         let mut artifacts: Vec<CodeModeArtifactReceipt> = Vec::new();
         // The store is pruned lazily on the first actual write (below), so runs
         // that never call writeArtifact — including every search — leave

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
@@ -141,6 +141,10 @@ impl CodeModeBroker<'_> {
         let mut calls = Vec::new();
         let mut pending_tool_calls = FuturesUnordered::new();
         let mut started_tool_calls = 0usize;
+        // Artifact writes have their own budget, decoupled from tool calls, so a
+        // run that emits many artifacts doesn't starve its upstream tool-call
+        // allowance (and vice versa). Both are gated by `max_tool_calls`.
+        let mut started_artifact_writes = 0usize;
         let deadline = tokio::time::Instant::now() + timeout;
         let artifact_run_id = Ulid::new().to_string();
         let artifact_root = code_mode_artifact_root(&artifact_run_id);
@@ -153,6 +157,9 @@ impl CodeModeBroker<'_> {
         // that never call writeArtifact — including every search — leave
         // `$LAB_HOME/code-mode-artifacts/` untouched.
         let mut artifact_store_pruned = false;
+        // The per-artifact size cap is constant for the run; resolve it once
+        // instead of re-reading the environment on every write.
+        let artifact_max_bytes = super::artifacts::artifact_max_bytes();
 
         loop {
             tokio::select! {
@@ -161,10 +168,7 @@ impl CodeModeBroker<'_> {
                         Ok(line) => line,
                         Err(_) => {
                             terminate_code_mode_runner(&mut child, child_pid).await;
-                            return Err(CodeModeExecutionError::with_trace(ToolError::Sdk {
-                                sdk_kind: "timeout".to_string(),
-                                message: "Code Mode execution timed out".to_string(),
-                            }, sorted_calls(&calls)));
+                            return Err(code_mode_timeout_error(&calls));
                         }
                     };
                     let Some(line) = line.map_err(|err| ToolError::Sdk {
@@ -190,7 +194,7 @@ impl CodeModeBroker<'_> {
                         }
                         })? {
                         CodeModeRunnerOutput::ToolCall { seq, id, params } => {
-                            if let Err(err) = ensure_call_budget(started_tool_calls, max_tool_calls, &calls) {
+                            if let Err(err) = ensure_within_limit(started_tool_calls, max_tool_calls, "tool call", &calls) {
                                 terminate_code_mode_runner(&mut child, child_pid).await;
                                 return Err(err);
                             }
@@ -221,34 +225,50 @@ impl CodeModeBroker<'_> {
                             content,
                             content_type,
                         } => {
-                            if let Err(err) = ensure_call_budget(started_tool_calls, max_tool_calls, &calls) {
+                            if let Err(err) = ensure_within_limit(started_artifact_writes, max_tool_calls, "artifact write", &calls) {
                                 terminate_code_mode_runner(&mut child, child_pid).await;
                                 return Err(err);
                             }
-                            started_tool_calls += 1;
-                            // Keep the on-disk store bounded — once per run, on the
-                            // first write that actually touches it.
-                            if !artifact_store_pruned {
-                                super::artifacts::prune_artifact_runs(
-                                    super::artifacts::artifact_retention_runs(),
+                            started_artifact_writes += 1;
+                            // Prune (lazy, once per run) and the write are host-side
+                            // filesystem work; bound them by the run deadline just
+                            // like tool calls so a hung or slow disk can't outlive
+                            // `timeout_ms`.
+                            let artifact_op = async {
+                                if !artifact_store_pruned {
+                                    super::artifacts::prune_artifact_runs(
+                                        super::artifacts::artifact_retention_runs(),
+                                    )
+                                    .await;
+                                    artifact_store_pruned = true;
+                                }
+                                handle_artifact_write(
+                                    &mut stdin,
+                                    &artifact_root,
+                                    &mut artifacts,
+                                    &mut calls,
+                                    seq,
+                                    CodeModeArtifactWrite {
+                                        path,
+                                        content,
+                                        content_type,
+                                    },
+                                    trace_params,
+                                    artifact_max_bytes,
                                 )
-                                .await;
-                                artifact_store_pruned = true;
+                                .await
+                            };
+                            match tokio::time::timeout_at(deadline, artifact_op).await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(err)) => {
+                                    terminate_code_mode_runner(&mut child, child_pid).await;
+                                    return Err(err.into());
+                                }
+                                Err(_) => {
+                                    terminate_code_mode_runner(&mut child, child_pid).await;
+                                    return Err(code_mode_timeout_error(&calls));
+                                }
                             }
-                            handle_artifact_write(
-                                &mut stdin,
-                                &artifact_root,
-                                &mut artifacts,
-                                &mut calls,
-                                seq,
-                                CodeModeArtifactWrite {
-                                    path,
-                                    content,
-                                    content_type,
-                                },
-                                trace_params,
-                            )
-                            .await?;
                         }
                         CodeModeRunnerOutput::Done { result, logs } => {
                             if !pending_tool_calls.is_empty() {
@@ -395,32 +415,51 @@ fn sorted_calls(calls: &[(u64, CodeModeExecutedCall)]) -> Vec<CodeModeExecutedCa
     calls.into_iter().map(|(_, call)| call).collect()
 }
 
-fn ensure_call_budget(
-    started_tool_calls: usize,
-    max_tool_calls: usize,
+/// The single source of the Code Mode deadline-timeout error, carrying the
+/// partial call trace. Used by both the runner-read and artifact-write timeout
+/// paths so the stable `timeout` kind/message lives in one place.
+fn code_mode_timeout_error(calls: &[(u64, CodeModeExecutedCall)]) -> CodeModeExecutionError {
+    CodeModeExecutionError::with_trace(
+        ToolError::Sdk {
+            sdk_kind: "timeout".to_string(),
+            message: "Code Mode execution timed out".to_string(),
+        },
+        sorted_calls(calls),
+    )
+}
+
+/// Shared budget gate for the two host-brokered operations. Tool calls and
+/// artifact writes each pass their own running count and share the
+/// `max_tool_calls` limit, so neither starves the other. `noun` names the
+/// operation in the error message; both reuse the `tool_call_limit_exceeded`
+/// kind (HTTP 429) per the error contract.
+fn ensure_within_limit(
+    started: usize,
+    limit: usize,
+    noun: &str,
     calls: &[(u64, CodeModeExecutedCall)],
 ) -> Result<(), CodeModeExecutionError> {
-    if started_tool_calls < max_tool_calls {
+    if started < limit {
         return Ok(());
     }
 
     Err(CodeModeExecutionError::with_trace(
         ToolError::Sdk {
             sdk_kind: "tool_call_limit_exceeded".to_string(),
-            message: format!("Code Mode execution exceeded max_tool_calls={max_tool_calls}"),
+            message: format!("Code Mode execution exceeded the {noun} limit of {limit}"),
         },
         sorted_calls(calls),
     ))
 }
 
-/// Test seam for the shared budget gate (tool calls + artifact writes both go
-/// through `ensure_call_budget`). Keeps the trace argument out of the assertion.
+/// Test seam for the shared budget gate. Keeps the trace argument out of the
+/// assertion.
 #[cfg(test)]
 pub(in crate::dispatch::gateway::code_mode) fn ensure_call_budget_for_test(
-    started_tool_calls: usize,
-    max_tool_calls: usize,
+    started: usize,
+    limit: usize,
 ) -> Result<(), CodeModeExecutionError> {
-    ensure_call_budget(started_tool_calls, max_tool_calls, &[])
+    ensure_within_limit(started, limit, "tool call", &[])
 }
 
 async fn handle_artifact_write(
@@ -431,11 +470,12 @@ async fn handle_artifact_write(
     seq: u64,
     request: CodeModeArtifactWrite,
     trace_params: bool,
+    max_bytes: usize,
 ) -> Result<(), ToolError> {
     let started = std::time::Instant::now();
     let redacted_params = artifact_trace_params(&request, trace_params);
 
-    match write_code_mode_artifact(artifact_root, &request).await {
+    match write_code_mode_artifact(artifact_root, &request, max_bytes).await {
         Ok(receipt) => {
             let result = json!(receipt);
             artifacts.push(receipt);

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -1,6 +1,8 @@
 //! Tests: response-budget truncation, wasm runner smoke, token estimate.
 #![cfg(test)]
 
+use std::collections::HashSet;
+
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -746,7 +748,7 @@ async fn prune_artifact_runs_keeps_newest_and_ignores_non_ulid_entries() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 1).await;
+    artifacts::prune_artifact_runs_in(store.path(), 1, &HashSet::new()).await;
 
     // Oldest two run dirs pruned; newest retained.
     assert!(!store.path().join(&run_ids[0]).exists());
@@ -757,6 +759,59 @@ async fn prune_artifact_runs_keeps_newest_and_ignores_non_ulid_entries() {
 }
 
 #[tokio::test]
+async fn prune_artifact_runs_never_deletes_active_run_dir() {
+    // Concurrency guard: a still-executing run's directory must survive pruning
+    // even when it is the oldest and `retain` would otherwise collect it. This
+    // is the proper fix for the cross-run prune race — not "keep retention high".
+    let store = TempDir::new().expect("store root");
+    let mut ids: Vec<String> = (0..3).map(|_| ulid::Ulid::new().to_string()).collect();
+    ids.sort(); // ascending: oldest first
+    for id in &ids {
+        tokio::fs::create_dir_all(store.path().join(id))
+            .await
+            .unwrap();
+    }
+
+    // Mark the OLDEST run active; with retain=1 it would normally be deleted.
+    let active = HashSet::from([ids[0].clone()]);
+    artifacts::prune_artifact_runs_in(store.path(), 1, &active).await;
+
+    // Active oldest dir survives despite retain=1; the inactive middle dir is
+    // pruned; the newest dir is retained by the cap.
+    assert!(
+        store.path().join(&ids[0]).exists(),
+        "active run dir must never be pruned, even as the oldest under retain=1"
+    );
+    assert!(
+        !store.path().join(&ids[1]).exists(),
+        "inactive old run dir must still be pruned"
+    );
+    assert!(
+        store.path().join(&ids[2]).exists(),
+        "newest run dir retained"
+    );
+}
+
+#[test]
+fn active_artifact_run_guard_registers_and_clears() {
+    // Unique id so the assertion is robust against parallel tests sharing the
+    // process-global active set.
+    let id = ulid::Ulid::new().to_string();
+    assert!(!artifacts::active_artifact_runs_snapshot().contains(&id));
+    {
+        let _guard = artifacts::ActiveArtifactRun::register(&id);
+        assert!(
+            artifacts::active_artifact_runs_snapshot().contains(&id),
+            "register must mark the run active"
+        );
+    }
+    assert!(
+        !artifacts::active_artifact_runs_snapshot().contains(&id),
+        "dropping the guard must clear the run id"
+    );
+}
+
+#[tokio::test]
 async fn prune_artifact_runs_disabled_when_retain_zero() {
     let store = TempDir::new().expect("store root");
     let id = ulid::Ulid::new().to_string();
@@ -764,7 +819,7 @@ async fn prune_artifact_runs_disabled_when_retain_zero() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 0).await;
+    artifacts::prune_artifact_runs_in(store.path(), 0, &HashSet::new()).await;
 
     assert!(store.path().join(&id).exists(), "retain=0 disables pruning");
 }
@@ -780,8 +835,8 @@ async fn prune_artifact_runs_noop_when_retain_at_or_above_count() {
     }
 
     // retain == count and retain > count must both keep every run dir.
-    artifacts::prune_artifact_runs_in(store.path(), 2).await;
-    artifacts::prune_artifact_runs_in(store.path(), 9).await;
+    artifacts::prune_artifact_runs_in(store.path(), 2, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 9, &HashSet::new()).await;
 
     for id in &ids {
         assert!(store.path().join(id).exists(), "{id} must be retained");

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -13,6 +13,11 @@ use super::artifacts::{
 use super::protocol::{CodeModeRunnerOutput, CodeModeRunnerResult};
 use super::*;
 
+/// Generous content cap for artifact tests whose subject is not the size limit
+/// (path safety, content-type defaulting, persistence, I/O failure). The
+/// dedicated size test passes its own explicit cap.
+const TEST_MAX_BYTES: usize = 8 * 1024 * 1024;
+
 #[test]
 fn code_mode_runner_wrapper_exposes_write_artifact() {
     let wrapped = runner::wrap_code_mode_for_test("async () => 'ok'", "var codemode = {};");
@@ -547,7 +552,7 @@ async fn write_code_mode_artifact_rejects_absolute_paths() {
         content_type: Some("text/markdown".to_string()),
     };
 
-    let err = write_code_mode_artifact(root.path(), &request)
+    let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect_err("absolute artifact path must be rejected");
 
@@ -567,7 +572,7 @@ async fn write_code_mode_artifact_rejects_parent_dir_paths() {
         content_type: Some("text/markdown".to_string()),
     };
 
-    let err = write_code_mode_artifact(root.path(), &request)
+    let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect_err("parent dir artifact path must be rejected");
 
@@ -594,7 +599,7 @@ async fn write_code_mode_artifact_rejects_backslash_relative_traversal() {
         content_type: None,
     };
 
-    let err = write_code_mode_artifact(root.path(), &request)
+    let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect_err("backslash traversal must be rejected");
 
@@ -617,7 +622,7 @@ async fn write_code_mode_artifact_rejects_backslash_absolute_path() {
         content_type: None,
     };
 
-    let err = write_code_mode_artifact(root.path(), &request)
+    let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect_err("backslash absolute path must be rejected");
 
@@ -642,7 +647,7 @@ async fn write_code_mode_artifact_rejects_symlinked_ancestor() {
         content_type: None,
     };
 
-    let err = write_code_mode_artifact(root.path(), &request)
+    let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect_err("symlinked ancestor must be rejected");
 
@@ -654,11 +659,15 @@ async fn write_code_mode_artifact_rejects_symlinked_ancestor() {
 }
 
 #[tokio::test]
-async fn write_code_mode_artifact_rejects_oversized_content() {
+async fn write_code_mode_artifact_enforces_the_passed_content_cap() {
     let root = TempDir::new().expect("temp root");
-    // Exactly 1 MiB succeeds; one byte over must be rejected as invalid_param.
-    let at_cap = "a".repeat(1024 * 1024);
-    let over_cap = "a".repeat(1024 * 1024 + 1);
+    // The cap is whatever the caller passes (resolved from
+    // LAB_CODE_MODE_ARTIFACT_MAX_MIB). Drive it with an explicit 1 MiB cap so the
+    // boundary is exercised cheaply: exactly at-cap succeeds, one byte over is a
+    // clean invalid_param.
+    let cap = 1024 * 1024;
+    let at_cap = "a".repeat(cap);
+    let over_cap = "a".repeat(cap + 1);
 
     let ok = write_code_mode_artifact(
         root.path(),
@@ -667,10 +676,11 @@ async fn write_code_mode_artifact_rejects_oversized_content() {
             content: at_cap,
             content_type: None,
         },
+        cap,
     )
     .await
-    .expect("exactly 1 MiB must be accepted");
-    assert_eq!(ok.bytes, 1024 * 1024);
+    .expect("exactly at-cap must be accepted");
+    assert_eq!(ok.bytes, cap);
 
     let err = write_code_mode_artifact(
         root.path(),
@@ -679,11 +689,103 @@ async fn write_code_mode_artifact_rejects_oversized_content() {
             content: over_cap,
             content_type: Some("text/markdown".to_string()),
         },
+        cap,
     )
     .await
-    .expect_err("over 1 MiB must be rejected");
+    .expect_err("over cap must be rejected");
     assert_eq!(err.kind(), "invalid_param");
     assert!(err.to_string().contains("maximum"), "error: {err}");
+}
+
+#[test]
+fn artifact_max_bytes_parses_env_and_falls_back() {
+    use crate::dispatch::helpers::with_env_override;
+    use std::collections::HashMap;
+
+    // Absent → 8 MiB default.
+    let default = artifacts::artifact_max_bytes();
+    assert_eq!(default, 8 * 1024 * 1024, "absent env must yield the 8 MiB default");
+
+    // Valid MiB value is honored and converted to bytes.
+    let valid = with_env_override(
+        HashMap::from([(
+            "LAB_CODE_MODE_ARTIFACT_MAX_MIB".to_string(),
+            "16".to_string(),
+        )]),
+        artifacts::artifact_max_bytes,
+    );
+    assert_eq!(valid, 16 * 1024 * 1024, "a valid MiB value must be honored");
+
+    // `0` and garbage both fall back to the default (a 0-byte cap rejects all).
+    for bad in ["0", "5O"] {
+        let got = with_env_override(
+            HashMap::from([(
+                "LAB_CODE_MODE_ARTIFACT_MAX_MIB".to_string(),
+                bad.to_string(),
+            )]),
+            artifacts::artifact_max_bytes,
+        );
+        assert_eq!(got, 8 * 1024 * 1024, "{bad:?} must fall back to the default");
+    }
+}
+
+#[test]
+fn artifact_max_store_bytes_parses_env_with_zero_disabling() {
+    use crate::dispatch::helpers::with_env_override;
+    use std::collections::HashMap;
+
+    // Absent → 4 GiB default.
+    assert_eq!(
+        artifacts::artifact_max_store_bytes(),
+        4096 * 1024 * 1024,
+        "absent env must yield the 4 GiB default"
+    );
+
+    let cases = [
+        ("8192", 8192u64 * 1024 * 1024), // valid MiB honored
+        ("0", 0),                        // 0 is meaningful here: disable byte pruning
+        ("5O", 4096 * 1024 * 1024),      // garbage → default
+    ];
+    for (raw, expected) in cases {
+        let got = with_env_override(
+            HashMap::from([(
+                "LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB".to_string(),
+                raw.to_string(),
+            )]),
+            artifacts::artifact_max_store_bytes,
+        );
+        assert_eq!(got, expected, "{raw:?} must resolve to {expected} bytes");
+    }
+}
+
+#[tokio::test]
+async fn write_code_mode_artifact_rejects_oversized_content_type() {
+    // content_type rides the receipt into the model's context, so it carries its
+    // own 256-byte cap independent of the (large) content cap.
+    let root = TempDir::new().expect("temp root");
+    let err = write_code_mode_artifact(
+        root.path(),
+        &CodeModeArtifactWrite {
+            path: "note.md".to_string(),
+            content: "body".to_string(),
+            content_type: Some("x".repeat(257)),
+        },
+        TEST_MAX_BYTES,
+    )
+    .await
+    .expect_err("oversized content_type must be rejected");
+    assert_eq!(err.kind(), "invalid_param");
+    assert!(
+        err.to_string().contains("content_type"),
+        "error should name the offending param: {err}"
+    );
+
+    // A normal-length content_type is accepted and nothing was written for the
+    // rejected one.
+    assert!(
+        !root.path().join("note.md").exists(),
+        "rejected content_type must not write a file"
+    );
 }
 
 #[tokio::test]
@@ -700,6 +802,7 @@ async fn write_code_mode_artifact_defaults_content_type_to_text_plain() {
                 content: "body".to_string(),
                 content_type,
             },
+            TEST_MAX_BYTES,
         )
         .await
         .expect("write succeeds");
@@ -725,6 +828,7 @@ async fn write_code_mode_artifact_maps_io_failure_to_internal_error() {
             content: "# nope".to_string(),
             content_type: None,
         },
+        TEST_MAX_BYTES,
     )
     .await
     .expect_err("write under a file must fail");
@@ -748,7 +852,7 @@ async fn prune_artifact_runs_keeps_newest_and_ignores_non_ulid_entries() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 1, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 1, 0, &HashSet::new()).await;
 
     // Oldest two run dirs pruned; newest retained.
     assert!(!store.path().join(&run_ids[0]).exists());
@@ -774,7 +878,7 @@ async fn prune_artifact_runs_never_deletes_active_run_dir() {
 
     // Mark the OLDEST run active; with retain=1 it would normally be deleted.
     let active = HashSet::from([ids[0].clone()]);
-    artifacts::prune_artifact_runs_in(store.path(), 1, &active).await;
+    artifacts::prune_artifact_runs_in(store.path(), 1, 0, &active).await;
 
     // Active oldest dir survives despite retain=1; the inactive middle dir is
     // pruned; the newest dir is retained by the cap.
@@ -790,6 +894,36 @@ async fn prune_artifact_runs_never_deletes_active_run_dir() {
         store.path().join(&ids[2]).exists(),
         "newest run dir retained"
     );
+}
+
+#[tokio::test]
+async fn prune_artifact_runs_enforces_byte_budget() {
+    // With the count cap effectively off (retain high), the byte budget alone
+    // must drop the oldest runs until the store fits. Three 1000-byte runs
+    // against a 2000-byte budget keep the newest two and prune the oldest.
+    let store = TempDir::new().expect("store root");
+    let mut ids: Vec<String> = (0..3).map(|_| ulid::Ulid::new().to_string()).collect();
+    ids.sort(); // ascending: oldest first
+    for id in &ids {
+        let dir = store.path().join(id);
+        // Nest the file so the recursive size walk is exercised.
+        tokio::fs::create_dir_all(dir.join("sub")).await.unwrap();
+        tokio::fs::write(dir.join("sub/a.md"), vec![b'x'; 1000])
+            .await
+            .unwrap();
+    }
+
+    artifacts::prune_artifact_runs_in(store.path(), 100, 2000, &HashSet::new()).await;
+
+    assert!(
+        !store.path().join(&ids[0]).exists(),
+        "oldest run must be pruned to honor the byte budget"
+    );
+    assert!(
+        store.path().join(&ids[1]).exists(),
+        "second-newest fits the budget"
+    );
+    assert!(store.path().join(&ids[2]).exists(), "newest fits the budget");
 }
 
 #[test]
@@ -819,9 +953,12 @@ async fn prune_artifact_runs_disabled_when_retain_zero() {
         .await
         .unwrap();
 
-    artifacts::prune_artifact_runs_in(store.path(), 0, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 0, 0, &HashSet::new()).await;
 
-    assert!(store.path().join(&id).exists(), "retain=0 disables pruning");
+    assert!(
+        store.path().join(&id).exists(),
+        "retain=0 and store-bytes=0 disables all pruning"
+    );
 }
 
 #[tokio::test]
@@ -835,8 +972,8 @@ async fn prune_artifact_runs_noop_when_retain_at_or_above_count() {
     }
 
     // retain == count and retain > count must both keep every run dir.
-    artifacts::prune_artifact_runs_in(store.path(), 2, &HashSet::new()).await;
-    artifacts::prune_artifact_runs_in(store.path(), 9, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 2, 0, &HashSet::new()).await;
+    artifacts::prune_artifact_runs_in(store.path(), 9, 0, &HashSet::new()).await;
 
     for id in &ids {
         assert!(store.path().join(id).exists(), "{id} must be retained");
@@ -888,7 +1025,7 @@ async fn write_code_mode_artifact_persists_content_and_returns_receipt() {
         content_type: Some("text/markdown".to_string()),
     };
 
-    let receipt = write_code_mode_artifact(root.path(), &request)
+    let receipt = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
         .await
         .expect("artifact write succeeds");
 

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -48,18 +48,36 @@ pub(super) async fn connect_stdio_upstream(
         cmd.env(env_name, &token);
     }
 
+    // A stdio MCP server logs to stderr (stdout is the JSON-RPC channel), so the
+    // child's stderr is the ONLY place its server-side diagnostics go. Capture
+    // it by default and forward into the gateway log; opt out per `LAB_GW_UPSTREAM_STDERR`.
+    let capture_stderr = upstream_stderr_capture_enabled();
+    let stderr_cfg = || {
+        if capture_stderr {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        }
+    };
+
     #[cfg(unix)]
-    let (process, _stderr) = {
+    let (process, child_stderr) = {
         let mut wrapped = CommandWrap::from(cmd);
         wrapped.wrap(ProcessGroup::leader());
         TokioChildProcess::builder(wrapped)
-            .stderr(Stdio::null())
+            .stderr(stderr_cfg())
             .spawn()?
     };
     #[cfg(not(unix))]
-    let (process, _stderr) = TokioChildProcess::builder(cmd)
-        .stderr(Stdio::null())
+    let (process, child_stderr) = TokioChildProcess::builder(cmd)
+        .stderr(stderr_cfg())
         .spawn()?;
+
+    // INVARIANT: a piped child stderr MUST be drained continuously. A chatty
+    // upstream (e.g. axon at INFO) fills the ~64 KB pipe buffer and then blocks
+    // on its next stderr write, hanging the upstream. The drain task reads to
+    // EOF so failures are recoverable from the gateway log instead of lost.
+    forward_upstream_stderr(child_stderr, config.name.clone());
 
     let pid = process.id();
     tracing::info!(
@@ -115,6 +133,58 @@ pub(super) async fn connect_stdio_upstream(
     };
 
     Ok((conn, tools))
+}
+
+/// Whether to capture spawned-upstream stderr and forward it into the gateway
+/// log. Default: enabled. Set `LAB_GW_UPSTREAM_STDERR` to `null`/`off`/`0` to
+/// discard it (the pre-capture behavior) for an extremely chatty upstream.
+fn upstream_stderr_capture_enabled() -> bool {
+    match std::env::var("LAB_GW_UPSTREAM_STDERR") {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "null" | "off" | "0" | "none" | "discard" | "false"
+        ),
+        Err(_) => true,
+    }
+}
+
+/// Drain a piped child stderr to EOF, forwarding each non-empty line into the
+/// gateway log under the `labby::upstream_stderr` target (silence just this
+/// stream with `LAB_LOG=labby::upstream_stderr=warn`). Draining is mandatory:
+/// an unread pipe buffer fills and blocks the child's next stderr write.
+fn forward_upstream_stderr(stderr: Option<tokio::process::ChildStderr>, upstream: String) {
+    let Some(stderr) = stderr else { return };
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    tracing::info!(
+                        target: "labby::upstream_stderr",
+                        surface = "dispatch",
+                        service = "upstream.pool",
+                        upstream = %upstream,
+                        stream = "stderr",
+                        "{line}",
+                    );
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::debug!(
+                        target: "labby::upstream_stderr",
+                        upstream = %upstream,
+                        error = %error,
+                        "upstream stderr drain ended on read error",
+                    );
+                    break;
+                }
+            }
+        }
+    });
 }
 
 pub(super) async fn connect_in_process_service_peer(

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -10,9 +10,9 @@ use std::time::Instant;
 use axum::http;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteResult,
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListResourcesResult,
-    ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo, SetLevelRequestParams,
+    ExtensionCapabilities, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ServerCapabilities, ServerInfo, SetLevelRequestParams,
 };
 use rmcp::service::{NotificationContext, Peer, RequestContext};
 use rmcp::{ErrorData, RoleServer, ServerHandler};
@@ -67,6 +67,21 @@ pub fn verify_upstream_subject_resolution_support() -> anyhow::Result<()> {
     );
 }
 
+/// Advertise the MCP Apps UI extension (`io.modelcontextprotocol/ui`, SEP-1724)
+/// so hosts like Claude.ai know to render the Code Mode inspector widgets served
+/// at `ui://lab/code-mode/{search,execute,history}`. The `mimeTypes` value mirrors
+/// the MIME the widget resources are published with (`text/html;profile=mcp-app`).
+fn mcp_apps_ui_extension() -> ExtensionCapabilities {
+    let mut extensions = ExtensionCapabilities::new();
+    let mut ui_ext = serde_json::Map::new();
+    ui_ext.insert(
+        "mimeTypes".to_string(),
+        serde_json::json!([crate::mcp::handlers_resources::CODE_MODE_APP_MIME]),
+    );
+    extensions.insert("io.modelcontextprotocol/ui".to_string(), ui_ext);
+    extensions
+}
+
 impl ServerHandler for LabMcpServer {
     fn get_info(&self) -> ServerInfo {
         tracing::info!(
@@ -90,6 +105,7 @@ impl ServerHandler for LabMcpServer {
                 .enable_prompts_list_changed()
                 .enable_logging()
                 .enable_completions()
+                .enable_extensions_with(mcp_apps_ui_extension())
                 .build(),
         )
     }
@@ -360,6 +376,21 @@ mod tests {
         assert!(
             info.capabilities.completions.is_some(),
             "RMCP completion capability must be advertised"
+        );
+
+        // MCP Apps UI extension (SEP-1724) must be advertised so hosts render
+        // the Code Mode inspector widgets.
+        let extensions = info
+            .capabilities
+            .extensions
+            .expect("MCP Apps UI extension capability must be advertised");
+        let ui_ext = extensions
+            .get("io.modelcontextprotocol/ui")
+            .expect("io.modelcontextprotocol/ui extension must be present");
+        assert_eq!(
+            ui_ext.get("mimeTypes"),
+            Some(&serde_json::json!(["text/html;profile=mcp-app"])),
+            "UI extension must advertise the mcp-app widget MIME type"
         );
     }
 

--- a/docs/dev/ERRORS.md
+++ b/docs/dev/ERRORS.md
@@ -57,9 +57,9 @@ Dispatch layers may add the following kinds on top of SDK errors:
 - `conflict` — resource already exists with the given identifier; HTTP 409
 - `ambiguous_tool` — unqualified tool name resolved to multiple upstream gateway candidates; envelope carries `valid: Vec<String>` of fully-qualified `{upstream}::{tool}` names the caller must choose from, plus a `hint` explaining that callers may either pass `name = "{upstream}::{tool}"` or set `upstream` separately. HTTP 409.
 - `invalid_code_mode_id` — Code Mode tool id parsing failed. Valid ids are `<upstream-name>::<tool-name>` only; Lab actions use `tool_execute`/`invoke`. HTTP 422.
-- `tool_call_limit_exceeded` — a Code Mode snippet attempted more host-brokered tool calls than `max_tool_calls` allows (artifact writes count against the same budget). HTTP 429.
+- `tool_call_limit_exceeded` — a Code Mode snippet exceeded a host-brokered operation budget. Tool calls and artifact writes have **separate** counters, each bounded by `max_tool_calls`; the message names which limit was hit. HTTP 429.
 
-> Note: Code Mode artifact writes (`writeArtifact(path, content, options?)`) reuse only kinds already defined in this contract — no artifact-specific kind is introduced. They emit `invalid_param` (empty/absolute/`..` path after `\`→`/` normalization, or content over the 1 MiB cap), `path_traversal`/`symlink_rejected` (the post-join containment check found the destination escaping the per-run root or resolving through a symlinked ancestor), or `internal_error` (a host-side filesystem write/flush failure).
+> Note: Code Mode artifact writes (`writeArtifact(path, content, options?)`) reuse only kinds already defined in this contract — no artifact-specific kind is introduced. They emit `invalid_param` (empty/absolute/`..` path after `\`→`/` normalization, content over the configured size cap — default 8 MiB, raise with `LAB_CODE_MODE_ARTIFACT_MAX_MIB` — or a `content_type` over 256 bytes), `path_traversal`/`symlink_rejected` (the post-join containment check found the destination escaping the per-run root or resolving through a symlinked ancestor), or `internal_error` (a host-side filesystem write/flush failure).
 
 > Note: `code_mode_disabled` and `code_execution_failed` are removed from the contract.
 > Code Mode execution disabled → `internal_error`. Sandbox/runner JS evaluation failure

--- a/docs/runtime/CONFIG.md
+++ b/docs/runtime/CONFIG.md
@@ -232,19 +232,35 @@ content is then written into a fresh per-run directory under
 }
 ```
 
-A single artifact is capped at **1 MiB**; oversized content is rejected with
-`invalid_param`. `options.contentType` defaults to `text/plain` when omitted or
-blank. Artifact writes do not bypass `timeout_ms`, `max_tool_calls`, or final
-response caps — each write counts against `max_tool_calls`. They are the
-preferred way to keep large markdown reports, source tables, crawl manifests,
-and follow-up snippets out of the final JSON response while still making them
-available on disk.
+Artifact **content** is written to disk and never returned to the model (only
+the receipt is), so its size cap is a resource bound, **not** a context guard. A
+single artifact defaults to a **8 MiB** cap, overridable with
+`LAB_CODE_MODE_ARTIFACT_MAX_MIB` (in MiB); oversized content is rejected with
+`invalid_param`. Keep it below ~64 so a write stays under the runner's JS heap
+and fails cleanly instead of as an opaque out-of-memory trap. `options.contentType`
+defaults to `text/plain` when omitted or blank and is itself capped at 256 bytes
+(it *does* ride the receipt back into the response). Artifact writes do not
+bypass `timeout_ms` or final response caps. Each write counts against a
+**separate** budget from tool calls — both are bounded by `max_tool_calls`
+(default `1000`), but artifact writes and upstream tool calls have independent
+counters, so a write-heavy run never starves its tool-call allowance and vice
+versa. They are the preferred way to keep large markdown reports, source tables,
+crawl manifests, and follow-up snippets out of the final JSON response while
+still making them available on disk.
 
-The store is bounded: on the first artifact write of a run (never on search or
-no-write runs) Labby prunes old per-run directories, keeping the newest
-`LAB_CODE_MODE_ARTIFACT_RETENTION_RUNS` (default `200`). Only ULID-named run
-directories this feature created are ever pruned; set the value to `0` to
-disable pruning (unbounded growth).
+The store is bounded on two axes, pruned on the first artifact write of a run
+(never on search or no-write runs):
+
+- **Run count** — keeps the newest `LAB_CODE_MODE_ARTIFACT_RETENTION_RUNS`
+  (default `200`) run directories; `0` disables the count rule.
+- **Total bytes** — drops the oldest runs until the whole store fits
+  `LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB` (default `4096`, i.e. 4 GiB); `0`
+  disables the byte rule. This matters once artifacts can be several MiB each,
+  where a run-count cap alone no longer bounds disk usage.
+
+Only ULID-named run directories this feature created are ever pruned, and a
+still-executing run is never collected. Set both knobs to `0` for unbounded
+growth.
 
 ### `[oauth.machines.<id>]`
 


### PR DESCRIPTION
Follow-up hardening on the artifact-first `writeArtifact` support ([#98](https://github.com/jmagar/lab/pull/98)).

## Why
The merged feature's caps were protecting the wrong thing: the 1 MiB **content** cap throttled the exact use case the feature exists for (offloading large output to disk), even though content never reaches the model — while `content_type`, the one field that *does* ride the receipt back into context, was uncapped. Plus a cross-run prune race and an inline write path that could outlive `timeout_ms`.

## Changes
**Caps**
- Content cap 1 MiB → **8 MiB** default, env-tunable `LAB_CODE_MODE_ARTIFACT_MAX_MIB`. It's a resource bound below the runner's 64 MiB JS heap (clean `invalid_param` instead of an opaque QuickJS OOM), not a context guard.
- Cap `content_type` at **256 B** — the only artifact field that reaches model context.

**Budgets**
- Decouple artifact writes from the tool-call budget: separate counter, each bounded by `max_tool_calls` independently. Generalized `ensure_call_budget` → `ensure_within_limit`.

**Retention**
- Bound the store on two axes: run count + **total bytes** (`LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB`, default 4 GiB). `retain=0` now disables only the count rule.

**Safety / robustness**
- Fix the cross-run prune race: process-global active-run registry + RAII guard make an in-flight run's directory unprunable regardless of retention or concurrency.
- Bound the inline prune+write by the run deadline (`timeout_at`) like tool calls.

**Cleanups** (from `/simplify`)
- Single-source the deadline-timeout error.
- Resolve the per-artifact cap once per run instead of per write.
- Size run directories concurrently (`join_all`) when byte-pruning.

## Verification
- `cargo nextest run -p labby --all-features code_mode` → **157 passed**
- `cargo clippy -p labby --all-features --tests` → clean
- `cargo check -p labby --all-features` → clean

New tests: byte-budget prune, active-run-never-pruned, store-bytes env parsing, content-type cap, configurable content cap.

Docs: `docs/runtime/CONFIG.md` and `docs/dev/ERRORS.md` updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks Code Mode artifact writes for safer caps, bounded retention, and deadline-aware disk ops. Also captures stdio upstream stderr and advertises the MCP Apps UI extension.

- **Bug Fixes**
  - Raise artifact content cap to 8 MiB by default (`LAB_CODE_MODE_ARTIFACT_MAX_MIB`); cap `content_type` at 256 B.
  - Give artifact writes their own counter; tool calls and writes are each bounded by `max_tool_calls`.
  - Add a total-byte store budget (`LAB_CODE_MODE_ARTIFACT_MAX_STORE_MIB`, default 4 GiB) alongside run-count; never prune a still-active run; prune and writes respect `timeout_ms`.
  - Capture stdio upstream stderr and forward to logs; disable with `LAB_GW_UPSTREAM_STDERR`.

- **New Features**
  - Advertise `io.modelcontextprotocol/ui` with `text/html;profile=mcp-app` so hosts render the Code Mode inspector widgets.

<sup>Written for commit e14b9a94d32eccfa724d74ce13545bf41ba51dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

