### PR TITLE
docs(skills): route unknown tool refs through gateway search/execute

### DIFF
--- a/plugins/labby/skills/using-labby/SKILL.md
+++ b/plugins/labby/skills/using-labby/SKILL.md
@@ -69,6 +69,8 @@ For direct MCP stdio use, run `labby mcp`. For browser/API/admin workflows, run 
 
 Labby exposes the public Code Mode tools as `search` and `execute`. Use `search` first to inspect live upstream tool IDs, schemas, output schemas, TypeScript signatures, and `codemode.*` helper names. Do not guess parameter names from memory or older examples.
 
+If another skill instructs you to call a tool you don't see in your tool list (e.g. `mcp__lab__<service>` or `mcp__<server>__<tool>`), that capability is almost certainly an upstream behind this gateway — not a missing tool. Translate the instruction: `search` for the tool, then `execute` it. Never conclude a capability is unavailable without searching first.
+
 Use `execute` with JavaScript that evaluates to an async function:
 
 ```js

--- a/plugins/vibin/skills/mcp-gateway-tools/SKILL.md
+++ b/plugins/vibin/skills/mcp-gateway-tools/SKILL.md
@@ -21,6 +21,17 @@ In Claude Code / Codex the callable tool names are namespaced by the gateway's M
 
 If your `list_tools` shows exactly one `*__search` and one `*__execute`, and the descriptions mention Code Mode or `const tools = [...]`, use them.
 
+## Tool Routing
+
+Every connected upstream — homelab services (dozzle, plex, sonarr, unraid, cortex, axon, …) AND general-purpose servers (github, context7, gmail, google-calendar, google-drive, …) — is hidden behind this gateway. None of them appear as direct `mcp__lab__<service>` or `mcp__<server>__<tool>` entries in your tool list.
+
+If a skill or request names a capability and you don't see a matching tool, do NOT conclude it's unavailable. Translate it:
+
+1. `search` the catalog for the capability.
+2. `execute` it via `callTool("<upstream>::<tool>", params)`.
+
+Exception: a server with its own native MCP endpoint registered directly in the client (e.g. dozzle per its skill) — use that directly, not the gateway.
+
 ## The Loop
 
 1. **Search.** Call `search` with JavaScript that filters the injected `tools` array.


### PR DESCRIPTION
## Problem

Service skills reference tools (`mcp__lab__<service>`, native per-server names) that don't exist as direct entries in Code Mode — the catalog collapses to `search` + `execute`. When a skill says "call tool X" and the model only sees `search`/`execute`, it doesn't make the leap that X is a gateway upstream, and concludes the capability is unavailable instead of searching for it.

## Change

Two skill edits, no per-service skill churn:

- **`mcp-gateway-tools`** — new **Tool Routing** section before *The Loop*. States that every connected upstream (homelab **and** general-purpose: github, context7, gmail, calendar, drive, …) is hidden behind the gateway, and to translate any unmatched tool reference into `search` → `execute` rather than giving up. Keeps the native-endpoint exception (e.g. dozzle).
- **`using-labby`** — translation note in *Code Mode Gotchas*: if a skill names a tool not in the list, treat it as a gateway upstream; search then execute; never conclude unavailable without searching first.

## Notes

- Wording is upstream-category-agnostic (not scoped to homelab).
- Docs-only; no code paths touched.
- Authored + pushed through the lab gateway's github upstream (Code Mode), which is fitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update skills docs to route unknown tool references through the MCP gateway. If a skill names a tool not in your list (e.g., `mcp__lab__<service>` or `mcp__<server>__<tool>`), `search` then `execute` via `callTool("<upstream>::<tool>", params)`; native MCP endpoints (e.g., dozzle) stay direct. Adds Tool Routing to `mcp-gateway-tools` and a translation note to `using-labby`.

<sup>Written for commit a2a932d94f9fb00d7c22ff0b439e86174d5881b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on searching for and executing MCP tool capabilities available upstream behind the gateway.
  * Documented the tool routing process, including the two-step search and execute workflow for invoking upstream MCP tools.
  * Clarified exception cases for upstream servers with native MCP endpoints registered directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->