### PR TITLE
feat(plugin): stop shipping the labby binary; explicit install + setup flow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# labby ships a compiled binary; track it via Git LFS (bitwarden/bin is a shell script, intentionally not LFS)
-plugins/labby/bin/labby filter=lfs diff=lfs merge=lfs -text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,8 +396,10 @@ just test-integration
 - Never add `clap`, `rmcp`, `ratatui`, `anyhow`, or `tabled` to `lab-apis` — they belong in `lab` only
 - **No `mod.rs` files.** Modern Rust module style only: a module `foo` is declared in `foo.rs` sibling to its `foo/` directory, never in `foo/mod.rs`
 
-## Plugin setup hooks
+## Plugin setup hooks and install flow
 
-Plugin setup is owned by the binary. `labby setup check` is read-only, `labby setup repair` is idempotent, and `labby setup plugin-hook --no-repair` is audit mode. If a lab plugin hook is added later, keep it as a thin adapter that maps `CLAUDE_PLUGIN_OPTION_*` values to environment variables, prepares appdata, ensures `labby` is on `PATH`, and then calls `labby setup plugin-hook "$@"`.
+Plugin setup is owned by the binary. `labby setup check` is read-only, `labby setup repair` is idempotent, and `labby setup plugin-hook --no-repair` is audit mode.
+
+**The plugin ships no binary and never auto-installs.** Installation is explicit: `scripts/install.sh` (release download → `~/.local/bin/labby`, cargo fallback) or `cargo install`, then `labby setup` for the first-run flow. The checked-in `plugins/labby` hooks are advisory shims that resolve `labby` from `PATH`: SessionStart runs `labby setup plugin-hook --no-repair` (audit only) and prints an install pointer when labby is absent; ConfigChange runs `labby setup plugin-hook` to sync changed plugin settings. Keep hooks that shape — never re-bundle a binary into `plugins/labby/bin/`, reference `${CLAUDE_PLUGIN_ROOT}/bin/labby`, or make a hook install/repair anything at session start.
 
 Do not add Docker Compose, systemd, or service bootstrap logic to plugin hook scripts.

--- a/Justfile
+++ b/Justfile
@@ -44,14 +44,15 @@ deny:
 build:
     cargo build --workspace --all-features
 
-# Build release binary with all features
+# Build release binary with all features.
+# bin/labby is the container bind-mount (docker-compose.yml); the plugin does
+# NOT ship a binary — hosts install labby via scripts/install.sh or cargo.
 build-release:
     cargo build --workspace --all-features --release
     install -D -m 755 target/release/labby bin/labby
-    install -D -m 755 target/release/labby plugins/labby/bin/labby
     just link-bin
 
-# Symlink the compiled release binary into PATH and all known plugin cache slots.
+# Symlink the compiled release binary into PATH.
 # Called automatically by `just build-release` and `just install`.
 link-bin:
     #!/usr/bin/env bash
@@ -67,17 +68,11 @@ link-bin:
     fi
     mkdir -p ~/.local/bin
     ln -sf "$LABBY_BIN" ~/.local/bin/labby
-    while IFS= read -r -d '' plugin_bin; do
-      ln -sf "$LABBY_BIN" "$plugin_bin"
-    done < <(find "${HOME}/.claude/plugins/cache/jmagar-lab/labby" -maxdepth 3 -name "labby" \( -type f -o -type l \) -print0 2>/dev/null)
     echo "labby → $LABBY_BIN"
-
-# Build the release binary and bundle it into the local plugin tree.
-build-plugin: build-release
 
 # Generate Claude Code marketplace tree from compiled service metadata
 marketplace: build-release
-    target/release/labby marketplace generate --out target/marketplace --binary target/release/labby
+    target/release/labby marketplace generate --out target/marketplace
 
 # Install release binary to ~/.local/bin/labby (updates the host CLI)
 install: build-release

--- a/README.md
+++ b/README.md
@@ -141,8 +141,18 @@ belong in `lab`.
 
 ## Quick Start
 
-The workspace uses Rust 2024 and the root toolchain requirement currently resolves to
-Rust 1.90+.
+### Install
+
+Prebuilt binary — downloads the latest GitHub release for this platform
+(sha256-verified) into `~/.local/bin/labby`, falling back to
+`cargo install --git` when no release asset exists:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh
+```
+
+Or build from source. The workspace uses Rust 2024 and the root toolchain
+requirement currently resolves to Rust 1.90+:
 
 ```bash
 git clone git@github.com:jmagar/lab.git
@@ -150,6 +160,11 @@ cd lab
 cargo build --workspace --all-features
 cargo install --path crates/lab --bin labby --all-features
 ```
+
+Then run `labby setup` for the first-run flow. The Claude Code plugin
+(`plugins/labby`) ships skills and MCP config only — it does **not** bundle
+the binary or auto-install anything; its session hook just reports setup
+status when `labby` is on `PATH`.
 
 Secrets and endpoint URLs belong in `~/.lab/.env`. Preferences belong in
 `config.toml`, searched in this order: `./config.toml`, `~/.lab/config.toml`,
@@ -518,7 +533,7 @@ just test-integration # cargo nextest run --workspace --all-features -- --ignore
 just lint             # cargo clippy --workspace --all-features -- -D warnings; cargo fmt --all -- --check
 just deny             # cargo deny check
 just build            # cargo build --workspace --all-features
-just build-release    # cargo build --workspace --all-features --release; install bin/labby
+just build-release    # cargo build --workspace --all-features --release; install bin/labby (container bind-mount) + ~/.local/bin symlink
 just web-build        # cd apps/gateway-admin && pnpm build
 just web-watch        # rebuild Labby static assets on frontend changes
 just run -- help      # cargo run --all-features -- <args>

--- a/crates/lab/src/cli/marketplace/generator.rs
+++ b/crates/lab/src/cli/marketplace/generator.rs
@@ -15,8 +15,13 @@ const DEFAULT_ORG: &str = match option_env!("LAB_PLUGIN_ORG") {
     None => "lab",
 };
 const CORE_PLUGIN: &str = "lab-core";
-const CORE_BINARY_NAME: &str = "labby";
-const CORE_BINARY_PATH: &str = "${HOME}/.claude/plugins/lab-core/bin/labby";
+/// Service plugins invoke labby from PATH. The plugin tree deliberately does
+/// NOT bundle the binary — hosts install labby explicitly (scripts/install.sh,
+/// a GitHub release archive, or `cargo install`) and `labby setup` owns the
+/// rest of the flow.
+const CORE_BINARY_COMMAND: &str = "labby";
+const INSTALL_SCRIPT_URL: &str =
+    "https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh";
 
 #[derive(Debug, Args)]
 pub struct GenerateArgs {
@@ -26,15 +31,11 @@ pub struct GenerateArgs {
     /// Marketplace/org suffix used in plugin ids, for example `lab`.
     #[arg(long, default_value = DEFAULT_ORG)]
     pub org: String,
-    /// Release binary to copy into lab-core/bin/labby.
-    #[arg(long)]
-    pub binary: Option<PathBuf>,
 }
 
 pub fn run_generate(args: GenerateArgs, format: OutputFormat) -> Result<ExitCode> {
     let theme = CliTheme::from_context(format.render_context());
-    let binary = args.binary.unwrap_or_else(default_binary_path);
-    generate_marketplace(&args.out, &args.org, &binary)?;
+    generate_marketplace(&args.out, &args.org)?;
     println!(
         "{} {}",
         theme.muted("generated marketplace at"),
@@ -43,13 +44,7 @@ pub fn run_generate(args: GenerateArgs, format: OutputFormat) -> Result<ExitCode
     Ok(ExitCode::SUCCESS)
 }
 
-fn generate_marketplace(out: &Path, org: &str, binary: &Path) -> Result<()> {
-    if !binary.is_file() {
-        anyhow::bail!(
-            "release binary not found at {}; run `just build-release` or pass --binary",
-            binary.display()
-        );
-    }
+fn generate_marketplace(out: &Path, org: &str) -> Result<()> {
     fs::create_dir_all(out).with_context(|| format!("create {}", out.display()))?;
 
     let registry = build_default_registry();
@@ -60,7 +55,7 @@ fn generate_marketplace(out: &Path, org: &str, binary: &Path) -> Result<()> {
         .collect::<Vec<_>>();
     service_names.sort();
 
-    write_core_plugin(out, org, binary)?;
+    write_core_plugin(out, org)?;
     for service in &service_names {
         write_service_plugin(out, org, service)?;
     }
@@ -68,16 +63,15 @@ fn generate_marketplace(out: &Path, org: &str, binary: &Path) -> Result<()> {
     Ok(())
 }
 
-fn write_core_plugin(out: &Path, org: &str, binary: &Path) -> Result<()> {
+fn write_core_plugin(out: &Path, org: &str) -> Result<()> {
     let root = out.join(CORE_PLUGIN);
     fs::create_dir_all(root.join(".claude-plugin"))?;
-    fs::create_dir_all(root.join("bin"))?;
     fs::create_dir_all(root.join("commands"))?;
-    fs::create_dir_all(root.join("skills/install-binary"))?;
+    fs::create_dir_all(root.join("skills/install-labby"))?;
 
     let manifest = plugin_manifest(
         CORE_PLUGIN,
-        "Core Labby binary and setup commands for Claude Code service plugins.",
+        "Setup commands and skills for Claude Code Labby service plugins.",
         org,
         &["labby", "setup", "homelab", "mcp"],
     );
@@ -93,19 +87,9 @@ fn write_core_plugin(out: &Path, org: &str, binary: &Path) -> Result<()> {
         setup_core_command(true),
     )?;
     fs::write(
-        root.join("skills/install-binary/SKILL.md"),
-        install_binary_skill(),
+        root.join("skills/install-labby/SKILL.md"),
+        install_labby_skill(),
     )?;
-
-    let dest = root.join("bin").join(CORE_BINARY_NAME);
-    fs::copy(binary, &dest).with_context(|| {
-        format!(
-            "copy release binary from {} to {}",
-            binary.display(),
-            dest.display()
-        )
-    })?;
-    set_executable(&dest)?;
     Ok(())
 }
 
@@ -131,7 +115,7 @@ fn write_service_plugin(out: &Path, org: &str, service: &str) -> Result<()> {
         &json!({
             "mcpServers": {
                 service: {
-                    "command": CORE_BINARY_PATH,
+                    "command": CORE_BINARY_COMMAND,
                     "args": ["mcp", "--services", service]
                 }
             }
@@ -150,7 +134,7 @@ fn write_marketplace_manifest(out: &Path, org: &str, services: &[String]) -> Res
     plugins.push(json!({
         "name": CORE_PLUGIN,
         "source": format!("./{CORE_PLUGIN}"),
-        "description": "Core Labby binary and setup commands for Claude Code service plugins."
+        "description": "Setup commands and skills for Claude Code Labby service plugins."
     }));
     for service in services {
         let Some(meta) = service_meta(service) else {
@@ -204,7 +188,7 @@ fn plugin_manifest(
 
 fn core_readme(org: &str) -> String {
     format!(
-        "# lab-core\n\nCore Labby plugin for Claude Code.\n\nCommands:\n\n- `/setup-core` runs `labby setup --mode plugin` for the plugin-focused setup flow.\n- `/setup-core-advanced` runs `labby setup --mode full` for the full operator setup flow.\n\nThe bundled binary lives at `bin/labby`. Service plugins call it directly from `{CORE_BINARY_PATH}` so they do not depend on PATH.\n\nInstall service plugins as `lab-<service>@{org}` after installing this core plugin.\n"
+        "# lab-core\n\nCore Labby plugin for Claude Code.\n\nThis plugin does **not** bundle the `labby` binary. Install it first:\n\n```bash\ncurl -fsSL {INSTALL_SCRIPT_URL} | sh\n# or: cargo install --git https://github.com/jmagar/lab --bin labby --all-features\n```\n\nthen run `labby setup`.\n\nCommands:\n\n- `/setup-core` runs `labby setup --mode plugin` for the plugin-focused setup flow.\n- `/setup-core-advanced` runs `labby setup --mode full` for the full operator setup flow.\n\nService plugins invoke `labby` from PATH.\n\nInstall service plugins as `lab-<service>@{org}` after installing this core plugin.\n"
     )
 }
 
@@ -229,7 +213,7 @@ fn service_readme(service: &str, org: &str) -> String {
             .collect::<String>()
     };
     format!(
-        "# lab-{service}\n\n{}\n\nThis plugin starts Labby with only `{service}` enabled:\n\n```json\n{{ \"command\": \"{CORE_BINARY_PATH}\", \"args\": [\"mcp\", \"--services\", \"{service}\"] }}\n```\n\nRun `/setup-core` to fill in service credentials.\n\nIf `lab-core` is not installed, run:\n\n```bash\nclaude plugin install lab-core@{org}\n```\n\n## Required env vars\n\n{required}\n## Optional env vars\n\n{optional}",
+        "# lab-{service}\n\n{}\n\nThis plugin starts Labby with only `{service}` enabled:\n\n```json\n{{ \"command\": \"{CORE_BINARY_COMMAND}\", \"args\": [\"mcp\", \"--services\", \"{service}\"] }}\n```\n\n`labby` must be installed on PATH first:\n\n```bash\ncurl -fsSL {INSTALL_SCRIPT_URL} | sh\n```\n\nRun `/setup-core` to fill in service credentials.\n\nIf `lab-core` is not installed, run:\n\n```bash\nclaude plugin install lab-core@{org}\n```\n\n## Required env vars\n\n{required}\n## Optional env vars\n\n{optional}",
         meta.description
     )
 }
@@ -251,54 +235,32 @@ fn install_core_command(org: &str) -> String {
     )
 }
 
-fn install_binary_skill() -> &'static str {
-    r#"---
-name: install-binary
-description: Ensure the bundled labby binary is reachable from ~/.local/bin.
+fn install_labby_skill() -> &'static str {
+    r"---
+name: install-labby
+description: Install the labby binary onto PATH when a lab plugin reports it missing.
 ---
 
-# Install Binary
+# Install Labby
 
-If `~/.local/bin/labby` does not exist or does not point at `${CLAUDE_PLUGIN_ROOT}/bin/labby`, offer to create a symlink.
-
-Use:
+Lab plugins do not bundle the `labby` binary. If `command -v labby` fails, offer to install it:
 
 ```bash
-mkdir -p ~/.local/bin
-ln -sfn "${CLAUDE_PLUGIN_ROOT}/bin/labby" ~/.local/bin/labby
+curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh
 ```
 
-If symlink creation fails, tell the user that the core binary is still available at `${CLAUDE_PLUGIN_ROOT}/bin/labby`; service plugins use that absolute plugin path directly and do not require PATH.
+The script downloads the latest GitHub release for this platform (sha256-verified) into `~/.local/bin/labby`, falling back to `cargo install --git https://github.com/jmagar/lab --bin labby --all-features` when no release asset exists.
+
+After installation, run `labby setup` to start the first-run flow (config, credentials, connectivity). Never run `labby setup repair` without telling the user what it will change.
 
 Never install other plugins, edit Claude Code config, or restart services.
-"#
+"
 }
 
 fn write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
     let mut bytes = serde_json::to_vec_pretty(value)?;
     bytes.push(b'\n');
     fs::write(path, bytes).with_context(|| format!("write {}", path.display()))
-}
-
-fn default_binary_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("target/release/labby")
-}
-
-#[cfg(unix)]
-fn set_executable(path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(perms.mode() | 0o755);
-    fs::set_permissions(path, perms)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_executable(_path: &Path) -> Result<()> {
-    Ok(())
 }
 
 #[cfg(test)]
@@ -327,10 +289,13 @@ mod tests {
     }
 
     #[test]
-    fn service_mcp_path_has_no_path_dependency() {
-        assert_eq!(
-            CORE_BINARY_PATH,
-            "${HOME}/.claude/plugins/lab-core/bin/labby"
-        );
+    fn service_mcp_command_resolves_labby_from_path() {
+        // The plugin tree deliberately ships NO binary: service plugins invoke
+        // `labby` from PATH and the install flow (scripts/install.sh →
+        // `labby setup`) is explicit, not plugin-driven.
+        assert_eq!(CORE_BINARY_COMMAND, "labby");
+        let readme = service_readme("deploy", "lab");
+        assert!(readme.contains("\"command\": \"labby\""));
+        assert!(!readme.contains(".claude/plugins/lab-core/bin"));
     }
 }

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,17 +1,44 @@
 # Lab Plugins
 
-`labby marketplace generate --out <dir>` builds a Claude Code plugin marketplace tree from the compiled service registry and each service `PluginMeta`.
+Lab plugins (the checked-in `plugins/labby` tree and the generated marketplace
+tree alike) ship **no binary**. Hosts install `labby` explicitly and the
+binary owns the setup flow from there:
 
-The generated tree contains:
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh
+labby setup
+```
 
-- `lab-core/`: the copied release binary at `bin/labby`, setup commands, and an install-binary skill.
+`scripts/install.sh` downloads the latest GitHub release archive for the
+platform (sha256-verified) into `~/.local/bin/labby`, falling back to
+`cargo install --git` when no release asset exists. Its only job is bootstrap —
+everything after first contact (config, credentials, connectivity, repair) is
+owned by `labby setup`.
+
+## Checked-in plugin (`plugins/labby`)
+
+Skills and MCP configuration only. Its `.mcp.json` connects over HTTP to a
+running `labby serve` (`${user_config.server_url}/mcp`), so machines that
+install the plugin remotely never need a local binary at all. Hooks are
+advisory: SessionStart runs `labby setup plugin-hook --no-repair` when `labby`
+is on PATH and prints an install pointer when it is not; ConfigChange syncs
+plugin settings via `labby setup plugin-hook` (again only when installed).
+Nothing is auto-installed or auto-repaired at session start.
+
+## Generated marketplace tree
+
+`labby marketplace generate --out <dir>` builds a Claude Code plugin
+marketplace tree from the compiled service registry and each service
+`PluginMeta`:
+
+- `lab-core/`: setup commands and an `install-labby` skill (no binary).
 - `lab-<service>/`: one config-only service plugin per service with required env vars.
 - `.claude-plugin/marketplace.json` and/or `.agents/plugins/marketplace.json`: indexes for generated plugin marketplaces.
 
-Service plugins do not depend on `PATH`. Their `.mcp.json` points at:
+Service plugins invoke `labby` from `PATH`. Their `.mcp.json` points at:
 
 ```json
-"${HOME}/.claude/plugins/lab-core/bin/labby"
+{ "command": "labby", "args": ["mcp", "--services", "<service>"] }
 ```
 
 The core plugin provides:

--- a/docs/coverage/PLUGINS.md
+++ b/docs/coverage/PLUGINS.md
@@ -163,7 +163,6 @@ Plugin manifests intentionally omit `version`; marketplace release identity is G
 | Type | Detail |
 |------|--------|
 | manifest | `.claude-plugin/plugin.json` |
-| bin | `bin/labby` |
 | hook | `hooks/hooks.json` |
 | skill | `skills/using-labby/SKILL.md` |
 | .mcp.json | `lab` -> `${user_config.server_url}/mcp` |

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -2672,9 +2672,6 @@ Options:
 
           [default: lab]
 
-      --binary <BINARY>
-          Release binary to copy into lab-core/bin/labby
-
   -h, --help
           Print help
 ```

--- a/plugins/labby/CHANGELOG.md
+++ b/plugins/labby/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — labby plugin
+
+## Unreleased
+
+- **Removed the bundled `labby` binary** (previously shipped via Git LFS at
+  `bin/labby`). The plugin is now skills + MCP config only. Install the binary
+  explicitly: `curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh`,
+  then run `labby setup`.
+- Hooks are now advisory and resolve `labby` from `PATH`: SessionStart audits
+  setup with `--no-repair` (no auto-repair at session start) and prints an
+  install pointer when labby is missing; ConfigChange still syncs changed
+  plugin settings.

--- a/plugins/labby/README.md
+++ b/plugins/labby/README.md
@@ -1,0 +1,33 @@
+# labby — Claude Code plugin
+
+Skills and MCP configuration for the Lab homelab control plane.
+
+This plugin does **not** bundle the `labby` binary and does not auto-install
+or auto-repair anything. It ships:
+
+- the `using-labby` skill,
+- an HTTP MCP server entry pointing at a running `labby serve`
+  (`${user_config.server_url}/mcp` — remote machines never need a local binary),
+- advisory hooks: SessionStart reports setup status via
+  `labby setup plugin-hook --no-repair` when `labby` is on `PATH` (and prints
+  an install pointer when it is not); ConfigChange syncs plugin settings via
+  `labby setup plugin-hook`.
+
+## Installing labby (server host only)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh
+labby setup
+```
+
+The script downloads the latest GitHub release for this platform
+(sha256-verified) into `~/.local/bin/labby`, falling back to
+`cargo install --git https://github.com/jmagar/lab --bin labby --all-features`
+when no release asset exists. Everything after install — config, credentials,
+connectivity checks, repair — is owned by `labby setup`.
+
+## Configuration
+
+Plugin settings (server URL, auth mode, token, …) are declared in
+`.claude-plugin/plugin.json` `userConfig` and synced into `~/.lab/.env` as
+`LAB_*` variables by `labby setup plugin-hook` when settings change.

--- a/plugins/labby/bin/labby
+++ b/plugins/labby/bin/labby
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3d6851674db3992d642fd77a4bc52c8c36697ab63bd1c094893d3a98dde90c1
-size 112314704

--- a/plugins/labby/hooks/hooks.json
+++ b/plugins/labby/hooks/hooks.json
@@ -5,8 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/labby setup plugin-hook",
-            "timeout": 60
+            "command": "if command -v labby >/dev/null 2>&1; then labby setup plugin-hook --no-repair; else echo 'labby is not installed — install it with: curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh  (then run: labby setup)'; fi",
+            "timeout": 30
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/labby setup plugin-hook",
+            "command": "if command -v labby >/dev/null 2>&1; then labby setup plugin-hook; else echo 'labby is not installed — plugin settings were NOT synced. Install labby, then run: labby setup'; fi",
             "timeout": 60
           }
         ]

--- a/scripts/cargo-rustc-wrapper
+++ b/scripts/cargo-rustc-wrapper
@@ -89,9 +89,10 @@ case "$out" in
   *) exit 0 ;;
 esac
 
+# Sync the freshly built labby into PATH. The plugin deliberately does NOT
+# ship a binary (hosts install labby explicitly — see scripts/install.sh), so
+# there is no plugin-bundle copy here.
 local_bin="${LABBY_RUSTC_WRAPPER_LOCAL_BIN:-$HOME/.local/bin/labby}"
-plugin_bin="${LABBY_RUSTC_WRAPPER_PLUGIN_BIN:-$repo/plugins/labby/bin/labby}"
 
-mkdir -p "$(dirname "$local_bin")" "$(dirname "$plugin_bin")"
+mkdir -p "$(dirname "$local_bin")"
 cp -f "$out" "$local_bin"
-cp -f "$out" "$plugin_bin"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Install labby — the Lab homelab control plane binary.
+#
+#   curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh
+#
+# Downloads the latest GitHub release archive for this platform, verifies its
+# SHA-256, and installs the binary to ~/.local/bin/labby. When no release
+# asset exists (or the platform has no prebuilt archive) it falls back to
+# `cargo install --git` if a Rust toolchain is available.
+#
+# This script's ONLY job is bootstrap: getting `labby` onto PATH. Everything
+# after that is owned by the binary — run `labby setup` for the first-run
+# flow (config, credentials, connectivity checks).
+#
+# Environment overrides:
+#   LAB_INSTALL_DIR     install directory       (default: ~/.local/bin)
+#   LAB_INSTALL_REPO    owner/repo to fetch     (default: jmagar/lab)
+#   LAB_INSTALL_VERSION release tag, e.g. v0.22.2 (default: latest)
+
+set -eu
+
+REPO="${LAB_INSTALL_REPO:-jmagar/lab}"
+INSTALL_DIR="${LAB_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${LAB_INSTALL_VERSION:-latest}"
+
+say() { printf '%s\n' "$*" >&2; }
+fail() { say "install.sh: $*"; exit 1; }
+
+target_triple() {
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os" in
+        Linux)
+            case "$arch" in
+                x86_64) echo "x86_64-unknown-linux-gnu" ;;
+                aarch64 | arm64) echo "aarch64-unknown-linux-gnu" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+sha256_check() {
+    # $1 = file, $2 = expected-checksum file (file is "<hex>  <name>" format)
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$(dirname "$1")" && sha256sum -c "$2" >/dev/null 2>&1) && return 0
+        # Some checksum files carry only the bare hex digest.
+        expected="$(awk '{print $1}' "$2")"
+        actual="$(sha256sum "$1" | awk '{print $1}')"
+        [ "$expected" = "$actual" ]
+    elif command -v shasum >/dev/null 2>&1; then
+        expected="$(awk '{print $1}' "$2")"
+        actual="$(shasum -a 256 "$1" | awk '{print $1}')"
+        [ "$expected" = "$actual" ]
+    else
+        say "warning: no sha256sum/shasum found — skipping checksum verification"
+        return 0
+    fi
+}
+
+install_from_release() {
+    triple="$(target_triple)" || return 1
+    asset="lab-${triple}.tar.gz"
+    if [ "$VERSION" = "latest" ]; then
+        base="https://github.com/${REPO}/releases/latest/download"
+    else
+        base="https://github.com/${REPO}/releases/download/${VERSION}"
+    fi
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    say "downloading ${base}/${asset} ..."
+    curl -fsSL --retry 3 -o "$tmp/$asset" "${base}/${asset}" || return 1
+    if curl -fsSL --retry 3 -o "$tmp/$asset.sha256" "${base}/${asset}.sha256"; then
+        sha256_check "$tmp/$asset" "$tmp/$asset.sha256" \
+            || fail "checksum verification FAILED for $asset — aborting"
+        say "sha256 verified"
+    else
+        say "warning: no .sha256 asset published — skipping checksum verification"
+    fi
+
+    tar -xzf "$tmp/$asset" -C "$tmp"
+    bin="$(find "$tmp" -type f -name labby | head -n 1)"
+    [ -n "$bin" ] || fail "archive $asset did not contain a 'labby' binary"
+
+    mkdir -p "$INSTALL_DIR"
+    install -m 755 "$bin" "$INSTALL_DIR/labby"
+    return 0
+}
+
+install_from_source() {
+    command -v cargo >/dev/null 2>&1 || return 1
+    say "no release asset available — building from source (this takes a while) ..."
+    cargo install --git "https://github.com/${REPO}" --bin labby --all-features --root "${INSTALL_DIR%/bin}" \
+        || cargo install --git "https://github.com/${REPO}" --bin labby --all-features
+}
+
+main() {
+    if install_from_release; then
+        :
+    elif install_from_source; then
+        :
+    else
+        fail "could not install: no prebuilt release for $(uname -s)/$(uname -m) and no cargo toolchain found.
+Install a Rust toolchain (https://rustup.rs) and re-run, or build from a clone:
+  git clone https://github.com/${REPO} && cd lab && cargo install --path crates/lab --bin labby --all-features"
+    fi
+
+    if ! command -v labby >/dev/null 2>&1; then
+        say ""
+        say "NOTE: $INSTALL_DIR is not on your PATH. Add it, e.g.:"
+        say "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    fi
+
+    say ""
+    say "labby installed: $("$INSTALL_DIR/labby" --version 2>/dev/null || echo "$INSTALL_DIR/labby")"
+    say "next: run 'labby setup' to start the first-run flow"
+}
+
+main "$@"

--- a/scripts/test-cargo-rustc-wrapper.sh
+++ b/scripts/test-cargo-rustc-wrapper.sh
@@ -7,9 +7,8 @@ trap 'rm -rf "$tmp"' EXIT
 
 export HOME="$tmp/home"
 export LABBY_RUSTC_WRAPPER_LOCAL_BIN="$HOME/.local/bin/labby"
-export LABBY_RUSTC_WRAPPER_PLUGIN_BIN="$tmp/plugin/labby"
 export LABBY_RUSTC_WRAPPER_NO_SCCACHE=1
-mkdir -p "$HOME/.local/bin" "$tmp/plugin" "$tmp/target/debug/deps"
+mkdir -p "$HOME/.local/bin" "$tmp/target/debug/deps"
 
 fake_rustc="$tmp/fake-rustc"
 cat >"$fake_rustc" <<'SH'
@@ -63,9 +62,8 @@ out="$tmp/target/debug/deps/labby-123"
   -o "$out"
 
 cmp "$out" "$HOME/.local/bin/labby"
-cmp "$out" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
 
-rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
+rm -f "$HOME/.local/bin/labby"
 "$repo/scripts/cargo-rustc-wrapper" "$fake_rustc" \
   --crate-name labby \
   --crate-type bin \
@@ -74,9 +72,8 @@ rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
   -o "$out"
 
 test ! -e "$HOME/.local/bin/labby"
-test ! -e "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
 
-rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
+rm -f "$HOME/.local/bin/labby"
 (
   cd "$tmp"
   "$repo/scripts/cargo-rustc-wrapper" "$fake_rustc" \
@@ -87,9 +84,8 @@ rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
 )
 
 cmp "$tmp/target/release/deps/labby-456" "$HOME/.local/bin/labby"
-cmp "$tmp/target/release/deps/labby-456" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
 
-rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
+rm -f "$HOME/.local/bin/labby"
 "$repo/scripts/cargo-rustc-wrapper" "$fake_rustc" \
   --crate-name labby \
   --crate-type bin \
@@ -98,6 +94,5 @@ rm -f "$HOME/.local/bin/labby" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
   -C extra-filename=-789
 
 cmp "$tmp/target/debug/deps/labby-789" "$HOME/.local/bin/labby"
-cmp "$tmp/target/debug/deps/labby-789" "$LABBY_RUSTC_WRAPPER_PLUGIN_BIN"
 
 echo "cargo rustc wrapper install behavior ok"


### PR DESCRIPTION
## Why

The labby Claude Code plugin bundled a 112MB release binary via Git LFS and ran `labby setup plugin-hook` (with repair) from the plugin bundle on every SessionStart. That made plugin installation an implicit install/setup mechanism, with recurring failure modes: forgotten `git lfs push` breaking fresh clones and plugin updates, the perpetually dirty `plugins/labby/bin/labby` on every build, and setup mutations happening as a session-start side effect.

## What

**The plugin is now skills + MCP config only. Install and setup are explicit and binary-owned.**

- **Removed** `plugins/labby/bin/labby` (LFS) and the `.gitattributes` LFS rule.
- **Hooks are advisory, PATH-based:** SessionStart runs `labby setup plugin-hook --no-repair` (audit only) when labby is installed, otherwise prints a one-line install pointer. ConfigChange syncs changed plugin settings via `labby setup plugin-hook`. Nothing auto-installs or auto-repairs at session start.
- **New `scripts/install.sh`** — bootstrap only: downloads the latest GitHub release archive for the platform, verifies sha256, installs to `~/.local/bin/labby`; falls back to `cargo install --git` when no release asset exists (none published yet). Hands off to `labby setup` for everything else.
- **Marketplace generator de-bundled:** `labby marketplace generate` drops `--binary`; `lab-core` no longer carries a binary; generated service plugins invoke `labby` from PATH (`{"command":"labby","args":["mcp","--services","<svc>"]}`); `install-binary` skill replaced with `install-labby` (release/cargo install guidance).
- **Build plumbing:** `just build-release` no longer installs into the plugin tree; `link-bin` no longer rewrites plugin cache slots; `build-plugin` target removed; `cargo-rustc-wrapper` drops the plugin-bundle copy (PATH sync only) with its test updated.
- **Docs:** README Quick Start install section, `docs/PLUGINS.md` rewritten for the no-binary model, coverage table, root CLAUDE.md plugin-hook contract, plugin README/CHANGELOG written, generated CLI help refreshed.

## Notes

- Remote machines installing the plugin connect over HTTP MCP (`server_url`) and never needed a local binary — only the server host installs labby.
- Once a `v*` tag is pushed, release.yml's published archives make install.sh's primary path live; until then the script falls back to `cargo install --git`.

## Verification

`cargo fmt --check` clean · `cargo clippy --workspace --all-features -- -D warnings` exit 0 · `cargo nextest run -p labby --all-features` 1643 passed · `just docs-check` fresh · `bash scripts/test-cargo-rustc-wrapper.sh` ok · `sh -n scripts/install.sh` ok · `labby marketplace generate` smoke-tested (no bin/, PATH-based .mcp.json)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop bundling the `labby` binary in the Claude Code plugin and make install + setup explicit. This reduces repo bloat, removes Git LFS pitfalls, and prevents side-effect installs on session start.

- **Refactors**
  - Removed `plugins/labby/bin/labby` and the LFS rule; plugin is now skills + MCP config only.
  - Hooks are PATH-based and advisory: SessionStart runs `labby setup plugin-hook --no-repair`; ConfigChange runs `labby setup plugin-hook`.
  - Added `scripts/install.sh` to install `labby` to `~/.local/bin/labby` (release download with sha256 verify; `cargo install --git` fallback).
  - Marketplace generator drops `--binary`; `lab-core` no longer bundles a binary; generated services use `{ "command": "labby", "args": [...] }`; skill renamed to `install-labby`.
  - Build plumbing cleaned up (`Justfile`, cargo rustc wrapper); docs updated (README, PLUGINS, coverage, CLAUDE.md, plugin README/CHANGELOG).

- **Migration**
  - Install `labby` on hosts: `curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh` or `cargo install --git https://github.com/jmagar/lab --bin labby --all-features`.
  - Run `labby setup` after install; ensure `labby` is on PATH for generated service plugins.
  - Remote machines using the checked-in plugin connect over HTTP MCP (`server_url`) and do not need a local binary.

<sup>Written for commit 2618cf6c8fbfdbe2071fa5bf253f37241e2a319b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

