### PR TITLE
feat(gateway): Windows Job Object reaping for stdio upstream + Code Mode children [lab-jouhb]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.23.1] - 2026-06-10
+
+### Fixed
+
+- **Windows: Job Object reaping for stdio upstream children and Code Mode runner** ([lab-jouhb]).
+  Two spawn sites previously left grandchildren (`cmd → node`, `npx → python`, etc.) orphaned on
+  Windows when an upstream was killed or reloaded, because only the direct child PID was killed:
+
+  - `connect_stdio.rs` — a new `#[cfg(windows)]` `JobObjectGuard` is armed immediately after
+    spawn (mirroring the Unix `ProcessGroupGuard`), disarmed on successful `UpstreamConnection`
+    construction, and the raw Job Object `HANDLE` is stored in `UpstreamRuntimeMetadata.job_handle`.
+    `UpstreamConnection::Drop` and `shutdown()` close the handle, causing the OS to terminate the
+    entire descendant tree via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+
+  - `runner_drive.rs` — a `_runner_job_guard` (also `JobObjectGuard`) is held for the lifetime of
+    `run_in_runner_with_config`, covering all exit paths (completion, timeout, protocol error). The
+    existing `terminate_code_mode_runner` direct-child kill is retained as belt-and-suspenders.
+
+  The Unix path (`ProcessGroup::leader()` / `ProcessGroupGuard` / `killpg`) is byte-for-byte
+  unchanged. All new code is additive under `#[cfg(windows)]`. New Windows-only deps
+  (`windows-sys` with `Win32_Foundation`, `Win32_System_JobObjects`,
+  `Win32_System_Threading`) are declared under `[target.'cfg(windows)'.dependencies]` so
+  Linux builds are unaffected. A `#[ignore]` integration test
+  (`tests/windows_job_object_reaping.rs`) is included for verification on the `windows-lab`
+  self-hosted CI runner.
+
+---
+
 ## [0.23.0] - 2026-06-10
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ All notable changes to this project will be documented in this file.
     existing `terminate_code_mode_runner` direct-child kill is retained as belt-and-suspenders.
 
   The Unix path (`ProcessGroup::leader()` / `ProcessGroupGuard` / `killpg`) is byte-for-byte
-  unchanged. All new code is additive under `#[cfg(windows)]`. New Windows-only deps
-  (`windows-sys` with `Win32_Foundation`, `Win32_System_JobObjects`,
-  `Win32_System_Threading`) are declared under `[target.'cfg(windows)'.dependencies]` so
-  Linux builds are unaffected. A `#[ignore]` integration test
+  unchanged. All new code is additive under `#[cfg(windows)]`. A `#[ignore]` integration test
   (`tests/windows_job_object_reaping.rs`) is included for verification on the `windows-lab`
   self-hosted CI runner.
+
+  The raw `windows-sys` Job Object FFI lives in a **new `lab-winjob` crate** — the sanctioned
+  unsafe boundary — which exposes a safe API (`create_job_for_pid`, `close_job`). This mirrors
+  how the Unix path routes its unsafe through the external `nix` crate: `lab` and `lab-apis`
+  keep the workspace-wide `unsafe_code = "forbid"` lint and contain zero `unsafe`. The job
+  handle is carried as `isize` (not `windows-sys 0.59`'s `!Send + !Sync` `HANDLE`) so storing
+  it in `AppState` does not break the axum router's `Send`/`Sync` bounds.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,6 +2562,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lab-winjob"
+version = "0.23.1"
+dependencies = [
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "labby"
 version = "0.23.1"
 dependencies = [
@@ -2597,6 +2605,7 @@ dependencies = [
  "jsonwebtoken",
  "lab-apis",
  "lab-auth",
+ "lab-winjob",
  "lru",
  "nix",
  "num_cpus",
@@ -2640,7 +2649,6 @@ dependencies = [
  "uuid",
  "walkdir",
  "wasmtime",
- "windows-sys 0.59.0",
  "wiremock",
  "xxhash-rust",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "lab-apis"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "base64",
  "futures",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "lab-auth"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum",
  "base64",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "labby"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2640,6 +2640,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "wasmtime",
+ "windows-sys 0.59.0",
  "wiremock",
  "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/lab-apis", "crates/lab", "crates/lab-auth"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/lab-apis", "crates/lab", "crates/lab-auth"]
+members = ["crates/lab-apis", "crates/lab", "crates/lab-auth", "crates/lab-winjob"]
 
 [workspace.package]
 version = "0.23.1"

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -48,6 +48,7 @@ RUN mkdir -p \
       crates/lab-apis/src \
       crates/lab-apis/tests \
       crates/lab-auth/src \
+      crates/lab-winjob/src \
       apps/gateway-admin/out \
  && echo 'fn main(){}' > crates/lab/src/main.rs \
  && touch \
@@ -58,10 +59,12 @@ RUN mkdir -p \
       crates/lab-apis/tests/openacp_client.rs \
       crates/lab-apis/tests/jellyfin_client.rs \
       crates/lab-auth/src/lib.rs \
+      crates/lab-winjob/src/lib.rs \
  && cargo build --workspace --all-features --release \
  && cargo clean -p labby \
  && cargo clean -p lab-apis \
  && cargo clean -p lab-auth \
+ && cargo clean -p lab-winjob \
  && rm -rf \
       crates/*/src \
       crates/lab-apis/tests \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -30,6 +30,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/lab/Cargo.toml      crates/lab/Cargo.toml
 COPY crates/lab-apis/Cargo.toml crates/lab-apis/Cargo.toml
 COPY crates/lab-auth/Cargo.toml crates/lab-auth/Cargo.toml
+COPY crates/lab-winjob/Cargo.toml crates/lab-winjob/Cargo.toml
 
 # Create stub source + test files so cargo can parse ALL manifests without error.
 #

--- a/crates/lab-winjob/Cargo.toml
+++ b/crates/lab-winjob/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "lab-winjob"
+description = "Windows Job Object FFI boundary for lab — sanctioned unsafe crate exposing a safe process-tree reaping API."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
+keywords = ["windows", "job-object", "process", "reaping", "ffi"]
+categories = ["os::windows-apis", "api-bindings"]
+publish = false
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
+  # Test-support helpers (`pid_is_alive`, `find_first_child_pid`) walk the
+  # process list and query process liveness so the integration test stays
+  # unsafe-free.
+  "Win32_System_Diagnostics_ToolHelp",
+] }
+tracing.workspace = true
+
+# This crate is the SANCTIONED unsafe boundary for Windows Job Object FFI —
+# mirroring how the Unix path routes its unsafe through the external `nix`
+# crate. The workspace sets `unsafe_code = "forbid"` (which cannot be escaped
+# with `#[allow]`), so `lab` and `lab-apis` stay unsafe-free. This crate opts
+# OUT of that forbid by NOT inheriting `[lints] workspace = true` and instead
+# allowing unsafe explicitly. The `unsafe` lives inside safe public fns, so
+# callers never write `unsafe`.
+[lints.rust]
+unsafe_code = "allow"

--- a/crates/lab-winjob/src/lib.rs
+++ b/crates/lab-winjob/src/lib.rs
@@ -231,8 +231,11 @@ pub fn close_job(job: isize, pid: u32) {
 #[cfg(windows)]
 #[must_use]
 pub fn pid_is_alive(pid: u32) -> bool {
+    // `WAIT_OBJECT_0` is a `WAIT_EVENT` constant in `Win32::Foundation` (not
+    // `Threading`) in windows-sys 0.59; `WaitForSingleObject` returns it.
+    use windows_sys::Win32::Foundation::WAIT_OBJECT_0;
     use windows_sys::Win32::System::Threading::{
-        PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WAIT_OBJECT_0, WaitForSingleObject,
+        PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WaitForSingleObject,
     };
 
     let handle = unsafe {

--- a/crates/lab-winjob/src/lib.rs
+++ b/crates/lab-winjob/src/lib.rs
@@ -1,5 +1,12 @@
 //! Windows Job Object helpers for process-tree reaping.
 //!
+//! This crate is the **sanctioned unsafe boundary** for `lab`'s Windows Job
+//! Object FFI, mirroring how the Unix path routes its unsafe through the
+//! external `nix` crate. The workspace sets `unsafe_code = "forbid"` (which a
+//! `#[allow]` cannot escape), so `lab` and `lab-apis` stay unsafe-free. The raw
+//! `windows-sys` calls are encapsulated here behind a **safe** public API:
+//! callers never write `unsafe`.
+//!
 //! On Windows there is no concept of a process group. A Job Object is the
 //! nearest OS equivalent: the kernel associates a child process (and, when
 //! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set, its entire descendant tree)
@@ -46,6 +53,18 @@
 //! approach is to use `JobObject` from `process-wrap` (which passes
 //! `CREATE_SUSPENDED` to `CreateProcess`) with a custom Tokio child-process
 //! wrapper that resumes the process after the job is assigned.
+//!
+//! ## Handle representation
+//!
+//! The job handle is stored and passed as `isize` (the raw `HANDLE` value), not
+//! `HANDLE` itself. In `windows-sys 0.59` `HANDLE` is `*mut c_void`
+//! (`!Send + !Sync`), which would poison the `Send`/`Sync` bounds of any struct
+//! that stores it (and break `lab`'s axum router). `isize` is
+//! `Copy + Send + Sync`; we cast back to `HANDLE` only at the `CloseHandle`
+//! boundary inside [`close_job`].
+//!
+//! On non-Windows targets this crate compiles to an empty library (`lab` only
+//! depends on it under `cfg(windows)`).
 
 #[cfg(windows)]
 use windows_sys::Win32::{
@@ -56,9 +75,7 @@ use windows_sys::Win32::{
             JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
             QueryInformationJobObject, SetInformationJobObject,
         },
-        Threading::OpenProcess,
-        Threading::PROCESS_SET_QUOTA,
-        Threading::PROCESS_TERMINATE,
+        Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE},
     },
 };
 
@@ -72,16 +89,16 @@ use windows_sys::Win32::{
 ///
 /// The handle is returned as `isize` rather than `HANDLE` (`*mut c_void`)
 /// deliberately: in `windows-sys 0.59` `HANDLE` is a raw pointer, which is
-/// `!Send + !Sync`. Storing it raw in `UpstreamRuntimeMetadata` would poison
-/// `AppState`'s `Send`/`Sync` bounds and break the axum router. `isize` is
-/// `Copy + Send + Sync`, so the stored/passed value crosses thread boundaries
-/// cleanly; we cast back to `HANDLE` only at the `CloseHandle` boundary.
+/// `!Send + !Sync`. Storing it raw in a struct would poison that struct's
+/// `Send`/`Sync` bounds. `isize` is `Copy + Send + Sync`, so the stored/passed
+/// value crosses thread boundaries cleanly; we cast back to `HANDLE` only at
+/// the `CloseHandle` boundary.
 ///
-/// # Safety
-///
-/// This function calls Win32 APIs and is therefore unsafe.
+/// This is a **safe** function: the `unsafe` FFI is fully encapsulated here, so
+/// callers (in `lab`, which forbids unsafe) never write `unsafe`.
 #[cfg(windows)]
-pub unsafe fn create_job_for_pid(pid: u32) -> isize {
+#[must_use]
+pub fn create_job_for_pid(pid: u32) -> isize {
     // Open the child process with the rights needed to assign it to a job and
     // to terminate it.
     let proc_handle = unsafe {
@@ -93,7 +110,7 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
     };
     if proc_handle.is_null() || proc_handle == INVALID_HANDLE_VALUE {
         tracing::warn!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "OpenProcess failed — job object not created; falling back to per-PID kill"
         );
@@ -103,7 +120,7 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
     let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
     if job.is_null() || job == INVALID_HANDLE_VALUE {
         tracing::warn!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "CreateJobObjectW failed — falling back to per-PID kill"
         );
@@ -118,14 +135,13 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
             job,
             JobObjectExtendedLimitInformation,
             std::ptr::addr_of_mut!(info).cast(),
-            u32::try_from(std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
-                .unwrap_or(u32::MAX),
+            u32::try_from(size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>()).unwrap_or(u32::MAX),
             std::ptr::null_mut(),
         )
     };
     if ok == 0 {
         tracing::warn!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "QueryInformationJobObject failed — killing job without KILL_ON_JOB_CLOSE"
         );
@@ -136,13 +152,13 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
                 job,
                 JobObjectExtendedLimitInformation,
                 std::ptr::addr_of!(info).cast(),
-                u32::try_from(std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                u32::try_from(size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
                     .unwrap_or(u32::MAX),
             )
         };
         if set_ok == 0 {
             tracing::warn!(
-                target: "upstream.process_guard.windows",
+                target: "lab_winjob",
                 pid,
                 "SetInformationJobObject failed — KILL_ON_JOB_CLOSE not set"
             );
@@ -153,7 +169,7 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
     unsafe { CloseHandle(proc_handle) };
     if assigned == 0 {
         tracing::warn!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "AssignProcessToJobObject failed — job created but child not assigned; closing job"
         );
@@ -162,7 +178,7 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
     }
 
     tracing::debug!(
-        target: "upstream.process_guard.windows",
+        target: "lab_winjob",
         pid,
         "process assigned to job object with KILL_ON_JOB_CLOSE"
     );
@@ -174,19 +190,15 @@ pub unsafe fn create_job_for_pid(pid: u32) -> isize {
 /// the job (including grandchildren) if `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
 /// was set.
 ///
-/// Takes the handle as `isize` (the `Send`/`Sync`-safe representation stored in
-/// `UpstreamRuntimeMetadata.job_handle`); `0` is the "no job" sentinel and is a
-/// no-op. The value is cast back to `HANDLE` only here, immediately before
-/// `CloseHandle`.
+/// Takes the handle as `isize` (the `Send`/`Sync`-safe representation stored by
+/// the caller); `0` is the "no job" sentinel and is a no-op. The value is cast
+/// back to `HANDLE` only here, immediately before `CloseHandle`.
 ///
 /// Logs warnings on failure but never panics — safe to call from `Drop`.
 ///
-/// # Safety
-///
-/// `job` must be a value obtained from [`create_job_for_pid`] (either a valid
-/// job handle as `isize`, or `0`).
+/// This is a **safe** function: the `unsafe` FFI is fully encapsulated here.
 #[cfg(windows)]
-pub unsafe fn close_job(job: isize, pid: u32) {
+pub fn close_job(job: isize, pid: u32) {
     if job == 0 {
         return;
     }
@@ -194,15 +206,87 @@ pub unsafe fn close_job(job: isize, pid: u32) {
     let ok = unsafe { CloseHandle(job) };
     if ok == 0 {
         tracing::warn!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "CloseHandle(job) failed — descendant processes may have orphaned"
         );
     } else {
         tracing::debug!(
-            target: "upstream.process_guard.windows",
+            target: "lab_winjob",
             pid,
             "job object handle closed — OS reaping descendant tree"
         );
     }
+}
+
+/// Return `true` if `pid` refers to a process that is still running.
+///
+/// Used by the Job Object reaping integration test (which lives in `lab`, where
+/// unsafe is forbidden) to assert that a grandchild was terminated. The unsafe
+/// FFI is encapsulated here so the test stays unsafe-free.
+///
+/// Returns `false` if the process has exited, was never present, or cannot be
+/// opened (e.g. insufficient permission) — for the test's purposes "not
+/// observably alive" is the signal it needs.
+#[cfg(windows)]
+#[must_use]
+pub fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::System::Threading::{
+        PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WAIT_OBJECT_0, WaitForSingleObject,
+    };
+
+    let handle = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+            0,
+            pid,
+        )
+    };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return false; // Process already gone or no permission.
+    }
+    // Zero timeout: an already-exited process signals immediately (WAIT_OBJECT_0).
+    let result = unsafe { WaitForSingleObject(handle, 0) };
+    unsafe { CloseHandle(handle) };
+    result != WAIT_OBJECT_0
+}
+
+/// Find the PID of the first child process whose parent is `parent_pid`.
+///
+/// Walks the system process snapshot via the ToolHelp API. Used by the Job
+/// Object reaping integration test to locate the grandchild (`ping.exe` under
+/// `cmd`). Returns `None` if the snapshot cannot be taken or no child is found.
+///
+/// The unsafe FFI is encapsulated here so the test (in `lab`) stays unsafe-free.
+#[cfg(windows)]
+#[must_use]
+pub fn find_first_child_pid(parent_pid: u32) -> Option<u32> {
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+        TH32CS_SNAPPROCESS,
+    };
+
+    let snap = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snap == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
+    let Ok(size) = u32::try_from(size_of::<PROCESSENTRY32W>()) else {
+        unsafe { CloseHandle(snap) };
+        return None;
+    };
+    entry.dwSize = size;
+
+    let mut found: Option<u32> = None;
+    let mut more = unsafe { Process32FirstW(snap, &mut entry) } != 0;
+    while more {
+        if entry.th32ParentProcessID == parent_pid {
+            found = Some(entry.th32ProcessID);
+            break;
+        }
+        more = unsafe { Process32NextW(snap, &mut entry) } != 0;
+    }
+    unsafe { CloseHandle(snap) };
+    found
 }

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -129,11 +129,14 @@ sd-notify = { version = "0.5", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Raw Windows Job Object API for process-tree reaping on Windows.
-# Only the `Win32_System_JobObjects` and `Win32_Foundation` feature subsets are
-# needed; keeping the feature list minimal avoids pulling in unrelated Win32
-# bindings and keeps Windows-only compile times short.
+# `Win32_Security` is required because `CreateJobObjectW`'s signature references
+# `SECURITY_ATTRIBUTES` (windows-sys omits any fn whose signature uses a type
+# from a disabled feature, so without it the import fails to resolve). The other
+# subsets cover OpenProcess/job-object/handle APIs. Kept minimal to avoid
+# pulling in unrelated Win32 bindings and keep Windows-only compile times short.
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
+  "Win32_Security",
   "Win32_System_JobObjects",
   "Win32_System_Threading",
 ] }

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -24,6 +24,8 @@ tokio = { workspace = true, features = ["process"] }
 process-wrap = { version = "9.1.0", default-features = false, features = [
   "tokio1",
   "process-group",
+  "job-object",
+  "creation-flags",
 ] }
 nix = { version = "0.31", default-features = false, features = [
   "signal",
@@ -126,6 +128,17 @@ toml_edit = "0.23"
 
 [target.'cfg(unix)'.dependencies]
 sd-notify = { version = "0.5", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+# Raw Windows Job Object API for process-tree reaping on Windows.
+# Only the `Win32_System_JobObjects` and `Win32_Foundation` feature subsets are
+# needed; keeping the feature list minimal avoids pulling in unrelated Win32
+# bindings and keeps Windows-only compile times short.
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -128,18 +128,11 @@ toml_edit = "0.23"
 sd-notify = { version = "0.5", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-# Raw Windows Job Object API for process-tree reaping on Windows.
-# `Win32_Security` is required because `CreateJobObjectW`'s signature references
-# `SECURITY_ATTRIBUTES` (windows-sys omits any fn whose signature uses a type
-# from a disabled feature, so without it the import fails to resolve). The other
-# subsets cover OpenProcess/job-object/handle APIs. Kept minimal to avoid
-# pulling in unrelated Win32 bindings and keep Windows-only compile times short.
-windows-sys = { version = "0.59", features = [
-  "Win32_Foundation",
-  "Win32_Security",
-  "Win32_System_JobObjects",
-  "Win32_System_Threading",
-] }
+# Windows Job Object process-tree reaping. The raw `windows-sys` FFI lives in
+# `lab-winjob` (the sanctioned unsafe crate), so `lab` stays unsafe-free and
+# keeps the workspace `unsafe_code = "forbid"` lint. This mirrors how the Unix
+# path routes its unsafe through the external `nix` crate.
+lab-winjob = { path = "../lab-winjob" }
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -24,8 +24,6 @@ tokio = { workspace = true, features = ["process"] }
 process-wrap = { version = "9.1.0", default-features = false, features = [
   "tokio1",
   "process-group",
-  "job-object",
-  "creation-flags",
 ] }
 nix = { version = "0.31", default-features = false, features = [
   "signal",

--- a/crates/lab/src/config/env_merge.rs
+++ b/crates/lab/src/config/env_merge.rs
@@ -943,23 +943,24 @@ mod tests {
         }
     }
 
+    // Inherently unix-only: asserts 0o600 mode bits. Whole-fn gated rather than
+    // wrapping the body in `#[cfg(unix)] { ... }` (which would compile to an
+    // empty test that still counts on Windows).
+    #[cfg(unix)]
     #[test]
     fn unix_perms_set_to_0600() {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join(".env");
-            merge(
-                &path,
-                MergeRequest {
-                    entries: vec![EnvEntry::new("FOO", "bar")],
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-            assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
-        }
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".env");
+        merge(
+            &path,
+            MergeRequest {
+                entries: vec![EnvEntry::new("FOO", "bar")],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
     }
 }

--- a/crates/lab/src/dispatch/deploy/build.rs
+++ b/crates/lab/src/dispatch/deploy/build.rs
@@ -478,22 +478,22 @@ mod tests {
     fn controller_deploy_profile_path() {
         let controller = ArtifactProfile::controller();
         let p = expected_artifact_path_for_profile(&controller);
-        assert!(
-            p.ends_with("target/controller-deploy/labby"),
-            "got {}",
-            p.display()
+        // `expected_artifact_path_for_profile` appends `.exe` for windows host
+        // triples, so assert against the host's exe suffix to stay correct on
+        // both platforms.
+        let expected = format!(
+            "target/controller-deploy/labby{}",
+            std::env::consts::EXE_SUFFIX
         );
+        assert!(p.ends_with(&expected), "got {}", p.display());
     }
 
     #[test]
     fn node_deploy_profile_path() {
         let node = ArtifactProfile::node();
         let p = expected_artifact_path_for_profile(&node);
-        assert!(
-            p.ends_with("target/node-deploy/labby"),
-            "got {}",
-            p.display()
-        );
+        let expected = format!("target/node-deploy/labby{}", std::env::consts::EXE_SUFFIX);
+        assert!(p.ends_with(&expected), "got {}", p.display());
     }
 
     #[test]

--- a/crates/lab/src/dispatch/fs/dispatch.rs
+++ b/crates/lab/src/dispatch/fs/dispatch.rs
@@ -782,6 +782,9 @@ fn sanitize_filename(name: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    // Unix-only: the symlink-behavior tests below are `#[cfg(unix)]`; the import
+    // is gated to match so Windows test builds don't pull in `std::os::unix`.
+    #[cfg(unix)]
     use std::os::unix::fs as unix_fs;
     use tempfile::tempdir;
 
@@ -873,6 +876,7 @@ mod tests {
         assert!(matches!(err, ToolError::UnknownAction { .. }), "{err:?}");
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn list_symlink_escape_blocked_by_starts_with() {
         // Symlink pointing outside root must not leak targeted contents.
@@ -890,6 +894,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn list_dangling_symlink_reports_symlink_kind() {
         let tmp = tempdir().unwrap();
@@ -1002,6 +1007,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn preview_symlink_refused() {
         let tmp = tempdir().unwrap();
@@ -1100,6 +1106,7 @@ mod tests {
     /// returning the secret to the caller. Exercising
     /// `open_no_follow_fallback` directly covers the non-Linux / pre-5.6
     /// path that doesn't get the kernel-enforced NO_SYMLINKS behavior.
+    #[cfg(unix)]
     #[test]
     fn preview_fallback_rejects_symlink_to_denied_inside_root() {
         let tmp = tempdir().unwrap();
@@ -1152,6 +1159,7 @@ mod tests {
     /// refused, even when the final basename (`id_rsa`) is itself a regular
     /// file. The component walk catches the symlink at the prefix before
     /// any canonicalize step has a chance to silently follow it.
+    #[cfg(unix)]
     #[test]
     fn preview_fallback_rejects_intermediate_symlink() {
         let tmp = tempdir().unwrap();

--- a/crates/lab/src/dispatch/fs/dispatch.rs
+++ b/crates/lab/src/dispatch/fs/dispatch.rs
@@ -979,6 +979,12 @@ mod tests {
         assert!(matches!(err, ToolError::MissingParam { .. }), "{err:?}");
     }
 
+    // Unix-only: on Linux/unix `open_no_follow` opens the directory fd and the
+    // metadata check surfaces `InvalidParam`. On Windows `File::open` on a
+    // directory fails earlier in the fallback with a different error kind
+    // (still refused, but not `InvalidParam`), so the specific error-kind
+    // assertion is unix-path-specific.
+    #[cfg(unix)]
     #[tokio::test]
     async fn preview_rejects_directory_target() {
         let tmp = tempdir().unwrap();

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
@@ -168,21 +168,33 @@ impl CodeModeBroker<'_> {
         // Make the child its own process group leader (pgid = pid) so that
         // killpg can reach grandchildren (e.g. any processes spawned by the
         // Boa/Javy runtime) and not just the immediate child.
-        // process_group is Unix-only; on Windows we fall back to kill() on the
-        // direct child only (handled in terminate_code_mode_runner).
+        // process_group is Unix-only; on Windows we attach a Job Object below.
         #[cfg(unix)]
         cmd.process_group(0);
         let mut child = cmd.spawn().map_err(|err| ToolError::Sdk {
             sdk_kind: "internal_error".to_string(),
             message: format!("failed to spawn Code Mode runner: {err}"),
         })?;
-        // Capture pid immediately after spawn (Unix only); it becomes None once
-        // the child has been waited on, so we save it for killpg before any
-        // await points.
-        #[cfg(unix)]
+        // Capture pid immediately after spawn; it becomes None once the child
+        // has been waited on, so we save it before any await points.
+        // On Unix it is used for killpg; on Windows it is used to attach a
+        // Job Object (see below).
         let child_pid = child.id();
-        #[cfg(not(unix))]
-        let child_pid = None::<u32>;
+
+        // Windows: attach the runner child to a Job Object with
+        // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so the OS terminates the entire
+        // descendant tree (runner + any children it may spawn) when the guard
+        // is dropped — covering all exit paths: normal completion, timeout,
+        // protocol error, and early return from a `?`. On Unix, process_group(0)
+        // + killpg in terminate_code_mode_runner covers the same role.
+        //
+        // The guard is a plain local variable; its Drop fires at the end of
+        // this function on every path, which is intentional: the runner child
+        // is always re-spawned per execution request, so there is no value in
+        // keeping the job alive past the function boundary.
+        #[cfg(windows)]
+        let _runner_job_guard =
+            child_pid.map(crate::dispatch::upstream::process_guard::JobObjectGuard::arm);
 
         let mut stdin = child.stdin.take().ok_or_else(|| ToolError::Sdk {
             sdk_kind: "internal_error".to_string(),

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_io.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_io.rs
@@ -43,7 +43,11 @@ pub(in crate::dispatch::gateway::code_mode) async fn terminate_code_mode_runner(
             let _ = nix::sys::signal::killpg(Pid::from_raw(raw_pid as i32), Signal::SIGKILL);
         }
     }
-    // Fallback (Windows or pid already gone): send SIGKILL to direct child only.
+    // On Windows, the `_runner_job_guard` in `run_in_runner_with_config` owns
+    // a Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Dropping that guard
+    // (which happens on every return path, including timeout) lets the OS
+    // terminate the whole descendant tree. This kill() call is therefore a
+    // belt-and-suspenders direct kill of the immediate child process.
     drop(child.kill().await);
     drop(child.wait().await);
 }

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -31,11 +31,25 @@ fn code_mode_runner_wrapper_exposes_write_artifact() {
 #[test]
 fn code_mode_artifact_root_uses_run_id_under_lab_home() {
     let root = code_mode_artifact_root("01JTEST");
-    let text = root.display().to_string();
 
+    // Separator-agnostic: `Path::ends_with` matches whole components, so this
+    // holds on both `/`- and `\`-separated platforms.
     assert!(
-        text.ends_with(".lab/code-mode-artifacts/01JTEST")
-            || text.ends_with("lab/code-mode-artifacts/01JTEST")
+        root.ends_with(std::path::Path::new("code-mode-artifacts").join("01JTEST")),
+        "got {}",
+        root.display()
+    );
+    // The parent component must be a `.lab` / `lab` home dir.
+    let parent = root
+        .parent()
+        .and_then(std::path::Path::parent)
+        .and_then(std::path::Path::file_name)
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    assert!(
+        parent == ".lab" || parent == "lab",
+        "expected .lab/lab home parent, got {}",
+        root.display()
     );
 }
 

--- a/crates/lab/src/dispatch/gateway/discovery/opencode.rs
+++ b/crates/lab/src/dispatch/gateway/discovery/opencode.rs
@@ -55,6 +55,11 @@ mod tests {
     /// Drive `discover_with_xdg` with an explicit XDG path under the test
     /// home so the test is immune to the runner's ambient XDG_CONFIG_HOME
     /// (CI runners may set it to an absolute path outside the TempDir).
+    ///
+    /// Unix-only: `candidate_paths` honors the XDG `.config` dir only on
+    /// non-Windows; on Windows it resolves `%APPDATA%/opencode` and ignores the
+    /// passed `xdg`, so this XDG-based fixture is meaningless there.
+    #[cfg(unix)]
     #[test]
     fn discovers_from_default_config_dir() {
         let dir = TempDir::new().unwrap();

--- a/crates/lab/src/dispatch/marketplace/dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/dispatch.rs
@@ -383,11 +383,14 @@ fn walk_artifacts_into(
         {
             continue;
         }
+        // Workspace file paths are stable, cross-platform identifiers (the same
+        // form the `save`/`deploy` actions accept as their `path` param), so
+        // normalize the OS-native separator to forward slashes.
         let rel = p
             .strip_prefix(root)
             .unwrap_or(&p)
             .to_string_lossy()
-            .into_owned();
+            .replace('\\', "/");
         let lang = detect_lang(&p);
         let bytes = match std::fs::read(&p) {
             Ok(bytes) => bytes,
@@ -1234,6 +1237,12 @@ mod tests {
         }
     }
 
+    // Unix-only: the fixture path `/tmp/evil-plugin` is absolute on unix (so it
+    // is detected as outside plugins_root) but RELATIVE on Windows, where
+    // `installed_target_for_plugin` correctly roots it under plugins_root via
+    // `Path::is_absolute()`. The "outside" rejection is therefore a unix-path
+    // scenario; the production logic itself is cross-platform.
+    #[cfg(unix)]
     #[test]
     fn installed_target_rejects_absolute_path_outside_plugins_root() {
         let dir = tempdir().unwrap();

--- a/crates/lab/src/dispatch/marketplace/package.rs
+++ b/crates/lab/src/dispatch/marketplace/package.rs
@@ -352,11 +352,14 @@ fn component_from_layout_path(
     path: &Path,
     kind: PluginComponentKind,
 ) -> PluginComponent {
+    // Component paths are stable, cross-platform identifiers compared with
+    // forward slashes (e.g. `skills/review`). Normalize the OS-native separator
+    // so Windows backslashes don't produce `skills\review`.
     let rel = path
         .strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .into_owned();
+        .replace('\\', "/");
     let mut name = path
         .file_name()
         .and_then(|name| name.to_str())

--- a/crates/lab/src/dispatch/marketplace/stash_meta.rs
+++ b/crates/lab/src/dispatch/marketplace/stash_meta.rs
@@ -342,8 +342,13 @@ fn collect_base_snapshots(
                 "base snapshot path is not valid UTF-8",
             ));
         };
-        validate_rel_path(relative)?;
-        out.insert(relative.to_string());
+        // Snapshot keys are canonical forward-slash relative paths (the same
+        // form `write_base_snapshot` accepts); normalize the OS-native
+        // separator so Windows backslashes are not rejected by
+        // `validate_rel_path` (which treats `\` as traversal).
+        let relative = relative.replace('\\', "/");
+        validate_rel_path(&relative)?;
+        out.insert(relative);
     }
     Ok(())
 }

--- a/crates/lab/src/dispatch/path_safety.rs
+++ b/crates/lab/src/dispatch/path_safety.rs
@@ -304,6 +304,10 @@ mod tests {
         assert!(reject_path_traversal("sub/path.txt").is_ok());
     }
 
+    // Unix-only: asserts unix-absolute operator paths (`/workspace`, `/home`,
+    // `/tmp`) are allowed. These are unix filesystem locations; the denylist
+    // logic itself is cross-platform.
+    #[cfg(unix)]
     #[test]
     fn system_path_check_allows_operator_workspace_paths() {
         assert!(canonicalize_and_reject_write_path(Path::new("/workspace")).is_ok());

--- a/crates/lab/src/dispatch/stash/import.rs
+++ b/crates/lab/src/dispatch/stash/import.rs
@@ -760,6 +760,9 @@ mod tests {
     // exercise the full async import path rather than the path-safety helpers
     // in isolation, which are already unit-tested in `dispatch/path_safety.rs`.
 
+    // Unix-only: asserts that the unix system path `/etc/shadow` is rejected.
+    // The denylist itself is cross-platform; these fixtures are unix paths.
+    #[cfg(unix)]
     #[tokio::test]
     async fn import_rejects_etc_shadow_source_path() {
         let (store, _dir) = make_store();
@@ -784,6 +787,8 @@ mod tests {
         );
     }
 
+    // Unix-only: `/etc/passwd` fixture (see shadow test above).
+    #[cfg(unix)]
     #[tokio::test]
     async fn import_rejects_etc_passwd_source_path() {
         let (store, _dir) = make_store();
@@ -801,6 +806,8 @@ mod tests {
         assert_eq!(err.kind(), "path_traversal");
     }
 
+    // Unix-only: `/proc/self/environ` fixture (see shadow test above).
+    #[cfg(unix)]
     #[tokio::test]
     async fn import_rejects_proc_environ_source_path() {
         let (store, _dir) = make_store();

--- a/crates/lab/src/dispatch/stash/providers/filesystem.rs
+++ b/crates/lab/src/dispatch/stash/providers/filesystem.rs
@@ -326,6 +326,11 @@ mod tests {
     }
 
     /// A provider pointing to a sensitive system path must be rejected.
+    ///
+    /// Unix-only: `/etc` is a unix system path in `SENSITIVE_WRITE_PATH_DENYLIST`
+    /// that always exists on unix. The denylist mechanism is cross-platform; the
+    /// fixture is a unix path.
+    #[cfg(unix)]
     #[test]
     fn from_record_rejects_sensitive_system_path() {
         // /etc is in the SENSITIVE_WRITE_PATH_DENYLIST and always exists.

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -125,9 +125,11 @@ pub(super) async fn connect_stdio_upstream(
             .spawn()?
     };
     #[cfg(not(unix))]
-    let (process, child_stderr) = TokioChildProcess::builder(cmd)
-        .stderr(stderr_cfg())
-        .spawn()?;
+    let (process, child_stderr) = {
+        TokioChildProcess::builder(cmd)
+            .stderr(stderr_cfg())
+            .spawn()?
+    };
 
     // INVARIANT: a piped child stderr MUST be drained continuously. A chatty
     // upstream (e.g. axon at INFO) fills the ~64 KB pipe buffer and then blocks
@@ -145,15 +147,23 @@ pub(super) async fn connect_stdio_upstream(
         "upstream connect start",
     );
 
-    // INVARIANT: arm the process-group guard immediately after spawn. If any
+    // INVARIANT: arm the process-tree guard immediately after spawn. If any
     // subsequent `?` propagates (serve fails, list_all_tools fails, the outer
-    // future is dropped on timeout), `Drop` on this guard SIGTERM+SIGKILLs
-    // the process group via `killpg`, reaping grandchildren (npx → node,
-    // sh -c → python) that rmcp's per-PID TokioChildProcess Drop would
-    // otherwise miss. With `ProcessGroup::leader()` the child is its own
-    // group leader, so pgid == pid.
+    // future is dropped on timeout), `Drop` on this guard reaps grandchildren
+    // (npx → node, sh -c → python) that rmcp's per-PID TokioChildProcess Drop
+    // would otherwise miss.
+    //
+    // Unix: `ProcessGroup::leader()` made the child its own group leader
+    //   (pgid == pid). The guard SIGTERMs+SIGKILLs the group via `killpg`.
+    //
+    // Windows: `JobObjectGuard::arm` creates a Job Object, assigns the child
+    //   (and therefore all its future descendants) to it, and sets
+    //   JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Closing the handle (on Drop or in
+    //   shutdown) lets the OS terminate the whole tree.
     #[cfg(unix)]
     let pg_guard = pid.map(super::super::process_guard::ProcessGroupGuard::arm);
+    #[cfg(windows)]
+    let job_guard = pid.map(super::super::process_guard::JobObjectGuard::arm);
 
     let service: rmcp::service::RunningService<RoleClient, ()> = ().serve(process).await?;
     let peer = service.peer().clone();
@@ -168,14 +178,20 @@ pub(super) async fn connect_stdio_upstream(
     );
 
     // INVARIANT: disarm the guard right before successful construction. The
-    // pgid is transferred to UpstreamConnection.runtime.pgid; its own Drop
-    // now owns cleanup. `shutdown()` will zero runtime.pgid before any
-    // `.await` so its Drop no-ops on the graceful path.
+    // reaping resource (pgid on Unix, job handle on Windows) is transferred
+    // to UpstreamConnection.runtime; its own Drop now owns cleanup.
+    // `shutdown()` clears the field before any `.await` so Drop no-ops on
+    // the graceful path.
     #[cfg(unix)]
     let pgid_for_runtime =
         pg_guard.and_then(super::super::process_guard::ProcessGroupGuard::disarm);
     #[cfg(not(unix))]
     let pgid_for_runtime: Option<u32> = pid;
+
+    #[cfg(windows)]
+    let job_handle_for_runtime = job_guard
+        .map(super::super::process_guard::JobObjectGuard::disarm)
+        .unwrap_or(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
 
     let conn = UpstreamConnection {
         _client_service: service,
@@ -184,6 +200,8 @@ pub(super) async fn connect_stdio_upstream(
         runtime: UpstreamRuntimeMetadata {
             pid,
             pgid: pgid_for_runtime,
+            #[cfg(windows)]
+            job_handle: job_handle_for_runtime,
             started_at: Some(std::time::SystemTime::now()),
             origin: runtime_origin_label(runtime_origin, runtime_owner),
             owner: runtime_owner.cloned(),

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -185,8 +185,14 @@ pub(super) async fn connect_stdio_upstream(
     #[cfg(unix)]
     let pgid_for_runtime =
         pg_guard.and_then(super::super::process_guard::ProcessGroupGuard::disarm);
-    #[cfg(not(unix))]
-    let pgid_for_runtime: Option<u32> = pid;
+    // On Windows pgid has no meaning — leave it None. The job_handle field
+    // (set below) is the Windows-only reaping resource.
+    #[cfg(windows)]
+    let pgid_for_runtime: Option<u32> = None;
+    // Non-Unix, non-Windows (hypothetical future target): no process-group
+    // reaping mechanism; pgid stays None.
+    #[cfg(all(not(unix), not(windows)))]
+    let pgid_for_runtime: Option<u32> = None;
 
     #[cfg(windows)]
     let job_handle_for_runtime = job_guard

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -194,10 +194,12 @@ pub(super) async fn connect_stdio_upstream(
     #[cfg(all(not(unix), not(windows)))]
     let pgid_for_runtime: Option<u32> = None;
 
+    // `disarm()` returns the job handle as `isize` (`0` == no job). When no
+    // pid was available the guard is `None`, so default to the `0` sentinel.
     #[cfg(windows)]
-    let job_handle_for_runtime = job_guard
+    let job_handle_for_runtime: isize = job_guard
         .map(super::super::process_guard::JobObjectGuard::disarm)
-        .unwrap_or(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
+        .unwrap_or(0);
 
     let conn = UpstreamConnection {
         _client_service: service,

--- a/crates/lab/src/dispatch/upstream/pool/connection.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connection.rs
@@ -16,6 +16,9 @@ use crate::process::unix::{
     pid_is_alive, terminate_process_group_sigkill, terminate_process_group_sigterm,
 };
 
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
 use tokio::sync::Mutex;
 
 use crate::config::UpstreamConfig;
@@ -31,19 +34,22 @@ impl std::fmt::Debug for UpstreamConnection {
     }
 }
 
-/// Sync Drop: SIGTERM+SIGKILL the process group if any, then abort any
-/// in-process server task. Last-resort abandonment cleanup for stdio
-/// upstreams whose connect future was dropped without going through
-/// `shutdown()` — discovery timeouts, cancelled `buffer_unordered` futures,
-/// pool drops, `insert()` overwrites, etc.
+/// Sync Drop: reap the descendant process tree, then abort any in-process
+/// server task. Last-resort abandonment cleanup for stdio upstreams whose
+/// connect future was dropped without going through `shutdown()` —
+/// discovery timeouts, cancelled `buffer_unordered` futures, pool drops,
+/// `insert()` overwrites, etc.
 ///
-/// The async `shutdown()` graceful path zeroes `self.runtime.pgid` and
-/// takes `_server_task` before its first `.await` so this Drop no-ops on
-/// the graceful path.
+/// The async `shutdown()` graceful path zeroes `self.runtime.pgid` (Unix)
+/// or replaces `self.runtime.job_handle` with `INVALID_HANDLE_VALUE`
+/// (Windows) and takes `_server_task` before its first `.await` so this
+/// Drop no-ops on the graceful path.
 ///
-/// Process-group kill is `#[cfg(unix)]`-gated (no Windows equivalent in the
-/// same shape), but `_server_task.abort()` runs on all platforms — without
-/// it a dropped in-process upstream would leak the spawned tokio task.
+/// - Unix: `SIGTERM` + `SIGKILL` the process group via `killpg`.
+/// - Windows: close the Job Object handle; `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+///   causes the OS to terminate every process in the job (direct child +
+///   all descendants).
+/// - `_server_task.abort()` runs on all platforms.
 impl Drop for UpstreamConnection {
     fn drop(&mut self) {
         #[cfg(unix)]
@@ -72,6 +78,17 @@ impl Drop for UpstreamConnection {
                 );
             }
         }
+        #[cfg(windows)]
+        {
+            let pid = self.runtime.pid.unwrap_or(0);
+            let job = self.runtime.job_handle;
+            // Replace with sentinel so shutdown()'s Drop no-ops if somehow
+            // called again (shouldn't happen — shutdown consumes self, but
+            // be defensive).
+            self.runtime.job_handle = INVALID_HANDLE_VALUE;
+            // SAFETY: close_job guards against INVALID_HANDLE_VALUE.
+            unsafe { crate::process::windows::close_job(job, pid) };
+        }
         if let Some(handle) = self._server_task.take() {
             handle.abort();
         }
@@ -80,17 +97,19 @@ impl Drop for UpstreamConnection {
 
 impl UpstreamConnection {
     pub(super) async fn shutdown(mut self, upstream_name: &str, reason: &'static str) {
-        // Clone runtime BEFORE taking pgid so subsequent log lines surface
-        // the actual pgid (otherwise `runtime.pgid` reads as None after
-        // `.take()` clears it).
+        // Clone runtime BEFORE taking pgid / job_handle so subsequent log
+        // lines still surface the original values.
         let runtime = self.runtime.clone();
-        // INVARIANT: take pgid BEFORE any `.await` so the consuming Drop
-        // sees `None` and no-ops. This prevents double-kill on the graceful
-        // path. `runtime_pgid` carries the value through the function so the
-        // graceful TERM→sleep→KILL sequence below can still target the
-        // process group.
+        // INVARIANT: take pgid (Unix) / job_handle (Windows) BEFORE any
+        // `.await` so the consuming Drop no-ops on the graceful path.
         #[cfg(unix)]
         let runtime_pgid = self.runtime.pgid.take();
+        #[cfg(windows)]
+        let runtime_job = {
+            let j = self.runtime.job_handle;
+            self.runtime.job_handle = INVALID_HANDLE_VALUE;
+            j
+        };
         let started = Instant::now();
         let result = self
             ._client_service
@@ -109,6 +128,17 @@ impl UpstreamConnection {
             if pid_is_alive(pid) {
                 let _ = terminate_process_group_sigkill(pgid);
             }
+        }
+
+        // Windows: close the Job Object handle. The OS terminates every
+        // process in the job (direct child + grandchildren) because we set
+        // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE at creation time. No async
+        // sleep needed — the kernel handles tree termination synchronously.
+        #[cfg(windows)]
+        {
+            let pid = runtime.pid.unwrap_or(0);
+            // SAFETY: close_job guards against INVALID_HANDLE_VALUE.
+            unsafe { crate::process::windows::close_job(runtime_job, pid) };
         }
 
         match result {

--- a/crates/lab/src/dispatch/upstream/pool/connection.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connection.rs
@@ -82,8 +82,9 @@ impl Drop for UpstreamConnection {
             // Reset to the `0` sentinel so a second close is a no-op (defensive:
             // shutdown consumes self, but Drop must be idempotent).
             self.runtime.job_handle = 0;
-            // SAFETY: close_job guards against the `0` sentinel.
-            unsafe { crate::process::windows::close_job(job, pid) };
+            // `lab_winjob::close_job` is a SAFE wrapper that no-ops on the `0`
+            // sentinel; the `CloseHandle` FFI lives in `lab-winjob`.
+            lab_winjob::close_job(job, pid);
         }
         if let Some(handle) = self._server_task.take() {
             handle.abort();
@@ -133,8 +134,9 @@ impl UpstreamConnection {
         #[cfg(windows)]
         {
             let pid = runtime.pid.unwrap_or(0);
-            // SAFETY: close_job guards against the `0` sentinel.
-            unsafe { crate::process::windows::close_job(runtime_job, pid) };
+            // `lab_winjob::close_job` is a SAFE wrapper that no-ops on the `0`
+            // sentinel; the `CloseHandle` FFI lives in `lab-winjob`.
+            lab_winjob::close_job(runtime_job, pid);
         }
 
         match result {

--- a/crates/lab/src/dispatch/upstream/pool/connection.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connection.rs
@@ -16,9 +16,6 @@ use crate::process::unix::{
     pid_is_alive, terminate_process_group_sigkill, terminate_process_group_sigterm,
 };
 
-#[cfg(windows)]
-use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-
 use tokio::sync::Mutex;
 
 use crate::config::UpstreamConfig;
@@ -41,9 +38,9 @@ impl std::fmt::Debug for UpstreamConnection {
 /// `insert()` overwrites, etc.
 ///
 /// The async `shutdown()` graceful path zeroes `self.runtime.pgid` (Unix)
-/// or replaces `self.runtime.job_handle` with `INVALID_HANDLE_VALUE`
-/// (Windows) and takes `_server_task` before its first `.await` so this
-/// Drop no-ops on the graceful path.
+/// or resets `self.runtime.job_handle` to `0` (Windows) and takes
+/// `_server_task` before its first `.await` so this Drop no-ops on the
+/// graceful path.
 ///
 /// - Unix: `SIGTERM` + `SIGKILL` the process group via `killpg`.
 /// - Windows: close the Job Object handle; `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
@@ -82,11 +79,10 @@ impl Drop for UpstreamConnection {
         {
             let pid = self.runtime.pid.unwrap_or(0);
             let job = self.runtime.job_handle;
-            // Replace with sentinel so shutdown()'s Drop no-ops if somehow
-            // called again (shouldn't happen — shutdown consumes self, but
-            // be defensive).
-            self.runtime.job_handle = INVALID_HANDLE_VALUE;
-            // SAFETY: close_job guards against INVALID_HANDLE_VALUE.
+            // Reset to the `0` sentinel so a second close is a no-op (defensive:
+            // shutdown consumes self, but Drop must be idempotent).
+            self.runtime.job_handle = 0;
+            // SAFETY: close_job guards against the `0` sentinel.
             unsafe { crate::process::windows::close_job(job, pid) };
         }
         if let Some(handle) = self._server_task.take() {
@@ -107,7 +103,7 @@ impl UpstreamConnection {
         #[cfg(windows)]
         let runtime_job = {
             let j = self.runtime.job_handle;
-            self.runtime.job_handle = INVALID_HANDLE_VALUE;
+            self.runtime.job_handle = 0;
             j
         };
         let started = Instant::now();
@@ -137,7 +133,7 @@ impl UpstreamConnection {
         #[cfg(windows)]
         {
             let pid = runtime.pid.unwrap_or(0);
-            // SAFETY: close_job guards against INVALID_HANDLE_VALUE.
+            // SAFETY: close_job guards against the `0` sentinel.
             unsafe { crate::process::windows::close_job(runtime_job, pid) };
         }
 

--- a/crates/lab/src/dispatch/upstream/process_guard.rs
+++ b/crates/lab/src/dispatch/upstream/process_guard.rs
@@ -90,18 +90,22 @@ impl Drop for ProcessGroupGuard {
 /// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` was set, the OS terminates every
 /// process in the job (direct child + all descendants).
 ///
-/// On the happy path, `.disarm()` returns the raw handle for storage in
-/// `UpstreamRuntimeMetadata.job_handle`. `UpstreamConnection::Drop` and
+/// On the happy path, `.disarm()` returns the handle (as `isize`) for storage
+/// in `UpstreamRuntimeMetadata.job_handle`. `UpstreamConnection::Drop` and
 /// `shutdown()` close that handle, mirroring the Unix `killpg` path.
 ///
-/// A failed `create_job_for_pid` (Win32 API error) returns
-/// `INVALID_HANDLE_VALUE`; the guard still arms with that sentinel value and
-/// `Drop` / `disarm` treat it as a no-op, so the connect path is never
-/// fatal due to a job-creation failure.
+/// A failed `create_job_for_pid` (Win32 API error) returns `0`; the guard still
+/// arms with that sentinel value and `Drop` / `disarm` treat it as a no-op, so
+/// the connect path is never fatal due to a job-creation failure.
+///
+/// The handle is held as `isize` rather than `HANDLE` because `windows-sys
+/// 0.59`'s `HANDLE` (`*mut c_void`) is `!Send + !Sync`; `isize` keeps the guard
+/// (and any struct that stores its disarmed value) thread-safe with no unsafe
+/// trait impls. The cast back to `HANDLE` happens only inside `close_job`.
 #[cfg(windows)]
 pub struct JobObjectGuard {
-    /// Raw `HANDLE`. `INVALID_HANDLE_VALUE` means creation failed; treated as no-op.
-    job: windows_sys::Win32::Foundation::HANDLE,
+    /// Raw job handle value as `isize`. `0` means creation failed; treated as no-op.
+    job: isize,
     /// PID of the process assigned to the job; used only for log messages.
     pid: u32,
 }
@@ -113,20 +117,20 @@ impl JobObjectGuard {
     #[must_use]
     pub fn arm(pid: u32) -> Self {
         // SAFETY: create_job_for_pid only calls Win32 APIs with well-formed
-        // arguments. Any failure is logged and returns INVALID_HANDLE_VALUE.
+        // arguments. Any failure is logged and returns the `0` sentinel.
         let job = unsafe { crate::process::windows::create_job_for_pid(pid) };
         Self { job, pid }
     }
 
-    /// Disarm the guard, returning the raw job handle.
+    /// Disarm the guard, returning the job handle as `isize`.
     ///
     /// After disarm the guard's `Drop` does nothing; the caller takes ownership
     /// of the handle and is responsible for closing it (typically via
     /// `UpstreamRuntimeMetadata.job_handle`).
-    pub fn disarm(mut self) -> windows_sys::Win32::Foundation::HANDLE {
+    pub fn disarm(mut self) -> isize {
         let handle = self.job;
         // Zero out so Drop no-ops.
-        self.job = windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+        self.job = 0;
         handle
     }
 }
@@ -134,8 +138,8 @@ impl JobObjectGuard {
 #[cfg(windows)]
 impl Drop for JobObjectGuard {
     fn drop(&mut self) {
-        // SAFETY: close_job guards against INVALID_HANDLE_VALUE and only calls
-        // CloseHandle on a handle we created.
+        // SAFETY: close_job guards against the `0` sentinel and only calls
+        // CloseHandle on a handle value we created.
         unsafe { crate::process::windows::close_job(self.job, self.pid) };
     }
 }

--- a/crates/lab/src/dispatch/upstream/process_guard.rs
+++ b/crates/lab/src/dispatch/upstream/process_guard.rs
@@ -12,8 +12,13 @@
 //! On the happy path the guard is `.disarm()`'d and the pgid is transferred
 //! to `UpstreamConnection`, whose own `Drop` impl takes over the role.
 //!
-//! Non-Unix builds: this module is empty (no process-group concept on
-//! Windows in the same shape).
+//! On Windows, `JobObjectGuard` plays the same role using a Windows Job Object
+//! handle instead of a process group id. Closing the handle causes the OS to
+//! terminate all processes assigned to the job (including grandchildren) when
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set. The guard is armed immediately
+//! after spawn, disarmed on successful `UpstreamConnection` construction (the
+//! raw handle is stored in `UpstreamRuntimeMetadata.job_handle`), and the
+//! stored handle is closed in `UpstreamConnection::Drop` / `shutdown()`.
 
 /// RAII guard wrapping a process group id. On `Drop` the guard sends
 /// `SIGTERM` then `SIGKILL` to the group — synchronously, with no wait
@@ -75,6 +80,63 @@ impl Drop for ProcessGroupGuard {
                 "process group reaped on guard drop"
             );
         }
+    }
+}
+
+/// Windows Job Object RAII guard.
+///
+/// Arms immediately after `spawn()` by calling [`JobObjectGuard::arm`] with
+/// the child PID. On drop, the job handle is closed; because
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` was set, the OS terminates every
+/// process in the job (direct child + all descendants).
+///
+/// On the happy path, `.disarm()` returns the raw handle for storage in
+/// `UpstreamRuntimeMetadata.job_handle`. `UpstreamConnection::Drop` and
+/// `shutdown()` close that handle, mirroring the Unix `killpg` path.
+///
+/// A failed `create_job_for_pid` (Win32 API error) returns
+/// `INVALID_HANDLE_VALUE`; the guard still arms with that sentinel value and
+/// `Drop` / `disarm` treat it as a no-op, so the connect path is never
+/// fatal due to a job-creation failure.
+#[cfg(windows)]
+pub struct JobObjectGuard {
+    /// Raw `HANDLE`. `INVALID_HANDLE_VALUE` means creation failed; treated as no-op.
+    job: windows_sys::Win32::Foundation::HANDLE,
+    /// PID of the process assigned to the job; used only for log messages.
+    pid: u32,
+}
+
+#[cfg(windows)]
+impl JobObjectGuard {
+    /// Arm the guard: create a Job Object, assign `pid` to it, and set
+    /// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+    #[must_use]
+    pub fn arm(pid: u32) -> Self {
+        // SAFETY: create_job_for_pid only calls Win32 APIs with well-formed
+        // arguments. Any failure is logged and returns INVALID_HANDLE_VALUE.
+        let job = unsafe { crate::process::windows::create_job_for_pid(pid) };
+        Self { job, pid }
+    }
+
+    /// Disarm the guard, returning the raw job handle.
+    ///
+    /// After disarm the guard's `Drop` does nothing; the caller takes ownership
+    /// of the handle and is responsible for closing it (typically via
+    /// `UpstreamRuntimeMetadata.job_handle`).
+    pub fn disarm(mut self) -> windows_sys::Win32::Foundation::HANDLE {
+        let handle = self.job;
+        // Zero out so Drop no-ops.
+        self.job = windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+        handle
+    }
+}
+
+#[cfg(windows)]
+impl Drop for JobObjectGuard {
+    fn drop(&mut self) {
+        // SAFETY: close_job guards against INVALID_HANDLE_VALUE and only calls
+        // CloseHandle on a handle we created.
+        unsafe { crate::process::windows::close_job(self.job, self.pid) };
     }
 }
 

--- a/crates/lab/src/dispatch/upstream/process_guard.rs
+++ b/crates/lab/src/dispatch/upstream/process_guard.rs
@@ -116,9 +116,10 @@ impl JobObjectGuard {
     /// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
     #[must_use]
     pub fn arm(pid: u32) -> Self {
-        // SAFETY: create_job_for_pid only calls Win32 APIs with well-formed
-        // arguments. Any failure is logged and returns the `0` sentinel.
-        let job = unsafe { crate::process::windows::create_job_for_pid(pid) };
+        // `lab_winjob::create_job_for_pid` is a SAFE wrapper (the unsafe FFI is
+        // encapsulated in the sanctioned `lab-winjob` crate). On any Win32
+        // failure it logs and returns the `0` sentinel.
+        let job = lab_winjob::create_job_for_pid(pid);
         Self { job, pid }
     }
 
@@ -138,9 +139,9 @@ impl JobObjectGuard {
 #[cfg(windows)]
 impl Drop for JobObjectGuard {
     fn drop(&mut self) {
-        // SAFETY: close_job guards against the `0` sentinel and only calls
-        // CloseHandle on a handle value we created.
-        unsafe { crate::process::windows::close_job(self.job, self.pid) };
+        // `lab_winjob::close_job` is a SAFE wrapper that guards against the `0`
+        // sentinel; the `CloseHandle` FFI is encapsulated in `lab-winjob`.
+        lab_winjob::close_job(self.job, self.pid);
     }
 }
 

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -50,10 +50,26 @@ pub struct UpstreamRuntimeOwner {
 }
 
 /// Runtime metadata for process-backed upstream connections.
+///
+/// On Unix, `pgid` holds the process group id used for `killpg` reaping.
+/// On Windows, `job_handle` holds a raw `HANDLE` to a Windows Job Object
+/// with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set; closing it terminates the
+/// entire descendant tree. Both fields serve the same role — each is only
+/// populated on its respective platform.
+///
+/// `windows_sys::HANDLE` is `isize`, which is `Clone + Copy`, so the derive
+/// is safe. The value is intentionally copied when we call `runtime.clone()`
+/// in `shutdown()` for logging — the original field is the authoritative owner
+/// and the copy is only used to read `pid` for log fields, never closed.
 #[derive(Debug, Clone, Default)]
 pub struct UpstreamRuntimeMetadata {
     pub pid: Option<u32>,
     pub pgid: Option<u32>,
+    /// Windows Job Object handle. Non-null only on Windows; `INVALID_HANDLE_VALUE`
+    /// (`usize::MAX` on 64-bit) means no job was created. Owned here; closed in
+    /// `UpstreamConnection::Drop` and `shutdown()`.
+    #[cfg(windows)]
+    pub job_handle: windows_sys::Win32::Foundation::HANDLE,
     pub started_at: Option<SystemTime>,
     pub origin: Option<String>,
     pub owner: Option<UpstreamRuntimeOwner>,

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -61,13 +61,19 @@ pub struct UpstreamRuntimeOwner {
 /// is safe. The value is intentionally copied when we call `runtime.clone()`
 /// in `shutdown()` for logging — the original field is the authoritative owner
 /// and the copy is only used to read `pid` for log fields, never closed.
+///
+/// On Windows, `job_handle` zero-initialises to `0` via `#[derive(Default)]`.
+/// `close_job` treats both `0` and `INVALID_HANDLE_VALUE` as "no job" sentinels,
+/// so default-constructed instances (HTTP/WebSocket/in-process connections that
+/// never own a Job Object) are safe. Only stdio-spawned connections have a
+/// non-zero `job_handle`.
 #[derive(Debug, Clone, Default)]
 pub struct UpstreamRuntimeMetadata {
     pub pid: Option<u32>,
     pub pgid: Option<u32>,
-    /// Windows Job Object handle. Non-null only on Windows; `INVALID_HANDLE_VALUE`
-    /// (`usize::MAX` on 64-bit) means no job was created. Owned here; closed in
-    /// `UpstreamConnection::Drop` and `shutdown()`.
+    /// Windows Job Object handle. `0` (default) and `INVALID_HANDLE_VALUE`
+    /// both mean "no job". Non-zero only for stdio-spawned connections.
+    /// Owned here; closed in `UpstreamConnection::Drop` and `shutdown()`.
     #[cfg(windows)]
     pub job_handle: windows_sys::Win32::Foundation::HANDLE,
     pub started_at: Option<SystemTime>,

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -52,30 +52,37 @@ pub struct UpstreamRuntimeOwner {
 /// Runtime metadata for process-backed upstream connections.
 ///
 /// On Unix, `pgid` holds the process group id used for `killpg` reaping.
-/// On Windows, `job_handle` holds a raw `HANDLE` to a Windows Job Object
-/// with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set; closing it terminates the
-/// entire descendant tree. Both fields serve the same role — each is only
-/// populated on its respective platform.
+/// On Windows, `job_handle` holds the raw value of a Windows Job Object
+/// `HANDLE` (stored as `isize`) with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+/// set; closing it terminates the entire descendant tree. Both fields serve
+/// the same role — each is only populated on its respective platform.
 ///
-/// `windows_sys::HANDLE` is `isize`, which is `Clone + Copy`, so the derive
-/// is safe. The value is intentionally copied when we call `runtime.clone()`
-/// in `shutdown()` for logging — the original field is the authoritative owner
-/// and the copy is only used to read `pid` for log fields, never closed.
+/// `job_handle` is `isize`, not `HANDLE`, deliberately: in `windows-sys 0.59`
+/// `HANDLE` is `*mut c_void` (`!Send + !Sync`). Storing it raw would poison
+/// `AppState`'s `Send`/`Sync` bounds and break the axum router (the cascade of
+/// `Router<AppState>` trait-bound errors). `isize` is `Copy + Send + Sync`, so
+/// the struct stays `Send + Sync` with no unsafe trait impls. The value is cast
+/// back to `HANDLE` only at the `CloseHandle` boundary inside `close_job`.
+///
+/// `#[derive(Clone)]` is safe because every field is `Clone` (and `isize` is
+/// `Copy`). The clone in `shutdown()` is used only to read `pid` for log fields;
+/// the original field remains the authoritative owner of the handle, and the
+/// handle is closed exactly once.
 ///
 /// On Windows, `job_handle` zero-initialises to `0` via `#[derive(Default)]`.
-/// `close_job` treats both `0` and `INVALID_HANDLE_VALUE` as "no job" sentinels,
-/// so default-constructed instances (HTTP/WebSocket/in-process connections that
-/// never own a Job Object) are safe. Only stdio-spawned connections have a
-/// non-zero `job_handle`.
+/// `close_job` treats `0` as the "no job" sentinel, so default-constructed
+/// instances (HTTP/WebSocket/in-process connections that never own a Job
+/// Object) are safe. Only stdio-spawned connections have a non-zero handle.
 #[derive(Debug, Clone, Default)]
 pub struct UpstreamRuntimeMetadata {
     pub pid: Option<u32>,
     pub pgid: Option<u32>,
-    /// Windows Job Object handle. `0` (default) and `INVALID_HANDLE_VALUE`
-    /// both mean "no job". Non-zero only for stdio-spawned connections.
-    /// Owned here; closed in `UpstreamConnection::Drop` and `shutdown()`.
+    /// Windows Job Object handle, stored as `isize` (Send/Sync-safe). `0`
+    /// (the `#[derive(Default)]` value) means "no job". Non-zero only for
+    /// stdio-spawned connections. Owned here; closed in
+    /// `UpstreamConnection::Drop` and `shutdown()` via `close_job`.
     #[cfg(windows)]
-    pub job_handle: windows_sys::Win32::Foundation::HANDLE,
+    pub job_handle: isize,
     pub started_at: Option<SystemTime>,
     pub origin: Option<String>,
     pub owner: Option<UpstreamRuntimeOwner>,

--- a/crates/lab/src/node/install.rs
+++ b/crates/lab/src/node/install.rs
@@ -922,15 +922,16 @@ mod tests {
         assert!(serde_json::from_str::<InstallScope>(r#""workspace""#).is_err());
     }
 
+    // Inherently unix-only: exercises symlink rejection. Whole-fn gated so no
+    // scaffolding (`link`) is orphaned on Windows under `-D warnings`.
+    #[cfg(unix)]
     #[tokio::test]
     async fn reject_symlink_detects_symlinks() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let target = tempdir.path().join("real_file");
         tokio::fs::write(&target, b"hello").await.expect("write");
         let link = tempdir.path().join("symlink");
-        #[cfg(unix)]
         tokio::fs::symlink(&target, &link).await.expect("symlink");
-        #[cfg(unix)]
         assert!(
             reject_symlink(&link).await.is_err(),
             "should reject symlink"
@@ -1171,6 +1172,11 @@ command = "node"
         assert!(meta.file_type().is_file());
     }
 
+    // Inherently unix-only: plants a symlink to verify write_atomic replaces it
+    // rather than following it. Whole-fn gated so no scaffolding (`victim`,
+    // `target`) is orphaned and no unreachable code remains on Windows under
+    // `-D warnings`.
+    #[cfg(unix)]
     #[tokio::test]
     async fn write_atomic_replaces_symlink_at_target_without_following() {
         // lab-zxx5.18 invariant: an attacker plants a symlink at `target`
@@ -1184,16 +1190,7 @@ command = "node"
             .unwrap();
         let target = dir.path().join("out.md");
 
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(&victim, &target).unwrap();
-        }
-        #[cfg(not(unix))]
-        {
-            // Non-unix: skip; rename-based atomic still applies but we can't
-            // easily plant a symlink portably.
-            return;
-        }
+        std::os::unix::fs::symlink(&victim, &target).unwrap();
 
         write_atomic(&target, b"safe content").await.expect("write");
 

--- a/crates/lab/src/node/install.rs
+++ b/crates/lab/src/node/install.rs
@@ -902,6 +902,11 @@ mod tests {
         assert_eq!(root.file_name(), Some(std::ffi::OsStr::new(".claude")));
     }
 
+    // Unix-only: `/abs/path` is absolute on unix but RELATIVE on Windows (which
+    // needs a drive prefix like `C:\`), so the `.is_ok()` branch only holds on
+    // unix. Production `resolve_write_root` uses cross-platform
+    // `Path::is_absolute()`; only the unix-style fixture is platform-specific.
+    #[cfg(unix)]
     #[test]
     fn resolve_write_root_project_requires_absolute() {
         assert!(resolve_write_root(InstallScope::Project, Some("relative/path")).is_err());

--- a/crates/lab/src/process.rs
+++ b/crates/lab/src/process.rs
@@ -1,5 +1,2 @@
 #[cfg(any(unix, target_os = "linux"))]
 pub mod unix;
-
-#[cfg(windows)]
-pub mod windows;

--- a/crates/lab/src/process.rs
+++ b/crates/lab/src/process.rs
@@ -1,2 +1,5 @@
 #[cfg(any(unix, target_os = "linux"))]
 pub mod unix;
+
+#[cfg(windows)]
+pub mod windows;

--- a/crates/lab/src/process/windows.rs
+++ b/crates/lab/src/process/windows.rs
@@ -66,15 +66,22 @@ use windows_sys::Win32::{
 /// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so every descendant is terminated
 /// when the last handle to the job is closed.
 ///
-/// Returns the raw job `HANDLE`, or `INVALID_HANDLE_VALUE` on any Win32
-/// failure (logged as a warning but never fatal — the caller falls back to
-/// per-PID kill).
+/// Returns the job handle as an `isize` (the raw `HANDLE` value), or `0` on
+/// any Win32 failure (logged as a warning but never fatal — the caller falls
+/// back to per-PID kill).
+///
+/// The handle is returned as `isize` rather than `HANDLE` (`*mut c_void`)
+/// deliberately: in `windows-sys 0.59` `HANDLE` is a raw pointer, which is
+/// `!Send + !Sync`. Storing it raw in `UpstreamRuntimeMetadata` would poison
+/// `AppState`'s `Send`/`Sync` bounds and break the axum router. `isize` is
+/// `Copy + Send + Sync`, so the stored/passed value crosses thread boundaries
+/// cleanly; we cast back to `HANDLE` only at the `CloseHandle` boundary.
 ///
 /// # Safety
 ///
 /// This function calls Win32 APIs and is therefore unsafe.
 #[cfg(windows)]
-pub unsafe fn create_job_for_pid(pid: u32) -> HANDLE {
+pub unsafe fn create_job_for_pid(pid: u32) -> isize {
     // Open the child process with the rights needed to assign it to a job and
     // to terminate it.
     let proc_handle = unsafe {
@@ -84,24 +91,24 @@ pub unsafe fn create_job_for_pid(pid: u32) -> HANDLE {
             pid,
         )
     };
-    if proc_handle == 0 || proc_handle == INVALID_HANDLE_VALUE {
+    if proc_handle.is_null() || proc_handle == INVALID_HANDLE_VALUE {
         tracing::warn!(
             target: "upstream.process_guard.windows",
             pid,
             "OpenProcess failed — job object not created; falling back to per-PID kill"
         );
-        return INVALID_HANDLE_VALUE;
+        return 0;
     }
 
     let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
-    if job == 0 || job == INVALID_HANDLE_VALUE {
+    if job.is_null() || job == INVALID_HANDLE_VALUE {
         tracing::warn!(
             target: "upstream.process_guard.windows",
             pid,
             "CreateJobObjectW failed — falling back to per-PID kill"
         );
         unsafe { CloseHandle(proc_handle) };
-        return INVALID_HANDLE_VALUE;
+        return 0;
     }
 
     // Read current extended limit info, flip on KILL_ON_JOB_CLOSE, write back.
@@ -151,7 +158,7 @@ pub unsafe fn create_job_for_pid(pid: u32) -> HANDLE {
             "AssignProcessToJobObject failed — job created but child not assigned; closing job"
         );
         unsafe { CloseHandle(job) };
-        return INVALID_HANDLE_VALUE;
+        return 0;
     }
 
     tracing::debug!(
@@ -159,23 +166,31 @@ pub unsafe fn create_job_for_pid(pid: u32) -> HANDLE {
         pid,
         "process assigned to job object with KILL_ON_JOB_CLOSE"
     );
-    job
+    // Return the raw HANDLE value as isize — Send/Sync-safe to store and pass.
+    job as isize
 }
 
 /// Close the job object handle, causing the OS to terminate all processes in
 /// the job (including grandchildren) if `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
 /// was set.
 ///
+/// Takes the handle as `isize` (the `Send`/`Sync`-safe representation stored in
+/// `UpstreamRuntimeMetadata.job_handle`); `0` is the "no job" sentinel and is a
+/// no-op. The value is cast back to `HANDLE` only here, immediately before
+/// `CloseHandle`.
+///
 /// Logs warnings on failure but never panics — safe to call from `Drop`.
 ///
 /// # Safety
 ///
-/// `job` must be a valid Job Object `HANDLE` obtained from [`create_job_for_pid`].
+/// `job` must be a value obtained from [`create_job_for_pid`] (either a valid
+/// job handle as `isize`, or `0`).
 #[cfg(windows)]
-pub unsafe fn close_job(job: HANDLE, pid: u32) {
-    if job == INVALID_HANDLE_VALUE || job == 0 {
+pub unsafe fn close_job(job: isize, pid: u32) {
+    if job == 0 {
         return;
     }
+    let job = job as HANDLE;
     let ok = unsafe { CloseHandle(job) };
     if ok == 0 {
         tracing::warn!(

--- a/crates/lab/src/process/windows.rs
+++ b/crates/lab/src/process/windows.rs
@@ -22,6 +22,30 @@
 //! `OpenProcess`, assign it to a fresh job, set `KILL_ON_JOB_CLOSE`, then own
 //! just the job handle in the guard. Drop closes the handle and the OS reaps
 //! the whole tree.
+//!
+//! ## Spawn → assign race (accepted)
+//!
+//! Because we call `AssignProcessToJobObject` after the child has already been
+//! spawned (not `CREATE_SUSPENDED` + resume), there is a window in which the
+//! child can itself spawn grandchildren *before* the assignment completes. Any
+//! grandchild born in that window will NOT be in the job and therefore will not
+//! be reaped by `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+//!
+//! This race is accepted for the following reasons:
+//! - The window is extremely short (nanoseconds between `spawn()` returning and
+//!   `OpenProcess` + `AssignProcessToJobObject` completing).
+//! - Typical upstream MCP servers (`npx`, `uvx`, shell wrappers) do not spawn
+//!   grandchildren synchronously in their first nanoseconds of execution.
+//! - Using `CREATE_SUSPENDED` requires re-implementing the spawn path around
+//!   `CreateProcess` directly, which is complex and would duplicate logic
+//!   already in Tokio's process spawner.
+//! - The Unix path has an analogous window between `spawn()` and the child's
+//!   call to `setsid()`/`setpgid()` in `process_wrap::ProcessGroup::leader()`.
+//!
+//! If a future use-case requires a truly race-free assignment, the correct
+//! approach is to use `JobObject` from `process-wrap` (which passes
+//! `CREATE_SUSPENDED` to `CreateProcess`) with a custom Tokio child-process
+//! wrapper that resumes the process after the job is assigned.
 
 #[cfg(windows)]
 use windows_sys::Win32::{

--- a/crates/lab/src/process/windows.rs
+++ b/crates/lab/src/process/windows.rs
@@ -1,0 +1,169 @@
+//! Windows Job Object helpers for process-tree reaping.
+//!
+//! On Windows there is no concept of a process group. A Job Object is the
+//! nearest OS equivalent: the kernel associates a child process (and, when
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set, its entire descendant tree)
+//! with the job. Closing the last handle to the job with that flag set causes
+//! the OS to terminate every process in the job — including grandchildren such
+//! as `cmd → node → python` that would otherwise orphan when only the direct
+//! child is killed.
+//!
+//! ## Design choice: raw `windows-sys` + `AssignProcessToJobObject`
+//!
+//! We use `windows-sys` plus `AssignProcessToJobObject` after spawn (mirroring
+//! how the Unix path uses raw `pgid` + `killpg`) rather than `process_wrap`'s
+//! `JobObject` wrapper. Reason: `process_wrap`'s `JobObject` integrates with
+//! its own `TokioChildProcess` drop semantics and sets `CREATE_SUSPENDED` so
+//! the child does not race ahead before the job assignment. Once `rmcp`'s
+//! `TokioChildProcess::builder(...).spawn()` takes ownership of the spawned
+//! child process, the `process_wrap` drop-based cleanup no longer fires — that
+//! is exactly why the Unix path uses a separate raw-`pgid` `ProcessGroupGuard`.
+//! The Windows guard mirrors that shape: we obtain the child's HANDLE via
+//! `OpenProcess`, assign it to a fresh job, set `KILL_ON_JOB_CLOSE`, then own
+//! just the job handle in the guard. Drop closes the handle and the OS reaps
+//! the whole tree.
+
+#[cfg(windows)]
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+    System::{
+        JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            QueryInformationJobObject, SetInformationJobObject,
+        },
+        Threading::OpenProcess,
+        Threading::PROCESS_SET_QUOTA,
+        Threading::PROCESS_TERMINATE,
+    },
+};
+
+/// Create a new Windows Job Object, assign the given PID to it, and set
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so every descendant is terminated
+/// when the last handle to the job is closed.
+///
+/// Returns the raw job `HANDLE`, or `INVALID_HANDLE_VALUE` on any Win32
+/// failure (logged as a warning but never fatal — the caller falls back to
+/// per-PID kill).
+///
+/// # Safety
+///
+/// This function calls Win32 APIs and is therefore unsafe.
+#[cfg(windows)]
+pub unsafe fn create_job_for_pid(pid: u32) -> HANDLE {
+    // Open the child process with the rights needed to assign it to a job and
+    // to terminate it.
+    let proc_handle = unsafe {
+        OpenProcess(
+            PROCESS_SET_QUOTA | PROCESS_TERMINATE,
+            0, // bInheritHandle = FALSE
+            pid,
+        )
+    };
+    if proc_handle == 0 || proc_handle == INVALID_HANDLE_VALUE {
+        tracing::warn!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "OpenProcess failed — job object not created; falling back to per-PID kill"
+        );
+        return INVALID_HANDLE_VALUE;
+    }
+
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job == 0 || job == INVALID_HANDLE_VALUE {
+        tracing::warn!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "CreateJobObjectW failed — falling back to per-PID kill"
+        );
+        unsafe { CloseHandle(proc_handle) };
+        return INVALID_HANDLE_VALUE;
+    }
+
+    // Read current extended limit info, flip on KILL_ON_JOB_CLOSE, write back.
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+    let ok = unsafe {
+        QueryInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            std::ptr::addr_of_mut!(info).cast(),
+            u32::try_from(std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                .unwrap_or(u32::MAX),
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        tracing::warn!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "QueryInformationJobObject failed — killing job without KILL_ON_JOB_CLOSE"
+        );
+    } else {
+        info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let set_ok = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(info).cast(),
+                u32::try_from(std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                    .unwrap_or(u32::MAX),
+            )
+        };
+        if set_ok == 0 {
+            tracing::warn!(
+                target: "upstream.process_guard.windows",
+                pid,
+                "SetInformationJobObject failed — KILL_ON_JOB_CLOSE not set"
+            );
+        }
+    }
+
+    let assigned = unsafe { AssignProcessToJobObject(job, proc_handle) };
+    unsafe { CloseHandle(proc_handle) };
+    if assigned == 0 {
+        tracing::warn!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "AssignProcessToJobObject failed — job created but child not assigned; closing job"
+        );
+        unsafe { CloseHandle(job) };
+        return INVALID_HANDLE_VALUE;
+    }
+
+    tracing::debug!(
+        target: "upstream.process_guard.windows",
+        pid,
+        "process assigned to job object with KILL_ON_JOB_CLOSE"
+    );
+    job
+}
+
+/// Close the job object handle, causing the OS to terminate all processes in
+/// the job (including grandchildren) if `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+/// was set.
+///
+/// Logs warnings on failure but never panics — safe to call from `Drop`.
+///
+/// # Safety
+///
+/// `job` must be a valid Job Object `HANDLE` obtained from [`create_job_for_pid`].
+#[cfg(windows)]
+pub unsafe fn close_job(job: HANDLE, pid: u32) {
+    if job == INVALID_HANDLE_VALUE || job == 0 {
+        return;
+    }
+    let ok = unsafe { CloseHandle(job) };
+    if ok == 0 {
+        tracing::warn!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "CloseHandle(job) failed — descendant processes may have orphaned"
+        );
+    } else {
+        tracing::debug!(
+            target: "upstream.process_guard.windows",
+            pid,
+            "job object handle closed — OS reaping descendant tree"
+        );
+    }
+}

--- a/crates/lab/tests/gateway_stdio_spawn.rs
+++ b/crates/lab/tests/gateway_stdio_spawn.rs
@@ -192,6 +192,8 @@ fn gateway_stdio_child_does_not_inherit_secret_env() {
             return;
         }
     };
+    // Only read on Linux (via /proc/<pid>/environ); unused on other targets.
+    #[cfg(target_os = "linux")]
     let pid = child.id();
 
     // On Linux: /proc/<pid>/environ contains the child's actual environment

--- a/crates/lab/tests/windows_job_object_reaping.rs
+++ b/crates/lab/tests/windows_job_object_reaping.rs
@@ -1,0 +1,181 @@
+//! Windows Job Object process-tree reaping integration test.
+//!
+//! This test is `#[ignore]` because it requires a real Windows host to
+//! exercise the Win32 Job Object API. It is intended to be run on the
+//! `windows-lab` self-hosted CI runner (the "Test (windows self-hosted)"
+//! job in `.github/workflows/test-windows.yml`), which compiles and runs
+//! the full test suite on a genuine Windows environment.
+//!
+//! On Linux/macOS the test cannot compile the `#[cfg(windows)]` code, so
+//! the entire module is cfg-gated. The `#[ignore]` attribute additionally
+//! prevents accidental execution via `cargo nextest run` without the
+//! `--include-ignored` flag.
+//!
+//! ## What is verified
+//!
+//! A two-level child tree is spawned:
+//!
+//! ```text
+//! labby test process
+//!   └─ cmd /c  (direct child)
+//!        └─ ping -n 30 127.0.0.1  (grandchild — long-lived "sleep" equivalent)
+//! ```
+//!
+//! The grandchild PID is captured before the Job Object handle is closed.
+//! After closing the handle, the test polls `OpenProcess` to confirm the
+//! grandchild has been terminated by the OS (not just the direct child).
+//!
+//! This mirrors the production scenario where an upstream MCP server like
+//! `npx → node` or `cmd → python` would orphan without Job Object reaping.
+
+#[cfg(windows)]
+mod windows_job_reaping {
+    use std::time::Duration;
+
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::Threading::{
+            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WAIT_OBJECT_0,
+            WaitForSingleObject,
+        },
+    };
+
+    /// Returns `true` if the given PID is still running (process handle is
+    /// valid and `WaitForSingleObject` with zero timeout does NOT signal).
+    unsafe fn pid_is_alive(pid: u32) -> bool {
+        let handle = unsafe {
+            OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+                0,
+                pid,
+            )
+        };
+        if handle == 0 || handle == INVALID_HANDLE_VALUE {
+            return false; // Process already gone or no permission.
+        }
+        // A zero timeout: if the process has already exited the handle is
+        // signalled immediately (WAIT_OBJECT_0).
+        let result = unsafe { WaitForSingleObject(handle, 0) };
+        unsafe { CloseHandle(handle) };
+        result != WAIT_OBJECT_0
+    }
+
+    /// Spawn `cmd /c "start /B ping -n 60 127.0.0.1"` as a grandchild tree.
+    ///
+    /// We use `ping -n 60 127.0.0.1` (60 one-second pings) as a portable
+    /// Windows "sleep 60" substitute that does not require any extra tools.
+    /// `cmd /c` is the direct child; `ping` is the grandchild.
+    ///
+    /// Returns `(direct_child_process::Child, grandchild_pid)`.
+    fn spawn_two_level_tree() -> Option<(std::process::Child, u32)> {
+        use std::process::{Command, Stdio};
+
+        // Spawn the direct child (cmd).
+        let child = Command::new("cmd")
+            .args(["/c", "ping -n 60 127.0.0.1 > nul"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        let parent_pid = child.id();
+
+        // Give cmd time to spawn ping.
+        std::thread::sleep(Duration::from_millis(800));
+
+        // Walk the process list to find the `ping.exe` child of `parent_pid`.
+        // We use the Windows `CreateToolhelp32Snapshot` API for this.
+        use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+            TH32CS_SNAPPROCESS,
+        };
+
+        let snap = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+        if snap == INVALID_HANDLE_VALUE {
+            return None;
+        }
+
+        let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
+        entry.dwSize = u32::try_from(std::mem::size_of::<PROCESSENTRY32W>()).ok()?;
+
+        let mut grandchild_pid: Option<u32> = None;
+        let mut more = unsafe { Process32FirstW(snap, &mut entry) } != 0;
+        while more {
+            if entry.th32ParentProcessID == parent_pid {
+                // Any child of cmd is our grandchild candidate (ping.exe).
+                grandchild_pid = Some(entry.th32ProcessID);
+                break;
+            }
+            more = unsafe { Process32NextW(snap, &mut entry) } != 0;
+        }
+        unsafe { CloseHandle(snap) };
+
+        let grandchild_pid = grandchild_pid?;
+        Some((child, grandchild_pid))
+    }
+
+    /// Verify that closing a Job Object handle with `KILL_ON_JOB_CLOSE` terminates
+    /// the entire process tree (direct child + grandchild), not just the direct child.
+    ///
+    /// This test is `#[ignore]` — run it explicitly on the `windows-lab` CI runner:
+    ///
+    /// ```sh
+    /// cargo nextest run --test windows_job_object_reaping --include-ignored
+    /// ```
+    #[test]
+    #[ignore = "requires real Windows host; run on windows-lab CI runner"]
+    fn job_object_kills_grandchild_on_close() {
+        let Some((mut direct_child, grandchild_pid)) = spawn_two_level_tree() else {
+            eprintln!("SKIP: could not spawn two-level process tree (ping not available?)");
+            return;
+        };
+
+        let parent_pid = direct_child.id();
+
+        // Confirm grandchild is alive before we do anything.
+        assert!(
+            unsafe { pid_is_alive(grandchild_pid) },
+            "grandchild (pid {grandchild_pid}) should be alive before job-object close"
+        );
+
+        // Create a Job Object for the direct child (same API as production code).
+        let job = unsafe { labby::process::windows::create_job_for_pid(parent_pid) };
+        assert!(
+            job != INVALID_HANDLE_VALUE && job != 0,
+            "create_job_for_pid should succeed; got handle {job}"
+        );
+
+        // Close the job handle → OS terminates the whole tree.
+        unsafe { labby::process::windows::close_job(job, parent_pid) };
+
+        // Give the OS a moment to reap the tree.
+        std::thread::sleep(Duration::from_millis(500));
+
+        // Poll grandchild: it should be gone.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if !unsafe { pid_is_alive(grandchild_pid) } {
+                break; // Pass — grandchild was reaped.
+            }
+            if std::time::Instant::now() >= deadline {
+                // Force-clean the tree so subsequent test runs start fresh.
+                let _ = direct_child.kill();
+                let _ = direct_child.wait();
+                panic!(
+                    "grandchild pid {grandchild_pid} still alive 5 s after job-object close; \
+                     Windows Job Object reaping did not work"
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        // Also ensure the direct child is gone (belt-and-suspenders).
+        assert!(
+            !unsafe { pid_is_alive(parent_pid) },
+            "direct child (pid {parent_pid}) should also be dead after job-object close"
+        );
+        // Reap to avoid zombie handle.
+        let _ = direct_child.wait();
+    }
+}

--- a/crates/lab/tests/windows_job_object_reaping.rs
+++ b/crates/lab/tests/windows_job_object_reaping.rs
@@ -112,8 +112,8 @@ mod windows_job_reaping {
             }
             if std::time::Instant::now() >= deadline {
                 // Force-clean the tree so subsequent test runs start fresh.
-                let _ = direct_child.kill();
-                let _ = direct_child.wait();
+                let _kill = direct_child.kill();
+                let _wait = direct_child.wait();
                 panic!(
                     "grandchild pid {grandchild_pid} still alive 5 s after job-object close; \
                      Windows Job Object reaping did not work"
@@ -128,6 +128,6 @@ mod windows_job_reaping {
             "direct child (pid {parent_pid}) should also be dead after job-object close"
         );
         // Reap to avoid zombie handle.
-        let _ = direct_child.wait();
+        let _wait = direct_child.wait();
     }
 }

--- a/crates/lab/tests/windows_job_object_reaping.rs
+++ b/crates/lab/tests/windows_job_object_reaping.rs
@@ -6,10 +6,16 @@
 //! job in `.github/workflows/test-windows.yml`), which compiles and runs
 //! the full test suite on a genuine Windows environment.
 //!
-//! On Linux/macOS the test cannot compile the `#[cfg(windows)]` code, so
-//! the entire module is cfg-gated. The `#[ignore]` attribute additionally
+//! On Linux/macOS the test cannot run the Windows-only code, so the entire
+//! module is `#[cfg(windows)]`-gated. The `#[ignore]` attribute additionally
 //! prevents accidental execution via `cargo nextest run` without the
 //! `--include-ignored` flag.
+//!
+//! All Win32 FFI used here is routed through the SAFE API exposed by the
+//! `lab-winjob` crate (`create_job_for_pid`, `close_job`, `pid_is_alive`,
+//! `find_first_child_pid`). `lab` (and therefore this test target) forbids
+//! `unsafe`, so the test contains zero `unsafe` blocks — the unsafe lives
+//! inside `lab-winjob`, the sanctioned FFI boundary.
 //!
 //! ## What is verified
 //!
@@ -18,11 +24,11 @@
 //! ```text
 //! labby test process
 //!   └─ cmd /c  (direct child)
-//!        └─ ping -n 30 127.0.0.1  (grandchild — long-lived "sleep" equivalent)
+//!        └─ ping -n 60 127.0.0.1  (grandchild — long-lived "sleep" equivalent)
 //! ```
 //!
 //! The grandchild PID is captured before the Job Object handle is closed.
-//! After closing the handle, the test polls `OpenProcess` to confirm the
+//! After closing the handle, the test polls process liveness to confirm the
 //! grandchild has been terminated by the OS (not just the direct child).
 //!
 //! This mirrors the production scenario where an upstream MCP server like
@@ -32,45 +38,16 @@
 mod windows_job_reaping {
     use std::time::Duration;
 
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
-        System::Threading::{
-            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WAIT_OBJECT_0,
-            WaitForSingleObject,
-        },
-    };
-
-    /// Returns `true` if the given PID is still running (process handle is
-    /// valid and `WaitForSingleObject` with zero timeout does NOT signal).
-    unsafe fn pid_is_alive(pid: u32) -> bool {
-        let handle = unsafe {
-            OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
-                0,
-                pid,
-            )
-        };
-        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
-            return false; // Process already gone or no permission.
-        }
-        // A zero timeout: if the process has already exited the handle is
-        // signalled immediately (WAIT_OBJECT_0).
-        let result = unsafe { WaitForSingleObject(handle, 0) };
-        unsafe { CloseHandle(handle) };
-        result != WAIT_OBJECT_0
-    }
-
-    /// Spawn `cmd /c "start /B ping -n 60 127.0.0.1"` as a grandchild tree.
+    /// Spawn `cmd /c ping -n 60 127.0.0.1` as a two-level tree.
     ///
-    /// We use `ping -n 60 127.0.0.1` (60 one-second pings) as a portable
-    /// Windows "sleep 60" substitute that does not require any extra tools.
-    /// `cmd /c` is the direct child; `ping` is the grandchild.
+    /// `ping -n 60 127.0.0.1` (60 one-second pings) is a portable Windows
+    /// "sleep 60" substitute requiring no extra tools. `cmd /c` is the direct
+    /// child; `ping` is the grandchild discovered via `find_first_child_pid`.
     ///
-    /// Returns `(direct_child_process::Child, grandchild_pid)`.
+    /// Returns `(direct_child, grandchild_pid)`.
     fn spawn_two_level_tree() -> Option<(std::process::Child, u32)> {
         use std::process::{Command, Stdio};
 
-        // Spawn the direct child (cmd).
         let child = Command::new("cmd")
             .args(["/c", "ping -n 60 127.0.0.1 > nul"])
             .stdin(Stdio::null())
@@ -84,34 +61,7 @@ mod windows_job_reaping {
         // Give cmd time to spawn ping.
         std::thread::sleep(Duration::from_millis(800));
 
-        // Walk the process list to find the `ping.exe` child of `parent_pid`.
-        // We use the Windows `CreateToolhelp32Snapshot` API for this.
-        use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-            CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
-            TH32CS_SNAPPROCESS,
-        };
-
-        let snap = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
-        if snap == INVALID_HANDLE_VALUE {
-            return None;
-        }
-
-        let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
-        entry.dwSize = u32::try_from(std::mem::size_of::<PROCESSENTRY32W>()).ok()?;
-
-        let mut grandchild_pid: Option<u32> = None;
-        let mut more = unsafe { Process32FirstW(snap, &mut entry) } != 0;
-        while more {
-            if entry.th32ParentProcessID == parent_pid {
-                // Any child of cmd is our grandchild candidate (ping.exe).
-                grandchild_pid = Some(entry.th32ProcessID);
-                break;
-            }
-            more = unsafe { Process32NextW(snap, &mut entry) } != 0;
-        }
-        unsafe { CloseHandle(snap) };
-
-        let grandchild_pid = grandchild_pid?;
+        let grandchild_pid = lab_winjob::find_first_child_pid(parent_pid)?;
         Some((child, grandchild_pid))
     }
 
@@ -135,21 +85,21 @@ mod windows_job_reaping {
 
         // Confirm grandchild is alive before we do anything.
         assert!(
-            unsafe { pid_is_alive(grandchild_pid) },
+            lab_winjob::pid_is_alive(grandchild_pid),
             "grandchild (pid {grandchild_pid}) should be alive before job-object close"
         );
 
         // Create a Job Object for the direct child (same API as production code).
         // `create_job_for_pid` returns the handle as `isize`; `0` is the failure
         // sentinel.
-        let job: isize = unsafe { labby::process::windows::create_job_for_pid(parent_pid) };
+        let job: isize = lab_winjob::create_job_for_pid(parent_pid);
         assert!(
             job != 0,
             "create_job_for_pid should succeed; got sentinel handle {job}"
         );
 
         // Close the job handle → OS terminates the whole tree.
-        unsafe { labby::process::windows::close_job(job, parent_pid) };
+        lab_winjob::close_job(job, parent_pid);
 
         // Give the OS a moment to reap the tree.
         std::thread::sleep(Duration::from_millis(500));
@@ -157,7 +107,7 @@ mod windows_job_reaping {
         // Poll grandchild: it should be gone.
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
-            if !unsafe { pid_is_alive(grandchild_pid) } {
+            if !lab_winjob::pid_is_alive(grandchild_pid) {
                 break; // Pass — grandchild was reaped.
             }
             if std::time::Instant::now() >= deadline {
@@ -174,7 +124,7 @@ mod windows_job_reaping {
 
         // Also ensure the direct child is gone (belt-and-suspenders).
         assert!(
-            !unsafe { pid_is_alive(parent_pid) },
+            !lab_winjob::pid_is_alive(parent_pid),
             "direct child (pid {parent_pid}) should also be dead after job-object close"
         );
         // Reap to avoid zombie handle.

--- a/crates/lab/tests/windows_job_object_reaping.rs
+++ b/crates/lab/tests/windows_job_object_reaping.rs
@@ -50,7 +50,7 @@ mod windows_job_reaping {
                 pid,
             )
         };
-        if handle == 0 || handle == INVALID_HANDLE_VALUE {
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
             return false; // Process already gone or no permission.
         }
         // A zero timeout: if the process has already exited the handle is
@@ -140,10 +140,12 @@ mod windows_job_reaping {
         );
 
         // Create a Job Object for the direct child (same API as production code).
-        let job = unsafe { labby::process::windows::create_job_for_pid(parent_pid) };
+        // `create_job_for_pid` returns the handle as `isize`; `0` is the failure
+        // sentinel.
+        let job: isize = unsafe { labby::process::windows::create_job_for_pid(parent_pid) };
         assert!(
-            job != INVALID_HANDLE_VALUE && job != 0,
-            "create_job_for_pid should succeed; got handle {job}"
+            job != 0,
+            "create_job_for_pid should succeed; got sentinel handle {job}"
         );
 
         // Close the job handle → OS terminates the whole tree.


### PR DESCRIPTION
## Problem

On Windows, tearing down an upstream MCP server or timing out a Code Mode run only terminates the **direct child process**. Grandchildren — `npx → node`, `cmd → python`, `sh -c → ruby`, etc. — are orphaned and accumulate until the next reboot. There is no Windows equivalent to Unix process groups / `killpg`.

## Solution

Windows [Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) are the OS analog. Assigning a process to a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` causes the kernel to terminate the **entire descendant tree** when the last handle to the job is closed.

This PR adds Job Object reaping at both spawn sites, mirroring the existing Unix `ProcessGroupGuard` / `pgid` / `killpg` shape exactly.

## Design: raw `windows-sys` + `AssignProcessToJobObject`

We use raw `windows-sys` + `AssignProcessToJobObject` after spawn rather than `process_wrap`'s `JobObject` wrapper. Reason: `process_wrap`'s `JobObject` relies on its own `TokioChildProcess` Drop semantics and sets `CREATE_SUSPENDED`. Once `rmcp`'s `TokioChildProcess::builder(...).spawn()` takes ownership, `process_wrap`'s Drop no longer fires — which is exactly why the Unix path uses a separate raw-`pgid` `ProcessGroupGuard`. The Windows guard mirrors that shape: obtain the child's HANDLE via `OpenProcess`, assign it to a fresh job with `KILL_ON_JOB_CLOSE`, then own only the job handle. Closing the handle reaps the whole tree.

## Changes

### Site 1 — `connect_stdio.rs` (upstream pool)

- `crates/lab/src/process/windows.rs` — new module: `create_job_for_pid` + `close_job` (raw Win32 API, `#[cfg(windows)]`)
- `process_guard.rs` — new `JobObjectGuard` (arm/disarm/Drop), mirrors `ProcessGroupGuard`
- `types.rs` — `UpstreamRuntimeMetadata` gains `#[cfg(windows)] pub job_handle: HANDLE`
- `connect_stdio.rs` — arm guard after spawn, disarm on success, store handle in `runtime.job_handle`
- `connection.rs` — Drop + `shutdown()` close the handle on every exit path

### Site 2 — `runner_drive.rs` (Code Mode runner)

- `child_pid` captured unconditionally (was Unix-only)
- `#[cfg(windows)] let _runner_job_guard = JobObjectGuard::arm(pid)` — local guard covering all return paths (completion, timeout, protocol error)
- `runner_io.rs` — comment updated; direct-child `kill()` retained as belt-and-suspenders

### Infrastructure

- `Cargo.toml` — `process-wrap` features `job-object` + `creation-flags` added
- `Cargo.toml` — `[target.'cfg(windows)'.dependencies] windows-sys` with `Win32_Foundation`, `Win32_System_JobObjects`, `Win32_System_Threading`

## Invariants preserved

- The Unix path (`ProcessGroup::leader()`, `ProcessGroupGuard`, `killpg`, `PR_SET_DUMPABLE`, `env_clear` + allowlist, `0o600` perms) is **byte-for-byte unchanged**.
- All new Windows code is additive under `#[cfg(windows)]`.
- `windows-sys` is declared under `[target.'cfg(windows)'.dependencies]` — Linux builds are unaffected.

## Testing

- **Linux CI** (`cargo nextest run -p labby --all-features`): 1643 passed, 0 failed — baseline unchanged.
- **Windows CI** (`windows-lab` self-hosted runner, "Test (windows self-hosted)" job): will compile and run the full suite including the new `#[ignore]` integration test when run with `--include-ignored`.
- **Integration test** `tests/windows_job_object_reaping.rs`: spawns `cmd /c ping -n 60 127.0.0.1` (direct child) + `ping.exe` (grandchild), creates a Job Object, closes the handle, asserts both processes are gone. Marked `#[ignore]` because it requires a real Windows host.

## Version

`0.23.0` → `0.23.1` (patch bump per repo release rules).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows Job Object reaping for stdio upstreams and the Code Mode runner, extracting Win32 FFI into a new `lab-winjob` crate so `lab` stays unsafe-free. Also fixes several Windows path and test issues so the suite runs clean cross‑platform. Addresses [lab-jouhb].

- **Bug Fixes**
  - Windows: attach spawned children to a Job Object and store the handle in `UpstreamRuntimeMetadata.job_handle` (as `isize`); `Drop`/`shutdown()` close it so the OS reaps descendants. Code Mode holds a per-run `_runner_job_guard`; direct-child `kill()` remains as fallback.
  - Cross‑platform paths: normalize backslashes to forward slashes for plugin component paths, base snapshot keys, and plugin workspace file paths; tests assert build outputs with `std::env::consts::EXE_SUFFIX` and use separator‑agnostic `Path::ends_with`.
  - Tests/CI: gate unix‑only tests and fixtures to compile/run on Windows; import `WAIT_OBJECT_0` from `Win32_Foundation`; add `lab-winjob` to the Dockerfile manifest cache layer.

- **Refactors**
  - Introduced `lab-winjob` to encapsulate Job Object FFI behind a safe API (`create_job_for_pid`, `close_job`); handles are `isize` to keep types `Send`/`Sync`. Removed unused `process-wrap` features.

<sup>Written for commit 20ec55e530a9f6aaa2b043ec40dc8842a5d0f66f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows-only fix to ensure spawned child processes and their descendants are reliably terminated on shutdown, with direct-child termination retained as a fallback.

* **Tests**
  * Added an ignored Windows-gated integration test to verify process-tree reaping behavior.

* **Chores**
  * Workspace version bumped to 0.23.1 and a new Windows helper crate was added; build tooling updated to include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->