### PR TITLE
feat(code-mode): render upstream MCP Apps (mcp-ui) widgets through the execute path

### DIFF
--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -52,6 +52,14 @@ pub(crate) fn process_code_mode_enabled() -> bool {
     PROCESS_CODE_MODE_ENABLED.load(Ordering::Acquire)
 }
 
+/// Parse a boolean env flag using the standard truthy set
+/// (`1` / `true` / `TRUE` / `yes` / `YES`). Absent or any other value is false.
+pub(crate) fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
 /// Whether mcp-ui widget → host tool callbacks are permitted while the Code
 /// Mode synthetic surface (`search`/`execute`) is active.
 ///
@@ -63,9 +71,7 @@ pub(crate) fn process_code_mode_enabled() -> bool {
 /// opt in knowingly because it also lets any caller on the session (including
 /// the model) invoke a known upstream tool by name.
 pub(crate) fn code_mode_widget_callbacks_enabled() -> bool {
-    std::env::var("LAB_CODE_MODE_WIDGET_CALLBACKS")
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+    env_flag_enabled("LAB_CODE_MODE_WIDGET_CALLBACKS")
 }
 
 use anyhow::{Context, Result};

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -52,6 +52,22 @@ pub(crate) fn process_code_mode_enabled() -> bool {
     PROCESS_CODE_MODE_ENABLED.load(Ordering::Acquire)
 }
 
+/// Whether mcp-ui widget → host tool callbacks are permitted while the Code
+/// Mode synthetic surface (`search`/`execute`) is active.
+///
+/// Default: **off**. When the synthetic surface is on, raw upstream tools are
+/// hidden from `list_tools` and normally not callable by name. Setting
+/// `LAB_CODE_MODE_WIDGET_CALLBACKS=1` (or `true`/`yes`) lets a rendered widget's
+/// callback reach the upstream proxy by tool name — the tool stays out of
+/// `list_tools`, so this only relaxes callability, never visibility. Operators
+/// opt in knowingly because it also lets any caller on the session (including
+/// the model) invoke a known upstream tool by name.
+pub(crate) fn code_mode_widget_callbacks_enabled() -> bool {
+    std::env::var("LAB_CODE_MODE_WIDGET_CALLBACKS")
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
 use anyhow::{Context, Result};
 use lab_auth::config as auth_config;
 use serde::{Deserialize, Serialize, Serializer};

--- a/crates/lab/src/dispatch/gateway/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode.rs
@@ -132,11 +132,20 @@ pub(in crate::dispatch::gateway::code_mode) fn lab_action_unknown_tool_hint() ->
 
 pub struct CodeModeBroker<'a> {
     gateway_manager: Option<&'a GatewayManager>,
+    /// Run-scoped sink for the last upstream MCP Apps (mcp-ui) widget link seen
+    /// during this execution. Recorded at the `call_upstream_tool` boundary
+    /// (last-wins) before the envelope is unwrapped, then surfaced via the
+    /// `{ __ui: <result> }` opt-in in `execute()`. A fresh broker is constructed
+    /// per request, so this is naturally scoped to a single run.
+    ui_capture: std::sync::Arc<std::sync::Mutex<Option<types::UiLink>>>,
 }
 
 impl<'a> CodeModeBroker<'a> {
     #[must_use]
     pub fn new(_registry: &'a ToolRegistry, gateway_manager: Option<&'a GatewayManager>) -> Self {
-        Self { gateway_manager }
+        Self {
+            gateway_manager,
+            ui_capture: std::sync::Arc::new(std::sync::Mutex::new(None)),
+        }
     }
 }

--- a/crates/lab/src/dispatch/gateway/code_mode/CLAUDE.md
+++ b/crates/lab/src/dispatch/gateway/code_mode/CLAUDE.md
@@ -90,7 +90,7 @@ and include a comment explaining the intended vs. actual state.
 | `runner.rs` | Subprocess lifecycle: `spawn_runner()`, read/write loop, graceful shutdown. |
 | `runner_drive.rs` | Higher-level driver: timeout wrapping, retry policy, `CodeModeHistory` tracking. |
 | `runner_io.rs` | Framed stdio line protocol with the child process. |
-| `execute.rs` | `execute()` entry point: build context, inject preamble, call driver, return result. |
+| `execute.rs` | `execute()` entry point: build context, inject preamble, call driver, return result. Also owns mcp-ui widget capture: `extract_ui_link` records an upstream result's `_meta.ui` (last-wins, into the per-run `CodeModeBroker::ui_capture` sink) before the envelope is unwrapped, and `apply_ui_opt_in` surfaces it when the user returns `{ __ui: <result> }`. |
 | `search.rs` | `search()` entry point: project catalog, call driver, return filtered tool list. |
 | `preamble.rs` | Injects the `callTool` bridge stub and catalog proxy into the JS environment. |
 | `protocol.rs` | Wire types for all parent↔runner messages (serialization-stable). |
@@ -114,7 +114,10 @@ and include a comment explaining the intended vs. actual state.
 - Do not call `wasm_runner.rs` from any live code path.
 - Do not add `code_mode_fuel_exhausted` to new match arms; the live kind is `"timeout"`.
 - Do not expose host network APIs to the runner child.
-- Keep `protocol.rs` as the single serialization-stable wire contract.
+- Keep `protocol.rs` as the single serialization-stable wire contract. The
+  mcp-ui `{ __ui: <result> }` opt-in is a **host-side return convention** detected
+  on the runner's returned `result` — it adds **no** new parent↔runner wire
+  fields.
 - Keep each file under 500 LOC; split following the existing pattern if a file grows.
 
 ---

--- a/crates/lab/src/dispatch/gateway/code_mode/execute.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/execute.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::CallToolRequestParams;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use serde_json::{Map, Value};
 
 use crate::dispatch::error::ToolError;
@@ -16,7 +16,7 @@ use super::schema::{unwrap_code_mode_upstream_result, validate_code_mode_params_
 use super::truncate::{response_within_budget, truncate_execution_response};
 use super::types::{
     CodeModeCaller, CodeModeCapabilityFilter, CodeModeExecutionError, CodeModeExecutionResponse,
-    CodeModeSurface, CodeModeToolId, CodeModeToolRef, destructive_permitted,
+    CodeModeSurface, CodeModeToolId, CodeModeToolRef, UiLink, destructive_permitted,
 };
 
 impl CodeModeBroker<'_> {
@@ -42,7 +42,7 @@ impl CodeModeBroker<'_> {
             .into());
         }
         let started = std::time::Instant::now();
-        let response = self
+        let mut response = self
             .execute_sandboxed(
                 code,
                 max_tool_calls.max(1).min(config.max_tool_calls.max(1)),
@@ -55,6 +55,10 @@ impl CodeModeBroker<'_> {
                 capability_filter,
             )
             .await?;
+        // `{ __ui: <result> }` opt-in: surface the last-wins captured mcp-ui
+        // widget link and unwrap the inner payload. Done before truncation so
+        // the (tiny) `ui` field is preserved while `result` may be capped.
+        self.apply_ui_opt_in(&mut response);
         let was_truncated = !response_within_budget(
             &response,
             config.max_response_bytes,
@@ -329,6 +333,14 @@ impl CodeModeBroker<'_> {
                     });
                 }
                 pool.record_success(upstream).await;
+                // Capture the mcp-ui widget link (if any) before the envelope is
+                // unwrapped and `_meta` is discarded. Last-wins across the run;
+                // surfaced only when the user opts in via `{ __ui: <result> }`.
+                if let Some(ui) = extract_ui_link(&result)
+                    && let Ok(mut sink) = self.ui_capture.lock()
+                {
+                    *sink = Some(ui);
+                }
                 Ok(unwrap_code_mode_upstream_result(result))
             }
             Some(Err(err)) => {
@@ -347,5 +359,123 @@ impl CodeModeBroker<'_> {
                 })
             }
         }
+    }
+
+    /// Apply the `{ __ui: <result> }` opt-in to a finished execution response.
+    ///
+    /// When the user code's return value is an object with a `__ui` key, the
+    /// inner value is unwrapped into `result` (so the model sees the payload it
+    /// chose to surface) and the last-wins captured widget link is attached to
+    /// `ui`. A no-op when the user did not opt in.
+    fn apply_ui_opt_in(&self, response: &mut CodeModeExecutionResponse) {
+        let inner = match response.result.as_ref() {
+            Some(Value::Object(map)) if map.contains_key("__ui") => {
+                map.get("__ui").cloned().unwrap_or(Value::Null)
+            }
+            _ => return,
+        };
+        response.result = Some(inner);
+        if let Ok(mut sink) = self.ui_capture.lock() {
+            response.ui = sink.take();
+        }
+    }
+}
+
+/// Extract a UI link from an upstream `CallToolResult`'s `_meta.ui` object.
+///
+/// Returns `None` unless `_meta.ui.resourceUri` is present. The whole `ui`
+/// object is captured verbatim so the final `execute` `CallToolResult` mirrors
+/// the upstream's `_meta.ui` identically.
+fn extract_ui_link(result: &CallToolResult) -> Option<UiLink> {
+    let meta = result.meta.as_ref()?;
+    let ui = meta.get("ui")?;
+    let resource_uri = ui.get("resourceUri")?.as_str()?.to_string();
+    Some(UiLink {
+        resource_uri,
+        ui_meta: ui.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::ToolRegistry;
+    use rmcp::model::{Content, Meta};
+    use serde_json::json;
+
+    fn result_with_meta_ui(ui: Value) -> CallToolResult {
+        let mut meta = Map::new();
+        meta.insert("ui".to_string(), ui);
+        let mut result = CallToolResult::success(vec![Content::text("{}")]);
+        result.meta = Some(Meta(meta));
+        result
+    }
+
+    #[test]
+    fn extract_ui_link_reads_meta_ui_resource_uri() {
+        let result = result_with_meta_ui(json!({
+            "resourceUri": "ui://axon/status-dashboard",
+            "mimeTypes": ["text/html;profile=mcp-app"],
+        }));
+        let link = extract_ui_link(&result).expect("ui link present");
+        assert_eq!(link.resource_uri, "ui://axon/status-dashboard");
+        // The whole `ui` object is captured verbatim for identical mirroring.
+        assert_eq!(link.ui_meta["resourceUri"], "ui://axon/status-dashboard");
+        assert_eq!(link.ui_meta["mimeTypes"][0], "text/html;profile=mcp-app");
+    }
+
+    #[test]
+    fn extract_ui_link_none_without_meta_ui() {
+        // No `_meta` at all.
+        assert!(extract_ui_link(&CallToolResult::success(vec![Content::text("{}")])).is_none());
+        // `_meta` present but no `ui` key.
+        let mut meta = Map::new();
+        meta.insert("other".to_string(), json!(1));
+        let mut result = CallToolResult::success(vec![Content::text("{}")]);
+        result.meta = Some(Meta(meta));
+        assert!(extract_ui_link(&result).is_none());
+    }
+
+    fn response_with_result(result: Value) -> CodeModeExecutionResponse {
+        CodeModeExecutionResponse {
+            result: Some(result),
+            ui: None,
+            calls: Vec::new(),
+            logs: Vec::new(),
+            artifacts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn apply_ui_opt_in_unwraps_and_attaches_captured_link() {
+        let registry = ToolRegistry::new();
+        let broker = CodeModeBroker::new(&registry, None);
+        *broker.ui_capture.lock().unwrap() = Some(UiLink {
+            resource_uri: "ui://axon/status-dashboard".to_string(),
+            ui_meta: json!({ "resourceUri": "ui://axon/status-dashboard" }),
+        });
+        let mut response = response_with_result(json!({ "__ui": { "degraded": false } }));
+        broker.apply_ui_opt_in(&mut response);
+        // Inner payload is surfaced as `result`, wrapper removed.
+        assert_eq!(response.result, Some(json!({ "degraded": false })));
+        assert_eq!(
+            response.ui.as_ref().expect("widget attached").resource_uri,
+            "ui://axon/status-dashboard"
+        );
+    }
+
+    #[test]
+    fn apply_ui_opt_in_without_optin_is_noop() {
+        let registry = ToolRegistry::new();
+        let broker = CodeModeBroker::new(&registry, None);
+        // Even with a captured link, no `__ui` key means no widget is surfaced.
+        *broker.ui_capture.lock().unwrap() = Some(UiLink {
+            resource_uri: "ui://x/y".to_string(),
+            ui_meta: json!({}),
+        });
+        let mut response = response_with_result(json!({ "degraded": false }));
+        broker.apply_ui_opt_in(&mut response);
+        assert_eq!(response.result, Some(json!({ "degraded": false })));
+        assert!(response.ui.is_none(), "no opt-in → no widget attached");
     }
 }

--- a/crates/lab/src/dispatch/gateway/code_mode/execute.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/execute.rs
@@ -19,6 +19,10 @@ use super::types::{
     CodeModeSurface, CodeModeToolId, CodeModeToolRef, UiLink, destructive_permitted,
 };
 
+/// Key a Code Mode `execute` snippet returns (`return { __ui: <result> }`) to
+/// request that the last-wins captured mcp-ui widget link be surfaced.
+const UI_OPT_IN_KEY: &str = "__ui";
+
 impl CodeModeBroker<'_> {
     pub(crate) async fn execute(
         &self,
@@ -368,12 +372,13 @@ impl CodeModeBroker<'_> {
     /// chose to surface) and the last-wins captured widget link is attached to
     /// `ui`. A no-op when the user did not opt in.
     fn apply_ui_opt_in(&self, response: &mut CodeModeExecutionResponse) {
+        // Clone the inner value out (ending the borrow of `response.result`)
+        // before reassigning. No `__ui` key → no-op.
         let inner = match response.result.as_ref() {
-            Some(Value::Object(map)) if map.contains_key("__ui") => {
-                map.get("__ui").cloned().unwrap_or(Value::Null)
-            }
-            _ => return,
+            Some(Value::Object(map)) => map.get(UI_OPT_IN_KEY).cloned(),
+            _ => None,
         };
+        let Some(inner) = inner else { return };
         response.result = Some(inner);
         if let Ok(mut sink) = self.ui_capture.lock() {
             response.ui = sink.take();

--- a/crates/lab/src/dispatch/gateway/code_mode/execute.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/execute.rs
@@ -394,9 +394,10 @@ impl CodeModeBroker<'_> {
 fn extract_ui_link(result: &CallToolResult) -> Option<UiLink> {
     let meta = result.meta.as_ref()?;
     let ui = meta.get("ui")?;
-    let resource_uri = ui.get("resourceUri")?.as_str()?.to_string();
+    // Require a string `resourceUri` to treat this as a renderable widget link;
+    // capture the whole `ui` object verbatim for identical mirroring.
+    ui.get("resourceUri")?.as_str()?;
     Some(UiLink {
-        resource_uri,
         ui_meta: ui.clone(),
     })
 }
@@ -423,7 +424,6 @@ mod tests {
             "mimeTypes": ["text/html;profile=mcp-app"],
         }));
         let link = extract_ui_link(&result).expect("ui link present");
-        assert_eq!(link.resource_uri, "ui://axon/status-dashboard");
         // The whole `ui` object is captured verbatim for identical mirroring.
         assert_eq!(link.ui_meta["resourceUri"], "ui://axon/status-dashboard");
         assert_eq!(link.ui_meta["mimeTypes"][0], "text/html;profile=mcp-app");
@@ -456,7 +456,6 @@ mod tests {
         let registry = ToolRegistry::new();
         let broker = CodeModeBroker::new(&registry, None);
         *broker.ui_capture.lock().unwrap() = Some(UiLink {
-            resource_uri: "ui://axon/status-dashboard".to_string(),
             ui_meta: json!({ "resourceUri": "ui://axon/status-dashboard" }),
         });
         let mut response = response_with_result(json!({ "__ui": { "degraded": false } }));
@@ -464,7 +463,7 @@ mod tests {
         // Inner payload is surfaced as `result`, wrapper removed.
         assert_eq!(response.result, Some(json!({ "degraded": false })));
         assert_eq!(
-            response.ui.as_ref().expect("widget attached").resource_uri,
+            response.ui.as_ref().expect("widget attached").ui_meta["resourceUri"],
             "ui://axon/status-dashboard"
         );
     }
@@ -475,8 +474,7 @@ mod tests {
         let broker = CodeModeBroker::new(&registry, None);
         // Even with a captured link, no `__ui` key means no widget is surfaced.
         *broker.ui_capture.lock().unwrap() = Some(UiLink {
-            resource_uri: "ui://x/y".to_string(),
-            ui_meta: json!({}),
+            ui_meta: json!({ "resourceUri": "ui://x/y" }),
         });
         let mut response = response_with_result(json!({ "degraded": false }));
         broker.apply_ui_opt_in(&mut response);

--- a/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs
@@ -570,6 +570,9 @@ async fn finalize_done(
     sorted.sort_by_key(|(seq, _)| *seq);
     Ok(CodeModeExecutionResponse {
         result: result.into_response_result(),
+        // `__ui` opt-in detection + last-wins capture is applied later in
+        // `execute()`; the runner-level response always starts with `ui: None`.
+        ui: None,
         calls: sorted.into_iter().map(|(_, call)| call).collect(),
         // Caller merges stderr drain into logs after await-ing the task.
         logs,

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -45,6 +45,7 @@ fn truncates_code_execute_final_result_when_oversized() {
     // result. An oversized final result is replaced with a truncation marker;
     // the calls metadata is preserved untouched.
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"payload": "x".repeat(5000)})),
         calls: vec![
             CodeModeExecutedCall {
@@ -88,6 +89,7 @@ fn truncates_code_execute_final_result_when_oversized() {
 #[test]
 fn does_not_truncate_when_final_result_within_budget() {
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"items": ["small"]})),
         calls: vec![CodeModeExecutedCall {
             id: "github::search_issues".to_string(),
@@ -110,6 +112,7 @@ fn truncates_oversized_logs_after_result() {
     // lines push the envelope over budget. After capping the (small) result,
     // logs must be trimmed until within budget, leaving a sentinel.
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"ok": true})),
         calls: vec![CodeModeExecutedCall {
             id: "test::ping".to_string(),
@@ -151,6 +154,7 @@ fn log_trimming_terminates_when_budget_unreachable() {
     // unreachable. The log-trimming loop must still terminate (best-effort),
     // collapsing logs to a single sentinel rather than looping forever.
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"ok": true})),
         calls: (0..200)
             .map(|i| CodeModeExecutedCall {
@@ -283,6 +287,7 @@ fn token_estimate_divisor_affects_truncation_decision() {
     // max_response_tokens=2000).  With divisor=1 → ~4000 tokens (exceeds 2000).
     let payload = "x".repeat(4000);
     let make_response = || CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"payload": payload.clone()})),
         calls: vec![CodeModeExecutedCall {
             id: "test::large".to_string(),
@@ -470,6 +475,7 @@ fn runner_protocol_preserves_null_distinct_from_undefined() {
     );
 
     let explicit_null = serde_json::to_value(CodeModeExecutionResponse {
+        ui: None,
         result: Some(Value::Null),
         calls: Vec::new(),
         logs: Vec::new(),
@@ -477,6 +483,7 @@ fn runner_protocol_preserves_null_distinct_from_undefined() {
     })
     .unwrap();
     let undefined = serde_json::to_value(CodeModeExecutionResponse {
+        ui: None,
         result: None,
         calls: Vec::new(),
         logs: Vec::new(),
@@ -517,6 +524,7 @@ fn code_mode_execution_error_carries_partial_calls() {
 #[test]
 fn truncation_preserves_artifact_receipts() {
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(serde_json::json!({
             "markdown": "x".repeat(10_000),
             "artifact": {
@@ -1152,6 +1160,7 @@ fn binary_search_log_truncation_boundary_is_tight() {
     let line_count = 50usize;
     let line_payload = "B".repeat(70);
     let make_response = || CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({"ok": true})),
         calls: vec![CodeModeExecutedCall {
             id: "test::ping".to_string(),

--- a/crates/lab/src/dispatch/gateway/code_mode/types.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/types.rs
@@ -142,11 +142,11 @@ impl CodeModeCatalogEntry {
 ///
 /// Recorded at the broker boundary when an upstream tool result carries
 /// `_meta.ui.resourceUri`, before `unwrap_code_mode_upstream_result` discards
-/// the envelope. `ui_meta` holds the upstream's `_meta.ui` object verbatim so
-/// the final `execute` `CallToolResult` can mirror the upstream identically.
+/// the envelope. `ui_meta` holds the upstream's `_meta.ui` object verbatim
+/// (including `resourceUri`) so the final `execute` `CallToolResult` can mirror
+/// the upstream identically.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UiLink {
-    pub resource_uri: String,
     pub ui_meta: Value,
 }
 

--- a/crates/lab/src/dispatch/gateway/code_mode/types.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/types.rs
@@ -138,6 +138,18 @@ impl CodeModeCatalogEntry {
     }
 }
 
+/// A captured upstream MCP Apps (mcp-ui) widget link.
+///
+/// Recorded at the broker boundary when an upstream tool result carries
+/// `_meta.ui.resourceUri`, before `unwrap_code_mode_upstream_result` discards
+/// the envelope. `ui_meta` holds the upstream's `_meta.ui` object verbatim so
+/// the final `execute` `CallToolResult` can mirror the upstream identically.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct UiLink {
+    pub resource_uri: String,
+    pub ui_meta: Value,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CodeModeExecutionResponse {
     /// The final return value of the async function. None when the function
@@ -146,6 +158,12 @@ pub struct CodeModeExecutionResponse {
     /// serializes as `"result": null`; undefined omits the field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
+    /// Captured mcp-ui widget link surfaced via the `{ __ui: <result> }` opt-in
+    /// (last-wins across the run). The MCP boundary attaches this as `_meta.ui`
+    /// on the returned `CallToolResult` so the host renders the native widget.
+    /// `None` when the user code did not opt in or no widget-bearing call ran.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui: Option<UiLink>,
     pub calls: Vec<CodeModeExecutedCall>,
     /// Captured console.log/warn/error lines from the runner. Sourced from the
     /// javy runner subprocess (drained from its stderr); the current javy path

--- a/crates/lab/src/dispatch/upstream/CLAUDE.md
+++ b/crates/lab/src/dispatch/upstream/CLAUDE.md
@@ -43,8 +43,8 @@ Dependency direction:
 | `pool/tools.rs` | Tool queries (`healthy_tools*`, `find_tool*`, `tool_schema`, exposure rows, summaries, runtime metadata, health). |
 | `pool/tools_call.rs` | `call_tool` + `subject_scoped_call_tool`. |
 | `pool/health.rs` | Circuit breaker: `record_*`, `should_reprobe*`, `*_last_error`, `filter_collisions`, `upstream_status`/`upstream_count`. |
-| `pool/resources_list.rs` | Resource listing + synthetic `gateway_*` documents. |
-| `pool/resources_read.rs` | `read_upstream_resource` + `subject_scoped_read_resource`. |
+| `pool/resources_list.rs` | Resource listing + synthetic `gateway_*` documents. Native `ui://` (mcp-ui) resources skip the `lab://upstream/{name}/…` rewrite so they stay addressable by the same URI a tool's `_meta.ui.resourceUri` references. |
+| `pool/resources_read.rs` | `read_upstream_resource` + `subject_scoped_read_resource` + `read_upstream_ui_resource` (reverse-looks-up the owning upstream by cached native `ui://` `resource_uris`, forwards the read, preserves the native URI — **no** `lab://upstream/` rewrite — for mcp-ui widget resources). |
 | `pool/prompts_list.rs` | Prompt listing + ownership lookup (`collect_upstream_prompts`, `find_prompt_owner`, …). |
 | `pool/prompts_get.rs` | `subject_scoped_prompts`, `get_prompt`, `subject_scoped_get_prompt`. |
 | `pool/testsupport.rs` | `#[cfg(test)]` shared fixtures + mock servers (`pub(super)`). |

--- a/crates/lab/src/dispatch/upstream/pool/resources_list.rs
+++ b/crates/lab/src/dispatch/upstream/pool/resources_list.rs
@@ -169,7 +169,15 @@ impl UpstreamPool {
                             );
                             break;
                         }
-                        rewrite_resource_uri(&mut resource, &name);
+                        // MCP Apps (mcp-ui) widget resources keep their native
+                        // `ui://…` URI: a tool result's `_meta.ui.resourceUri`
+                        // references that exact URI, and the host reads it back
+                        // verbatim (routed via `read_upstream_ui_resource`).
+                        // Rewriting to the `lab://upstream/{name}/…` gateway form
+                        // would break that reference, so skip the rewrite here.
+                        if !resource.uri.starts_with("ui://") {
+                            rewrite_resource_uri(&mut resource, &name);
+                        }
                         resources.push(resource);
                     }
                 }

--- a/crates/lab/src/dispatch/upstream/pool/resources_read.rs
+++ b/crates/lab/src/dispatch/upstream/pool/resources_read.rs
@@ -54,41 +54,10 @@ impl UpstreamPool {
             return None;
         }
 
-        // Clone the peer handle out, then drop the lock before awaiting.
-        let peer = self
-            .acquire_peer(
-                upstream_name,
-                UpstreamCapability::Resources,
-                "resource.read",
-            )
-            .await?;
-
-        let redacted_uri = redact_resource_uri_for_logging(uri);
-        let event = UpstreamRequestLog::resource(upstream_name, redacted_uri, false);
-        log_upstream_request_start(event);
-
-        let params = rmcp::model::ReadResourceRequestParams::new(original_uri);
-        let gateway_uri = uri.to_string();
-        let timeout_ms = self.request_timeout.as_millis();
-
-        // Use timed_capability_call for timeout/size-cap/log skeleton, then
-        // normalize the URI in the success path.
-        Some(
-            timed_capability_call(
-                self,
-                upstream_name,
-                UpstreamCapability::Resources,
-                event,
-                start,
-                peer.read_resource(params),
-                estimate_resource_response_size,
-                None,
-                |e| format!("upstream resource read failed: {e}"),
-                format!("upstream resource read timed out after {timeout_ms}ms"),
-            )
+        // Send the original URI upstream; normalize content URIs back to the
+        // gateway-prefixed form the caller passed in.
+        self.read_resource_from_peer(upstream_name, original_uri, uri, start)
             .await
-            .map(|result| normalize_resource_result_uri(result, &gateway_uri)),
-        )
     }
 
     /// Read a native upstream `ui://…` resource by reverse-looking-up the
@@ -98,8 +67,8 @@ impl UpstreamPool {
     /// MCP Apps (mcp-ui) widget resources are referenced by their native
     /// `ui://<upstream>/…` URI — carried in a tool result's
     /// `_meta.ui.resourceUri` — so they must be routed by reverse-lookup and
-    /// returned without any URI rewriting. The success path normalizes content
-    /// URIs back to the same native URI so the host sees a self-consistent read.
+    /// returned without any URI rewriting. Content URIs are normalized back to
+    /// the same native URI so the host sees a self-consistent read.
     ///
     /// Returns `None` if no routable upstream lists the URI (caller falls
     /// through to a resource-not-found).
@@ -126,26 +95,43 @@ impl UpstreamPool {
                 .map(|(name, _)| name.clone())
         }?;
 
+        // Native `ui://` URI is both the request and the normalization target.
+        self.read_resource_from_peer(&upstream_name, uri, uri, start)
+            .await
+    }
+
+    /// Acquire the upstream peer and forward `read_resource(request_uri)` with
+    /// the shared timeout / size-cap / structured-log skeleton, normalizing
+    /// returned content URIs to `normalize_uri`. Returns `None` when the peer
+    /// cannot be acquired. `start` is threaded in so the caller's lookup time is
+    /// included in the measured elapsed.
+    async fn read_resource_from_peer(
+        &self,
+        upstream_name: &str,
+        request_uri: &str,
+        normalize_uri: &str,
+        start: Instant,
+    ) -> Option<Result<ReadResourceResult, String>> {
+        // Clone the peer handle out, then drop the lock before awaiting.
         let peer = self
             .acquire_peer(
-                &upstream_name,
+                upstream_name,
                 UpstreamCapability::Resources,
                 "resource.read",
             )
             .await?;
 
-        let redacted_uri = redact_resource_uri_for_logging(uri);
-        let event = UpstreamRequestLog::resource(&upstream_name, redacted_uri, false);
+        let redacted_uri = redact_resource_uri_for_logging(normalize_uri);
+        let event = UpstreamRequestLog::resource(upstream_name, redacted_uri, false);
         log_upstream_request_start(event);
 
-        let params = rmcp::model::ReadResourceRequestParams::new(uri);
-        let native_uri = uri.to_string();
+        let params = rmcp::model::ReadResourceRequestParams::new(request_uri);
         let timeout_ms = self.request_timeout.as_millis();
 
         Some(
             timed_capability_call(
                 self,
-                &upstream_name,
+                upstream_name,
                 UpstreamCapability::Resources,
                 event,
                 start,
@@ -156,7 +142,7 @@ impl UpstreamPool {
                 format!("upstream resource read timed out after {timeout_ms}ms"),
             )
             .await
-            .map(|result| normalize_resource_result_uri(result, &native_uri)),
+            .map(|result| normalize_resource_result_uri(result, normalize_uri)),
         )
     }
 

--- a/crates/lab/src/dispatch/upstream/pool/resources_read.rs
+++ b/crates/lab/src/dispatch/upstream/pool/resources_read.rs
@@ -91,6 +91,75 @@ impl UpstreamPool {
         )
     }
 
+    /// Read a native upstream `ui://…` resource by reverse-looking-up the
+    /// owning upstream from each entry's cached `resource_uris`.
+    ///
+    /// Unlike [`read_upstream_resource`], the URI is **not** gateway-prefixed:
+    /// MCP Apps (mcp-ui) widget resources are referenced by their native
+    /// `ui://<upstream>/…` URI — carried in a tool result's
+    /// `_meta.ui.resourceUri` — so they must be routed by reverse-lookup and
+    /// returned without any URI rewriting. The success path normalizes content
+    /// URIs back to the same native URI so the host sees a self-consistent read.
+    ///
+    /// Returns `None` if no routable upstream lists the URI (caller falls
+    /// through to a resource-not-found).
+    ///
+    /// [`read_upstream_resource`]: Self::read_upstream_resource
+    pub async fn read_upstream_ui_resource(
+        &self,
+        uri: &str,
+    ) -> Option<Result<ReadResourceResult, String>> {
+        let start = Instant::now();
+
+        // Reverse-lookup the owning upstream by scanning cached resource URIs,
+        // mirroring the `find_tool` pattern. `resource_uris` is only populated
+        // for resource-proxy-enabled upstreams (via `list_upstream_resources`),
+        // so a routable match already implies resource proxying is enabled.
+        let upstream_name = {
+            let catalog = self.catalog.read().await;
+            catalog
+                .iter()
+                .find(|(_, entry)| {
+                    entry.resource_health.is_routable()
+                        && entry.resource_uris.iter().any(|cached| cached == uri)
+                })
+                .map(|(name, _)| name.clone())
+        }?;
+
+        let peer = self
+            .acquire_peer(
+                &upstream_name,
+                UpstreamCapability::Resources,
+                "resource.read",
+            )
+            .await?;
+
+        let redacted_uri = redact_resource_uri_for_logging(uri);
+        let event = UpstreamRequestLog::resource(&upstream_name, redacted_uri, false);
+        log_upstream_request_start(event);
+
+        let params = rmcp::model::ReadResourceRequestParams::new(uri);
+        let native_uri = uri.to_string();
+        let timeout_ms = self.request_timeout.as_millis();
+
+        Some(
+            timed_capability_call(
+                self,
+                &upstream_name,
+                UpstreamCapability::Resources,
+                event,
+                start,
+                peer.read_resource(params),
+                estimate_resource_response_size,
+                None,
+                |e| format!("upstream resource read failed: {e}"),
+                format!("upstream resource read timed out after {timeout_ms}ms"),
+            )
+            .await
+            .map(|result| normalize_resource_result_uri(result, &native_uri)),
+        )
+    }
+
     pub async fn subject_scoped_read_resource(
         &self,
         config: &UpstreamConfig,
@@ -328,6 +397,103 @@ mod tests {
         assert!(
             result.contains("bytes"),
             "expected byte count in error, got: {result}"
+        );
+    }
+
+    /// `read_upstream_ui_resource` reverse-looks-up the owning upstream by its
+    /// cached native `ui://` URI, forwards the read, and preserves the native
+    /// URI (no `lab://upstream/` rewrite). An unknown `ui://` returns `None`.
+    #[tokio::test]
+    async fn read_upstream_ui_resource_routes_native_uri_to_owner() {
+        use std::collections::HashMap;
+
+        use rmcp::model::{
+            ErrorData, ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
+        };
+        use rmcp::{RoleClient, RoleServer, ServerHandler, ServiceExt};
+
+        use super::super::super::types::UpstreamRuntimeMetadata;
+        use super::super::entries::healthy_in_process_entry;
+        use super::super::helpers::IN_PROCESS_PEER_BUFFER_BYTES;
+        use super::super::{UpstreamConnection, UpstreamPool};
+
+        const WIDGET_URI: &str = "ui://mock/widget";
+        const WIDGET_HTML: &str = "<html><body>dashboard</body></html>";
+
+        struct UiResourceServer;
+        impl ServerHandler for UiResourceServer {
+            fn get_info(&self) -> ServerInfo {
+                ServerInfo::new(ServerCapabilities::builder().enable_resources().build())
+            }
+            async fn read_resource(
+                &self,
+                params: rmcp::model::ReadResourceRequestParams,
+                _: rmcp::service::RequestContext<RoleServer>,
+            ) -> Result<ReadResourceResult, ErrorData> {
+                // Echo back the requested (native ui://) URI with mcp-app HTML.
+                Ok(ReadResourceResult::new(vec![
+                    ResourceContents::text(WIDGET_HTML, params.uri)
+                        .with_mime_type("text/html;profile=mcp-app"),
+                ]))
+            }
+        }
+
+        let upstream_name = "mock";
+        let (server_transport, client_transport) = tokio::io::duplex(IN_PROCESS_PEER_BUFFER_BYTES);
+        let _server_task = tokio::spawn(async move {
+            let running = UiResourceServer
+                .serve(server_transport)
+                .await
+                .expect("ui resource server starts");
+            running.waiting().await.ok();
+        });
+        let client_service: rmcp::service::RunningService<RoleClient, ()> = ()
+            .serve(client_transport)
+            .await
+            .expect("ui resource client starts");
+        let peer = client_service.peer().clone();
+
+        let pool = Arc::new(UpstreamPool::new());
+        let upstream_name_arc: Arc<str> = Arc::from(upstream_name);
+        let mut entry = healthy_in_process_entry(Arc::clone(&upstream_name_arc), HashMap::new());
+        entry.resource_count = 1;
+        entry.resource_uris = vec![WIDGET_URI.to_string()];
+        pool.catalog
+            .write()
+            .await
+            .insert(upstream_name.to_string(), entry);
+        pool.connections.write().await.insert(
+            upstream_name.to_string(),
+            UpstreamConnection {
+                _client_service: client_service,
+                _server_task: Some(_server_task),
+                peer,
+                runtime: UpstreamRuntimeMetadata::default(),
+            },
+        );
+
+        // Owned native ui:// URI routes to the owner and returns the HTML, with
+        // the content URI left as the native ui:// (no gateway rewrite).
+        let result = pool
+            .read_upstream_ui_resource(WIDGET_URI)
+            .await
+            .expect("an upstream owns the ui:// resource")
+            .expect("ui resource read succeeds");
+        let contents = result.contents.first().expect("one content block");
+        match contents {
+            ResourceContents::TextResourceContents { text, uri, .. } => {
+                assert_eq!(text, WIDGET_HTML);
+                assert_eq!(uri, WIDGET_URI, "native ui:// URI must be preserved");
+            }
+            other => panic!("expected text contents, got {other:?}"),
+        }
+
+        // An unknown ui:// URI is owned by no upstream → None (caller 404s).
+        assert!(
+            pool.read_upstream_ui_resource("ui://mock/missing")
+                .await
+                .is_none(),
+            "unknown ui:// must reverse-lookup to no owner"
         );
     }
 }

--- a/crates/lab/src/mcp/CLAUDE.md
+++ b/crates/lab/src/mcp/CLAUDE.md
@@ -107,6 +107,17 @@ Never duplicate catalog logic. If you need richer data, extend the builder.
 
 Resources are read-only. Do not use them for mutations.
 
+### `ui://` resources (MCP Apps / mcp-ui)
+
+`read_resource_impl` splits the `ui://` namespace:
+
+- `ui://lab/code-mode/*` — Lab's own Code Mode app resources, served locally
+  from bundled HTML (`read_code_mode_app_resource_impl`).
+- any other `ui://<upstream>/…` — an upstream mcp-ui widget resource (referenced
+  by a tool result's `_meta.ui.resourceUri`). Routed to the owning upstream peer
+  via `pool.read_upstream_ui_resource` (catalog reverse-lookup, native URI
+  preserved). See `resource_proxy.rs::read_upstream_ui_resource_impl`.
+
 ## Transport auth for fs
 
 The `fs` service exposes workspace filesystem contents (`fs.list`,

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -115,15 +115,37 @@ impl LabMcpServer {
         }
 
         if self.code_mode_visibility().await.hides_raw_tools() {
-            let envelope = build_error(
-                &service,
-                &action,
-                "not_found",
-                &format!("tool `{service}` is hidden while code_mode mode is enabled"),
-            );
-            return Ok(CallToolResult::error(vec![Content::text(
-                envelope.to_string(),
-            )]));
+            // mcp-ui widget callbacks: when the operator has explicitly enabled
+            // them, a raw call that names a known upstream tool is allowed to
+            // fall through to the upstream proxy so a rendered widget can drive
+            // its tool. The tool stays hidden from `list_tools` — this relaxes
+            // callability, never visibility. Default off (strict boundary); see
+            // `config::code_mode_widget_callbacks_enabled`.
+            let widget_callback = svc.is_none()
+                && crate::config::code_mode_widget_callbacks_enabled()
+                && match self.current_upstream_pool().await {
+                    Some(pool) => pool.find_tool(&service).await.is_some(),
+                    None => false,
+                };
+            if widget_callback {
+                tracing::info!(
+                    surface = "mcp",
+                    service = %service,
+                    action = %action,
+                    route = "upstream_widget_callback",
+                    "code_mode raw-tool gate bypassed for enabled widget callback"
+                );
+            } else {
+                let envelope = build_error(
+                    &service,
+                    &action,
+                    "not_found",
+                    &format!("tool `{service}` is hidden while code_mode mode is enabled"),
+                );
+                return Ok(CallToolResult::error(vec![Content::text(
+                    envelope.to_string(),
+                )]));
+            }
         }
 
         if let Some(entry) = svc

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -121,30 +121,54 @@ impl LabMcpServer {
             // its tool. The tool stays hidden from `list_tools` — this relaxes
             // callability, never visibility. Default off (strict boundary); see
             // `config::code_mode_widget_callbacks_enabled`.
-            let widget_callback = svc.is_none()
+            let widget_tool = if svc.is_none()
                 && crate::config::code_mode_widget_callbacks_enabled()
-                && match self.current_upstream_pool().await {
-                    Some(pool) => pool.find_tool(&service).await.is_some(),
-                    None => false,
-                };
-            if widget_callback {
-                tracing::info!(
-                    surface = "mcp",
-                    service = %service,
-                    action = %action,
-                    route = "upstream_widget_callback",
-                    "code_mode raw-tool gate bypassed for enabled widget callback"
-                );
+                && let Some(pool) = self.current_upstream_pool().await
+            {
+                pool.find_tool(&service).await
             } else {
-                let envelope = build_error(
-                    &service,
-                    &action,
-                    "not_found",
-                    &format!("tool `{service}` is hidden while code_mode mode is enabled"),
-                );
-                return Ok(CallToolResult::error(vec![Content::text(
-                    envelope.to_string(),
-                )]));
+                None
+            };
+            match widget_tool {
+                // Destructive upstream effects are NOT reachable over the
+                // callback bypass: it has no confirmation channel, so unlike the
+                // `execute` path (which gates destructive upstream calls behind
+                // `confirm: true`) it could otherwise run a destructive tool
+                // unconfirmed. The sanctioned path for those is `execute`.
+                Some((_upstream, tool)) if tool.destructive => {
+                    let envelope = build_error(
+                        &service,
+                        &action,
+                        "confirmation_required",
+                        &format!(
+                            "destructive upstream tool `{service}` is not callable via the \
+                             widget callback bypass — use the `execute` tool with confirm:true"
+                        ),
+                    );
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        envelope.to_string(),
+                    )]));
+                }
+                Some(_) => {
+                    tracing::info!(
+                        surface = "mcp",
+                        service = %service,
+                        action = %action,
+                        route = "upstream_widget_callback",
+                        "code_mode raw-tool gate bypassed for enabled widget callback"
+                    );
+                }
+                None => {
+                    let envelope = build_error(
+                        &service,
+                        &action,
+                        "not_found",
+                        &format!("tool `{service}` is hidden while code_mode mode is enabled"),
+                    );
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        envelope.to_string(),
+                    )]));
+                }
             }
         }
 

--- a/crates/lab/src/mcp/call_tool_codemode.rs
+++ b/crates/lab/src/mcp/call_tool_codemode.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{CallToolResult, Content, JsonObject};
+use rmcp::model::{CallToolResult, Content, JsonObject, Meta};
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
@@ -228,7 +228,8 @@ impl LabMcpServer {
                     output_tokens,
                     "gateway code search ok"
                 );
-                Ok(call_result_with_structured(output, structured))
+                // `search` never surfaces a widget — it runs pure catalog JS.
+                Ok(call_result_with_structured(output, structured, None))
             }
             Err(err) => {
                 let elapsed_ms = started.elapsed().as_millis();
@@ -408,6 +409,16 @@ impl LabMcpServer {
                 match_count: None,
             })
             .await;
+        // Mirror the upstream's `_meta.ui` verbatim onto the execute result so
+        // the host renders the native mcp-ui widget (last-wins, opt-in via
+        // `{ __ui: <result> }`). The widget itself is driven by the `ui://`
+        // resource read, not by inline content, so the execute trace content is
+        // left intact.
+        let ui_meta = response.ui.as_ref().map(|ui| {
+            let mut map = serde_json::Map::new();
+            map.insert("ui".to_string(), ui.ui_meta.clone());
+            Meta(map)
+        });
         let output = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
         let structured = code_mode_execute_trace(&response);
         let output_tokens = estimate_tokens(&output);
@@ -423,13 +434,18 @@ impl LabMcpServer {
             output_tokens,
             "gateway code execute ok"
         );
-        Ok(call_result_with_structured(output, structured))
+        Ok(call_result_with_structured(output, structured, ui_meta))
     }
 }
 
-fn call_result_with_structured(text: String, structured: Value) -> CallToolResult {
+fn call_result_with_structured(
+    text: String,
+    structured: Value,
+    ui_meta: Option<Meta>,
+) -> CallToolResult {
     let mut result = CallToolResult::success(vec![Content::text(text)]);
     result.structured_content = Some(structured);
+    result.meta = ui_meta;
     result
 }
 

--- a/crates/lab/src/mcp/call_tool_codemode/tests.rs
+++ b/crates/lab/src/mcp/call_tool_codemode/tests.rs
@@ -81,6 +81,7 @@ fn gateway_search_input_schema_is_code_only() {
 #[test]
 fn execute_trace_contains_redacted_params_and_compact_result_shape() {
     let response = CodeModeExecutionResponse {
+        ui: None,
         result: Some(json!({
             "items": ["raw payload that should not be copied into trace"],
             "secret": "result payloads are summarized, not previewed"

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -31,6 +31,9 @@ use crate::mcp::logging::DispatchLogOutcome;
 use crate::mcp::server::LabMcpServer;
 
 pub(crate) const CODE_MODE_APP_MIME: &str = "text/html;profile=mcp-app";
+/// URI namespace reserved for Lab's own Code Mode app resources, served locally.
+/// Any other `ui://` is an upstream mcp-ui widget resource routed to its peer.
+pub(crate) const CODE_MODE_APP_URI_PREFIX: &str = "ui://lab/code-mode/";
 pub(crate) const CODE_MODE_SEARCH_APP_URI: &str = "ui://lab/code-mode/search";
 pub(crate) const CODE_MODE_EXECUTE_APP_URI: &str = "ui://lab/code-mode/execute";
 pub(crate) const CODE_MODE_HISTORY_APP_URI: &str = "ui://lab/code-mode/history";
@@ -157,18 +160,19 @@ impl LabMcpServer {
 
         // Branch 0: MCP Apps UI resources. This must precede all lab://
         // fallbacks so ui:// has its own exact lookup semantics.
+        //
+        // Local Code Mode app resources own the `ui://lab/code-mode/*` namespace
+        // and are served from the bundled HTML.
+        if uri.starts_with(CODE_MODE_APP_URI_PREFIX) {
+            return self
+                .read_code_mode_app_resource_impl(uri, &subject, start, &context)
+                .await;
+        }
+        // Any other `ui://` is an upstream MCP Apps (mcp-ui) widget resource
+        // (referenced by a tool result's `_meta.ui.resourceUri`): reverse-look-up
+        // the owning upstream peer via the pool and forward the read under the
+        // native `ui://` URI.
         if uri.starts_with("ui://") {
-            // Local Code Mode app resources own the `ui://lab/code-mode/*`
-            // namespace and are served from the bundled HTML.
-            if uri.starts_with("ui://lab/code-mode/") {
-                return self
-                    .read_code_mode_app_resource_impl(uri, &subject, start, &context)
-                    .await;
-            }
-            // Any other `ui://` is an upstream MCP Apps (mcp-ui) widget resource
-            // (referenced by a tool result's `_meta.ui.resourceUri`): reverse-
-            // look-up the owning upstream peer via the pool and forward the read
-            // under the native `ui://` URI.
             if let Some(pool) = self.current_upstream_pool().await {
                 return self
                     .read_upstream_ui_resource_impl(&pool, uri, &subject, start, &context)

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -171,8 +171,20 @@ impl LabMcpServer {
         // Any other `ui://` is an upstream MCP Apps (mcp-ui) widget resource
         // (referenced by a tool result's `_meta.ui.resourceUri`): reverse-look-up
         // the owning upstream peer via the pool and forward the read under the
-        // native `ui://` URI.
+        // native `ui://` URI. These widgets are surfaced through the Code Mode
+        // synthetic surface, so gate them behind the same read scope as Lab's own
+        // Code Mode app resources rather than leaving them ungated.
         if uri.starts_with("ui://") {
+            let auth = auth_context_from_extensions(&context.extensions);
+            if !code_mode_search_scope_allowed(auth) {
+                return Err(ErrorData::invalid_params(
+                    "UI resources require one of scopes: lab:read, lab, lab:admin",
+                    Some(json!({
+                        "kind": "forbidden",
+                        "required_scopes": ["lab:read", "lab", "lab:admin"],
+                    })),
+                ));
+            }
             if let Some(pool) = self.current_upstream_pool().await {
                 return self
                     .read_upstream_ui_resource_impl(&pool, uri, &subject, start, &context)

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -158,9 +158,26 @@ impl LabMcpServer {
         // Branch 0: MCP Apps UI resources. This must precede all lab://
         // fallbacks so ui:// has its own exact lookup semantics.
         if uri.starts_with("ui://") {
-            return self
-                .read_code_mode_app_resource_impl(uri, &subject, start, &context)
-                .await;
+            // Local Code Mode app resources own the `ui://lab/code-mode/*`
+            // namespace and are served from the bundled HTML.
+            if uri.starts_with("ui://lab/code-mode/") {
+                return self
+                    .read_code_mode_app_resource_impl(uri, &subject, start, &context)
+                    .await;
+            }
+            // Any other `ui://` is an upstream MCP Apps (mcp-ui) widget resource
+            // (referenced by a tool result's `_meta.ui.resourceUri`): reverse-
+            // look-up the owning upstream peer via the pool and forward the read
+            // under the native `ui://` URI.
+            if let Some(pool) = self.current_upstream_pool().await {
+                return self
+                    .read_upstream_ui_resource_impl(&pool, uri, &subject, start, &context)
+                    .await;
+            }
+            return Err(ErrorData::resource_not_found(
+                format!("unknown UI resource: {uri}"),
+                None,
+            ));
         }
 
         // Branch 1: gateway-synthetic resources.

--- a/crates/lab/src/mcp/resource_proxy.rs
+++ b/crates/lab/src/mcp/resource_proxy.rs
@@ -273,6 +273,106 @@ impl LabMcpServer {
         }
     }
 
+    /// Upstream MCP Apps (mcp-ui) widget resource branch (`ui://<upstream>/…`).
+    ///
+    /// These are native `ui://` resources owned by an upstream peer (referenced
+    /// by a tool result's `_meta.ui.resourceUri`). The caller invokes this only
+    /// for non-local `ui://` URIs — `ui://lab/code-mode/*` stays on the local
+    /// Code Mode app handler. Reverse-lookup + forwarding lives in the pool;
+    /// this method stays envelope-only.
+    pub(crate) async fn read_upstream_ui_resource_impl(
+        &self,
+        pool: &Arc<UpstreamPool>,
+        uri: &str,
+        subject: &str,
+        start: Instant,
+        context: &RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        tracing::info!(
+            surface = "mcp",
+            service = "labby",
+            action = "read_resource",
+            resource_uri = redact_resource_uri_for_logging(uri),
+            route = "upstream_ui",
+            "dispatch route selected"
+        );
+        match pool.read_upstream_ui_resource(uri).await {
+            Some(Ok(result)) => {
+                let elapsed_ms = start.elapsed().as_millis();
+                tracing::info!(
+                    surface = "mcp",
+                    service = "labby",
+                    action = "read_resource",
+                    subject,
+                    resource_uri = redact_resource_uri_for_logging(uri),
+                    elapsed_ms,
+                    "ui resource proxy ok"
+                );
+                self.emit_dispatch_notification(
+                    context,
+                    "lab",
+                    "read_resource",
+                    elapsed_ms,
+                    DispatchLogOutcome::Success,
+                )
+                .await;
+                Ok(result)
+            }
+            Some(Err(message)) => {
+                let elapsed_ms = start.elapsed().as_millis();
+                tracing::warn!(
+                    surface = "mcp",
+                    service = "labby",
+                    action = "read_resource",
+                    resource_uri = redact_resource_uri_for_logging(uri),
+                    elapsed_ms,
+                    kind = "internal_error",
+                    error = %message,
+                    "ui resource proxy failed"
+                );
+                self.emit_dispatch_notification(
+                    context,
+                    "lab",
+                    "read_resource",
+                    elapsed_ms,
+                    DispatchLogOutcome::Failure {
+                        level: LoggingLevel::Error,
+                        kind: "internal_error",
+                    },
+                )
+                .await;
+                Err(ErrorData::internal_error(message, None))
+            }
+            None => {
+                let elapsed_ms = start.elapsed().as_millis();
+                tracing::warn!(
+                    surface = "mcp",
+                    service = "labby",
+                    action = "read_resource",
+                    resource_uri = redact_resource_uri_for_logging(uri),
+                    elapsed_ms,
+                    kind = "not_found",
+                    "no upstream owns ui resource"
+                );
+                self.emit_dispatch_notification(
+                    context,
+                    "lab",
+                    "read_resource",
+                    elapsed_ms,
+                    DispatchLogOutcome::Failure {
+                        level: LoggingLevel::Warning,
+                        kind: "not_found",
+                    },
+                )
+                .await;
+                Err(ErrorData::resource_not_found(
+                    format!("unknown UI resource: {uri}"),
+                    None,
+                ))
+            }
+        }
+    }
+
     /// Subject-scoped resource proxy branch. The caller passes the
     /// already-resolved `pool`, `config`, and `oauth_subject` and invokes
     /// this only when all guards matched.

--- a/crates/lab/src/mcp/resource_proxy.rs
+++ b/crates/lab/src/mcp/resource_proxy.rs
@@ -296,9 +296,10 @@ impl LabMcpServer {
             route = "upstream_ui",
             "dispatch route selected"
         );
-        match pool.read_upstream_ui_resource(uri).await {
+        let result = pool.read_upstream_ui_resource(uri).await;
+        let elapsed_ms = start.elapsed().as_millis();
+        let (outcome, response) = match result {
             Some(Ok(result)) => {
-                let elapsed_ms = start.elapsed().as_millis();
                 tracing::info!(
                     surface = "mcp",
                     service = "labby",
@@ -308,18 +309,9 @@ impl LabMcpServer {
                     elapsed_ms,
                     "ui resource proxy ok"
                 );
-                self.emit_dispatch_notification(
-                    context,
-                    "lab",
-                    "read_resource",
-                    elapsed_ms,
-                    DispatchLogOutcome::Success,
-                )
-                .await;
-                Ok(result)
+                (DispatchLogOutcome::Success, Ok(result))
             }
             Some(Err(message)) => {
-                let elapsed_ms = start.elapsed().as_millis();
                 tracing::warn!(
                     surface = "mcp",
                     service = "labby",
@@ -330,21 +322,15 @@ impl LabMcpServer {
                     error = %message,
                     "ui resource proxy failed"
                 );
-                self.emit_dispatch_notification(
-                    context,
-                    "lab",
-                    "read_resource",
-                    elapsed_ms,
+                (
                     DispatchLogOutcome::Failure {
                         level: LoggingLevel::Error,
                         kind: "internal_error",
                     },
+                    Err(ErrorData::internal_error(message, None)),
                 )
-                .await;
-                Err(ErrorData::internal_error(message, None))
             }
             None => {
-                let elapsed_ms = start.elapsed().as_millis();
                 tracing::warn!(
                     surface = "mcp",
                     service = "labby",
@@ -354,23 +340,21 @@ impl LabMcpServer {
                     kind = "not_found",
                     "no upstream owns ui resource"
                 );
-                self.emit_dispatch_notification(
-                    context,
-                    "lab",
-                    "read_resource",
-                    elapsed_ms,
+                (
                     DispatchLogOutcome::Failure {
                         level: LoggingLevel::Warning,
                         kind: "not_found",
                     },
+                    Err(ErrorData::resource_not_found(
+                        format!("unknown UI resource: {uri}"),
+                        None,
+                    )),
                 )
-                .await;
-                Err(ErrorData::resource_not_found(
-                    format!("unknown UI resource: {uri}"),
-                    None,
-                ))
             }
-        }
+        };
+        self.emit_dispatch_notification(context, "lab", "read_resource", elapsed_ms, outcome)
+            .await;
+        response
     }
 
     /// Subject-scoped resource proxy branch. The caller passes the

--- a/crates/lab/src/registry.rs
+++ b/crates/lab/src/registry.rs
@@ -289,9 +289,7 @@ const ALWAYS_VISIBLE_SERVICES: &[&str] = &[
 
 #[must_use]
 pub fn lab_show_all_enabled() -> bool {
-    std::env::var("LAB_SHOW_ALL")
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+    crate::config::env_flag_enabled("LAB_SHOW_ALL")
 }
 
 #[must_use]

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -173,6 +173,55 @@ When the envelope is too large, the final `result` is replaced with a truncation
 marker containing `truncated`, `original_size`, `original_tokens`, `preview`, and
 `next_action`. Logs are trimmed after result truncation if needed.
 
+## MCP Apps (mcp-ui) widgets
+
+An upstream tool can return a native MCP Apps (mcp-ui) widget by carrying
+`_meta.ui.resourceUri` (a `ui://<upstream>/...` URI served as
+`text/html;profile=mcp-app`). Inside `execute`, the unwrapped `callTool` payload
+drops that envelope metadata, so a widget would otherwise collapse to plain JSON.
+
+To render the widget through `execute`, the caller opts in explicitly by
+returning an object with a `__ui` key:
+
+```ts
+async () => {
+  const dashboard = await codemode.axon.status_dashboard({});
+  return { __ui: dashboard };   // render the widget; surface `dashboard` as the result
+}
+```
+
+Semantics:
+
+- **Opt-in only.** Without a `__ui` key the run behaves exactly as before — no
+  widget metadata is attached.
+- **Last-wins.** The broker records the most recent widget-bearing upstream call
+  during the run; that link is the one surfaced. `<result>` inside `{ __ui:
+  <result> }` is unwrapped into the execute `result` field so the model still
+  sees the payload.
+- **Native URIs.** The widget's `ui://<upstream>/...` URI is preserved verbatim.
+  The gateway routes a `resources/read` of that URI to the owning upstream peer
+  via catalog reverse-lookup (it is **not** rewritten to `lab://upstream/...`).
+  `ui://lab/code-mode/*` remains reserved for Lab's own Code Mode app resources.
+- **Identical mirroring.** The execute `CallToolResult` carries the upstream's
+  `_meta.ui` object verbatim, so the host renders the widget identically to a
+  direct connector. The widget itself is driven by the `ui://` resource read, not
+  by inline content, so the execute trace content is left intact.
+- The `CodeModeExecutionResponse` gains an optional `ui` field that is `null`
+  unless the opt-in fired.
+
+### Widget → host callbacks (opt-in)
+
+While the synthetic `search`/`execute` surface is active, raw upstream tools are
+hidden from `list_tools` and are not callable by name — so an interactive
+widget's callback (`tools/call` for an upstream tool) is rejected by default.
+Operators who want interactive widgets can set
+`LAB_CODE_MODE_WIDGET_CALLBACKS=1` (or `true`/`yes`) to let a call that names a
+known upstream tool fall through to the upstream proxy. This relaxes
+**callability**, never **visibility** — the tool stays out of `list_tools`. It is
+**off by default** because, on the same MCP session, it also lets the model
+invoke a known upstream tool by name. Leave it off unless interactive widgets are
+required.
+
 ## Error Contract
 
 Tool errors reject with a JSON-encoded string that can be decoded in the sandbox:


### PR DESCRIPTION
Closes #109.

## Summary

Renders upstream **MCP Apps (mcp-ui)** widgets produced *inside* the Code Mode `execute` path. A widget-producing upstream tool (e.g. `axon`'s `status_dashboard`, which returns `_meta.ui.resourceUri = "ui://axon/status-dashboard"` plus a `ui://` resource served as `text/html;profile=mcp-app`) previously collapsed to plain JSON because the `_meta.ui` link and the backing `ui://` resource were dropped. It now renders its native widget in the host — identical to a direct connector — while `search` + `execute` stay the **only** model-visible tools.

Root cause: Code Mode is model-facing JSON orchestration, mcp-ui is client-facing iframe rendering. The `_meta.ui` link was discarded in `unwrap_code_mode_upstream_result`, and `read_resource_impl` routed *all* `ui://` reads to Lab's own code-mode apps (404-ing on upstream `ui://`).

## What changed (by phase)

**1. Resource routing (foundational — fixes both direct & code-mode paths)**
- `UpstreamPool::read_upstream_ui_resource` (`pool/resources_read.rs`): reverse-looks-up the owning upstream by cached `resource_uris` (mirrors the `find_tool` pattern), forwards `resources/read` under the **native** `ui://` URI, no rewrite.
- `read_resource_impl` (`handlers_resources.rs`) splits the `ui://` branch: `ui://lab/code-mode/*` stays local; any other `ui://` routes to the new `read_upstream_ui_resource_impl` (`resource_proxy.rs`).
- `list_upstream_resources` (`pool/resources_list.rs`) skips the `lab://upstream/{name}/…` rewrite for `ui://` URIs so the listed URI matches `_meta.ui.resourceUri`.

**2. UI link capture (last-wins)**
- `CodeModeBroker` gains a run-scoped `ui_capture` sink. In `call_upstream_tool`, `extract_ui_link` records the upstream result's `_meta.ui` **before** the envelope is unwrapped (`_meta` is otherwise discarded).

**3. Result shaping (opt-in)**
- New `UiLink` type + `CodeModeExecutionResponse.ui`. Returning `{ __ui: <result> }` from execute surfaces the last-wins captured link as `_meta.ui` on the execute `CallToolResult` (mirroring the upstream verbatim) and unwraps the inner value as the model-facing `result`. Without the opt-in, behavior is unchanged. The widget is driven by the `ui://` resource read, so the execute trace content is left intact.

**4. Bidirectional bridge (opt-in flag, default OFF)**
- While the synthetic surface is active, `hides_raw_tools` blocks raw tool calls (including a widget's callback). `LAB_CODE_MODE_WIDGET_CALLBACKS=1` lets a call naming a **known upstream tool** fall through to the upstream proxy — relaxing *callability*, never *visibility* (the tool stays out of `list_tools`). **Default off** keeps the strict trust boundary, because on the same session it also lets the model call a known upstream tool by name. See `config::code_mode_widget_callbacks_enabled`.

**5. Tests + docs**
- Pool reverse-lookup + native-passthrough test; `extract_ui_link` and `apply_ui_opt_in` (opt-in unwrap + last-wins, and no-opt-in no-op) tests.
- `docs/dev/CODE_MODE.md` + `code_mode` / `upstream` / `mcp` `CLAUDE.md` updated.

## Design constraints honored
- Native `ui://<upstream>/...` routed via catalog reverse-lookup (no rewrite).
- Last-wins, explicit opt-in via `return { __ui: <result> }`.
- Execute result mirrors the upstream `_meta.ui` identically.
- No parent↔runner wire-protocol change — `__ui` is a host-side return convention.

## Verification
- `cargo check --all-features` ✅ · `cargo clippy --all-features` ✅ (clean) · `cargo fmt` ✅
- New tests pass; 161 `code_mode` lib tests + resource-handler tests pass.
- Manual smoke (per CLAUDE.md dev flow): `execute` with `async () => { const r = await codemode.axon.status_dashboard({}); return { __ui: r }; }` → `CallToolResult._meta.ui.resourceUri == "ui://axon/status-dashboard"`, and `resources/read` of that URI routes to the axon peer returning `text/html;profile=mcp-app`.

## Follow-up (not in this PR)
- Subject-scoped (OAuth) upstream `ui://` widgets keep the `lab://upstream/` rewrite — interactive widgets for OAuth upstreams would need a subject-aware reverse-lookup.
- A full subprocess end-to-end execute test (real Javy runner + mock upstream emitting `_meta.ui`) — the pieces are unit/pool-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EQ5ZCYL7QNNRiK16PtxUj)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render upstream MCP Apps (`mcp-ui`) widgets inside Code Mode `execute`, preserving `_meta.ui` and proxying native `ui://` resources to their owners. Secures the path by gating `ui://` reads behind lab scopes and blocking destructive tools over the widget-callback bypass.

- **New Features**
  - Opt-in widget surfacing: return `{ __ui: <result> }` to unwrap `<result>` and attach upstream `_meta.ui` to the `execute` `CallToolResult`.
  - Native `ui://<upstream>/…` resources are reverse-looked up and proxied verbatim; `ui://lab/code-mode/*` remains local.
  - Optional widget→tool callbacks when `LAB_CODE_MODE_WIDGET_CALLBACKS=1` (relaxes callability only; tools stay hidden from `list_tools`).

- **Bug Fixes**
  - Gate upstream `ui://` widget reads behind `lab:read`/`lab`/`lab:admin` scopes.
  - Reject destructive upstream tools via the callback bypass; use `execute` with `confirm: true` instead.
  - Refactored resource reading into a shared helper and extracted `env_flag_enabled` (no behavior change).

<sup>Written for commit 8b0b6812144897fd9bab52cda7a8e661866a1ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

