### PR TITLE
Polish Code Mode Inspector UI

### DIFF
--- a/apps/gateway-admin/.gitignore
+++ b/apps/gateway-admin/.gitignore
@@ -12,6 +12,7 @@ next.user-config.*
 
 # Common ignores
 node_modules
+next-env.d.ts
 .next/
 out/
 .DS_Store

--- a/apps/gateway-admin/components/code-mode-app/code-mode-inspector.test.tsx
+++ b/apps/gateway-admin/components/code-mode-app/code-mode-inspector.test.tsx
@@ -29,8 +29,10 @@ test('renders execute call rows with redacted params', async () => {
     />,
   )
 
-  assert.match(container.textContent ?? '', /Broker-observed execute calls/)
+  assert.match(container.textContent ?? '', /Execute calls/)
   assert.match(container.textContent ?? '', /github \/ search_issues/)
+  assert.doesNotMatch(container.textContent ?? '', /\bok\b/)
+  assert.ok(container.querySelector('[aria-label="success"]'))
   assert.match(container.textContent ?? '', /12ms/)
   assert.match(container.textContent ?? '', /\[redacted\]/)
   assert.doesNotMatch(container.textContent ?? '', /raw-secret-token/)
@@ -59,7 +61,7 @@ test('renders search match rows', async () => {
     />,
   )
 
-  assert.match(container.textContent ?? '', /Catalog-inferred search matches/)
+  assert.match(container.textContent ?? '', /Search matches/)
   assert.match(container.textContent ?? '', /axon \/ ask/)
   assert.match(container.textContent ?? '', /schema/)
   await unmount()

--- a/apps/gateway-admin/components/code-mode-app/code-mode-inspector.tsx
+++ b/apps/gateway-admin/components/code-mode-app/code-mode-inspector.tsx
@@ -1,8 +1,25 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { AlertTriangle, CheckCircle2, Clock3, Database, Search, XCircle } from 'lucide-react'
+import { type CSSProperties, useEffect, useState } from 'react'
+import {
+  AlertTriangle,
+  Braces,
+  CheckCircle2,
+  Clock3,
+  Database,
+  History,
+  Search,
+  Sparkles,
+} from 'lucide-react'
 
+import {
+  AURORA_CARD_TITLE,
+  AURORA_DENSE_META,
+  AURORA_MESSAGE_SURFACE,
+  AURORA_MUTED_LABEL,
+  AURORA_PAGE_SHELL,
+  AURORA_STRONG_PANEL,
+} from '@/components/aurora/tokens'
 import {
   type CodeModeTrace,
   flattenTraceRows,
@@ -10,6 +27,42 @@ import {
   stringifyRedactedParams,
 } from '@/lib/code-mode-app/trace'
 import { cn } from '@/lib/utils'
+
+const AURORA_DARK_TOKENS = {
+  '--aurora-page-bg': '#07131c',
+  '--aurora-panel-medium': '#102330',
+  '--aurora-panel-strong': '#13293a',
+  '--aurora-control-surface': '#0c1a24',
+  '--aurora-border-default': '#1d3d4e',
+  '--aurora-border-strong': '#24536c',
+  '--aurora-text-primary': '#e6f4fb',
+  '--aurora-text-muted': '#a7bcc9',
+  '--aurora-accent-primary': '#29b6f6',
+  '--aurora-accent-strong': '#67cbfa',
+  '--aurora-warn': '#c6a36b',
+  '--aurora-error': '#c78490',
+  '--aurora-success': '#7dd3c7',
+  '--aurora-hover-bg': '#17364b',
+  '--aurora-active-glow': '0 0 0 1px rgba(41, 182, 246, 0.18), 0 0 16px rgba(41, 182, 246, 0.08)',
+  '--aurora-shadow-medium': '0 12px 24px rgba(0, 0, 0, 0.18)',
+  '--aurora-shadow-strong': '0 20px 38px rgba(0, 0, 0, 0.26)',
+  '--aurora-highlight-medium': 'inset 0 1px 0 rgba(255, 255, 255, 0.035)',
+  '--aurora-highlight-strong': 'inset 0 1px 0 rgba(255, 255, 255, 0.05)',
+  '--color-aurora-page-bg': 'var(--aurora-page-bg)',
+  '--color-aurora-panel-medium': 'var(--aurora-panel-medium)',
+  '--color-aurora-panel-strong': 'var(--aurora-panel-strong)',
+  '--color-aurora-control-surface': 'var(--aurora-control-surface)',
+  '--color-aurora-border-default': 'var(--aurora-border-default)',
+  '--color-aurora-border-strong': 'var(--aurora-border-strong)',
+  '--color-aurora-text-primary': 'var(--aurora-text-primary)',
+  '--color-aurora-text-muted': 'var(--aurora-text-muted)',
+  '--color-aurora-accent-primary': 'var(--aurora-accent-primary)',
+  '--color-aurora-accent-strong': 'var(--aurora-accent-strong)',
+  '--color-aurora-warn': 'var(--aurora-warn)',
+  '--color-aurora-error': 'var(--aurora-error)',
+  '--color-aurora-success': 'var(--aurora-success)',
+  '--color-aurora-hover-bg': 'var(--aurora-hover-bg)',
+} as CSSProperties
 
 declare global {
   interface Window {
@@ -84,23 +137,39 @@ export function CodeModeInspector({ initialTrace }: CodeModeInspectorProps) {
     trace?.kind === 'code_mode_search_trace' ? formatSearchCount(trace) : undefined
 
   return (
-    <main className="min-h-screen bg-aurora-page-bg text-aurora-text-primary">
-      <section className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4 sm:p-5">
-        <header className="flex flex-col gap-3 border-b border-aurora-border-default pb-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-aurora-text-muted">
-              <Database className="size-4 text-aurora-accent-primary" />
-              Code Mode trace
+    <main
+      className={cn('h-[100dvh] overflow-hidden bg-aurora-page-bg text-aurora-text-primary', AURORA_PAGE_SHELL)}
+      style={AURORA_DARK_TOKENS}
+    >
+      <section className="aurora-scrollbar mx-auto flex h-full w-full max-w-5xl flex-col gap-3 overflow-y-auto p-3 sm:gap-4 sm:p-5">
+        <header className={cn('relative overflow-visible px-3 py-2.5 sm:p-4', AURORA_STRONG_PANEL)}>
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-aurora-accent-primary/50 to-transparent" />
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 gap-2.5">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-aurora-accent-primary/35 bg-[color-mix(in_srgb,var(--aurora-accent-primary)_14%,transparent)] shadow-[var(--aurora-active-glow)] sm:size-10 sm:rounded-aurora-2">
+                <Sparkles className="size-4 text-aurora-accent-strong sm:size-5" strokeWidth={1.65} />
+              </div>
+              <div className="min-w-0">
+                <div className={cn('flex items-center gap-1.5', AURORA_MUTED_LABEL, 'text-[10px] tracking-[0.12em] sm:text-[11px] sm:tracking-[0.18em]')}>
+                  <Database className="size-3.5 text-aurora-accent-primary" strokeWidth={1.65} />
+                  Code Mode trace
+                </div>
+                <h1 className="mt-0.5 font-display text-[19px] font-extrabold leading-tight text-aurora-text-primary sm:mt-1 sm:text-[22px]">
+                  Call inspector
+                </h1>
+                <p className={cn('mt-0.5 hidden max-w-2xl text-aurora-text-muted sm:mt-1 sm:block', AURORA_DENSE_META)}>
+                  {trace
+                    ? 'Live calls, search matches, and recent history from the active MCP app session.'
+                    : 'Waiting for an MCP Apps tool result or history snapshot.'}
+                </p>
+              </div>
             </div>
-            <h1 className="mt-1 text-xl font-semibold text-aurora-text-primary">
-              Call inspector
-            </h1>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-aurora-text-muted">
-            <StatusPill tone={bridgeState === 'connected' ? 'success' : 'neutral'}>
-              {bridgeState}
-            </StatusPill>
-            {trace ? <StatusPill tone="info">{trace.kind.replace('code_mode_', '')}</StatusPill> : null}
+            <div className="flex flex-wrap items-center gap-1.5 text-xs text-aurora-text-muted">
+              <StatusPill tone={bridgeState === 'connected' ? 'success' : 'neutral'}>
+                {bridgeState}
+              </StatusPill>
+              {trace ? <StatusPill tone="info">{trace.kind.replace('code_mode_', '')}</StatusPill> : null}
+            </div>
           </div>
         </header>
 
@@ -108,8 +177,16 @@ export function CodeModeInspector({ initialTrace }: CodeModeInspectorProps) {
 
         {warnings.length > 0 ? <WarningBanner warnings={warnings} /> : null}
 
+        {trace ? (
+          <SummaryStrip
+            calls={rows.calls.length}
+            matches={searchCountLabel ?? rows.matches.length}
+            history={rows.history.length}
+          />
+        ) : null}
+
         {rows.calls.length > 0 ? (
-          <Panel title="Broker-observed execute calls" count={rows.calls.length}>
+          <Panel title="Execute calls" count={rows.calls.length}>
             <div className="grid gap-2">
               {rows.calls.map((call, index) => (
                 <CallRow key={`${call.id}-${index}`} call={call} />
@@ -120,8 +197,12 @@ export function CodeModeInspector({ initialTrace }: CodeModeInspectorProps) {
 
         {rows.matches.length > 0 ? (
           <Panel
-            title="Catalog-inferred search matches"
-            count={searchCountLabel ?? rows.matches.length}
+            title="Search matches"
+            count={
+              trace?.kind === 'code_mode_search_trace' && trace.truncated
+                ? `${rows.matches.length} shown`
+                : rows.matches.length
+            }
             meta={trace?.kind === 'code_mode_search_trace' && trace.truncated ? 'truncated' : undefined}
           >
             <div className="grid gap-2">
@@ -144,9 +225,13 @@ export function CodeModeInspector({ initialTrace }: CodeModeInspectorProps) {
                     <span className="text-sm font-medium text-aurora-text-primary">
                       #{entry.seq} {entry.kind}
                     </span>
-                    <StatusPill tone={entry.ok ? 'success' : 'error'}>
-                      {entry.ok ? 'ok' : entry.error_kind ?? 'error'}
-                    </StatusPill>
+                    {entry.ok ? (
+                      <span aria-label="success" className="inline-flex" role="img">
+                        <CheckCircle2 aria-hidden="true" className="size-4 shrink-0 text-aurora-success" />
+                      </span>
+                    ) : (
+                      <StatusPill tone="error">{entry.error_kind ?? 'error'}</StatusPill>
+                    )}
                   </div>
                   <p className="text-xs text-aurora-text-muted">
                     {entry.elapsed_ms}ms
@@ -174,26 +259,26 @@ function Panel({
   children: React.ReactNode
 }) {
   return (
-    <section className="rounded-md border border-aurora-border-default bg-aurora-panel-medium shadow-aurora-medium">
-      <div className="flex items-center justify-between gap-3 border-b border-aurora-border-default px-4 py-3">
-        <h2 className="text-sm font-semibold text-aurora-text-primary">{title}</h2>
-        <span className="rounded border border-aurora-border-default bg-aurora-control-surface px-2 py-0.5 text-xs tabular-nums text-aurora-text-muted">
-          {count}
-        </span>
-        {meta ? (
-          <span className="rounded border border-aurora-warn/50 bg-aurora-warn/10 px-2 py-0.5 text-xs text-aurora-warn">
-            {meta}
+    <section className={cn('overflow-hidden', AURORA_STRONG_PANEL)}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-aurora-border-default/80 px-4 py-3">
+        <div className="min-w-0">
+          <h2 className={cn(AURORA_CARD_TITLE, 'text-aurora-text-primary')}>{title}</h2>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-md border border-aurora-border-strong bg-aurora-control-surface px-2.5 py-1 text-[11px] font-semibold tabular-nums text-aurora-text-muted shadow-[var(--aurora-highlight-medium)]">
+            {count}
           </span>
-        ) : null}
+          {meta ? <StatusPill tone="warning">{meta}</StatusPill> : null}
+        </div>
       </div>
-      <div className="p-3">{children}</div>
+      <div className="grid gap-2 p-3">{children}</div>
     </section>
   )
 }
 
 function WarningBanner({ warnings }: { warnings: string[] }) {
   return (
-    <section className="rounded-md border border-aurora-warn/50 bg-aurora-warn/10 p-3 text-sm text-aurora-warn">
+    <section className="rounded-aurora-2 border border-aurora-warn/50 bg-[color-mix(in_srgb,var(--aurora-warn)_12%,transparent)] p-3 text-sm text-aurora-warn shadow-[var(--aurora-highlight-medium)]">
       <div className="flex gap-2">
         <AlertTriangle className="mt-0.5 size-4 shrink-0" />
         <div className="grid gap-1">
@@ -212,40 +297,101 @@ function formatSearchCount(trace: Extract<CodeModeTrace, { kind: 'code_mode_sear
   return displayed
 }
 
+function SummaryStrip({
+  calls,
+  matches,
+  history,
+}: {
+  calls: number
+  matches: number | string
+  history: number
+}) {
+  return (
+    <section className="grid grid-cols-3 gap-1.5 sm:gap-2">
+      <SummaryStat icon={Braces} label="Execute calls" value={calls} />
+      <SummaryStat icon={Search} label="Catalog matches" value={matches} accent />
+      <SummaryStat icon={History} label="History entries" value={history} />
+    </section>
+  )
+}
+
+function SummaryStat({
+  icon: Icon,
+  label,
+  value,
+  accent,
+}: {
+  icon: typeof Braces
+  label: string
+  value: number | string
+  accent?: boolean
+}) {
+  const compactLabel = label.replace('Execute calls', 'Calls').replace('Catalog matches', 'Matches').replace('History entries', 'History')
+  const compactValue =
+    typeof value === 'string' ? value.replace(/\bof\b/g, '/').replace(/\s+/g, '') : value
+
+  return (
+    <div className={cn('flex min-w-0 items-center justify-between gap-1 px-1.5 py-1 sm:gap-3 sm:p-3', AURORA_MESSAGE_SURFACE)}>
+      <div className="flex min-w-0 items-center gap-1.5 sm:gap-2">
+        <span
+          className={cn(
+            'hidden size-8 items-center justify-center rounded-aurora-1 border sm:flex',
+            accent
+              ? 'border-aurora-accent-primary/35 bg-[color-mix(in_srgb,var(--aurora-accent-primary)_12%,transparent)] text-aurora-accent-strong'
+              : 'border-aurora-border-strong bg-aurora-control-surface text-aurora-text-muted',
+          )}
+        >
+          <Icon className="size-4" strokeWidth={1.65} />
+        </span>
+        <span className={cn(AURORA_MUTED_LABEL, 'truncate text-[8px] tracking-[0.06em] sm:text-[11px] sm:tracking-[0.14em]')}>
+          <span className="sm:hidden">{compactLabel}</span>
+          <span className="hidden sm:inline">{label}</span>
+        </span>
+      </div>
+      <span className="shrink-0 whitespace-nowrap font-display text-[12px] font-extrabold tabular-nums text-aurora-text-primary sm:text-[18px]">
+        <span className="sm:hidden">{compactValue}</span>
+        <span className="hidden sm:inline">{value}</span>
+      </span>
+    </div>
+  )
+}
+
 function CallRow({ call }: { call: ReturnType<typeof flattenTraceRows>['calls'][number] }) {
   const params = stringifyRedactedParams(call.params)
   return (
-    <article className="rounded-md border border-aurora-border-default bg-aurora-control-surface p-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <article
+      className={cn(
+        'p-2.5 transition-colors hover:border-aurora-accent-primary/60 hover:bg-aurora-hover-bg/45 sm:p-3',
+        AURORA_MESSAGE_SURFACE,
+      )}
+    >
+      <div className="flex flex-col gap-1.5">
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
+          <p className="truncate font-mono text-[13px] font-semibold text-aurora-text-primary">
+            {call.upstream} / {call.tool}
+          </p>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-aurora-text-muted">
+            <span className="truncate font-mono text-[11px] sm:text-xs">{call.id}</span>
             {call.ok ? (
-              <CheckCircle2 className="size-4 text-aurora-success" />
+              <span aria-label="success" className="inline-flex" role="img">
+                <CheckCircle2 aria-hidden="true" className="size-4 shrink-0 text-aurora-success" />
+              </span>
             ) : (
-              <XCircle className="size-4 text-aurora-error" />
+              <StatusPill tone="error">{call.error_kind ?? 'error'}</StatusPill>
             )}
-            <p className="truncate text-sm font-medium text-aurora-text-primary">
-              {call.upstream} / {call.tool}
-            </p>
+            <span className="flex items-center gap-1 whitespace-nowrap">
+              <Clock3 className="size-3" />
+              {call.elapsed_ms}ms
+            </span>
           </div>
-          <p className="mt-1 truncate font-mono text-xs text-aurora-text-muted">{call.id}</p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <StatusPill tone={call.ok ? 'success' : 'error'}>
-            {call.ok ? 'ok' : call.error_kind ?? 'error'}
-          </StatusPill>
-          <span className="flex items-center gap-1 text-xs text-aurora-text-muted">
-            <Clock3 className="size-3" />
-            {call.elapsed_ms}ms
-          </span>
         </div>
       </div>
       {params ? (
-        <details className="mt-3 rounded border border-aurora-border-default bg-aurora-panel-strong">
-          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-aurora-text-muted">
+        <details className="mt-1.5 rounded-md border border-aurora-border-default bg-aurora-panel-strong sm:mt-3 sm:rounded-aurora-2">
+          <summary className="cursor-pointer px-2.5 py-1 text-xs font-semibold text-aurora-accent-strong sm:px-3 sm:py-2">
             Redacted params
           </summary>
-          <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-3 pb-3 font-mono text-xs text-aurora-text-primary">
+          <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 pb-2.5 font-mono text-xs text-aurora-text-primary sm:px-3 sm:pb-3">
             {params}
           </pre>
         </details>
@@ -256,16 +402,16 @@ function CallRow({ call }: { call: ReturnType<typeof flattenTraceRows>['calls'][
 
 function SearchRow({ match }: { match: ReturnType<typeof flattenTraceRows>['matches'][number] }) {
   return (
-    <article className="rounded-md border border-aurora-border-default bg-aurora-control-surface p-3">
+    <article className={cn('p-2.5 transition-colors hover:border-aurora-accent-primary/60 hover:bg-aurora-hover-bg/45 sm:p-3', AURORA_MESSAGE_SURFACE)}>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <Search className="size-4 text-aurora-accent-primary" />
-            <p className="truncate text-sm font-medium text-aurora-text-primary">
+            <p className="truncate font-mono text-[13px] font-semibold text-aurora-text-primary">
               {match.upstream} / {match.tool}
             </p>
           </div>
-          <p className="mt-1 line-clamp-2 text-xs text-aurora-text-muted">{match.description}</p>
+          <p className="mt-1 line-clamp-1 text-xs text-aurora-text-muted sm:line-clamp-2">{match.description}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {match.has_schema ? <StatusPill tone="info">schema</StatusPill> : null}
@@ -278,8 +424,11 @@ function SearchRow({ match }: { match: ReturnType<typeof flattenTraceRows>['matc
 
 function EmptyState() {
   return (
-    <section className="rounded-md border border-aurora-border-default bg-aurora-panel-medium p-5 text-sm text-aurora-text-muted">
-      Waiting for an MCP Apps tool result or history snapshot.
+    <section className={cn('flex items-center gap-3 p-5 text-sm text-aurora-text-muted', AURORA_STRONG_PANEL)}>
+      <div className="flex size-9 items-center justify-center rounded-aurora-1 border border-aurora-border-strong bg-aurora-control-surface text-aurora-accent-primary">
+        <Search className="size-4" strokeWidth={1.65} />
+      </div>
+      <span>Waiting for an MCP Apps tool result or history snapshot.</span>
     </section>
   )
 }
@@ -288,20 +437,21 @@ function StatusPill({
   tone,
   children,
 }: {
-  tone: 'success' | 'error' | 'info' | 'neutral'
+  tone: 'success' | 'error' | 'info' | 'neutral' | 'warning'
   children: React.ReactNode
 }) {
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium',
+        'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold shadow-[var(--aurora-highlight-medium)]',
         tone === 'success' &&
           'border-aurora-success/50 bg-aurora-success/10 text-aurora-success',
         tone === 'error' && 'border-aurora-error/50 bg-aurora-error/10 text-aurora-error',
         tone === 'info' &&
           'border-aurora-accent-primary/50 bg-aurora-accent-primary/10 text-aurora-accent-primary',
+        tone === 'warning' && 'border-aurora-warn/50 bg-aurora-warn/10 text-aurora-warn',
         tone === 'neutral' &&
-          'border-aurora-border-default bg-aurora-control-surface text-aurora-text-muted',
+          'border-aurora-border-strong bg-aurora-control-surface text-aurora-text-muted',
       )}
     >
       {children}

--- a/apps/gateway-admin/next-env.d.ts
+++ b/apps/gateway-admin/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/crates/lab/src/mcp/assets/code_mode_app.html
+++ b/crates/lab/src/mcp/assets/code_mode_app.html
@@ -5,31 +5,48 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Lab Code Mode Inspector</title>
 <style>
-:root{color-scheme:dark;background:#07131c;color:#e6f4fb;font-family:Inter,system-ui,sans-serif}
+:root{color-scheme:dark;--aurora-page-bg:#07131c;--aurora-panel-medium:#102330;--aurora-panel-strong:#13293a;--aurora-control-surface:#0c1a24;--aurora-border-default:#1d3d4e;--aurora-border-strong:#24536c;--aurora-text-primary:#e6f4fb;--aurora-text-muted:#a7bcc9;--aurora-accent-primary:#29b6f6;--aurora-accent-strong:#67cbfa;--aurora-success:#7dd3c7;--aurora-warn:#c6a36b;--aurora-error:#c78490;--aurora-shadow-strong:0 20px 38px rgba(0,0,0,.26);--aurora-highlight-strong:inset 0 1px 0 rgba(255,255,255,.05);--aurora-highlight-medium:inset 0 1px 0 rgba(255,255,255,.035);--aurora-active-glow:0 0 0 1px rgba(41,182,246,.18),0 0 16px rgba(41,182,246,.08);background:var(--aurora-page-bg);color:var(--aurora-text-primary);font-family:Inter,"Segoe UI",system-ui,sans-serif}
 *{box-sizing:border-box}
-body{margin:0;padding:14px;background:#07131c;color:#e6f4fb}
-main{display:grid;gap:12px}
-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;border-bottom:1px solid #1d3d4e;padding-bottom:10px}
-h1{font-size:16px;line-height:1.25;margin:0;font-weight:700}
-.sub{color:#a7bcc9;font-size:12px;margin-top:3px}
-.badge{border:1px solid #1d3d4e;border-radius:999px;padding:3px 8px;color:#72c8f5;font-size:11px;white-space:nowrap}
+body{height:100dvh;margin:0;padding:12px;overflow:hidden;background:radial-gradient(circle at top left,rgba(41,182,246,.10),transparent 32%),radial-gradient(circle at top right,rgba(103,203,250,.08),transparent 26%),var(--aurora-page-bg);color:var(--aurora-text-primary)}
+main{display:grid;gap:10px;max-width:940px;height:calc(100dvh - 24px);margin:0 auto;overflow-y:auto;overscroll-behavior:contain;padding-right:2px}
+header{position:relative;overflow:visible;display:flex;align-items:flex-start;justify-content:space-between;gap:10px;border:1px solid var(--aurora-border-strong);border-radius:16px;background:linear-gradient(180deg,var(--aurora-panel-strong),var(--aurora-panel-medium));padding:10px 12px;box-shadow:var(--aurora-shadow-strong),var(--aurora-highlight-strong)}
+header:before{content:"";position:absolute;inset:0 0 auto;height:1px;background:linear-gradient(90deg,transparent,rgba(41,182,246,.58),transparent)}
+.titleline{display:flex;gap:10px;min-width:0}
+.mark{display:grid;place-items:center;width:32px;height:32px;flex:0 0 auto;border:1px solid rgba(41,182,246,.38);border-radius:8px;background:color-mix(in srgb,var(--aurora-accent-primary) 14%,transparent);color:var(--aurora-accent-strong);box-shadow:var(--aurora-active-glow)}
+.eyebrow{display:flex;align-items:center;gap:6px;color:var(--aurora-text-muted);font-size:10px;font-weight:750;letter-spacing:.12em;text-transform:uppercase}
+h1{font-family:Manrope,Inter,system-ui,sans-serif;font-size:19px;line-height:1.06;margin:1px 0 0;font-weight:850}
+.sub{max-width:620px;color:var(--aurora-text-muted);font-size:11px;line-height:1.35;margin-top:3px}
+.badge{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--aurora-border-strong);border-radius:6px;background:var(--aurora-control-surface);padding:3px 8px;color:var(--aurora-text-muted);font-size:11px;font-weight:650;white-space:nowrap;box-shadow:var(--aurora-highlight-medium)}
+.badge.connected{border-color:rgba(125,211,199,.52);background:color-mix(in srgb,var(--aurora-success) 10%,transparent);color:var(--aurora-success)}
 .grid{display:grid;gap:8px}
-.card{border:1px solid #1d3d4e;border-radius:8px;background:#102330;padding:10px}
-.row{display:flex;gap:8px;align-items:center;justify-content:space-between}
-.name{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:12px;color:#e6f4fb;overflow-wrap:anywhere}
-.meta{font-size:11px;color:#a7bcc9}
-.ok{color:#7dd3c7}.err{color:#c78490}.info{color:#72c8f5}
-details{margin-top:8px}
-summary{cursor:pointer;color:#67cbfa;font-size:12px}
-pre{margin:8px 0 0;white-space:pre-wrap;overflow-wrap:anywhere;border:1px solid #1d3d4e;border-radius:6px;background:#07131c;padding:8px;color:#e6f4fb;font-size:11px}
+.stats{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+.stat{display:flex;align-items:center;justify-content:space-between;gap:10px;min-width:0;border:1px solid var(--aurora-border-strong);border-radius:14px;background:linear-gradient(180deg,rgba(18,40,56,.96),rgba(14,31,44,.98));padding:10px 11px;box-shadow:0 8px 16px rgba(0,0,0,.16),var(--aurora-highlight-medium)}
+.stat span:first-child{color:var(--aurora-text-muted);font-size:10px;font-weight:750;letter-spacing:.14em;text-transform:uppercase}
+.stat strong{font-family:Manrope,Inter,system-ui,sans-serif;font-size:17px;font-weight:850;font-variant-numeric:tabular-nums}
+.panel{overflow:hidden;border:1px solid var(--aurora-border-strong);border-radius:18px;background:linear-gradient(180deg,var(--aurora-panel-strong),var(--aurora-panel-medium));box-shadow:var(--aurora-shadow-strong),var(--aurora-highlight-strong)}
+.panel-head{display:flex;align-items:center;justify-content:space-between;gap:12px;border-bottom:1px solid rgba(29,61,78,.8);padding:12px 14px}
+.panel-title{font-family:Manrope,Inter,system-ui,sans-serif;font-size:15px;font-weight:850}
+.panel-body{display:grid;gap:8px;padding:10px}
+.card{border:1px solid var(--aurora-border-strong);border-radius:12px;background:linear-gradient(180deg,rgba(18,40,56,.96),rgba(14,31,44,.98));padding:9px;box-shadow:0 8px 16px rgba(0,0,0,.16),var(--aurora-highlight-medium)}
+.row{display:flex;gap:8px;align-items:flex-start;justify-content:space-between}
+.name{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:12px;font-weight:700;color:var(--aurora-text-primary);overflow-wrap:anywhere}
+.meta{font-size:11px;line-height:1.45;color:var(--aurora-text-muted)}
+.pill{display:inline-flex;align-items:center;border:1px solid var(--aurora-border-strong);border-radius:6px;background:var(--aurora-control-surface);padding:3px 8px;font-size:11px;font-weight:700;white-space:nowrap}
+.ok{color:var(--aurora-success)}.err{color:var(--aurora-error)}.info{color:var(--aurora-accent-primary)}
+.pill.ok{border-color:rgba(125,211,199,.52);background:color-mix(in srgb,var(--aurora-success) 10%,transparent)}.pill.err{border-color:rgba(199,132,144,.52);background:color-mix(in srgb,var(--aurora-error) 10%,transparent)}.pill.info{border-color:rgba(41,182,246,.52);background:color-mix(in srgb,var(--aurora-accent-primary) 10%,transparent)}
+details{margin-top:6px}
+summary{cursor:pointer;color:var(--aurora-accent-strong);font-size:12px;font-weight:700}
+pre{margin:8px 0 0;white-space:pre-wrap;overflow-wrap:anywhere;border:1px solid var(--aurora-border-default);border-radius:10px;background:var(--aurora-page-bg);padding:8px;color:var(--aurora-text-primary);font-size:11px}
+@media(max-width:620px){body{padding:10px}main{height:calc(100dvh - 20px);gap:10px}header{flex-direction:column}.sub{display:none}.stats{grid-template-columns:repeat(3,minmax(0,1fr));gap:6px}.stat{gap:3px;border-radius:10px;padding:4px 6px}.stat span:first-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:8px;letter-spacing:.06em}.stat strong{white-space:nowrap;font-size:12px}.row{flex-direction:column}.card{border-radius:12px;padding:8px}.meta{display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical;overflow:hidden}details{margin-top:5px}}
 </style>
 </head>
 <body>
 <main>
 <header>
-<div><h1>Code Mode Inspector</h1><div class="sub" id="summary">Waiting for a tool result</div></div>
+<div class="titleline"><div class="mark" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M12 3v18M3 12h18M6.7 6.7l10.6 10.6M17.3 6.7 6.7 17.3" stroke="currentColor" stroke-width="1.65" stroke-linecap="round"/></svg></div><div><div class="eyebrow">Code Mode trace</div><h1>Code Mode Inspector</h1><div class="sub" id="summary">Waiting for a tool result</div></div></div>
 <div class="badge" id="state">read only</div>
 </header>
+<section class="stats" id="stats" hidden></section>
 <section class="grid" id="content"></section>
 </main>
 <script>window.__LAB_CODE_MODE_INITIAL_TRACE__ = null;</script>
@@ -118,29 +135,37 @@ const { App } = globalThis.ExtApps;
 const content=document.getElementById("content");
 const summary=document.getElementById("summary");
 const state=document.getElementById("state");
+const stats=document.getElementById("stats");
 function esc(value){return String(value??"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
 function json(value){try{return JSON.stringify(value,null,2)}catch{return String(value)}}
 function shape(s){if(!s)return"";return [s.type,s.key_count&&`${s.key_count} keys`,s.length&&`${s.length} items`].filter(Boolean).join(" / ")}
 function card(body){return `<article class="card">${body}</article>`}
+function panel(title,count,body,meta=""){return `<section class="panel"><div class="panel-head"><div class="panel-title">${esc(title)}</div><div class="row"><span class="pill info">${esc(count)}</span>${meta?`<span class="pill err">${esc(meta)}</span>`:""}</div></div><div class="panel-body">${body}</div></section>`}
+function compactStatLabel(label){return String(label).replace("Execute calls","Calls").replace("Catalog matches","Matches").replace("History entries","History")}
+function compactStatValue(value){return String(value).replace(/\bof\b/g,"/").replace(/\s+/g,"")}
+function renderStats(values){if(!stats)return;stats.hidden=false;stats.innerHTML=values.map(([label,value])=>`<div class="stat"><span>${esc(compactStatLabel(label))}</span><strong>${esc(compactStatValue(value))}</strong></div>`).join("")}
+function clearStats(){if(!stats)return;stats.hidden=true;stats.innerHTML=""}
 function statusLabel(item){return item.ok?"ok":(item.error_kind||"error")}
 function callRow(call){
   const cls=call.ok?"ok":"err";
   const params=call.params?`<details><summary>Params</summary><pre>${esc(json(call.params))}</pre></details>`:"";
-  return card(`<div class="row"><div class="name">${esc(call.upstream||"upstream")} / ${esc(call.tool||"tool")}</div><div class="${cls}">${esc(statusLabel(call))}</div></div><div class="meta">${esc(call.elapsed_ms??0)} ms ${call.error_kind?` / ${esc(call.error_kind)}`:""}</div>${call.result_shape?`<div class="meta">${esc(shape(call.result_shape))}</div>`:""}${params}`);
+  const status=call.ok?`<span class="ok" role="img" aria-label="success">✓</span>`:`<span class="pill ${cls}">${esc(statusLabel(call))}</span>`;
+  return card(`<div class="name">${esc(call.upstream||"upstream")} / ${esc(call.tool||"tool")}</div><div class="meta">${esc(call.id||"call")} ${status} ${esc(call.elapsed_ms??0)} ms${call.result_shape?` / ${esc(shape(call.result_shape))}`:""}</div>${params}`);
 }
-function matchRow(match){return card(`<div class="row"><div class="name">${esc(match.id||match.name||"match")}</div><div class="info">${esc(match.upstream||"")}</div></div><div class="meta">${esc(match.description||"")}</div>`)}
+function matchRow(match){return card(`<div class="row"><div class="name">${esc(match.id||match.name||"match")}</div><div class="pill info">${esc(match.upstream||"")}</div></div><div class="meta">${esc(match.description||"")}</div>`)}
 function historyRow(entry){
   const count=Array.isArray(entry.calls)?entry.calls.length:0;
-  return card(`<div class="row"><div class="name">${esc(entry.kind||"entry")}</div><div class="${entry.ok?"ok":"err"}">${esc(statusLabel(entry))}</div></div><div class="meta">${esc(entry.elapsed_ms??0)} ms / ${count} calls${entry.match_count!==undefined?` / ${esc(entry.match_count)} matches`:""}</div>`);
+  const status=entry.ok?`<span class="ok" role="img" aria-label="success">✓</span>`:`<span class="pill err">${esc(statusLabel(entry))}</span>`;
+  return card(`<div class="row"><div class="name">${esc(entry.kind||"entry")}</div>${status}</div><div class="meta">${esc(entry.elapsed_ms??0)} ms / ${count} calls${entry.match_count!==undefined?` / ${esc(entry.match_count)} matches`:""}</div>`);
 }
 function searchCount(t){const displayed=t.displayed_count??(Array.isArray(t.matches)?t.matches.length:0);return (t.truncated||displayed!==t.match_count)?`${displayed} of ${t.match_count||0}`:`${t.match_count||0}`;}
 function render(trace){
   const t=trace&&trace.structuredContent?trace.structuredContent:trace;
-  if(!t||!t.kind){content.innerHTML=card('<div class="meta">Run Code Mode search or execute to populate the inspector.</div>');return;}
-  if(t.kind==="code_mode_execute_trace"){summary.textContent=`${t.call_count||0} broker calls captured`;content.innerHTML=(t.calls||[]).map(callRow).join("")||card('<div class="meta">No broker calls were made.</div>');return;}
-  if(t.kind==="code_mode_search_trace"){summary.textContent=`${searchCount(t)} catalog matches${t.truncated?" (truncated)":""}`;content.innerHTML=(t.matches||[]).map(matchRow).join("")||card('<div class="meta">No matches.</div>');return;}
-  if(t.kind==="code_mode_history"){summary.textContent=`${(t.entries||[]).length} bounded history entries`;content.innerHTML=(t.entries||[]).map(historyRow).join("")||card('<div class="meta">History is empty.</div>');return;}
-  content.innerHTML=card(`<pre>${esc(json(t))}</pre>`);
+  if(!t||!t.kind){clearStats();content.innerHTML=card('<div class="meta">Run Code Mode search or execute to populate the inspector.</div>');return;}
+  if(t.kind==="code_mode_execute_trace"){const rows=(t.calls||[]).map(callRow).join("")||card('<div class="meta">No calls were made.</div>');summary.textContent=`${t.call_count||0} calls captured`;renderStats([["Execute calls",t.call_count||0],["Catalog matches",0],["History entries",0]]);content.innerHTML=panel("Execute calls",t.call_count||0,rows);return;}
+  if(t.kind==="code_mode_search_trace"){const count=searchCount(t);const shown=`${(t.matches||[]).length} shown`;const rows=(t.matches||[]).map(matchRow).join("")||card('<div class="meta">No matches.</div>');summary.textContent=t.truncated?"Search matches truncated to the current display window":"Search matches from current search";renderStats([["Execute calls",0],["Catalog matches",count],["History entries",0]]);content.innerHTML=panel("Search matches",t.truncated?shown:count,rows);return;}
+  if(t.kind==="code_mode_history"){const rows=(t.entries||[]).map(historyRow).join("")||card('<div class="meta">History is empty.</div>');summary.textContent=`${(t.entries||[]).length} bounded history entries`;renderStats([["Execute calls",0],["Catalog matches",0],["History entries",(t.entries||[]).length]]);content.innerHTML=panel("Recent history",(t.entries||[]).length,rows);return;}
+  clearStats();content.innerHTML=card(`<pre>${esc(json(t))}</pre>`);
 }
 // Render immediately from the server-injected snapshot (history widget).
 render(window.__LAB_CODE_MODE_INITIAL_TRACE__);
@@ -148,10 +173,10 @@ render(window.__LAB_CODE_MODE_INITIAL_TRACE__);
 const app = new App({ name: "LabCodeModeInspector", version: "1.0.0" }, {});
 app.onhostcontextchanged = (ctx) => { if (ctx && ctx.theme) { document.documentElement.classList.toggle("dark", ctx.theme === "dark"); } };
 app.ontoolresult = (result) => render(result && result.structuredContent ? result.structuredContent : result);
-try { state.textContent = "connected"; } catch (_) {}
+try { state.textContent = "connected"; state.classList.add("connected"); } catch (_) {}
 // Fire-and-forget per the MCP Apps spec — resolves async after the host
 // postMessage handshake, which may be delayed or unavailable.
-app.connect().catch(() => { try { state.textContent = "read only"; } catch (_) {} });
+app.connect().catch(() => { try { state.textContent = "read only"; state.classList.remove("connected"); } catch (_) {} });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- restyle the Code Mode Inspector with Aurora-aligned dark UI, compact mobile layout, and fixed scrollable panels
- remove tracked Next-generated next-env.d.ts churn and ignore it locally
- update the standalone MCP app HTML asset to match the React UI

## Verification
- pnpm exec tsx --test components/code-mode-app/code-mode-inspector.test.tsx
- just web-build
- cargo test -p labby mcp::handlers_resources::tests::code_mode_app --all-features

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Code Mode Inspector with an Aurora-aligned dark UI, compact mobile layout, and fixed, scrollable panels. Simplified labels, added a summary strip with accessible status icons, updated the standalone MCP HTML to mirror React, refreshed tests, and ignored `next-env.d.ts`.

- **New Features**
  - Aurora dark theme with full-height shell and strong panels; compact mobile layout and denser rows.
  - Summary strip showing Execute calls, Catalog matches, and History entries; compact labels/values on mobile.
  - Clear labels: "Execute calls" and "Search matches"; show "N shown" when truncated; history panel uses "Recent history".
  - Status UI: success via icons (no "ok" text), error/info/warn pills, monospace titles, and redacted params toggle.
  - Standalone MCP HTML now mirrors the React UI: header with eyebrow, stats strip, panelized sections, and a "connected" badge.
  - Removed tracked `next-env.d.ts` and added to `.gitignore`; tests updated for new labels and success icon.

<sup>Written for commit bc9987d537558d7577f2fdfd5ddf1a5595c3c7dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

