### PR TITLE
Fix code mode MCP App sibling callbacks

### DIFF
--- a/crates/lab/src/acp/providers.rs
+++ b/crates/lab/src/acp/providers.rs
@@ -220,7 +220,7 @@ mod tests {
                 "--config".to_string(),
                 "value with spaces".to_string(),
                 "--quoted=\"already-quoted\"".to_string(),
-                "".to_string(),
+                String::new(),
             ],
             cwd: Some(PathBuf::from("/var/lib/with spaces")),
             env,

--- a/crates/lab/src/acp/runtime.rs
+++ b/crates/lab/src/acp/runtime.rs
@@ -2637,6 +2637,7 @@ fn map_stop_reason(stop_reason: &StopReason) -> &'static str {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module, clippy::panic)]
 mod tests {
     use super::*;
     use agent_client_protocol::schema::{

--- a/crates/lab/src/api/nodes/fleet.rs
+++ b/crates/lab/src/api/nodes/fleet.rs
@@ -1226,6 +1226,7 @@ struct InitializedDevice {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::sync::Arc;
 
@@ -1915,7 +1916,7 @@ mod tests {
 
         let result = require_master_store(&state);
         assert!(result.is_err(), "NonMaster must be rejected");
-        let err = result.err().expect("err");
+        let err = result.expect_err("err");
         assert_eq!(
             err.kind(),
             "not_found",

--- a/crates/lab/src/api/services/acp.rs
+++ b/crates/lab/src/api/services/acp.rs
@@ -291,7 +291,7 @@ mod tests {
             Some("claude".to_string())
         );
         assert_eq!(
-            preferred_model_param(Some("".to_string()), Some(" ".to_string())),
+            preferred_model_param(Some(String::new()), Some(" ".to_string())),
             None
         );
     }

--- a/crates/lab/src/cli.rs
+++ b/crates/lab/src/cli.rs
@@ -130,6 +130,7 @@ pub async fn dispatch(cli: Cli, config: LabConfig) -> Result<ExitCode> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use clap::Parser;
 

--- a/crates/lab/src/cli/doctor.rs
+++ b/crates/lab/src/cli/doctor.rs
@@ -20,9 +20,6 @@ use crate::dispatch::doctor::{Finding, Report, Severity, run_auth_checks, run_sy
 use crate::output::OutputFormat;
 use crate::output::theme::CliTheme;
 
-#[cfg(test)]
-pub use crate::dispatch::doctor::service_env_checks;
-
 #[derive(Debug, Args)]
 pub struct DoctorArgs {
     #[command(subcommand)]

--- a/crates/lab/src/cli/gateway.rs
+++ b/crates/lab/src/cli/gateway.rs
@@ -1265,6 +1265,7 @@ fn render_gateway_list_human(
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use clap::CommandFactory;
     use clap::Parser;

--- a/crates/lab/src/cli/oauth.rs
+++ b/crates/lab/src/cli/oauth.rs
@@ -63,6 +63,7 @@ async fn run_relay_local(args: RelayLocalArgs, config: &LabConfig) -> Result<Exi
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use clap::{CommandFactory, Parser};

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -1251,6 +1251,8 @@ async fn run_stdio(
             crate::mcp::logging::logging_level_rank(rmcp::model::LoggingLevel::Info),
         )),
         route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+        #[cfg(test)]
+        code_mode_widget_callbacks_enabled_for_test: false,
     };
     let running = server.serve(rmcp::transport::stdio()).await?;
     tracing::info!(
@@ -1394,6 +1396,8 @@ fn build_mcp_service_with_scope(
                     crate::mcp::logging::logging_level_rank(rmcp::model::LoggingLevel::Info),
                 )),
                 route_scope,
+                #[cfg(test)]
+                code_mode_widget_callbacks_enabled_for_test: false,
             })
         },
         session_manager,

--- a/crates/lab/src/cli/serve.rs
+++ b/crates/lab/src/cli/serve.rs
@@ -1650,6 +1650,7 @@ fn find_listening_inode(path: &str, hex_port: &str) -> Option<u64> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::ffi::OsString;
     use std::path::PathBuf;
@@ -1816,7 +1817,7 @@ mod tests {
     fn lab_spawn_depth_resolution_tolerates_bad_env() {
         assert_eq!(resolve_lab_spawn_depth(Some("2".into())), Some(2));
         assert_eq!(resolve_lab_spawn_depth(Some(" 3 ".into())), Some(3));
-        assert_eq!(resolve_lab_spawn_depth(Some("".into())), None);
+        assert_eq!(resolve_lab_spawn_depth(Some(String::new())), None);
         assert_eq!(resolve_lab_spawn_depth(Some("not-a-number".into())), None);
         assert_eq!(resolve_lab_spawn_depth(None), None);
     }

--- a/crates/lab/src/cli/setup.rs
+++ b/crates/lab/src/cli/setup.rs
@@ -316,6 +316,7 @@ async fn run_plugin_mutation(
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use clap::Parser as _;

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -2919,6 +2919,7 @@ fn quote_env_value(v: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
 
@@ -3649,13 +3650,13 @@ url = "https://acme.example.com/mcp"
         assert_eq!(default_cfg.code_mode.max_response_tokens, 6000);
 
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 [code_mode]
 timeout_ms = 2500
 max_tool_calls = 3
 max_response_bytes = 12000
 max_response_tokens = 3000
-"#,
+",
         )
         .expect("root code_mode parses");
 
@@ -3674,9 +3675,9 @@ max_response_tokens = 3000
         );
 
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 upstream_request_timeout_ms = 60000
-"#,
+",
         )
         .expect("root upstream request timeout parses");
 
@@ -3691,11 +3692,11 @@ upstream_request_timeout_ms = 60000
     #[test]
     fn code_mode_validation_rejects_unbounded_execution_settings() {
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 [code_mode]
 timeout_ms = 0
 max_tool_calls = 8
-"#,
+",
         )
         .expect("code_mode parses");
         assert!(matches!(
@@ -3704,11 +3705,11 @@ max_tool_calls = 8
         ));
 
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 [code_mode]
 timeout_ms = 5000
 max_tool_calls = 0
-"#,
+",
         )
         .expect("code_mode parses");
         assert!(matches!(
@@ -3717,12 +3718,12 @@ max_tool_calls = 0
         ));
 
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 [code_mode]
 timeout_ms = 5000
 max_tool_calls = 8
 max_response_bytes = 100
-"#,
+",
         )
         .expect("code_mode parses");
         assert!(matches!(
@@ -3731,12 +3732,12 @@ max_response_bytes = 100
         ));
 
         let cfg = toml::from_str::<LabConfig>(
-            r#"
+            r"
 [code_mode]
 timeout_ms = 5000
 max_tool_calls = 8
 max_response_tokens = 100
-"#,
+",
         )
         .expect("code_mode parses");
         assert!(matches!(

--- a/crates/lab/src/config/env_merge.rs
+++ b/crates/lab/src/config/env_merge.rs
@@ -584,6 +584,7 @@ pub fn strip_quotes(value: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
 

--- a/crates/lab/src/dispatch/acp/persistence.rs
+++ b/crates/lab/src/dispatch/acp/persistence.rs
@@ -985,6 +985,7 @@ fn generate_ephemeral_hmac_key(pid: u32, now_nanos: u128) -> Vec<u8> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod db_load_events_tests {
     use super::*;
 

--- a/crates/lab/src/dispatch/doctor.rs
+++ b/crates/lab/src/dispatch/doctor.rs
@@ -17,6 +17,4 @@ mod types;
 pub use catalog::ACTIONS;
 pub use dispatch::{dispatch, dispatch_with_clients};
 pub use system::{run_auth_checks, run_system_checks};
-#[cfg(test)]
-pub use types::service_env_checks;
 pub use types::{Finding, Report, Severity};

--- a/crates/lab/src/dispatch/doctor/proxy.rs
+++ b/crates/lab/src/dispatch/doctor/proxy.rs
@@ -287,6 +287,7 @@ fn join_url(base: &str, path: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use wiremock::matchers::{method, path};

--- a/crates/lab/src/dispatch/doctor/system.rs
+++ b/crates/lab/src/dispatch/doctor/system.rs
@@ -233,6 +233,7 @@ fn disk_check(findings: &mut Vec<Finding>) {
 fn disk_check(_findings: &mut Vec<Finding>) {}
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 

--- a/crates/lab/src/dispatch/fs/dispatch.rs
+++ b/crates/lab/src/dispatch/fs/dispatch.rs
@@ -779,6 +779,7 @@ fn sanitize_filename(name: &str) -> String {
 }
 
 #[cfg(all(test, feature = "fs"))]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_broker.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_broker.rs
@@ -1,5 +1,6 @@
 //! Tests: broker search/execute/call_tool over a live upstream catalog.
 #![cfg(test)]
+#![allow(clippy::panic)]
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_ids_schema.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_ids_schema.rs
@@ -1,5 +1,6 @@
 //! Tests: tool-id parsing, capability filter, upstream error/result, schema validation, catalog entry.
 #![cfg(test)]
+#![allow(clippy::panic)]
 
 use rmcp::model::{CallToolResult, Content};
 use serde_json::json;

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -1,5 +1,6 @@
 //! Tests: response-budget truncation, wasm runner smoke, token estimate.
 #![cfg(test)]
+#![allow(clippy::panic)]
 
 use std::collections::HashSet;
 
@@ -1114,7 +1115,7 @@ fn runner_process_group_is_reaped_after_kill() {
     // the `process_group(0)` call in `runner_drive.rs`.
     // `process_group(0)` is a safe method on `std::process::Command` (stable
     // since Rust 1.64) — no `pre_exec` or `unsafe` needed.
-    let child = std::process::Command::new("/bin/sleep")
+    let mut child = std::process::Command::new("/bin/sleep")
         .arg("60")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -1150,6 +1151,7 @@ fn runner_process_group_is_reaped_after_kill() {
             panic!("unexpected waitpid result after killpg: {other:?}");
         }
     }
+    drop(child.wait());
 
     // On Linux, verify the process is gone from /proc as an extra check.
     #[cfg(target_os = "linux")]

--- a/crates/lab/src/dispatch/gateway/config.rs
+++ b/crates/lab/src/dispatch/gateway/config.rs
@@ -1091,6 +1091,7 @@ pub(crate) fn set_file_permissions_600(path: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use crate::config::{LabConfig, ProtectedMcpRouteConfig, UpstreamConfig};
 

--- a/crates/lab/src/dispatch/gateway/discovery/opencode.rs
+++ b/crates/lab/src/dispatch/gateway/discovery/opencode.rs
@@ -42,6 +42,7 @@ fn discover_with_xdg(home: &Path, xdg: Option<&Path>) -> Vec<DiscoveredServer> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use std::path::Path;
     use tempfile::TempDir;

--- a/crates/lab/src/dispatch/gateway/dispatch.rs
+++ b/crates/lab/src/dispatch/gateway/dispatch.rs
@@ -817,6 +817,7 @@ pub async fn dispatch(action: &str, params_value: Value) -> Result<Value, ToolEr
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::collections::HashSet;
 

--- a/crates/lab/src/dispatch/gateway/manager.rs
+++ b/crates/lab/src/dispatch/gateway/manager.rs
@@ -60,6 +60,7 @@ mod virtual_servers;
 // monolith's public `manager::` paths; they currently have no callers outside
 // the manager tree, so the re-exports are allowed to be unused in non-test
 // builds (the test suite imports them through these paths).
+pub(crate) use self::code_mode_resolve::CallbackToolLookup;
 #[allow(unused_imports)]
 pub use self::config_ops::BatchAddOutcome;
 pub use self::core::{GatewayManagerConfig, GatewayOauthConfig};

--- a/crates/lab/src/dispatch/gateway/manager/code_mode_resolve.rs
+++ b/crates/lab/src/dispatch/gateway/manager/code_mode_resolve.rs
@@ -5,11 +5,61 @@ use std::collections::HashMap;
 
 use crate::dispatch::error::ToolError;
 use crate::dispatch::gateway::code_mode::split_upstream_tool;
+use crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource;
 use crate::dispatch::upstream::types::{UpstreamRuntimeOwner, UpstreamTool};
 
 use super::GatewayManager;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallbackToolLookup {
+    LegacyAnyExposed,
+    DirectMcpApp,
+    SiblingOfMcpApp,
+}
+
 impl GatewayManager {
+    pub(crate) async fn resolve_widget_callback_tool_candidates_scoped(
+        &self,
+        tool: &str,
+        allowed_upstreams: Option<&std::collections::BTreeSet<String>>,
+        _owner: Option<&UpstreamRuntimeOwner>,
+        _oauth_subject: Option<&str>,
+        lookup: CallbackToolLookup,
+    ) -> Result<Vec<(String, UpstreamTool)>, ToolError> {
+        let cfg = self.config.read().await.clone();
+        let Some(pool) = self.current_pool().await else {
+            return Ok(Vec::new());
+        };
+
+        let mut matches = Vec::new();
+        for upstream in cfg.upstream.iter().filter(|upstream| {
+            upstream.enabled
+                && is_routable(upstream.priority)
+                && allowed_upstreams.is_none_or(|allowed| allowed.contains(&upstream.name))
+        }) {
+            let upstream_tools = pool.healthy_tools_for_upstream(&upstream.name).await;
+            let Some(candidate) = upstream_tools
+                .iter()
+                .find(|candidate| candidate.tool.name.as_ref() == tool)
+            else {
+                continue;
+            };
+
+            let matched = match lookup {
+                CallbackToolLookup::LegacyAnyExposed => true,
+                CallbackToolLookup::DirectMcpApp => tool_has_mcp_app_ui_resource(candidate),
+                CallbackToolLookup::SiblingOfMcpApp => {
+                    upstream_tools.iter().any(tool_has_mcp_app_ui_resource)
+                }
+            };
+            if matched {
+                matches.push((upstream.name.clone(), candidate.clone()));
+            }
+        }
+        matches.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(matches)
+    }
+
     pub async fn resolve_code_mode_upstream_tool(
         &self,
         upstream: &str,

--- a/crates/lab/src/dispatch/gateway/manager/tests/cleanup.rs
+++ b/crates/lab/src/dispatch/gateway/manager/tests/cleanup.rs
@@ -1,4 +1,5 @@
 //! Upstream process cleanup pattern + matcher tests.
+#![allow(clippy::panic)]
 
 #[cfg(target_os = "linux")]
 use crate::dispatch::gateway::runtime::process_matches_patterns;

--- a/crates/lab/src/dispatch/gateway/manager/tests/code_mode.rs
+++ b/crates/lab/src/dispatch/gateway/manager/tests/code_mode.rs
@@ -1,4 +1,5 @@
 //! Code Mode runtime readiness + tool resolution tests.
+#![allow(clippy::panic)]
 
 use crate::dispatch::error::ToolError;
 

--- a/crates/lab/src/dispatch/gateway/manager/tests/lifecycle.rs
+++ b/crates/lab/src/dispatch/gateway/manager/tests/lifecycle.rs
@@ -90,7 +90,7 @@ async fn gateway_test_does_not_schedule_background_reprobes() {
 #[test]
 fn catalog_diff_detects_removed_tool_provider() {
     let before = GatewayCatalogSnapshot {
-        tools: ["fixture-http-echo".to_string()].into_iter().collect(),
+        tools: std::iter::once("fixture-http-echo".to_string()).collect(),
         resources: BTreeSet::new(),
         prompts: BTreeSet::new(),
     };

--- a/crates/lab/src/dispatch/logs/metrics/tests.rs
+++ b/crates/lab/src/dispatch/logs/metrics/tests.rs
@@ -377,7 +377,7 @@ fn tier_two_fields_populate_actor_ip_and_code_mode_metrics() {
     assert_eq!(m.actors.ip.top[0].id, "10.0.0.8");
     assert_eq!(m.fan_out.runs, 1);
     assert_eq!(m.fan_out.total_calls, 3);
-    assert_eq!(m.fan_out.truncation_rate, 1.0);
+    assert!((m.fan_out.truncation_rate - 1.0).abs() < f64::EPSILON);
     assert_eq!(m.fan_out.artifact_writes, 2);
     assert_eq!(m.agents_seen.new, 1);
     assert_eq!(m.agents_seen.returning, 1);

--- a/crates/lab/src/dispatch/marketplace.rs
+++ b/crates/lab/src/dispatch/marketplace.rs
@@ -38,6 +38,7 @@ pub use mcp_params::{resolve_search_for_rest, validate_registry_url};
 pub const LAB_REGISTRY_META_NAMESPACE: &str = "tv.tootie.lab/registry";
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use serde_json::json;
 

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -1312,10 +1312,9 @@ mod tests {
             assert_eq!(err.kind(), "invalid_param");
         }
 
-        for url in ["https://192.168.1.20/agent.tar.gz"] {
-            let err = validate_archive_url(url).expect_err(url);
-            assert_eq!(err.kind(), "ssrf_blocked");
-        }
+        let url = "https://192.168.1.20/agent.tar.gz";
+        let err = validate_archive_url(url).expect_err(url);
+        assert_eq!(err.kind(), "ssrf_blocked");
     }
 
     #[test]

--- a/crates/lab/src/dispatch/marketplace/backends/codex.rs
+++ b/crates/lab/src/dispatch/marketplace/backends/codex.rs
@@ -419,7 +419,7 @@ mod tests {
         let _guard = TEST_CODEX_HOME_LOCK.lock().unwrap();
         let previous = {
             let mut slot = TEST_CODEX_HOME_OVERRIDE.lock().unwrap();
-            std::mem::replace(&mut *slot, Some(home.to_path_buf()))
+            (*slot).replace(home.to_path_buf())
         };
         let result = run();
         let mut slot = TEST_CODEX_HOME_OVERRIDE.lock().unwrap();

--- a/crates/lab/src/dispatch/marketplace/client.rs
+++ b/crates/lab/src/dispatch/marketplace/client.rs
@@ -504,7 +504,7 @@ pub(super) fn with_test_plugins_root<T>(home: &Path, run: impl FnOnce() -> T) ->
         let mut slot = TEST_PLUGINS_ROOT_OVERRIDE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        std::mem::replace(&mut *slot, Some(plugins_root))
+        (*slot).replace(plugins_root)
     };
 
     // RAII guard: restore the override slot in `Drop` so that a panicking

--- a/crates/lab/src/dispatch/marketplace/dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/dispatch.rs
@@ -884,6 +884,7 @@ fn validate_node_install_result(result: &Value) -> Result<(), &'static str> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/lab/src/dispatch/node/send.rs
+++ b/crates/lab/src/dispatch/node/send.rs
@@ -411,8 +411,7 @@ mod tests {
         // No entry in sender_registry; send should fail fast with not_found.
         let err = send_rpc_to_node("ghost-node", "nodes/ping", json!({}))
             .await
-            .err()
-            .expect("must error");
+            .expect_err("must error");
         assert_eq!(err.kind(), "not_found");
         // pending map must be empty (no leaked entry).
         // Note: other tests may run in parallel — just check no entries

--- a/crates/lab/src/dispatch/setup/bootstrap.rs
+++ b/crates/lab/src/dispatch/setup/bootstrap.rs
@@ -96,6 +96,7 @@ fn bootstrap_at(env: &Path) -> Result<BootstrapOutcome, ToolError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::{BootstrapOutcome, bootstrap_at, should_bootstrap};
 

--- a/crates/lab/src/dispatch/setup/dispatch.rs
+++ b/crates/lab/src/dispatch/setup/dispatch.rs
@@ -788,6 +788,8 @@ fn assert_action_count_const() {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::await_holding_lock, clippy::panic)]
+
     use super::*;
     use crate::registry::build_default_registry;
     use std::sync::Mutex;
@@ -861,19 +863,17 @@ mod tests {
 
     #[test]
     fn settings_update_accepts_flat_and_nested_toggle_param() {
-        assert_eq!(
-            parse_built_in_upstream_apis_enabled(
+        assert!(
+            !parse_built_in_upstream_apis_enabled(
                 &json!({"services.built_in_upstream_apis_enabled": false})
             )
-            .unwrap(),
-            false
+            .unwrap()
         );
-        assert_eq!(
+        assert!(
             parse_built_in_upstream_apis_enabled(
                 &json!({"services": {"built_in_upstream_apis_enabled": true}})
             )
-            .unwrap(),
-            true
+            .unwrap()
         );
     }
 
@@ -923,6 +923,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn settings_update_dispatch_persists_and_preserves_config_toml() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let previous_runtime = crate::registry::runtime_built_in_upstream_apis_enabled();

--- a/crates/lab/src/dispatch/stash/store.rs
+++ b/crates/lab/src/dispatch/stash/store.rs
@@ -905,6 +905,7 @@ fn invalid_param(param: &str, message: &str) -> ToolError {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use lab_apis::stash::types::{StashComponentKind, StashWorkspaceShape};

--- a/crates/lab/src/dispatch/upstream/http_client.rs
+++ b/crates/lab/src/dispatch/upstream/http_client.rs
@@ -515,6 +515,7 @@ impl StreamableHttpClient for BodyCappedHttpClient {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use wiremock::matchers::{method, path};

--- a/crates/lab/src/dispatch/upstream/pool/ensure.rs
+++ b/crates/lab/src/dispatch/upstream/pool/ensure.rs
@@ -324,6 +324,7 @@ impl UpstreamPool {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/crates/lab/src/dispatch/upstream/pool/prompts_list.rs
+++ b/crates/lab/src/dispatch/upstream/pool/prompts_list.rs
@@ -349,6 +349,7 @@ mod tests {
             peers: Arc::new(RwLock::new(Vec::new())),
             logging_level: Arc::new(AtomicU8::new(logging_level_rank(LoggingLevel::Info))),
             route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+            code_mode_widget_callbacks_enabled_for_test: false,
         };
 
         let snapshot = server.snapshot_catalog().await;

--- a/crates/lab/src/dispatch/upstream/pool/resources_read.rs
+++ b/crates/lab/src/dispatch/upstream/pool/resources_read.rs
@@ -317,6 +317,7 @@ mod tests {
             peers: Arc::new(RwLock::new(Vec::new())),
             logging_level: Arc::new(AtomicU8::new(logging_level_rank(LoggingLevel::Info))),
             route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+            code_mode_widget_callbacks_enabled_for_test: false,
         };
 
         let snapshot = server.snapshot_catalog().await;

--- a/crates/lab/src/dispatch/upstream/pool/resources_read.rs
+++ b/crates/lab/src/dispatch/upstream/pool/resources_read.rs
@@ -261,6 +261,7 @@ fn ui_uri_authority(uri: &str) -> Option<&str> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::AtomicU8;

--- a/crates/lab/src/dispatch/upstream/pool/tools.rs
+++ b/crates/lab/src/dispatch/upstream/pool/tools.rs
@@ -147,6 +147,44 @@ impl UpstreamPool {
         matches
     }
 
+    /// Return exposed tools whose upstream also exposes at least one MCP App UI tool.
+    ///
+    /// Code Mode keeps ordinary raw tools out of `list_tools`, but a rendered MCP
+    /// App can only talk back to its server through host `callServerTool`
+    /// callbacks. This lookup is the narrow callback allowlist: the requested
+    /// tool must still be exposed by its upstream, and that same upstream must
+    /// expose an MCP App UI tool.
+    pub async fn find_mcp_app_sibling_tool_candidates(
+        &self,
+        tool_name: &str,
+        allowed: Option<&BTreeSet<String>>,
+    ) -> Vec<(String, UpstreamTool)> {
+        let catalog = self.catalog.read().await;
+        let mut matches = Vec::new();
+        for (upstream_name, entry) in catalog.iter() {
+            if !upstream_allowed(allowed, upstream_name) || !entry.tool_health.is_routable() {
+                continue;
+            }
+            let Some(tool) = entry.tools.get(tool_name) else {
+                continue;
+            };
+            if !entry.exposure_policy.matches(tool.tool.name.as_ref()) {
+                continue;
+            }
+            let has_ui_sibling = entry.tools.values().any(|candidate| {
+                entry
+                    .exposure_policy
+                    .matches(candidate.tool.name.as_ref())
+                    && tool_has_mcp_app_ui_resource(candidate)
+            });
+            if has_ui_sibling {
+                matches.push((upstream_name.clone(), tool.clone()));
+            }
+        }
+        matches.sort_by(|a, b| a.0.cmp(&b.0));
+        matches
+    }
+
     /// Return tool lists for all OAuth upstreams visible to `subject`.
     ///
     /// P-C1 fix: uses `acquire_or_connect_subject` so the per-(upstream,subject)
@@ -376,6 +414,8 @@ pub(crate) fn tool_has_mcp_app_ui_resource(tool: &UpstreamTool) -> bool {
 mod tests {
     use std::sync::Arc;
 
+    use rmcp::model::Meta;
+
     use super::super::super::types::ToolExposurePolicy;
     use super::super::entries::healthy_in_process_entry;
     use super::super::testsupport::*;
@@ -433,6 +473,96 @@ mod tests {
 
         assert!(pool.find_tool("search_repos").await.is_some());
         assert!(pool.find_tool("delete_repo").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn mcp_app_sibling_lookup_requires_exposed_ui_tool_on_same_upstream() {
+        let pool = UpstreamPool::new();
+
+        let apps_name: Arc<str> = Arc::from("apps");
+        let mut apps_tools =
+            test_upstream_tools(&apps_name, &["youtube_search_ui", "youtube_probe"]);
+        let ui_meta = Meta(serde_json::Map::from_iter([(
+            "ui".to_string(),
+            serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
+        )]));
+        apps_tools
+            .get_mut("youtube_search_ui")
+            .expect("ui tool")
+            .tool
+            .meta = Some(ui_meta);
+        let apps_entry = healthy_in_process_entry(Arc::clone(&apps_name), apps_tools);
+        pool.catalog
+            .write()
+            .await
+            .insert("apps".to_string(), apps_entry);
+
+        let plain_name: Arc<str> = Arc::from("plain");
+        let plain_tools = test_upstream_tools(&plain_name, &["youtube_probe"]);
+        let plain_entry = healthy_in_process_entry(Arc::clone(&plain_name), plain_tools);
+        pool.catalog
+            .write()
+            .await
+            .insert("plain".to_string(), plain_entry);
+
+        let candidates = pool
+            .find_mcp_app_sibling_tool_candidates("youtube_probe", None)
+            .await;
+        let upstreams = candidates
+            .iter()
+            .map(|(upstream, _)| upstream.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(upstreams, vec!["apps"]);
+
+        let allowed = BTreeSet::from(["plain".to_string()]);
+        assert!(
+            pool.find_mcp_app_sibling_tool_candidates("youtube_probe", Some(&allowed))
+                .await
+                .is_empty(),
+            "route scope must still constrain MCP App callback siblings"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_app_sibling_lookup_respects_exposure_policy() {
+        let pool = UpstreamPool::new();
+        let upstream_name: Arc<str> = Arc::from("apps");
+        let mut tools = test_upstream_tools(
+            &upstream_name,
+            &["youtube_search_ui", "youtube_probe", "internal_delete"],
+        );
+        tools
+            .get_mut("youtube_search_ui")
+            .expect("ui tool")
+            .tool
+            .meta = Some(Meta(serde_json::Map::from_iter([(
+                "ui".to_string(),
+                serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
+            )])));
+        let mut entry = healthy_in_process_entry(Arc::clone(&upstream_name), tools);
+        entry.exposure_policy = ToolExposurePolicy::from_patterns(vec![
+            "youtube_search_ui".to_string(),
+            "youtube_probe".to_string(),
+        ])
+        .expect("policy");
+        pool.catalog
+            .write()
+            .await
+            .insert("apps".to_string(), entry);
+
+        assert_eq!(
+            pool.find_mcp_app_sibling_tool_candidates("youtube_probe", None)
+                .await
+                .len(),
+            1
+        );
+        assert!(
+            pool.find_mcp_app_sibling_tool_candidates("internal_delete", None)
+                .await
+                .is_empty(),
+            "unexposed sibling tools must remain uncallable"
+        );
     }
 
     // --- lab-tad5: oversized catalog bounds regression tests ---

--- a/crates/lab/src/dispatch/upstream/pool/tools.rs
+++ b/crates/lab/src/dispatch/upstream/pool/tools.rs
@@ -172,9 +172,7 @@ impl UpstreamPool {
                 continue;
             }
             let has_ui_sibling = entry.tools.values().any(|candidate| {
-                entry
-                    .exposure_policy
-                    .matches(candidate.tool.name.as_ref())
+                entry.exposure_policy.matches(candidate.tool.name.as_ref())
                     && tool_has_mcp_app_ui_resource(candidate)
             });
             if has_ui_sibling {
@@ -537,19 +535,16 @@ mod tests {
             .expect("ui tool")
             .tool
             .meta = Some(Meta(serde_json::Map::from_iter([(
-                "ui".to_string(),
-                serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
-            )])));
+            "ui".to_string(),
+            serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
+        )])));
         let mut entry = healthy_in_process_entry(Arc::clone(&upstream_name), tools);
         entry.exposure_policy = ToolExposurePolicy::from_patterns(vec![
             "youtube_search_ui".to_string(),
             "youtube_probe".to_string(),
         ])
         .expect("policy");
-        pool.catalog
-            .write()
-            .await
-            .insert("apps".to_string(), entry);
+        pool.catalog.write().await.insert("apps".to_string(), entry);
 
         assert_eq!(
             pool.find_mcp_app_sibling_tool_candidates("youtube_probe", None)

--- a/crates/lab/src/dispatch/upstream/process_guard.rs
+++ b/crates/lab/src/dispatch/upstream/process_guard.rs
@@ -146,6 +146,7 @@ impl Drop for JobObjectGuard {
 }
 
 #[cfg(all(test, unix))]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use std::process::{Command as StdCommand, Stdio};

--- a/crates/lab/src/dispatch/upstream/types.rs
+++ b/crates/lab/src/dispatch/upstream/types.rs
@@ -295,6 +295,7 @@ pub struct UpstreamEntry {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{ToolExposurePolicy, wildcard_matches};
 

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -23,13 +23,29 @@ use rmcp::model::{
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
+use crate::dispatch::upstream::types::UpstreamTool;
 use crate::mcp::catalog::{CODE_MODE_SEARCH_TOOL_NAME, TOOL_EXECUTE_TOOL_NAME};
-use crate::mcp::context::{auth_context_from_extensions, tool_execute_builtin_action_allowed};
+use crate::mcp::context::{
+    auth_context_from_extensions, tool_execute_builtin_action_allowed, tool_execute_scope_allowed,
+};
 use crate::mcp::elicitation::{ElicitResult, elicit_confirm};
 use crate::mcp::envelope::{build_error, build_error_extra};
 use crate::mcp::error::DispatchError;
 use crate::mcp::result_format::{estimate_tokens_args, format_dispatch_result};
 use crate::mcp::server::LabMcpServer;
+
+enum WidgetCallbackGate {
+    Allowed {
+        route: &'static str,
+        upstream_name: String,
+        tool: Box<UpstreamTool>,
+        hidden_sibling: bool,
+    },
+    Ambiguous {
+        valid: Vec<String>,
+    },
+    Destructive,
+}
 
 fn route_scope_denied_result(service: &str, action: &str, message: String) -> CallToolResult {
     let envelope = build_error(service, action, "route_scope_denied", &message);
@@ -218,6 +234,7 @@ impl LabMcpServer {
             )]));
         }
 
+        let mut resolved_upstream_tool = None;
         if self.code_mode_visibility().await.hides_raw_tools() {
             let widget_callback = if svc.is_none()
                 && let Some(pool) = self.current_upstream_pool().await
@@ -226,37 +243,58 @@ impl LabMcpServer {
                 if crate::config::code_mode_widget_callbacks_enabled() {
                     pool.find_tool_allowed(&service, allowed)
                         .await
-                        .map(|(_, tool)| ("upstream_widget_callback_legacy", Some(tool)))
-                } else if let Some((_, tool)) = pool
+                        .map(|(upstream_name, tool)| WidgetCallbackGate::Allowed {
+                            route: "upstream_widget_callback_legacy",
+                            upstream_name,
+                            tool: Box::new(tool),
+                            hidden_sibling: false,
+                        })
+                } else if let Some((upstream_name, tool)) = pool
                     .find_tool_allowed(&service, allowed)
                     .await
                     .filter(|(_, tool)| {
                         crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
                     })
                 {
-                    Some(("upstream_widget_callback", Some(tool)))
+                    Some(WidgetCallbackGate::Allowed {
+                        route: "upstream_widget_callback",
+                        upstream_name,
+                        tool: Box::new(tool),
+                        hidden_sibling: false,
+                    })
                 } else {
                     let candidates = pool
                         .find_mcp_app_sibling_tool_candidates(&service, allowed)
                         .await;
                     if candidates.is_empty() {
                         None
-                    } else if let Some((_, tool)) = candidates
+                    } else if candidates
                         .iter()
-                        .find(|(_, candidate)| candidate.destructive)
+                        .any(|(_, candidate)| candidate.destructive)
                     {
-                        Some(("upstream_widget_sibling_callback", Some(tool.clone())))
+                        Some(WidgetCallbackGate::Destructive)
+                    } else if candidates.len() > 1 {
+                        let valid = candidates
+                            .iter()
+                            .map(|(upstream, tool)| format!("{upstream}::{}", tool.tool.name))
+                            .collect();
+                        Some(WidgetCallbackGate::Ambiguous { valid })
                     } else {
-                        let tool = (candidates.len() == 1)
-                            .then(|| candidates.into_iter().next().expect("checked len").1);
-                        Some(("upstream_widget_sibling_callback", tool))
+                        let (upstream_name, tool) =
+                            candidates.into_iter().next().expect("checked len");
+                        Some(WidgetCallbackGate::Allowed {
+                            route: "upstream_widget_sibling_callback",
+                            upstream_name,
+                            tool: Box::new(tool),
+                            hidden_sibling: true,
+                        })
                     }
                 }
             } else {
                 None
             };
             match widget_callback {
-                Some((_, Some(tool))) if tool.destructive => {
+                Some(WidgetCallbackGate::Destructive) => {
                     let envelope = build_error(
                         &service,
                         &action,
@@ -270,7 +308,42 @@ impl LabMcpServer {
                         envelope.to_string(),
                     )]));
                 }
-                Some((route, _)) => {
+                Some(WidgetCallbackGate::Ambiguous { valid }) => {
+                    let envelope = build_error_extra(
+                        &service,
+                        &action,
+                        "ambiguous_tool",
+                        &format!("tool `{service}` matched multiple MCP App sibling tools"),
+                        &serde_json::json!({ "valid": valid }),
+                    );
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        envelope.to_string(),
+                    )]));
+                }
+                Some(WidgetCallbackGate::Allowed {
+                    route,
+                    upstream_name,
+                    tool,
+                    hidden_sibling,
+                }) => {
+                    if hidden_sibling
+                        && !tool_execute_scope_allowed(auth_context_from_extensions(
+                            &context.extensions,
+                        ))
+                    {
+                        let envelope = build_error_extra(
+                            &service,
+                            &action,
+                            "forbidden",
+                            "MCP App sibling callbacks require one of scopes: lab, lab:admin",
+                            &serde_json::json!({
+                                "required_scopes": ["lab", "lab:admin"],
+                            }),
+                        );
+                        return Ok(CallToolResult::error(vec![Content::text(
+                            envelope.to_string(),
+                        )]));
+                    }
                     tracing::info!(
                         surface = "mcp",
                         service = %service,
@@ -278,6 +351,7 @@ impl LabMcpServer {
                         route,
                         "code_mode raw-tool gate bypassed for MCP App widget callback"
                     );
+                    resolved_upstream_tool = Some((upstream_name, *tool));
                 }
                 None => {
                     let envelope = build_error(
@@ -428,6 +502,7 @@ impl LabMcpServer {
             &service,
             &action,
             raw_arguments,
+            resolved_upstream_tool,
             start,
             &subject,
             actor_key,

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -219,28 +219,39 @@ impl LabMcpServer {
         }
 
         if self.code_mode_visibility().await.hides_raw_tools() {
-            // MCP App tools stay visible in `list_tools` even while Code Mode
-            // hides ordinary raw tools, so their host callbacks must be allowed
-            // through the same raw proxy path. Operators can still opt into the
-            // broader legacy callback bypass for non-UI tools with
-            // `LAB_CODE_MODE_WIDGET_CALLBACKS=1`.
-            let widget_tool = if svc.is_none()
+            let widget_callback = if svc.is_none()
                 && let Some(pool) = self.current_upstream_pool().await
             {
-                pool.find_tool(&service).await.filter(|(_, tool)| {
-                    crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
-                        || crate::config::code_mode_widget_callbacks_enabled()
-                })
+                let allowed = self.route_scope.allowed_upstreams();
+                if crate::config::code_mode_widget_callbacks_enabled() {
+                    pool.find_tool_allowed(&service, allowed)
+                        .await
+                        .map(|(_, tool)| ("upstream_widget_callback_legacy", Some(tool)))
+                } else if let Some((_, tool)) =
+                    pool.find_tool_allowed(&service, allowed)
+                        .await
+                        .filter(|(_, tool)| {
+                            crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
+                        })
+                {
+                    Some(("upstream_widget_callback", Some(tool)))
+                } else {
+                    let candidates = pool
+                        .find_mcp_app_sibling_tool_candidates(&service, allowed)
+                        .await;
+                    if candidates.is_empty() {
+                        None
+                    } else {
+                        let tool = (candidates.len() == 1)
+                            .then(|| candidates.into_iter().next().expect("checked len").1);
+                        Some(("upstream_widget_sibling_callback", tool))
+                    }
+                }
             } else {
                 None
             };
-            match widget_tool {
-                // Destructive upstream effects are NOT reachable over the
-                // callback bypass: it has no confirmation channel, so unlike the
-                // `execute` path (which gates destructive upstream calls behind
-                // `confirm: true`) it could otherwise run a destructive tool
-                // unconfirmed. The sanctioned path for those is `execute`.
-                Some((_upstream, tool)) if tool.destructive => {
+            match widget_callback {
+                Some((_, Some(tool))) if tool.destructive => {
                     let envelope = build_error(
                         &service,
                         &action,
@@ -254,12 +265,12 @@ impl LabMcpServer {
                         envelope.to_string(),
                     )]));
                 }
-                Some(_) => {
+                Some((route, _)) => {
                     tracing::info!(
                         surface = "mcp",
                         service = %service,
                         action = %action,
-                        route = "upstream_widget_callback",
+                        route,
                         "code_mode raw-tool gate bypassed for MCP App widget callback"
                     );
                 }

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -23,7 +23,10 @@ use rmcp::model::{
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
+use crate::dispatch::error::ToolError;
+use crate::dispatch::gateway::manager::CallbackToolLookup;
 use crate::dispatch::upstream::types::UpstreamTool;
+use crate::mcp::call_tool_upstream::PreResolvedUpstreamTool;
 use crate::mcp::catalog::{CODE_MODE_SEARCH_TOOL_NAME, TOOL_EXECUTE_TOOL_NAME};
 use crate::mcp::context::{
     auth_context_from_extensions, tool_execute_builtin_action_allowed, tool_execute_scope_allowed,
@@ -31,14 +34,14 @@ use crate::mcp::context::{
 use crate::mcp::elicitation::{ElicitResult, elicit_confirm};
 use crate::mcp::envelope::{build_error, build_error_extra};
 use crate::mcp::error::DispatchError;
-use crate::mcp::result_format::{estimate_tokens_args, format_dispatch_result};
+use crate::mcp::result_format::{
+    estimate_tokens_args, format_dispatch_result, tool_error_envelope,
+};
 use crate::mcp::server::LabMcpServer;
 
 enum WidgetCallbackGate {
     Allowed {
-        route: &'static str,
-        upstream_name: String,
-        tool: Box<UpstreamTool>,
+        resolved: Box<PreResolvedUpstreamTool>,
         hidden_sibling: bool,
     },
     Ambiguous {
@@ -236,58 +239,14 @@ impl LabMcpServer {
 
         let mut resolved_upstream_tool = None;
         if self.code_mode_visibility().await.hides_raw_tools() {
-            let widget_callback = if svc.is_none()
-                && let Some(pool) = self.current_upstream_pool().await
-            {
-                let allowed = self.route_scope.allowed_upstreams();
-                if self.code_mode_widget_callbacks_enabled() {
-                    pool.find_tool_allowed(&service, allowed)
-                        .await
-                        .map(|(upstream_name, tool)| WidgetCallbackGate::Allowed {
-                            route: "upstream_widget_callback_legacy",
-                            upstream_name,
-                            tool: Box::new(tool),
-                            hidden_sibling: false,
-                        })
-                } else if let Some((upstream_name, tool)) = pool
-                    .find_tool_allowed(&service, allowed)
-                    .await
-                    .filter(|(_, tool)| {
-                        crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
-                    })
-                {
-                    Some(WidgetCallbackGate::Allowed {
-                        route: "upstream_widget_callback",
-                        upstream_name,
-                        tool: Box::new(tool),
-                        hidden_sibling: false,
-                    })
-                } else {
-                    let candidates = pool
-                        .find_mcp_app_sibling_tool_candidates(&service, allowed)
-                        .await;
-                    if candidates.is_empty() {
-                        None
-                    } else if candidates.len() > 1 {
-                        let valid = candidates
-                            .iter()
-                            .map(|(upstream, tool)| format!("{upstream}::{}", tool.tool.name))
-                            .collect();
-                        Some(WidgetCallbackGate::Ambiguous { valid })
-                    } else if candidates
-                        .iter()
-                        .any(|(_, candidate)| candidate.destructive)
-                    {
-                        Some(WidgetCallbackGate::Destructive)
-                    } else {
-                        let (upstream_name, tool) =
-                            candidates.into_iter().next().expect("checked len");
-                        Some(WidgetCallbackGate::Allowed {
-                            route: "upstream_widget_sibling_callback",
-                            upstream_name,
-                            tool: Box::new(tool),
-                            hidden_sibling: true,
-                        })
+            let widget_callback = if svc.is_none() {
+                match self.resolve_widget_callback_gate(&service, &context).await {
+                    Ok(gate) => gate,
+                    Err(err) => {
+                        let envelope = tool_error_envelope(&service, "call_tool", &err);
+                        return Ok(CallToolResult::error(vec![Content::text(
+                            envelope.to_string(),
+                        )]));
                     }
                 }
             } else {
@@ -321,25 +280,9 @@ impl LabMcpServer {
                     )]));
                 }
                 Some(WidgetCallbackGate::Allowed {
-                    route,
-                    upstream_name,
-                    tool,
+                    resolved,
                     hidden_sibling,
                 }) => {
-                    if tool.destructive {
-                        let envelope = build_error(
-                            &service,
-                            &action,
-                            "confirmation_required",
-                            &format!(
-                                "destructive upstream tool `{service}` is not callable via the \
-                                 widget callback bypass — use the `execute` tool with confirm:true"
-                            ),
-                        );
-                        return Ok(CallToolResult::error(vec![Content::text(
-                            envelope.to_string(),
-                        )]));
-                    }
                     if hidden_sibling
                         && !tool_execute_scope_allowed(auth_context_from_extensions(
                             &context.extensions,
@@ -362,10 +305,11 @@ impl LabMcpServer {
                         surface = "mcp",
                         service = %service,
                         action = %action,
-                        route,
+                        upstream = %resolved.upstream_name,
+                        route = resolved.route,
                         "code_mode raw-tool gate bypassed for MCP App widget callback"
                     );
-                    resolved_upstream_tool = Some((upstream_name, *tool));
+                    resolved_upstream_tool = Some(*resolved);
                 }
                 None => {
                     let envelope = build_error(
@@ -527,6 +471,71 @@ impl LabMcpServer {
 }
 
 impl LabMcpServer {
+    async fn resolve_widget_callback_gate(
+        &self,
+        service: &str,
+        context: &RequestContext<RoleServer>,
+    ) -> Result<Option<WidgetCallbackGate>, ToolError> {
+        let Some(manager) = &self.gateway_manager else {
+            return Ok(None);
+        };
+        let owner = self.request_runtime_owner(context);
+        let oauth_subject = crate::mcp::context::oauth_upstream_subject_for_request(
+            auth_context_from_extensions(&context.extensions),
+            self.request_subject(context),
+        );
+        let allowed = self.route_scope.allowed_upstreams();
+
+        if self.code_mode_widget_callbacks_enabled() {
+            let candidates = manager
+                .resolve_widget_callback_tool_candidates_scoped(
+                    service,
+                    allowed,
+                    Some(&owner),
+                    oauth_subject.as_deref(),
+                    CallbackToolLookup::LegacyAnyExposed,
+                )
+                .await?;
+            return Ok(classify_widget_callback_candidates(
+                "upstream_widget_callback_legacy",
+                false,
+                candidates,
+            ));
+        }
+
+        let direct_candidates = manager
+            .resolve_widget_callback_tool_candidates_scoped(
+                service,
+                allowed,
+                Some(&owner),
+                oauth_subject.as_deref(),
+                CallbackToolLookup::DirectMcpApp,
+            )
+            .await?;
+        if !direct_candidates.is_empty() {
+            return Ok(classify_widget_callback_candidates(
+                "upstream_widget_callback",
+                false,
+                direct_candidates,
+            ));
+        }
+
+        let sibling_candidates = manager
+            .resolve_widget_callback_tool_candidates_scoped(
+                service,
+                allowed,
+                Some(&owner),
+                oauth_subject.as_deref(),
+                CallbackToolLookup::SiblingOfMcpApp,
+            )
+            .await?;
+        Ok(classify_widget_callback_candidates(
+            "upstream_widget_sibling_callback",
+            true,
+            sibling_candidates,
+        ))
+    }
+
     fn code_mode_widget_callbacks_enabled(&self) -> bool {
         #[cfg(test)]
         if self.code_mode_widget_callbacks_enabled_for_test {
@@ -535,4 +544,38 @@ impl LabMcpServer {
 
         crate::config::code_mode_widget_callbacks_enabled()
     }
+}
+
+fn classify_widget_callback_candidates(
+    route: &'static str,
+    hidden_sibling: bool,
+    candidates: Vec<(String, UpstreamTool)>,
+) -> Option<WidgetCallbackGate> {
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() > 1 {
+        let valid = candidates
+            .iter()
+            .map(|(upstream, tool)| format!("{upstream}::{}", tool.tool.name))
+            .collect();
+        return Some(WidgetCallbackGate::Ambiguous { valid });
+    }
+    if candidates
+        .iter()
+        .any(|(_, candidate)| candidate.destructive)
+    {
+        return Some(WidgetCallbackGate::Destructive);
+    }
+
+    let (upstream_name, tool) = candidates.into_iter().next().expect("checked len");
+    Some(WidgetCallbackGate::Allowed {
+        resolved: PreResolvedUpstreamTool {
+            upstream_name,
+            tool,
+            route,
+        }
+        .into(),
+        hidden_sibling,
+    })
 }

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -240,7 +240,7 @@ impl LabMcpServer {
                 && let Some(pool) = self.current_upstream_pool().await
             {
                 let allowed = self.route_scope.allowed_upstreams();
-                if crate::config::code_mode_widget_callbacks_enabled() {
+                if self.code_mode_widget_callbacks_enabled() {
                     pool.find_tool_allowed(&service, allowed)
                         .await
                         .map(|(upstream_name, tool)| WidgetCallbackGate::Allowed {
@@ -268,17 +268,17 @@ impl LabMcpServer {
                         .await;
                     if candidates.is_empty() {
                         None
-                    } else if candidates
-                        .iter()
-                        .any(|(_, candidate)| candidate.destructive)
-                    {
-                        Some(WidgetCallbackGate::Destructive)
                     } else if candidates.len() > 1 {
                         let valid = candidates
                             .iter()
                             .map(|(upstream, tool)| format!("{upstream}::{}", tool.tool.name))
                             .collect();
                         Some(WidgetCallbackGate::Ambiguous { valid })
+                    } else if candidates
+                        .iter()
+                        .any(|(_, candidate)| candidate.destructive)
+                    {
+                        Some(WidgetCallbackGate::Destructive)
                     } else {
                         let (upstream_name, tool) =
                             candidates.into_iter().next().expect("checked len");
@@ -326,6 +326,20 @@ impl LabMcpServer {
                     tool,
                     hidden_sibling,
                 }) => {
+                    if tool.destructive {
+                        let envelope = build_error(
+                            &service,
+                            &action,
+                            "confirmation_required",
+                            &format!(
+                                "destructive upstream tool `{service}` is not callable via the \
+                                 widget callback bypass — use the `execute` tool with confirm:true"
+                            ),
+                        );
+                        return Ok(CallToolResult::error(vec![Content::text(
+                            envelope.to_string(),
+                        )]));
+                    }
                     if hidden_sibling
                         && !tool_execute_scope_allowed(auth_context_from_extensions(
                             &context.extensions,
@@ -509,5 +523,16 @@ impl LabMcpServer {
             &context,
         )
         .await
+    }
+}
+
+impl LabMcpServer {
+    fn code_mode_widget_callbacks_enabled(&self) -> bool {
+        #[cfg(test)]
+        if self.code_mode_widget_callbacks_enabled_for_test {
+            return true;
+        }
+
+        crate::config::code_mode_widget_callbacks_enabled()
     }
 }

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -227,12 +227,12 @@ impl LabMcpServer {
                     pool.find_tool_allowed(&service, allowed)
                         .await
                         .map(|(_, tool)| ("upstream_widget_callback_legacy", Some(tool)))
-                } else if let Some((_, tool)) =
-                    pool.find_tool_allowed(&service, allowed)
-                        .await
-                        .filter(|(_, tool)| {
-                            crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
-                        })
+                } else if let Some((_, tool)) = pool
+                    .find_tool_allowed(&service, allowed)
+                    .await
+                    .filter(|(_, tool)| {
+                        crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
+                    })
                 {
                     Some(("upstream_widget_callback", Some(tool)))
                 } else {
@@ -241,6 +241,11 @@ impl LabMcpServer {
                         .await;
                     if candidates.is_empty() {
                         None
+                    } else if let Some((_, tool)) = candidates
+                        .iter()
+                        .find(|(_, candidate)| candidate.destructive)
+                    {
+                        Some(("upstream_widget_sibling_callback", Some(tool.clone())))
                     } else {
                         let tool = (candidates.len() == 1)
                             .then(|| candidates.into_iter().next().expect("checked len").1);

--- a/crates/lab/src/mcp/call_tool_codemode/tests.rs
+++ b/crates/lab/src/mcp/call_tool_codemode/tests.rs
@@ -91,16 +91,14 @@ fn code_execute_description_contains_protocol_contract() {
 
 #[test]
 fn gateway_search_input_schema_is_code_only() {
-    for schema in [serde_json::json!({
+    let schema = serde_json::json!({
         "type": "object",
         "properties": { "code": { "type": "string" } },
         "required": ["code"]
-    })] {
-        let props = schema["properties"].as_object().expect("properties object");
-        let prop_names: std::collections::BTreeSet<&str> =
-            props.keys().map(String::as_str).collect();
-        assert_eq!(prop_names, std::collections::BTreeSet::from(["code"]));
-    }
+    });
+    let props = schema["properties"].as_object().expect("properties object");
+    let prop_names: std::collections::BTreeSet<&str> = props.keys().map(String::as_str).collect();
+    assert_eq!(prop_names, std::collections::BTreeSet::from(["code"]));
 }
 
 #[test]

--- a/crates/lab/src/mcp/call_tool_upstream.rs
+++ b/crates/lab/src/mcp/call_tool_upstream.rs
@@ -34,6 +34,8 @@ use crate::mcp::result_format::{
 use crate::mcp::server::LabMcpServer;
 use crate::mcp::upstream::normalize_upstream_result;
 
+use crate::dispatch::upstream::types::UpstreamTool;
+
 impl LabMcpServer {
     /// Upstream-proxy tail. Reached by fall-through from `call_tool_impl`
     /// when `svc.is_none()`. Owns raw + subject-scoped proxy branches and
@@ -44,6 +46,7 @@ impl LabMcpServer {
         service: &str,
         action: &str,
         raw_arguments: Option<JsonObject>,
+        resolved_upstream_tool: Option<(String, UpstreamTool)>,
         start: Instant,
         subject: &str,
         actor_key: Option<&str>,
@@ -59,7 +62,9 @@ impl LabMcpServer {
             auth_context_from_extensions(&context.extensions),
             self.request_subject(context),
         );
-        let raw_resolved = if let Some(manager) = &self.gateway_manager {
+        let raw_resolved = if let Some(resolved) = resolved_upstream_tool {
+            Some(Ok(resolved))
+        } else if let Some(manager) = &self.gateway_manager {
             Some(
                 manager
                     .resolve_raw_upstream_tool_scoped(

--- a/crates/lab/src/mcp/call_tool_upstream.rs
+++ b/crates/lab/src/mcp/call_tool_upstream.rs
@@ -34,6 +34,7 @@ use crate::mcp::result_format::{
 use crate::mcp::server::LabMcpServer;
 use crate::mcp::upstream::normalize_upstream_result;
 
+use crate::config::UpstreamConfig;
 use crate::dispatch::upstream::types::UpstreamTool;
 
 impl LabMcpServer {
@@ -62,6 +63,19 @@ impl LabMcpServer {
             auth_context_from_extensions(&context.extensions),
             self.request_subject(context),
         );
+        let pre_resolved_upstream = resolved_upstream_tool
+            .as_ref()
+            .map(|(upstream_name, _)| upstream_name.clone());
+        let route_scoped_oauth_configs = self.route_scoped_oauth_upstream_configs().await;
+        let pre_resolved_oauth_config: Option<UpstreamConfig> = raw_oauth_subject
+            .as_ref()
+            .and(pre_resolved_upstream.as_ref())
+            .and_then(|upstream_name| {
+                route_scoped_oauth_configs
+                    .iter()
+                    .find(|config| config.name == *upstream_name && config.oauth.is_some())
+                    .cloned()
+            });
         let raw_resolved = if let Some(resolved) = resolved_upstream_tool {
             Some(Ok(resolved))
         } else if let Some(manager) = &self.gateway_manager {
@@ -111,6 +125,7 @@ impl LabMcpServer {
         }
         if let Some(pool) = self.current_upstream_pool().await
             && let Some(Ok((upstream_name, _tool))) = raw_resolved
+            && pre_resolved_oauth_config.is_none()
         {
             let before = self.snapshot_catalog().await;
             tracing::info!(
@@ -295,22 +310,28 @@ impl LabMcpServer {
             oauth_upstream_subject_for_request(auth, self.request_subject(context))
             && let Some(pool) = self.current_upstream_pool().await
         {
-            let configs = self.route_scoped_oauth_upstream_configs().await;
-            let mut owner = None;
-            for (upstream_name, tools) in pool
-                .subject_scoped_tools(&configs, oauth_subject.as_ref())
-                .await
-            {
-                if tools.iter().any(|tool| tool.name.as_ref() == service) {
-                    owner = Some(upstream_name);
-                    break;
+            let mut owner = pre_resolved_oauth_config
+                .as_ref()
+                .map(|config| config.name.clone());
+            if owner.is_none() {
+                for (upstream_name, tools) in pool
+                    .subject_scoped_tools(&route_scoped_oauth_configs, oauth_subject.as_ref())
+                    .await
+                {
+                    if tools.iter().any(|tool| tool.name.as_ref() == service) {
+                        owner = Some(upstream_name);
+                        break;
+                    }
                 }
             }
 
             if let Some(upstream_name) = owner
-                && let Some(config) = configs
-                    .into_iter()
-                    .find(|config| config.name == upstream_name)
+                && let Some(config) = pre_resolved_oauth_config.or_else(|| {
+                    route_scoped_oauth_configs
+                        .iter()
+                        .find(|config| config.name == upstream_name)
+                        .cloned()
+                })
             {
                 tracing::info!(
                     surface = "mcp",

--- a/crates/lab/src/mcp/call_tool_upstream.rs
+++ b/crates/lab/src/mcp/call_tool_upstream.rs
@@ -37,6 +37,13 @@ use crate::mcp::upstream::normalize_upstream_result;
 use crate::config::UpstreamConfig;
 use crate::dispatch::upstream::types::UpstreamTool;
 
+#[derive(Debug, Clone)]
+pub(crate) struct PreResolvedUpstreamTool {
+    pub(crate) upstream_name: String,
+    pub(crate) tool: UpstreamTool,
+    pub(crate) route: &'static str,
+}
+
 impl LabMcpServer {
     /// Upstream-proxy tail. Reached by fall-through from `call_tool_impl`
     /// when `svc.is_none()`. Owns raw + subject-scoped proxy branches and
@@ -47,7 +54,7 @@ impl LabMcpServer {
         service: &str,
         action: &str,
         raw_arguments: Option<JsonObject>,
-        resolved_upstream_tool: Option<(String, UpstreamTool)>,
+        resolved_upstream_tool: Option<PreResolvedUpstreamTool>,
         start: Instant,
         subject: &str,
         actor_key: Option<&str>,
@@ -65,7 +72,7 @@ impl LabMcpServer {
         );
         let pre_resolved_upstream = resolved_upstream_tool
             .as_ref()
-            .map(|(upstream_name, _)| upstream_name.clone());
+            .map(|resolved| resolved.upstream_name.clone());
         let route_scoped_oauth_configs = self.route_scoped_oauth_upstream_configs().await;
         let pre_resolved_oauth_config: Option<UpstreamConfig> = raw_oauth_subject
             .as_ref()
@@ -77,7 +84,7 @@ impl LabMcpServer {
                     .cloned()
             });
         let raw_resolved = if let Some(resolved) = resolved_upstream_tool {
-            Some(Ok(resolved))
+            Some(Ok((resolved.upstream_name, resolved.tool, resolved.route)))
         } else if let Some(manager) = &self.gateway_manager {
             Some(
                 manager
@@ -87,7 +94,8 @@ impl LabMcpServer {
                         Some(&raw_runtime_owner),
                         raw_oauth_subject.as_deref(),
                     )
-                    .await,
+                    .await
+                    .map(|(upstream_name, tool)| (upstream_name, tool, "upstream")),
             )
         } else {
             None
@@ -124,7 +132,7 @@ impl LabMcpServer {
             )]));
         }
         if let Some(pool) = self.current_upstream_pool().await
-            && let Some(Ok((upstream_name, _tool))) = raw_resolved
+            && let Some(Ok((upstream_name, _tool, route))) = raw_resolved
             && pre_resolved_oauth_config.is_none()
         {
             let before = self.snapshot_catalog().await;
@@ -134,7 +142,7 @@ impl LabMcpServer {
                 action = upstream_action,
                 tool = %service,
                 upstream = %upstream_name,
-                route = "upstream",
+                route,
                 "dispatch route selected"
             );
             tracing::debug!(

--- a/crates/lab/src/mcp/handlers_prompts.rs
+++ b/crates/lab/src/mcp/handlers_prompts.rs
@@ -419,6 +419,7 @@ mod tests {
             peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             logging_level: Arc::new(AtomicU8::new(logging_level_rank(LoggingLevel::Emergency))),
             route_scope,
+            code_mode_widget_callbacks_enabled_for_test: false,
         }
     }
 

--- a/crates/lab/src/mcp/handlers_prompts.rs
+++ b/crates/lab/src/mcp/handlers_prompts.rs
@@ -440,9 +440,7 @@ mod tests {
         );
         let mut request = GetPromptRequestParams::new("service-discover");
         request.arguments = Some(
-            [("service".to_string(), Value::String("deploy".to_string()))]
-                .into_iter()
-                .collect(),
+            std::iter::once(("service".to_string(), Value::String("deploy".to_string()))).collect(),
         );
 
         let err = running
@@ -471,8 +469,7 @@ mod tests {
         );
         let mut request = GetPromptRequestParams::new("service-discover");
         request.arguments = Some(
-            [("service".to_string(), Value::String("gateway".to_string()))]
-                .into_iter()
+            std::iter::once(("service".to_string(), Value::String("gateway".to_string())))
                 .collect(),
         );
 

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -524,6 +524,7 @@ mod tests {
                 crate::mcp::logging::logging_level_rank(LoggingLevel::Emergency),
             )),
             route_scope,
+            code_mode_widget_callbacks_enabled_for_test: false,
         }
     }
 

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -489,6 +489,7 @@ pub(crate) fn code_mode_app_resource_meta(uri: &str) -> Meta {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use rmcp::service::{Peer, RequestContext};

--- a/crates/lab/src/mcp/handlers_tools.rs
+++ b/crates/lab/src/mcp/handlers_tools.rs
@@ -58,7 +58,9 @@ impl LabMcpServer {
             oauth_upstream_subject_for_request(auth, self.request_subject(&context));
         let mut builtin_names = Vec::new();
         for svc in self.registry.services() {
-            if self.service_visible_on_mcp(svc.name).await {
+            if self.route_scope.allows_service(svc.name)
+                && self.service_visible_on_mcp(svc.name).await
+            {
                 builtin_names.push(svc.name);
                 if hide_raw_tools {
                     suppressed_builtin_tool_count += 1;

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -460,7 +460,90 @@ async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
 
     assert!(result.is_error.unwrap_or(false));
     let text = result.content[0].as_text().expect("text").text.as_str();
-    assert!(text.contains("\"kind\":\"confirmation_required\""), "{text}");
+    assert!(
+        text.contains("\"kind\":\"confirmation_required\""),
+        "{text}"
+    );
+    assert!(
+        text.contains("not callable via the widget callback bypass"),
+        "{text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_blocks_ambiguous_destructive_mcp_app_sibling_callbacks() {
+    let safe_name: Arc<str> = Arc::from("safe_apps");
+    let safe_ui_tool = fixture_upstream_tool(
+        &safe_name,
+        "youtube_search_ui",
+        Some("ui://safe-apps/youtube-search.html"),
+    );
+    let safe_probe = fixture_upstream_tool(&safe_name, "youtube_probe", None);
+
+    let destructive_name: Arc<str> = Arc::from("destructive_apps");
+    let destructive_ui_tool = fixture_upstream_tool(
+        &destructive_name,
+        "youtube_search_ui",
+        Some("ui://destructive-apps/youtube-search.html"),
+    );
+    let mut destructive_probe = fixture_upstream_tool(&destructive_name, "youtube_probe", None);
+    destructive_probe.destructive = true;
+
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "safe_apps",
+        fixture_upstream_entry(
+            "safe_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), safe_ui_tool),
+                ("youtube_probe".to_string(), safe_probe),
+            ]),
+        ),
+    )
+    .await;
+    pool.insert_entry_for_test(
+        "destructive_apps",
+        fixture_upstream_entry(
+            "destructive_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), destructive_ui_tool),
+                ("youtube_probe".to_string(), destructive_probe),
+            ]),
+        ),
+    )
+    .await;
+
+    let manager =
+        code_mode_manager_with_pool(true, fixture_upstream_config("safe_apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        text.contains("\"kind\":\"confirmation_required\""),
+        "{text}"
+    );
     assert!(
         text.contains("not callable via the widget callback bypass"),
         "{text}"

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -348,18 +348,11 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
         .map(|tool| tool.name.as_ref())
         .collect::<Vec<_>>();
 
-    assert!(
-        names.contains(&"youtube_search_ui"),
-        "MCP App upstream tools must stay visible to the host"
-    );
-    assert!(
-        !names.contains(&"youtube_probe"),
-        "ordinary raw upstream tools stay hidden in Code Mode"
-    );
-    assert!(
-        !names.contains(&"radarr"),
-        "built-in raw tools stay hidden in Code Mode"
-    );
+    assert!(names.contains(&"youtube_search_ui"));
+    assert!(!names.contains(&"youtube_probe"));
+    assert!(names.contains(&CODE_MODE_SEARCH_TOOL_NAME));
+    assert!(names.contains(&TOOL_EXECUTE_TOOL_NAME));
+    assert!(!names.contains(&"radarr"));
 }
 
 #[tokio::test]

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -132,6 +132,14 @@ async fn code_mode_manager_with_pool(
     upstream: crate::config::UpstreamConfig,
     pool: Arc<UpstreamPool>,
 ) -> Arc<crate::dispatch::gateway::manager::GatewayManager> {
+    code_mode_manager_with_pool_and_upstreams(enabled, vec![upstream], pool).await
+}
+
+async fn code_mode_manager_with_pool_and_upstreams(
+    enabled: bool,
+    upstream: Vec<crate::config::UpstreamConfig>,
+    pool: Arc<UpstreamPool>,
+) -> Arc<crate::dispatch::gateway::manager::GatewayManager> {
     let runtime = crate::dispatch::gateway::manager::GatewayRuntimeHandle::default();
     runtime.swap(Some(pool)).await;
     let manager = Arc::new(crate::dispatch::gateway::manager::GatewayManager::new(
@@ -144,7 +152,7 @@ async fn code_mode_manager_with_pool(
                 enabled,
                 ..crate::config::CodeModeConfig::default()
             },
-            upstream: vec![upstream],
+            upstream,
             ..crate::config::LabConfig::default()
         })
         .await;
@@ -215,6 +223,26 @@ fn fixture_upstream_tool(
         upstream_name: Arc::clone(upstream),
         destructive: false,
     }
+}
+
+fn scoped_context(
+    peer: rmcp::service::Peer<rmcp::RoleServer>,
+    scopes: &[&str],
+) -> rmcp::service::RequestContext<rmcp::RoleServer> {
+    let mut context =
+        rmcp::service::RequestContext::new(rmcp::model::NumberOrString::Number(1), peer);
+    let mut parts = axum::http::Request::new(()).into_parts().0;
+    parts.extensions.insert(crate::api::oauth::AuthContext {
+        sub: "reader".to_string(),
+        actor_key: None,
+        scopes: scopes.iter().map(|scope| scope.to_string()).collect(),
+        issuer: "https://lab.example.com".to_string(),
+        via_session: true,
+        csrf_token: None,
+        email: None,
+    });
+    context.extensions.insert(parts);
+    context
 }
 
 #[test]
@@ -409,6 +437,133 @@ async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() 
     assert!(
         text.contains("upstream_error"),
         "test fixture has no live peer, so allowed callbacks should fail at proxy call, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_preserves_selected_mcp_app_sibling_upstream() {
+    let unrelated_name: Arc<str> = Arc::from("aaa_plain");
+    let unrelated_probe = fixture_upstream_tool(&unrelated_name, "youtube_probe", None);
+
+    let app_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &app_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let app_probe = fixture_upstream_tool(&app_name, "youtube_probe", None);
+
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "aaa_plain",
+        fixture_upstream_entry(
+            "aaa_plain",
+            HashMap::from([("youtube_probe".to_string(), unrelated_probe)]),
+        ),
+    )
+    .await;
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), app_probe),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool_and_upstreams(
+        true,
+        vec![
+            fixture_upstream_config("aaa_plain"),
+            fixture_upstream_config("apps"),
+        ],
+        pool,
+    )
+    .await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        text.contains("upstream `apps` is not connected"),
+        "MCP App sibling callbacks should dispatch to the UI sibling upstream, got {text}"
+    );
+    assert!(
+        !text.contains("upstream `aaa_plain` is not connected"),
+        "callback dispatch must not fall through to an unrelated same-name tool, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_requires_execute_scope_for_hidden_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+
+    let result = Box::pin(running.service().call_tool_impl(
+        CallToolRequestParams::new("youtube_probe"),
+        scoped_context(running.peer().clone(), &["lab:read"]),
+    ))
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "forbidden");
+    assert_eq!(
+        envelope["error"]["required_scopes"],
+        serde_json::json!(["lab", "lab:admin"])
     );
 }
 

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -104,6 +104,7 @@ fn test_server(
         peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         logging_level: Arc::new(AtomicU8::new(logging_level_rank(logging_level))),
         route_scope,
+        code_mode_widget_callbacks_enabled_for_test: false,
     }
 }
 
@@ -177,6 +178,20 @@ fn fixture_upstream_config(name: &str) -> crate::config::UpstreamConfig {
         imported_from: None,
         priority: 1.0,
     }
+}
+
+fn fixture_oauth_upstream_config(name: &str) -> crate::config::UpstreamConfig {
+    let mut config = fixture_upstream_config(name);
+    config.oauth = Some(crate::config::UpstreamOauthConfig {
+        mode: crate::config::UpstreamOauthMode::AuthorizationCodePkce,
+        registration: crate::config::UpstreamOauthRegistration::Preregistered {
+            client_id: "client-id".to_string(),
+            client_secret_env: None,
+        },
+        scopes: None,
+        prefer_client_metadata_document: None,
+    });
+    config
 }
 
 fn fixture_upstream_entry(upstream: &str, tools: HashMap<String, UpstreamTool>) -> UpstreamEntry {
@@ -568,6 +583,179 @@ async fn call_tool_requires_execute_scope_for_hidden_mcp_app_sibling_callbacks()
 }
 
 #[tokio::test]
+async fn call_tool_allows_execute_scope_for_hidden_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+
+    let result = Box::pin(running.service().call_tool_impl(
+        CallToolRequestParams::new("youtube_probe"),
+        scoped_context(running.peer().clone(), &["lab"]),
+    ))
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        !text.contains("\"kind\":\"forbidden\""),
+        "lab scope should pass the callback execute-scope gate, got {text}"
+    );
+    assert!(
+        text.contains("upstream `apps` is not connected"),
+        "allowed callback should reach selected upstream proxy routing, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_honors_route_scope_for_mcp_app_sibling_callbacks() {
+    let blocked_name: Arc<str> = Arc::from("blocked_apps");
+    let ui_tool = fixture_upstream_tool(
+        &blocked_name,
+        "youtube_search_ui",
+        Some("ui://blocked-apps/youtube-search.html"),
+    );
+    let blocked_probe = fixture_upstream_tool(&blocked_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "blocked_apps",
+        fixture_upstream_entry(
+            "blocked_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), blocked_probe),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool_and_upstreams(
+        true,
+        vec![
+            fixture_upstream_config("allowed_apps"),
+            fixture_upstream_config("blocked_apps"),
+        ],
+        pool,
+    )
+    .await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::protected_subset(
+            "allowed-only",
+            ["allowed_apps"],
+            ["gateway"],
+            true,
+        ),
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "not_found");
+    assert!(
+        !text.contains("blocked_apps"),
+        "route-scope denial should not reach the blocked upstream, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_uses_subject_scoped_route_for_oauth_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("oauth_apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://oauth-apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "oauth_apps",
+        fixture_upstream_entry(
+            "oauth_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager =
+        code_mode_manager_with_pool(true, fixture_oauth_upstream_config("oauth_apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+
+    let result = Box::pin(running.service().call_tool_impl(
+        CallToolRequestParams::new("youtube_probe"),
+        scoped_context(running.peer().clone(), &["lab"]),
+    ))
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        text.contains("upstream `oauth_apps` call failed"),
+        "OAuth callback should use subject-scoped call routing, got {text}"
+    );
+    assert!(
+        !text.contains("upstream `oauth_apps` is not connected"),
+        "OAuth callback must not use shared raw-pool routing, got {text}"
+    );
+}
+
+#[tokio::test]
 async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
     let upstream_name: Arc<str> = Arc::from("apps");
     let ui_tool = fixture_upstream_tool(
@@ -626,7 +814,100 @@ async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
 }
 
 #[tokio::test]
-async fn call_tool_blocks_ambiguous_destructive_mcp_app_sibling_callbacks() {
+async fn call_tool_blocks_destructive_direct_mcp_app_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let mut ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_delete_ui",
+        Some("ui://apps/youtube-delete.html"),
+    );
+    ui_tool.destructive = true;
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([("youtube_delete_ui".to_string(), ui_tool)]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_delete_ui"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "confirmation_required");
+}
+
+#[tokio::test]
+async fn call_tool_blocks_destructive_legacy_widget_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let mut delete_tool = fixture_upstream_tool(&upstream_name, "youtube_delete", None);
+    delete_tool.destructive = true;
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([("youtube_delete".to_string(), delete_tool)]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let mut server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    server.code_mode_widget_callbacks_enabled_for_test = true;
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_delete"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "confirmation_required");
+}
+
+#[tokio::test]
+async fn call_tool_rejects_ambiguous_mcp_app_sibling_callbacks_when_one_candidate_is_destructive() {
     let safe_name: Arc<str> = Arc::from("safe_apps");
     let safe_ui_tool = fixture_upstream_tool(
         &safe_name,
@@ -668,8 +949,15 @@ async fn call_tool_blocks_ambiguous_destructive_mcp_app_sibling_callbacks() {
     )
     .await;
 
-    let manager =
-        code_mode_manager_with_pool(true, fixture_upstream_config("safe_apps"), pool).await;
+    let manager = code_mode_manager_with_pool_and_upstreams(
+        true,
+        vec![
+            fixture_upstream_config("safe_apps"),
+            fixture_upstream_config("destructive_apps"),
+        ],
+        pool,
+    )
+    .await;
     let server = test_server(
         completion_test_registry(),
         Some(manager),
@@ -695,13 +983,98 @@ async fn call_tool_blocks_ambiguous_destructive_mcp_app_sibling_callbacks() {
 
     assert!(result.is_error.unwrap_or(false));
     let text = result.content[0].as_text().expect("text").text.as_str();
-    assert!(
-        text.contains("\"kind\":\"confirmation_required\""),
-        "{text}"
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "ambiguous_tool");
+    assert_eq!(
+        envelope["error"]["valid"],
+        serde_json::json!([
+            "destructive_apps::youtube_probe",
+            "safe_apps::youtube_probe"
+        ])
     );
-    assert!(
-        text.contains("not callable via the widget callback bypass"),
-        "{text}"
+}
+
+#[tokio::test]
+async fn call_tool_rejects_ambiguous_non_destructive_mcp_app_sibling_callbacks() {
+    let alpha_name: Arc<str> = Arc::from("alpha_apps");
+    let alpha_ui_tool = fixture_upstream_tool(
+        &alpha_name,
+        "youtube_search_ui",
+        Some("ui://alpha-apps/youtube-search.html"),
+    );
+    let alpha_probe = fixture_upstream_tool(&alpha_name, "youtube_probe", None);
+
+    let beta_name: Arc<str> = Arc::from("beta_apps");
+    let beta_ui_tool = fixture_upstream_tool(
+        &beta_name,
+        "youtube_search_ui",
+        Some("ui://beta-apps/youtube-search.html"),
+    );
+    let beta_probe = fixture_upstream_tool(&beta_name, "youtube_probe", None);
+
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "alpha_apps",
+        fixture_upstream_entry(
+            "alpha_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), alpha_ui_tool),
+                ("youtube_probe".to_string(), alpha_probe),
+            ]),
+        ),
+    )
+    .await;
+    pool.insert_entry_for_test(
+        "beta_apps",
+        fixture_upstream_entry(
+            "beta_apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), beta_ui_tool),
+                ("youtube_probe".to_string(), beta_probe),
+            ]),
+        ),
+    )
+    .await;
+
+    let manager = code_mode_manager_with_pool_and_upstreams(
+        true,
+        vec![
+            fixture_upstream_config("alpha_apps"),
+            fixture_upstream_config("beta_apps"),
+        ],
+        pool,
+    )
+    .await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "ambiguous_tool");
+    assert_eq!(
+        envelope["error"]["valid"],
+        serde_json::json!(["alpha_apps::youtube_probe", "beta_apps::youtube_probe"])
     );
 }
 
@@ -816,6 +1189,7 @@ async fn server_reads_current_pool_from_gateway_manager() {
             rmcp::model::LoggingLevel::Info,
         ))),
         route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+        code_mode_widget_callbacks_enabled_for_test: false,
     };
 
     assert!(server.current_upstream_pool().await.is_none());

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -363,6 +363,118 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
 }
 
 #[tokio::test]
+async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        !text.contains("hidden while code_mode mode is enabled"),
+        "MCP App sibling callbacks should reach upstream proxy routing, got {text}"
+    );
+    assert!(
+        text.contains("upstream_error"),
+        "test fixture has no live peer, so allowed callbacks should fail at proxy call, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let mut delete_tool = fixture_upstream_tool(&upstream_name, "youtube_delete", None);
+    delete_tool.destructive = true;
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_delete".to_string(), delete_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_delete"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(text.contains("\"kind\":\"confirmation_required\""), "{text}");
+    assert!(
+        text.contains("not callable via the widget callback bypass"),
+        "{text}"
+    );
+}
+
+#[tokio::test]
 async fn snapshot_catalog_hides_builtin_tools_when_code_mode_is_enabled() {
     let server = test_server(
         completion_test_registry(),

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -399,6 +399,106 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
 }
 
 #[tokio::test]
+async fn protected_code_mode_list_tools_hides_raw_siblings_and_disallowed_builtins() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::protected_subset(
+            "media",
+            ["apps"],
+            ["radarr"],
+            true,
+        ),
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = running
+        .service()
+        .list_tools_impl(None, context)
+        .await
+        .expect("list tools");
+    let names = result
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert!(!names.contains(&"radarr"));
+    assert!(!names.contains(&"sonarr"));
+    assert!(names.contains(&CODE_MODE_SEARCH_TOOL_NAME));
+    assert!(names.contains(&TOOL_EXECUTE_TOOL_NAME));
+    assert!(names.contains(&"youtube_search_ui"));
+    assert!(!names.contains(&"youtube_probe"));
+}
+
+#[tokio::test]
+async fn protected_list_tools_filters_disallowed_builtins_when_code_mode_is_off() {
+    let server = test_server(
+        completion_test_registry(),
+        Some(code_mode_manager(false).await),
+        crate::mcp::route_scope::McpRouteScope::protected_subset(
+            "media",
+            ["apps"],
+            ["radarr"],
+            false,
+        ),
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = running
+        .service()
+        .list_tools_impl(None, context)
+        .await
+        .expect("list tools");
+    let names = result
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"radarr"));
+    assert!(!names.contains(&"sonarr"));
+    assert!(!names.contains(&CODE_MODE_SEARCH_TOOL_NAME));
+    assert!(!names.contains(&TOOL_EXECUTE_TOOL_NAME));
+}
+
+#[tokio::test]
 async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() {
     let upstream_name: Arc<str> = Arc::from("apps");
     let ui_tool = fixture_upstream_tool(
@@ -452,6 +552,221 @@ async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() 
     assert!(
         text.contains("upstream_error"),
         "test fixture has no live peer, so allowed callbacks should fail at proxy call, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_allows_direct_mcp_app_ui_callbacks_with_read_scope() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([("youtube_search_ui".to_string(), ui_tool)]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+
+    let result = Box::pin(running.service().call_tool_impl(
+        CallToolRequestParams::new("youtube_search_ui"),
+        scoped_context(running.peer().clone(), &["lab:read"]),
+    ))
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        !text.contains("\"kind\":\"forbidden\""),
+        "direct MCP App UI tools are render entry points and should not use the sibling execute-scope gate, got {text}"
+    );
+    assert!(
+        text.contains("upstream_error"),
+        "test fixture has no live peer, so allowed UI callbacks should fail at proxy call, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_rejects_priority_zero_direct_mcp_app_ui_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([("youtube_search_ui".to_string(), ui_tool)]),
+        ),
+    )
+    .await;
+    let mut upstream = fixture_upstream_config("apps");
+    upstream.priority = 0.0;
+    let manager = code_mode_manager_with_pool(true, upstream, pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_search_ui"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "not_found");
+    assert!(
+        text.contains("hidden while code_mode mode is enabled"),
+        "priority-zero upstream must not be callable through the UI callback bypass, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_rejects_priority_zero_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let mut upstream = fixture_upstream_config("apps");
+    upstream.priority = 0.0;
+    let manager = code_mode_manager_with_pool(true, upstream, pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "not_found");
+    assert!(
+        text.contains("hidden while code_mode mode is enabled"),
+        "priority-zero upstream must not be callable through the sibling callback bypass, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_rejects_disabled_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let mut upstream = fixture_upstream_config("apps");
+    upstream.enabled = false;
+    let manager = code_mode_manager_with_pool(true, upstream, pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "not_found");
+    assert!(
+        text.contains("hidden while code_mode mode is enabled"),
+        "disabled upstream must not be callable through the sibling callback bypass, got {text}"
     );
 }
 
@@ -904,6 +1219,119 @@ async fn call_tool_blocks_destructive_legacy_widget_callbacks() {
     let text = result.content[0].as_text().expect("text").text.as_str();
     let envelope: Value = serde_json::from_str(text).expect("error envelope");
     assert_eq!(envelope["error"]["kind"], "confirmation_required");
+}
+
+#[tokio::test]
+async fn call_tool_allows_legacy_widget_callbacks_for_route_allowed_upstream() {
+    let upstream_name: Arc<str> = Arc::from("allowed_apps");
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "allowed_apps",
+        fixture_upstream_entry(
+            "allowed_apps",
+            HashMap::from([("youtube_probe".to_string(), plain_tool)]),
+        ),
+    )
+    .await;
+    let manager =
+        code_mode_manager_with_pool(true, fixture_upstream_config("allowed_apps"), pool).await;
+    let mut server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::protected_subset(
+            "allowed-only",
+            ["allowed_apps"],
+            ["gateway"],
+            true,
+        ),
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    server.code_mode_widget_callbacks_enabled_for_test = true;
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        text.contains("upstream_error"),
+        "legacy callback should reach the route-allowed upstream proxy, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_honors_route_scope_for_legacy_widget_callbacks() {
+    let blocked_name: Arc<str> = Arc::from("blocked_apps");
+    let blocked_probe = fixture_upstream_tool(&blocked_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "blocked_apps",
+        fixture_upstream_entry(
+            "blocked_apps",
+            HashMap::from([("youtube_probe".to_string(), blocked_probe)]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool_and_upstreams(
+        true,
+        vec![
+            fixture_upstream_config("allowed_apps"),
+            fixture_upstream_config("blocked_apps"),
+        ],
+        pool,
+    )
+    .await;
+    let mut server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::protected_subset(
+            "allowed-only",
+            ["allowed_apps"],
+            ["gateway"],
+            true,
+        ),
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    server.code_mode_widget_callbacks_enabled_for_test = true;
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    let envelope: Value = serde_json::from_str(text).expect("error envelope");
+    assert_eq!(envelope["error"]["kind"], "not_found");
+    assert!(
+        !text.contains("blocked_apps"),
+        "legacy callback should not reach a route-disallowed upstream, got {text}"
+    );
 }
 
 #[tokio::test]

--- a/crates/lab/src/mcp/in_process_peer.rs
+++ b/crates/lab/src/mcp/in_process_peer.rs
@@ -41,6 +41,8 @@ async fn connect_in_process_service_peer(
         peers: Arc::new(RwLock::new(Vec::new())),
         logging_level: Arc::new(AtomicU8::new(logging_level_rank(LoggingLevel::Emergency))),
         route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+        #[cfg(test)]
+        code_mode_widget_callbacks_enabled_for_test: false,
     };
     let service_name = service.name;
     let server_task = tokio::spawn(async move {

--- a/crates/lab/src/mcp/server.rs
+++ b/crates/lab/src/mcp/server.rs
@@ -39,6 +39,8 @@ pub struct LabMcpServer {
     pub logging_level: Arc<AtomicU8>,
     /// Visibility and dispatch constraints for this MCP route/session.
     pub(crate) route_scope: McpRouteScope,
+    #[cfg(test)]
+    pub(crate) code_mode_widget_callbacks_enabled_for_test: bool,
 }
 
 pub fn verify_upstream_subject_resolution_support() -> anyhow::Result<()> {
@@ -358,6 +360,7 @@ mod tests {
                 logging_level_rank(rmcp::model::LoggingLevel::Info),
             )),
             route_scope: crate::mcp::route_scope::McpRouteScope::Root,
+            code_mode_widget_callbacks_enabled_for_test: false,
         };
 
         let info = server.get_info();

--- a/crates/lab/src/mcp/services/fs.rs
+++ b/crates/lab/src/mcp/services/fs.rs
@@ -99,6 +99,7 @@ pub async fn dispatch(action: &str, params: Value) -> Result<Value, ToolError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
 

--- a/crates/lab/src/node/runtime.rs
+++ b/crates/lab/src/node/runtime.rs
@@ -205,6 +205,7 @@ impl NodeRuntime {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     #[test]
     fn runtime_flush_loop_has_unexpected_exit_observability() {

--- a/crates/lab/src/node/ws_client.rs
+++ b/crates/lab/src/node/ws_client.rs
@@ -1198,6 +1198,7 @@ fn stable_seed(node_id: &str, attempt: u32) -> u64 {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use std::sync::Arc;
 
@@ -1871,18 +1872,14 @@ mod tests {
         use base64::Engine as _;
         drop(base64::engine::general_purpose::STANDARD.encode(b"x"));
         let files = vec![json!({ "path": "a.md", "content": "hi" })];
-        let err = decode_component_files(Some(&files))
-            .err()
-            .expect("must reject");
+        let err = decode_component_files(Some(&files)).expect_err("must reject");
         assert_eq!(err.kind, "invalid_encoding");
     }
 
     #[test]
     fn decode_component_files_rejects_unknown_encoding() {
         let files = vec![json!({ "path": "a.md", "content": "hi", "encoding": "rot13" })];
-        let err = decode_component_files(Some(&files))
-            .err()
-            .expect("must reject");
+        let err = decode_component_files(Some(&files)).expect_err("must reject");
         assert_eq!(err.kind, "invalid_encoding");
     }
 
@@ -1890,9 +1887,8 @@ mod tests {
     fn decode_component_files_rejects_per_file_oversize() {
         let big = "a".repeat(17);
         let files = vec![json!({ "path": "big.bin", "content": big, "encoding": "utf8" })];
-        let err = decode_component_files_with_limits(Some(&files), 16, 64)
-            .err()
-            .expect("must reject");
+        let err =
+            decode_component_files_with_limits(Some(&files), 16, 64).expect_err("must reject");
         assert_eq!(err.kind, "content_too_large");
     }
 
@@ -1904,9 +1900,8 @@ mod tests {
         let files: Vec<Value> = (0..7)
             .map(|i| json!({ "path": format!("f{i}.bin"), "content": chunk, "encoding": "utf8" }))
             .collect();
-        let err = decode_component_files_with_limits(Some(&files), 16, 64)
-            .err()
-            .expect("must reject");
+        let err =
+            decode_component_files_with_limits(Some(&files), 16, 64).expect_err("must reject");
         assert_eq!(err.kind, "content_too_large");
     }
 
@@ -1927,18 +1922,14 @@ mod tests {
     #[test]
     fn decode_component_files_rejects_missing_path() {
         let files = vec![json!({ "content": "hi", "encoding": "utf8" })];
-        let err = decode_component_files(Some(&files))
-            .err()
-            .expect("must reject");
+        let err = decode_component_files(Some(&files)).expect_err("must reject");
         assert_eq!(err.kind, "invalid_param");
     }
 
     #[test]
     fn decode_component_files_rejects_missing_content() {
         let files = vec![json!({ "path": "a.md", "encoding": "utf8" })];
-        let err = decode_component_files(Some(&files))
-            .err()
-            .expect("must reject");
+        let err = decode_component_files(Some(&files)).expect_err("must reject");
         assert_eq!(err.kind, "invalid_param");
     }
 
@@ -1946,9 +1937,7 @@ mod tests {
     fn decode_component_files_rejects_malformed_base64() {
         let files =
             vec![json!({ "path": "a.bin", "content": "!!!not-b64!!!", "encoding": "base64" })];
-        let err = decode_component_files(Some(&files))
-            .err()
-            .expect("must reject");
+        let err = decode_component_files(Some(&files)).expect_err("must reject");
         assert_eq!(err.kind, "invalid_encoding");
     }
 }

--- a/crates/lab/src/oauth/local_relay.rs
+++ b/crates/lab/src/oauth/local_relay.rs
@@ -561,7 +561,7 @@ mod tests {
         );
         assert_eq!(
             suffix_path_for_request("/callback", "/callback"),
-            Ok("".to_string())
+            Ok(String::new())
         );
     }
 

--- a/crates/lab/src/oauth/upstream/encryption.rs
+++ b/crates/lab/src/oauth/upstream/encryption.rs
@@ -129,7 +129,7 @@ mod tests {
     fn test_key() -> EncryptionKey {
         load_key(&base64::Engine::encode(
             &base64::engine::general_purpose::STANDARD,
-            &[0u8; 32],
+            [0u8; 32],
         ))
         .unwrap()
     }
@@ -148,7 +148,7 @@ mod tests {
         let key1 = test_key();
         let key2 = load_key(&base64::Engine::encode(
             &base64::engine::general_purpose::STANDARD,
-            &[1u8; 32],
+            [1u8; 32],
         ))
         .unwrap();
         let (ct, nonce) = seal(&key1, b"secret").unwrap();
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn short_key_rejected() {
-        let short = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &[0u8; 16]);
+        let short = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, [0u8; 16]);
         assert!(load_key(&short).is_err());
     }
 

--- a/crates/lab/src/output/render.rs
+++ b/crates/lab/src/output/render.rs
@@ -854,7 +854,7 @@ mod tests {
         assert!(out.contains("radarr"));
         assert!(out.contains("unifi"));
         assert!(out.contains("✓") || out.contains("ok"));
-        assert!(out.contains("✗") || out.contains("x"));
+        assert!(out.contains("✗") || out.contains('x'));
     }
 
     #[test]
@@ -872,7 +872,7 @@ mod tests {
         assert!(out.contains("radarr"));
         assert!(out.contains("env"));
         assert!(out.contains("✓") || out.contains("ok"));
-        assert!(out.contains("✗") || out.contains("x"));
+        assert!(out.contains("✗") || out.contains('x'));
         // Per-check detail is hidden in default (grouped) mode.
         assert!(!out.contains("is set"));
         assert!(!out.contains("is missing"));

--- a/crates/lab/tests/acp_backend_contract.rs
+++ b/crates/lab/tests/acp_backend_contract.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic)]
+
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{Arc, OnceLock};

--- a/crates/lab/tests/code_mode_runner.rs
+++ b/crates/lab/tests/code_mode_runner.rs
@@ -415,7 +415,7 @@ fn code_mode_runner_round_trips_date_typed_array_and_array_buffer() {
     let mut stdout = BufReader::new(stdout);
 
     // Args carry a Date, an Int16Array([256, -1]), and an ArrayBuffer.
-    let code = r#"async () => {
+    let code = r"async () => {
         const buf = new Uint8Array([9, 8, 7]).buffer;
         const echoed = await callTool('test::echo', {
           when: new Date(0),
@@ -427,7 +427,7 @@ fn code_mode_runner_round_trips_date_typed_array_and_array_buffer() {
           ctor: echoed && echoed.constructor && echoed.constructor.name,
           values: Array.from(echoed)
         };
-    }"#;
+    }";
 
     writeln!(stdin, "{}", json!({ "type": "start", "code": code })).expect("write start");
 

--- a/crates/lab/tests/deploy_runner.rs
+++ b/crates/lab/tests/deploy_runner.rs
@@ -7,6 +7,7 @@
 //! correctly and respects the concurrency/abort knobs.
 
 #![cfg(feature = "deploy")]
+#![allow(clippy::panic)]
 #![allow(unused_qualifications)]
 
 use std::collections::HashMap;

--- a/crates/lab/tests/device_cli.rs
+++ b/crates/lab/tests/device_cli.rs
@@ -135,12 +135,14 @@ async fn master_client_applies_bearer_token_to_master_requests() {
 
 fn config_for_master(uri: &str) -> LabConfig {
     let parsed = Url::parse(uri).unwrap();
-    let mut config = LabConfig::default();
-    config.node = Some(NodePreferences {
-        controller: parsed.host_str().map(str::to_string),
-        log_retention_days: None,
-        role: None,
-    });
+    let mut config = LabConfig {
+        node: Some(NodePreferences {
+            controller: parsed.host_str().map(str::to_string),
+            log_retention_days: None,
+            role: None,
+        }),
+        ..LabConfig::default()
+    };
     config.mcp.port = parsed.port();
     config
 }

--- a/crates/lab/tests/device_runtime.rs
+++ b/crates/lab/tests/device_runtime.rs
@@ -77,11 +77,10 @@ async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
         ".claude.json"
     );
     assert!(
-        drained[0].payload["discovered_configs"][0]["content_hash"]
+        !drained[0].payload["discovered_configs"][0]["content_hash"]
             .as_str()
             .unwrap()
-            .len()
-            > 0
+            .is_empty()
     );
 }
 

--- a/crates/lab/tests/device_scan.rs
+++ b/crates/lab/tests/device_scan.rs
@@ -34,7 +34,7 @@ command = "lab"
     assert!(inventory.iter().all(|entry| {
         entry.servers.values().all(|server| {
             !server.fingerprint.is_empty()
-                && !matches!(server.transport.as_deref(), Some("lab") | Some("serve"))
+                && !matches!(server.transport.as_deref(), Some("lab" | "serve"))
         })
     }));
 }

--- a/crates/lab/tests/gateway_stdio_spawn.rs
+++ b/crates/lab/tests/gateway_stdio_spawn.rs
@@ -1,4 +1,5 @@
 //! Integration test: real stdio MCP child-process spawn + reaping.
+#![allow(clippy::panic)]
 //!
 //! These tests are `#[ignore]` (local-only, per repo convention) because they
 //! spawn real child processes and require the `labby` binary compiled into

--- a/crates/lab/tests/logs_api.rs
+++ b/crates/lab/tests/logs_api.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic)]
+
 use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/lab/tests/nodes_cli.rs
+++ b/crates/lab/tests/nodes_cli.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic)]
+
 use clap::Parser;
 use labby::cli::nodes::NodesCommand;
 use labby::cli::{Cli, Command};
@@ -180,11 +182,13 @@ fn serve_role_controller_parses() {
 
 fn config_for_master(uri: &str) -> LabConfig {
     let parsed = Url::parse(uri).unwrap();
-    let mut config = LabConfig::default();
-    config.node = Some(NodePreferences {
-        controller: parsed.host_str().map(str::to_string),
+    let mut config = LabConfig {
+        node: Some(NodePreferences {
+            controller: parsed.host_str().map(str::to_string),
+            ..Default::default()
+        }),
         ..Default::default()
-    });
+    };
     config.mcp.port = parsed.port();
     config
 }

--- a/crates/lab/tests/nodes_runtime.rs
+++ b/crates/lab/tests/nodes_runtime.rs
@@ -77,11 +77,10 @@ async fn non_master_runtime_uploads_discovered_ai_cli_inventory() {
         ".claude.json"
     );
     assert!(
-        drained[0].payload["discovered_configs"][0]["content_hash"]
+        !drained[0].payload["discovered_configs"][0]["content_hash"]
             .as_str()
             .unwrap()
-            .len()
-            > 0
+            .is_empty()
     );
 }
 

--- a/crates/lab/tests/upstream_oauth.rs
+++ b/crates/lab/tests/upstream_oauth.rs
@@ -478,6 +478,7 @@ async fn subject_lookup_survives_restart_for_saved_state() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
 async fn build_auth_client_logs_near_expiry_refresh_lifecycle_without_secrets() {
     let _tracing_lock = TRACING_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let buf = SharedBuf::default();

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -230,9 +230,10 @@ Destructive sibling callbacks return `confirmation_required`; callers should use
 the `execute` tool with `confirm:true` for destructive upstream actions.
 
 `LAB_CODE_MODE_WIDGET_CALLBACKS=1` remains as a broader legacy operator bypass.
-With that variable set, any known exposed upstream tool may pass the raw-tool
-gate while Code Mode is enabled. Leave it off unless a legacy widget depends on
-callbacks that cannot be represented by the same-upstream MCP App sibling rule.
+With that variable set, any known exposed non-destructive upstream tool may pass
+the raw-tool gate while Code Mode is enabled. It does not bypass destructive
+confirmation. Leave it off unless a legacy widget depends on callbacks that
+cannot be represented by the same-upstream MCP App sibling rule.
 
 ## Error Contract
 

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -209,18 +209,30 @@ Semantics:
 - The `CodeModeExecutionResponse` gains an optional `ui` field when a
   widget-bearing upstream result was captured.
 
-### Widget → host callbacks (opt-in)
+### Widget → host callbacks
 
-While the synthetic `search`/`execute` surface is active, raw upstream tools are
-hidden from `list_tools` and are not callable by name — so an interactive
-widget's callback (`tools/call` for an upstream tool) is rejected by default.
-Operators who want interactive widgets can set
-`LAB_CODE_MODE_WIDGET_CALLBACKS=1` (or `true`/`yes`) to let a call that names a
-known upstream tool fall through to the upstream proxy. This relaxes
-**callability**, never **visibility** — the tool stays out of `list_tools`. It is
-**off by default** because, on the same MCP session, it also lets the model
-invoke a known upstream tool by name. Leave it off unless interactive widgets are
-required.
+While the synthetic `search`/`execute` surface is active, raw upstream tools stay
+hidden from `list_tools`. MCP App tools that carry `_meta.ui.resourceUri` may
+still be advertised so the host can render the widget.
+
+A rendered MCP App can call back to its server only through host
+`callServerTool` / `tools/call`. Lab allows those callback calls through Code
+Mode's raw-tool gate only when all of these are true:
+
+- the requested tool is an exposed upstream tool, not a Lab built-in service;
+- the upstream is routable and allowed by the current protected route scope;
+- the same upstream exposes at least one MCP App UI tool;
+- the requested tool is not destructive.
+
+The callback exemption changes callability only. It does not put sibling tools
+back into `list_tools`, so the model-facing surface remains collapsed.
+Destructive sibling callbacks return `confirmation_required`; callers should use
+the `execute` tool with `confirm:true` for destructive upstream actions.
+
+`LAB_CODE_MODE_WIDGET_CALLBACKS=1` remains as a broader legacy operator bypass.
+With that variable set, any known exposed upstream tool may pass the raw-tool
+gate while Code Mode is enabled. Leave it off unless a legacy widget depends on
+callbacks that cannot be represented by the same-upstream MCP App sibling rule.
 
 ## Error Contract
 

--- a/docs/sessions/2026-06-12-code-mode-mcp-app-callbacks.md
+++ b/docs/sessions/2026-06-12-code-mode-mcp-app-callbacks.md
@@ -1,0 +1,228 @@
+---
+date: 2026-06-12 22:07:09 EDT
+repo: git@github.com:jmagar/lab.git
+branch: codex/code-mode-mcp-app-callbacks
+head: e2559d7b
+plan: docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md
+working directory: /home/jmagar/workspace/lab/.worktrees/code-mode-mcp-app-callbacks
+worktree: /home/jmagar/workspace/lab/.worktrees/code-mode-mcp-app-callbacks e2559d7b [codex/code-mode-mcp-app-callbacks]
+pr: "#118 Fix code mode MCP App sibling callbacks (https://github.com/jmagar/lab/pull/118)"
+---
+
+# Code mode MCP App callback session
+
+## User Request
+
+Create a plan to address the issue where code mode hides sibling upstream tools needed by rendered MCP Apps, then execute the plan with `$vibin:work-it`.
+
+## Session Overview
+
+Implemented and published PR #118 to let code mode MCP Apps call safe same-upstream sibling tools through `callServerTool` without re-exposing those tools in `tools/list`. The final pushed state blocks destructive direct UI, legacy-widget, and sibling callbacks, rejects ambiguous duplicate-name sibling matches, preserves route scope and execute-scope checks, and routes pre-resolved OAuth callbacks through subject-scoped routing.
+
+## Sequence of Events
+
+1. Wrote `docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md` for the host-side fix.
+2. Created clean worktree `/home/jmagar/workspace/lab/.worktrees/code-mode-mcp-app-callbacks` on branch `codex/code-mode-mcp-app-callbacks`.
+3. Added upstream sibling lookup, code-mode callback gate behavior, docs, and tests.
+4. Fixed unrelated all-features clippy drift already exposed by the branch verification gate.
+5. Rebased onto current `origin/main`, verified, pushed, and opened PR #118.
+6. Ran review waves, addressed findings around same-name upstream routing, execute scope, destructive callback bypasses, ambiguity ordering, OAuth subject-scoped routing, and missing handler tests.
+7. Refreshed the PR body with final verification and saved this session note.
+
+## Key Findings
+
+- Code mode hid raw upstream sibling tools while still exposing MCP-App UI tools, making rendered apps able to display but unable to call their server-side helpers.
+- `UpstreamPool::find_mcp_app_sibling_tool_candidates` now provides a narrow allowlist: same upstream, exposed target tool, routable upstream, and at least one exposed MCP App UI sibling (`crates/lab/src/dispatch/upstream/pool/tools.rs:150`).
+- `call_tool_impl` now classifies callback attempts before raw upstream fallback, binding allowed callbacks to the selected upstream and returning `ambiguous_tool`, `confirmation_required`, or `forbidden` where appropriate (`crates/lab/src/mcp/call_tool.rs:237`).
+- Pre-resolved OAuth callbacks now bypass the shared raw-pool call path and use subject-scoped routing (`crates/lab/src/mcp/call_tool_upstream.rs:66`, `crates/lab/src/mcp/call_tool_upstream.rs:126`, `crates/lab/src/mcp/call_tool_upstream.rs:308`).
+- PR comments had no actionable review threads; Codex review and CodeRabbit both reported usage/rate limits on the final pushed state.
+
+## Technical Decisions
+
+- Keep model-facing `tools/list` collapsed in code mode; only callback dispatch gets the scoped exception.
+- Require the sibling tool to be exposed by the upstream policy and paired with an exposed MCP-App UI tool on the same upstream.
+- Require `lab` or `lab:admin` scope for hidden sibling callbacks, matching the execute-scope boundary.
+- Reject destructive callbacks instead of trying to run confirmation elicitation through widget callbacks; the message points callers to `execute` with confirmation.
+- Prefer ambiguity over destructive classification when duplicate sibling matches exist, because the caller has not identified which upstream should own the call.
+- Add a `cfg(test)` server flag for the legacy widget callback branch instead of mutating process environment in Rust 2024 tests.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | crates/lab/src/acp/providers.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/acp/runtime.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/api/nodes/fleet.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/api/services/acp.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli/doctor.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli/gateway.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli/oauth.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli/serve.rs | - | Test-only server field initialization and cleanup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/cli/setup.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/config.rs | - | Code mode/config cleanup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/config/env_merge.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/acp/persistence.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/doctor.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/doctor/proxy.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/doctor/system.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/fs/dispatch.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/code_mode/tests_broker.rs | - | Code mode test adjustment | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/code_mode/tests_ids_schema.rs | - | Code mode test adjustment | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs | - | Code mode test adjustment | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/config.rs | - | Code mode config support | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/discovery/opencode.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/dispatch.rs | - | Code mode dispatch support | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/manager/tests/cleanup.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/manager/tests/code_mode.rs | - | Code mode test coverage | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/gateway/manager/tests/lifecycle.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/logs/metrics/tests.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/marketplace.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/marketplace/acp_dispatch.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/marketplace/backends/codex.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/marketplace/client.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/marketplace/dispatch.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/node/send.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/setup/bootstrap.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/setup/dispatch.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/stash/store.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/http_client.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/pool/ensure.rs | - | Upstream pool cleanup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/pool/prompts_list.rs | - | Test-only server field initialization | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/pool/resources_read.rs | - | Test-only server field initialization and cleanup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/pool/tools.rs | - | MCP App UI listing and sibling candidate lookup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/process_guard.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/dispatch/upstream/types.rs | - | Upstream type cleanup | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/call_tool.rs | - | Callback gate, ambiguity/destructive/scope handling, selected-upstream binding | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/call_tool_codemode/tests.rs | - | Code mode test adjustments | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/call_tool_upstream.rs | - | Pre-resolved OAuth callback routing | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/handlers_prompts.rs | - | Test-only server field initialization | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/handlers_resources.rs | - | Test-only server field initialization | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/handlers_tools/tests.rs | - | Handler-level callback safety and routing tests | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/in_process_peer.rs | - | Test-only server field initialization | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/server.rs | - | Test-only server flag for legacy widget callback branch | `origin/main...HEAD` diff |
+| modified | crates/lab/src/mcp/services/fs.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/node/runtime.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/node/ws_client.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/oauth/local_relay.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/oauth/upstream/encryption.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/src/output/render.rs | - | Clippy cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/acp_backend_contract.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/code_mode_runner.rs | - | Code mode test adjustment | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/deploy_runner.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/device_cli.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/device_runtime.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/device_scan.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/gateway_stdio_spawn.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/logs_api.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/nodes_cli.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/nodes_runtime.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | crates/lab/tests/upstream_oauth.rs | - | Test cleanup from all-features gate | `origin/main...HEAD` diff |
+| modified | docs/dev/CODE_MODE.md | - | Document code-mode MCP App callback rules | `origin/main...HEAD` diff |
+| created | docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md | - | Execution plan | `origin/main...HEAD` diff |
+| modified | docs/surfaces/MCP.md | - | Document MCP surface callback behavior | `origin/main...HEAD` diff |
+
+## Beads Activity
+
+No bead activity observed. `bd list --all --sort updated --reverse --limit 100 --json` returned only historical closed issues, and `tail -200 .beads/interactions.jsonl` returned `none`.
+
+## Repository Maintenance
+
+### Plans
+
+`find docs/plans docs/superpowers/plans -maxdepth 2 -type f` found the completed plan in `docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md`. I did not move it because the save workflow only names `docs/plans/complete/`, and this repo currently has many active historical superpowers plans without a matching `docs/superpowers/plans/complete/` convention.
+
+### Beads
+
+No bead was created or closed during this session. There is no observed relevant open bead to close.
+
+### Worktrees and branches
+
+`git worktree list --porcelain` showed active worktrees for this branch plus unrelated branches: `codex/feature-slice-cleanup`, `codex/fix-code-mode-mcp-app-callbacks`, `codex/readme-rewrite`, `main`, and `codex/settings-page-config-plan`. I did not remove any worktree or branch because they are separate active contexts or protected base branches.
+
+### Stale docs
+
+`docs/dev/CODE_MODE.md` and `docs/surfaces/MCP.md` were updated in the implementation commits to reflect the new callback rule. No additional stale-doc update was found during the closeout pass.
+
+### Transparency
+
+The branch was clean before writing this session note. The PR body was updated through GitHub to reflect final verification; that did not change local files.
+
+## Tools and Skills Used
+
+- Shell commands: git, cargo, nextest, clippy, formatter, find, bead reads, and date/status inspection.
+- File tools: `apply_patch` for the plan, implementation fixes, and this session artifact.
+- GitHub connector: created and inspected PR #118, fetched comments/reviews/threads, and updated the PR body.
+- Skills/plugins: `superpowers:writing-plans` for the plan, `vibin:work-it` for execution flow, and `vibin:save-to-md` for session closeout.
+- Subagents/reviewers: implementation and review waves produced findings that drove the `a7ff3abb` and `e2559d7b` follow-up commits.
+- External review bots: Codex review and CodeRabbit both reported usage/rate limits; no actionable review threads were present.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `cargo fmt --all --check` | passed |
+| `cargo test -p labby call_tool_ --all-features` | passed; 24 tests passed |
+| `cargo test -p labby mcp_app_sibling_lookup --all-features` | passed; 2 tests passed |
+| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | passed |
+| `cargo nextest run --workspace --all-features` | passed; 1942 tests run, 1942 passed, 27 skipped |
+| `git push` | pushed `e2559d7b` to `origin/codex/code-mode-mcp-app-callbacks` |
+| GitHub PR comment/review/thread fetches | no actionable review threads; bot comments were rate/usage-limit notices |
+| `bd list --all --sort updated --reverse --limit 100 --json` | historical closed issues only |
+| `tail -200 .beads/interactions.jsonl` | `none` |
+
+## Errors Encountered
+
+- `cargo fmt --all --check` initially failed on formatting in `call_tool_upstream.rs` and an expected JSON array test assertion; `cargo fmt --all` fixed it.
+- A first draft of the legacy widget callback test used unsafe process-env mutation, which is rejected by the crate's unsafe-code lint under tests. Replaced it with a `cfg(test)` per-server flag.
+- Starting two cargo checks in parallel caused cargo build-lock waiting. The commands serialized and completed successfully.
+- CodeRabbit and Codex review bots could not run final external reviews due usage/rate limits; direct PR thread inspection found no actionable review comments.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| MCP App in code mode | Rendered UI could be exposed while its safe sibling tools were hidden and unreachable. | Safe same-upstream sibling callbacks can dispatch while remaining hidden from `tools/list`. |
+| Same-name upstream tools | A callback could be approved for one upstream but fall through to another raw same-name upstream. | Callback dispatch binds to the selected upstream or rejects ambiguity. |
+| Destructive callbacks | Direct UI and legacy-widget callbacks could bypass confirmation. | Destructive callback paths return `confirmation_required`. |
+| Hidden sibling callbacks | Review found missing execute-scope enforcement risk. | Hidden sibling callbacks require `lab` or `lab:admin` scope. |
+| OAuth upstream callbacks | Pre-resolved OAuth callbacks could use the shared raw pool. | Pre-resolved OAuth callbacks use subject-scoped routing. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo fmt --all --check` | Rust formatting clean | exited 0 | pass |
+| `cargo test -p labby call_tool_ --all-features` | callback handler tests pass | 24 passed | pass |
+| `cargo test -p labby mcp_app_sibling_lookup --all-features` | sibling lookup tests pass | 2 passed | pass |
+| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | no clippy warnings | exited 0 | pass |
+| `cargo nextest run --workspace --all-features` | all-features workspace tests pass | 1942 passed, 27 skipped | pass |
+
+## Risks and Rollback
+
+Risk is concentrated in MCP upstream callback routing. Rollback is to revert PR #118 or specifically revert `e2559d7b` plus earlier callback commits if post-merge behavior differs from expected host routing. Destructive callbacks are intentionally conservative and can be loosened later only with a confirmed safe confirmation channel.
+
+## Decisions Not Taken
+
+- Did not expose sibling tools in `tools/list`; that would undo code mode's collapsed model-facing surface.
+- Did not allow destructive widget callbacks through elicitation; widget-originated callbacks do not provide the same explicit confirmation path as `execute`.
+- Did not move the superpowers plan into a new `complete/` directory because no matching convention was observed for `docs/superpowers/plans`.
+
+## References
+
+- PR #118: https://github.com/jmagar/lab/pull/118
+- Downstream mitigation PR from the original issue: https://github.com/jmagar/ytdl-mcp/pull/4
+- Plan: `docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md`
+- Code mode docs: `docs/dev/CODE_MODE.md`
+- MCP surface docs: `docs/surfaces/MCP.md`
+
+## Open Questions
+
+- External CodeRabbit/Codex bot review was rate-limited on the final pushed state, so there is no final third-party bot pass to summarize.
+- CI status was not fetched after the final push in this session artifact; local verification passed all required Rust gates.
+
+## Next Steps
+
+1. Watch PR #118 CI on GitHub and merge when checks are green.
+2. If desired after CodeRabbit limits reset, trigger `@coderabbitai review` for one more external pass.
+3. After merge, validate a live `ytdl-mcp` panel in code mode: `youtube_search_ui` should render, safe Probe/Audio/Video sibling actions should dispatch, and destructive callbacks should be rejected unless run through `execute` with confirmation.

--- a/docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md
+++ b/docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md
@@ -1,0 +1,705 @@
+# Code Mode MCP App Callbacks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP Apps rendered through Lab's Code Mode surface able to call exposed sibling tools on the same upstream without re-exposing ordinary raw tools to the model-facing `tools/list`.
+
+**Architecture:** Keep Code Mode's collapsed model surface intact: `list_tools` continues to show only synthetic `search`/`execute` plus widget-bearing MCP App tools. Add a narrow `tools/call` bypass at the existing raw-tool hidden gate that allows callbacks only when the requested upstream tool is exposed, routable, non-destructive, route-scope-allowed, and belongs to an upstream that also exposes an MCP App UI tool. Preserve the existing opt-in `LAB_CODE_MODE_WIDGET_CALLBACKS=1` legacy bypass as the broader operator escape hatch.
+
+**Tech Stack:** Rust 2024, rmcp, Tokio, serde_json, Lab `UpstreamPool`, Lab MCP `call_tool` and `list_tools` handlers, `cargo test`.
+
+---
+
+## File Structure
+
+- Modify `crates/lab/src/dispatch/upstream/pool/tools.rs`
+  - Owns upstream tool catalog lookup helpers. Add or verify a helper that finds same-upstream MCP App sibling callback candidates without importing `mcp/` types.
+- Modify `crates/lab/src/mcp/call_tool.rs`
+  - Owns the Code Mode raw-tool hidden gate in MCP `tools/call`. Add or verify the narrow callback bypass here, before returning `tool hidden while code_mode mode is enabled`.
+- Modify `crates/lab/src/mcp/handlers_tools/tests.rs`
+  - Owns MCP tool-list and tool-call visibility tests. Add regression coverage for direct failure, same-upstream sibling success path, ambiguity, destructive denial, and continued hidden `tools/list` behavior.
+- Modify `docs/dev/CODE_MODE.md`
+  - Document the default safe MCP App callback behavior and clarify that `LAB_CODE_MODE_WIDGET_CALLBACKS=1` is now only the broad legacy bypass.
+- Modify `docs/surfaces/MCP.md`
+  - Document host-visible behavior: widget-bearing tools may stay visible, sibling callback tools stay hidden from `tools/list`, and callback calls are scoped.
+
+## Current Evidence To Recheck
+
+Before editing, inspect the live checkout because parts of this fix may already be present:
+
+```bash
+rg -n "find_mcp_app_sibling|tool_has_mcp_app_ui_resource|widget_callback|hidden while code_mode" crates/lab/src
+sed -n '210,305p' crates/lab/src/mcp/call_tool.rs
+sed -n '150,185p' crates/lab/src/dispatch/upstream/pool/tools.rs
+sed -n '304,425p' crates/lab/src/mcp/handlers_tools/tests.rs
+```
+
+Expected: either no sibling callback support exists yet, or the current branch already contains a partial implementation that must be hardened against the tests below.
+
+### Task 1: Add Upstream-Pool MCP App Sibling Lookup
+
+**Files:**
+- Modify: `crates/lab/src/dispatch/upstream/pool/tools.rs`
+- Test: `crates/lab/src/dispatch/upstream/pool/tools.rs`
+
+- [ ] **Step 1: Write the failing pool tests**
+
+Append these tests inside the existing `#[cfg(test)] mod tests` in `crates/lab/src/dispatch/upstream/pool/tools.rs`. If a similarly named test already exists, replace it with this fuller version so it covers exposure policy, route scope, and ambiguous same-name tools.
+
+```rust
+#[tokio::test]
+async fn mcp_app_sibling_lookup_requires_exposed_ui_tool_on_same_upstream() {
+    let pool = UpstreamPool::new();
+
+    let apps_name: Arc<str> = Arc::from("apps");
+    let mut apps_tools =
+        test_upstream_tools(&apps_name, &["youtube_search_ui", "youtube_probe"]);
+    let ui_meta = Meta(serde_json::Map::from_iter([(
+        "ui".to_string(),
+        serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
+    )]));
+    apps_tools
+        .get_mut("youtube_search_ui")
+        .expect("ui tool")
+        .tool
+        .meta = Some(ui_meta);
+    let apps_entry = healthy_in_process_entry(Arc::clone(&apps_name), apps_tools);
+    pool.catalog
+        .write()
+        .await
+        .insert("apps".to_string(), apps_entry);
+
+    let plain_name: Arc<str> = Arc::from("plain");
+    let plain_tools = test_upstream_tools(&plain_name, &["youtube_probe"]);
+    let plain_entry = healthy_in_process_entry(Arc::clone(&plain_name), plain_tools);
+    pool.catalog
+        .write()
+        .await
+        .insert("plain".to_string(), plain_entry);
+
+    let candidates = pool
+        .find_mcp_app_sibling_tool_candidates("youtube_probe", None)
+        .await;
+    let upstreams = candidates
+        .iter()
+        .map(|(upstream, _)| upstream.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(upstreams, vec!["apps"]);
+
+    let allowed = BTreeSet::from(["plain".to_string()]);
+    assert!(
+        pool.find_mcp_app_sibling_tool_candidates("youtube_probe", Some(&allowed))
+            .await
+            .is_empty(),
+        "route scope must still constrain MCP App callback siblings"
+    );
+}
+
+#[tokio::test]
+async fn mcp_app_sibling_lookup_respects_exposure_policy() {
+    let pool = UpstreamPool::new();
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let mut tools = test_upstream_tools(
+        &upstream_name,
+        &["youtube_search_ui", "youtube_probe", "internal_delete"],
+    );
+    tools
+        .get_mut("youtube_search_ui")
+        .expect("ui tool")
+        .tool
+        .meta = Some(Meta(serde_json::Map::from_iter([(
+            "ui".to_string(),
+            serde_json::json!({ "resourceUri": "ui://apps/youtube-search.html" }),
+        )])));
+    let mut entry = healthy_in_process_entry(Arc::clone(&upstream_name), tools);
+    entry.exposure_policy = ToolExposurePolicy::from_patterns(vec![
+        "youtube_search_ui".to_string(),
+        "youtube_probe".to_string(),
+    ])
+    .expect("policy");
+    pool.catalog
+        .write()
+        .await
+        .insert("apps".to_string(), entry);
+
+    assert_eq!(
+        pool.find_mcp_app_sibling_tool_candidates("youtube_probe", None)
+            .await
+            .len(),
+        1
+    );
+    assert!(
+        pool.find_mcp_app_sibling_tool_candidates("internal_delete", None)
+            .await
+            .is_empty(),
+        "unexposed sibling tools must remain uncallable"
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test -p lab mcp_app_sibling_lookup --all-features
+```
+
+Expected before implementation: compile failure for missing `find_mcp_app_sibling_tool_candidates`, or assertion failure showing the helper does not filter correctly.
+
+- [ ] **Step 3: Implement the lookup helper**
+
+In `crates/lab/src/dispatch/upstream/pool/tools.rs`, add this helper near `find_tool_candidates`. Keep it in the dispatch layer and do not import anything from `crate::mcp`.
+
+```rust
+/// Return exposed tools whose upstream also exposes at least one MCP App UI tool.
+///
+/// Code Mode keeps ordinary raw tools out of `list_tools`, but a rendered MCP
+/// App can only talk back to its server through host `callServerTool`
+/// callbacks. This lookup is the narrow callback allowlist: the requested
+/// tool must still be exposed by its upstream, and that same upstream must
+/// expose an MCP App UI tool.
+pub async fn find_mcp_app_sibling_tool_candidates(
+    &self,
+    tool_name: &str,
+    allowed: Option<&BTreeSet<String>>,
+) -> Vec<(String, UpstreamTool)> {
+    let catalog = self.catalog.read().await;
+    let mut matches = Vec::new();
+    for (upstream_name, entry) in catalog.iter() {
+        if !upstream_allowed(allowed, upstream_name) || !entry.tool_health.is_routable() {
+            continue;
+        }
+        let Some(tool) = entry.tools.get(tool_name) else {
+            continue;
+        };
+        if !entry.exposure_policy.matches(tool.tool.name.as_ref()) {
+            continue;
+        }
+        let has_ui_sibling = entry.tools.values().any(|candidate| {
+            entry.exposure_policy.matches(candidate.tool.name.as_ref())
+                && tool_has_mcp_app_ui_resource(candidate)
+        });
+        if has_ui_sibling {
+            matches.push((upstream_name.clone(), tool.clone()));
+        }
+    }
+    matches.sort_by(|a, b| a.0.cmp(&b.0));
+    matches
+}
+```
+
+Also ensure `tool_has_mcp_app_ui_resource` exists in the same file:
+
+```rust
+pub(crate) fn tool_has_mcp_app_ui_resource(tool: &UpstreamTool) -> bool {
+    tool.tool
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.0.get("ui"))
+        .and_then(|ui| ui.get("resourceUri"))
+        .and_then(Value::as_str)
+        .is_some_and(|uri| uri.starts_with("ui://"))
+}
+```
+
+If `BTreeSet` or `Value` is not already in scope, add:
+
+```rust
+use std::collections::BTreeSet;
+use serde_json::Value;
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+cargo test -p lab mcp_app_sibling_lookup --all-features
+```
+
+Expected: both `mcp_app_sibling_lookup_*` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lab/src/dispatch/upstream/pool/tools.rs
+git commit -m "test: cover mcp app sibling lookup"
+```
+
+### Task 2: Allow Narrow MCP App Sibling Callbacks Through Code Mode Gate
+
+**Files:**
+- Modify: `crates/lab/src/mcp/call_tool.rs`
+- Test: `crates/lab/src/mcp/handlers_tools/tests.rs`
+
+- [ ] **Step 1: Write failing MCP call-tool tests**
+
+Add these tests to `crates/lab/src/mcp/handlers_tools/tests.rs`, near the existing Code Mode visibility tests. If `call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden` already exists, replace it with this version and add the additional destructive denial test.
+
+```rust
+#[tokio::test]
+async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_probe"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(
+        !text.contains("hidden while code_mode mode is enabled"),
+        "MCP App sibling callbacks should reach upstream proxy routing, got {text}"
+    );
+    assert!(
+        text.contains("upstream_error"),
+        "test fixture has no live peer, so allowed callbacks should fail at proxy call, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let mut delete_tool = fixture_upstream_tool(&upstream_name, "youtube_delete", None);
+    delete_tool.destructive = true;
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_delete".to_string(), delete_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = Box::pin(
+        running
+            .service()
+            .call_tool_impl(CallToolRequestParams::new("youtube_delete"), context),
+    )
+    .await
+    .expect("call tool result");
+
+    assert!(result.is_error.unwrap_or(false));
+    let text = result.content[0].as_text().expect("text").text.as_str();
+    assert!(text.contains("\"kind\":\"confirmation_required\""), "{text}");
+    assert!(
+        text.contains("not callable via the widget callback bypass"),
+        "{text}"
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test -p lab call_tool_ --all-features
+```
+
+Expected before implementation: `call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden` fails with `hidden while code_mode mode is enabled`, and the destructive callback test either reaches the proxy or returns the wrong error kind.
+
+- [ ] **Step 3: Implement the narrow bypass**
+
+In `crates/lab/src/mcp/call_tool.rs`, replace the `if self.code_mode_visibility().await.hides_raw_tools()` block with this logic. Keep it after the built-in service visibility/action checks and before admin-scope/destructive built-in checks.
+
+```rust
+if self.code_mode_visibility().await.hides_raw_tools() {
+    let widget_callback = if svc.is_none()
+        && let Some(pool) = self.current_upstream_pool().await
+    {
+        let allowed = self.route_scope.allowed_upstreams();
+        if crate::config::code_mode_widget_callbacks_enabled() {
+            pool.find_tool_allowed(&service, allowed)
+                .await
+                .map(|(_, tool)| ("upstream_widget_callback_legacy", Some(tool)))
+        } else if let Some((_, tool)) = pool
+            .find_tool_allowed(&service, allowed)
+            .await
+            .filter(|(_, tool)| {
+                crate::dispatch::upstream::pool::tool_has_mcp_app_ui_resource(tool)
+            })
+        {
+            Some(("upstream_widget_callback", Some(tool)))
+        } else {
+            let candidates = pool
+                .find_mcp_app_sibling_tool_candidates(&service, allowed)
+                .await;
+            if candidates.is_empty() {
+                None
+            } else {
+                let tool = (candidates.len() == 1)
+                    .then(|| candidates.into_iter().next().expect("checked len").1);
+                Some(("upstream_widget_sibling_callback", tool))
+            }
+        }
+    } else {
+        None
+    };
+    match widget_callback {
+        Some((_, Some(tool))) if tool.destructive => {
+            let envelope = build_error(
+                &service,
+                &action,
+                "confirmation_required",
+                &format!(
+                    "destructive upstream tool `{service}` is not callable via the \
+                     widget callback bypass — use the `execute` tool with confirm:true"
+                ),
+            );
+            return Ok(CallToolResult::error(vec![Content::text(
+                envelope.to_string(),
+            )]));
+        }
+        Some((route, _)) => {
+            tracing::info!(
+                surface = "mcp",
+                service = %service,
+                action = %action,
+                route,
+                "code_mode raw-tool gate bypassed for MCP App widget callback"
+            );
+        }
+        None => {
+            let envelope = build_error(
+                &service,
+                &action,
+                "not_found",
+                &format!("tool `{service}` is hidden while code_mode mode is enabled"),
+            );
+            return Ok(CallToolResult::error(vec![Content::text(
+                envelope.to_string(),
+            )]));
+        }
+    }
+}
+```
+
+Why `candidates.len() == 1`: if two allowed upstreams expose the same sibling tool name and both have UI apps, Lab cannot prove which rendered app originated the callback from `tools/call` alone. In that ambiguous case, the helper returns multiple candidates, this block leaves `tool` as `None`, and the call is allowed to reach normal upstream routing only if that existing routing can disambiguate; otherwise it should fail safely with the existing upstream ambiguity/error path.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+cargo test -p lab call_tool_ --all-features
+```
+
+Expected: sibling callback and destructive denial tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lab/src/mcp/call_tool.rs crates/lab/src/mcp/handlers_tools/tests.rs
+git commit -m "fix: allow safe mcp app callbacks in code mode"
+```
+
+### Task 3: Prove Tool Visibility Stays Collapsed
+
+**Files:**
+- Modify: `crates/lab/src/mcp/handlers_tools/tests.rs`
+
+- [ ] **Step 1: Write the visibility regression test**
+
+Ensure this test exists in `crates/lab/src/mcp/handlers_tools/tests.rs`; replace any weaker version with this exact assertion set.
+
+```rust
+#[tokio::test]
+async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() {
+    let upstream_name: Arc<str> = Arc::from("apps");
+    let ui_tool = fixture_upstream_tool(
+        &upstream_name,
+        "youtube_search_ui",
+        Some("ui://apps/youtube-search.html"),
+    );
+    let plain_tool = fixture_upstream_tool(&upstream_name, "youtube_probe", None);
+    let pool = Arc::new(UpstreamPool::new());
+    pool.insert_entry_for_test(
+        "apps",
+        fixture_upstream_entry(
+            "apps",
+            HashMap::from([
+                ("youtube_search_ui".to_string(), ui_tool),
+                ("youtube_probe".to_string(), plain_tool),
+            ]),
+        ),
+    )
+    .await;
+    let manager = code_mode_manager_with_pool(true, fixture_upstream_config("apps"), pool).await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = running
+        .service()
+        .list_tools_impl(None, context)
+        .await
+        .expect("list tools");
+    let names = result
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"youtube_search_ui"));
+    assert!(!names.contains(&"youtube_probe"));
+    assert!(names.contains(&CODE_MODE_SEARCH_TOOL_NAME));
+    assert!(names.contains(&TOOL_EXECUTE_TOOL_NAME));
+    assert!(!names.contains(&"radarr"));
+}
+```
+
+- [ ] **Step 2: Run test to verify behavior**
+
+Run:
+
+```bash
+cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
+```
+
+Expected: PASS. If `youtube_probe` appears in `names`, the implementation accidentally widened model visibility and must be fixed before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lab/src/mcp/handlers_tools/tests.rs
+git commit -m "test: keep code mode app siblings hidden from listings"
+```
+
+### Task 4: Update Code Mode and MCP Surface Docs
+
+**Files:**
+- Modify: `docs/dev/CODE_MODE.md`
+- Modify: `docs/surfaces/MCP.md`
+
+- [ ] **Step 1: Update `docs/dev/CODE_MODE.md` widget callback section**
+
+Replace the `### Widget → host callbacks (opt-in)` section with:
+
+```markdown
+### Widget → host callbacks
+
+While the synthetic `search`/`execute` surface is active, raw upstream tools stay
+hidden from `list_tools`. MCP App tools that carry `_meta.ui.resourceUri` may
+still be advertised so the host can render the widget.
+
+A rendered MCP App can call back to its server only through host
+`callServerTool` / `tools/call`. Lab allows those callback calls through Code
+Mode's raw-tool gate only when all of these are true:
+
+- the requested tool is an exposed upstream tool, not a Lab built-in service;
+- the upstream is routable and allowed by the current protected route scope;
+- the same upstream exposes at least one MCP App UI tool;
+- the requested tool is not destructive.
+
+The callback exemption changes callability only. It does not put sibling tools
+back into `list_tools`, so the model-facing surface remains collapsed.
+Destructive sibling callbacks return `confirmation_required`; callers should use
+the `execute` tool with `confirm:true` for destructive upstream actions.
+
+`LAB_CODE_MODE_WIDGET_CALLBACKS=1` remains as a broader legacy operator bypass.
+With that variable set, any known exposed upstream tool may pass the raw-tool
+gate while Code Mode is enabled. Leave it off unless a legacy widget depends on
+callbacks that cannot be represented by the same-upstream MCP App sibling rule.
+```
+
+- [ ] **Step 2: Update `docs/surfaces/MCP.md` Code Mode MCP Apps section**
+
+Add this paragraph after the Code Mode MCP Apps resource description:
+
+```markdown
+For upstream MCP Apps, Code Mode keeps widget-bearing tools host-visible so the
+host can render their `_meta.ui.resourceUri` resources. Ordinary sibling tools
+remain hidden from `tools/list`, but a rendered app's `callServerTool` callback
+may call an exposed, non-destructive sibling tool on the same routable upstream.
+The exemption is scoped to callback callability and route scope; it does not
+expand the model-facing catalog.
+```
+
+- [ ] **Step 3: Run doc sanity checks**
+
+Run:
+
+```bash
+rg -n "Widget → host callbacks|same-upstream MCP App sibling|LAB_CODE_MODE_WIDGET_CALLBACKS|callServerTool" docs/dev/CODE_MODE.md docs/surfaces/MCP.md
+```
+
+Expected: output includes the new default callback behavior and the legacy env-var note.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/dev/CODE_MODE.md docs/surfaces/MCP.md
+git commit -m "docs: document code mode mcp app callbacks"
+```
+
+### Task 5: Full Verification and Issue Closure Evidence
+
+**Files:**
+- No code files unless earlier tasks exposed a bug.
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+cargo test -p lab mcp_app_sibling_lookup --all-features
+cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
+cargo test -p lab call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features
+cargo test -p lab call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run all MCP handler tests**
+
+Run:
+
+```bash
+cargo test -p lab mcp::handlers_tools --all-features
+cargo test -p lab mcp::call_tool_codemode --all-features
+```
+
+Expected: all tests pass. If the module path filter does not match in this workspace, run:
+
+```bash
+cargo test -p lab handlers_tools --all-features
+cargo test -p lab call_tool_codemode --all-features
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run default all-features verification**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo nextest run --workspace --all-features
+cargo clippy --workspace --all-features --all-targets -- -D warnings
+```
+
+Expected: formatting is clean, nextest passes, and clippy emits no warnings.
+
+- [ ] **Step 4: Capture live-style reproduction notes**
+
+Use this issue comment body after tests pass:
+
+```markdown
+Implemented and verified in Lab:
+
+- Code Mode still hides ordinary raw upstream tools from `tools/list`.
+- MCP App tools with `_meta.ui.resourceUri` remain host-visible so widgets render.
+- A rendered app can call an exposed, non-destructive sibling tool on the same allowed upstream through `callServerTool`.
+- Destructive sibling callbacks are rejected with `confirmation_required`.
+- `LAB_CODE_MODE_WIDGET_CALLBACKS=1` remains as the broad legacy escape hatch, but is no longer required for normal same-upstream MCP App callbacks.
+
+Verification:
+
+- `cargo test -p lab mcp_app_sibling_lookup --all-features`
+- `cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features`
+- `cargo test -p lab call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features`
+- `cargo test -p lab call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features`
+- `cargo nextest run --workspace --all-features`
+```
+
+- [ ] **Step 5: Final commit if any verification-only docs changed**
+
+```bash
+git status --short
+git add docs/dev/CODE_MODE.md docs/surfaces/MCP.md crates/lab/src/dispatch/upstream/pool/tools.rs crates/lab/src/mcp/call_tool.rs crates/lab/src/mcp/handlers_tools/tests.rs
+git commit -m "fix: restore mcp app callbacks under code mode"
+```
+
+Expected: if all prior task commits were already made and `git status --short` is clean, skip this commit.
+
+## Self-Review
+
+Spec coverage:
+- Reproduces the ytdl-mcp failure mode: `youtube_search_ui` is visible, `youtube_probe`/`youtube_download` are hidden from `tools/list`, and callback `tools/call` can reach exposed same-upstream siblings.
+- Preserves Code Mode's model-facing collapse to `search`/`execute` plus MCP App UI tools.
+- Keeps route scope, exposure policy, health/routability, and destructive confirmation boundaries intact.
+- Documents the new default callback behavior and the remaining `LAB_CODE_MODE_WIDGET_CALLBACKS=1` escape hatch.
+
+Placeholder scan:
+- No task contains `TBD`, `TODO`, "implement later", or "write tests for the above".
+- Every code-changing step includes concrete code blocks and commands.
+
+Type consistency:
+- `find_mcp_app_sibling_tool_candidates` returns `Vec<(String, UpstreamTool)>` in Task 1 and is called with `allowed: Option<&BTreeSet<String>>` in Task 2.
+- The MCP tests use existing fixture names from `handlers_tools/tests.rs`: `fixture_upstream_tool`, `fixture_upstream_entry`, `code_mode_manager_with_pool`, `fixture_upstream_config`, and `test_server`.
+- Error assertions use the existing JSON envelope string path through `CallToolResult::error`.

--- a/docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md
+++ b/docs/superpowers/plans/2026-06-12-code-mode-mcp-app-callbacks.md
@@ -143,7 +143,7 @@ async fn mcp_app_sibling_lookup_respects_exposure_policy() {
 Run:
 
 ```bash
-cargo test -p lab mcp_app_sibling_lookup --all-features
+cargo test -p labby mcp_app_sibling_lookup --all-features
 ```
 
 Expected before implementation: compile failure for missing `find_mcp_app_sibling_tool_candidates`, or assertion failure showing the helper does not filter correctly.
@@ -216,7 +216,7 @@ use serde_json::Value;
 Run:
 
 ```bash
-cargo test -p lab mcp_app_sibling_lookup --all-features
+cargo test -p labby mcp_app_sibling_lookup --all-features
 ```
 
 Expected: both `mcp_app_sibling_lookup_*` tests pass.
@@ -357,7 +357,7 @@ async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
 Run:
 
 ```bash
-cargo test -p lab call_tool_ --all-features
+cargo test -p labby call_tool_ --all-features
 ```
 
 Expected before implementation: `call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden` fails with `hidden while code_mode mode is enabled`, and the destructive callback test either reaches the proxy or returns the wrong error kind.
@@ -445,7 +445,7 @@ Why `candidates.len() == 1`: if two allowed upstreams expose the same sibling to
 Run:
 
 ```bash
-cargo test -p lab call_tool_ --all-features
+cargo test -p labby call_tool_ --all-features
 ```
 
 Expected: sibling callback and destructive denial tests pass.
@@ -528,7 +528,7 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
 Run:
 
 ```bash
-cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
+cargo test -p labby list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
 ```
 
 Expected: PASS. If `youtube_probe` appears in `names`, the implementation accidentally widened model visibility and must be fixed before continuing.
@@ -617,10 +617,10 @@ git commit -m "docs: document code mode mcp app callbacks"
 Run:
 
 ```bash
-cargo test -p lab mcp_app_sibling_lookup --all-features
-cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
-cargo test -p lab call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features
-cargo test -p lab call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features
+cargo test -p labby mcp_app_sibling_lookup --all-features
+cargo test -p labby list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features
+cargo test -p labby call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features
+cargo test -p labby call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features
 ```
 
 Expected: all focused tests pass.
@@ -630,15 +630,15 @@ Expected: all focused tests pass.
 Run:
 
 ```bash
-cargo test -p lab mcp::handlers_tools --all-features
-cargo test -p lab mcp::call_tool_codemode --all-features
+cargo test -p labby mcp::handlers_tools --all-features
+cargo test -p labby mcp::call_tool_codemode --all-features
 ```
 
 Expected: all tests pass. If the module path filter does not match in this workspace, run:
 
 ```bash
-cargo test -p lab handlers_tools --all-features
-cargo test -p lab call_tool_codemode --all-features
+cargo test -p labby handlers_tools --all-features
+cargo test -p labby call_tool_codemode --all-features
 ```
 
 Expected: all tests pass.
@@ -670,10 +670,10 @@ Implemented and verified in Lab:
 
 Verification:
 
-- `cargo test -p lab mcp_app_sibling_lookup --all-features`
-- `cargo test -p lab list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features`
-- `cargo test -p lab call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features`
-- `cargo test -p lab call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features`
+- `cargo test -p labby mcp_app_sibling_lookup --all-features`
+- `cargo test -p labby list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden --all-features`
+- `cargo test -p labby call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden --all-features`
+- `cargo test -p labby call_tool_blocks_destructive_mcp_app_sibling_callbacks --all-features`
 - `cargo nextest run --workspace --all-features`
 ```
 

--- a/docs/surfaces/MCP.md
+++ b/docs/surfaces/MCP.md
@@ -185,6 +185,13 @@ build verification for the richer Next route lives under
 The history resource is process-local inspection state, not a durable audit log
 or a hard quota guarantee.
 
+For upstream MCP Apps, Code Mode keeps widget-bearing tools host-visible so the
+host can render their `_meta.ui.resourceUri` resources. Ordinary sibling tools
+remain hidden from `tools/list`, but a rendered app's `callServerTool` callback
+may call an exposed, non-destructive sibling tool on the same routable upstream.
+The exemption is scoped to callback callability and route scope; it does not
+expand the model-facing catalog.
+
 ## Top-Level Catalog
 
 `lab://catalog` is generated from the same action metadata that powers


### PR DESCRIPTION
## Summary

Fixes code mode MCP App dead-ends by allowing rendered upstream MCP Apps to call safe same-upstream sibling tools while keeping those sibling tools hidden from the model-facing tool list.

Key changes:
- keep upstream MCP-App UI tools exposed in code mode while recognizing safe same-upstream sibling callback tools
- allow non-destructive widget sibling callbacks through `call_tool_impl` when the originating upstream has an exposed MCP-App UI tool
- bind pre-resolved widget callbacks to the selected upstream so same-name tools on other upstreams cannot receive the call
- resolve widget callback candidates through gateway policy so disabled and priority-zero upstreams stay unavailable
- preserve protected-route scope for both upstream tools and built-in `tools/list` entries
- preserve the existing code-mode collapse for model-facing `tools/list`
- block destructive direct UI, legacy-widget, and sibling callbacks with `confirmation_required`
- reject duplicate same-name sibling matches as `ambiguous_tool` before destructive confirmation
- route pre-resolved OAuth upstream callbacks through subject-scoped routing instead of the shared raw pool
- document the host-side rule in `docs/dev/CODE_MODE.md` and `docs/surfaces/MCP.md`
- include the execution plan under `docs/superpowers/plans/`
- clean up pre-existing all-features clippy drift so the branch passes the repo's strict lint gate

## Review follow-up

PR Review Toolkit agents reviewed the entire PR. Actionable findings were addressed in `70fa7cae`:
- callback candidate lookup now filters by gateway config eligibility (`enabled` and routable priority) instead of trusting only cached pool entries
- direct MCP-App callbacks and same-upstream sibling callbacks share the same policy-aware resolver
- protected `tools/list` no longer advertises built-in services outside the route scope
- the widget callback gate is extracted from `call_tool_impl`, with a named `PreResolvedUpstreamTool` handoff that carries route/upstream/tool together
- regression tests now cover disabled upstreams, priority-zero upstreams, direct UI render-entry callbacks with read scope, protected built-in list filtering, and legacy widget route-scope behavior

External PR review bots did not leave actionable review threads. Codex review and CodeRabbit both reported usage/rate limits on the final pushed state.

## Verification

- `cargo fmt --all --check` passed
- `cargo test -p labby call_tool_ --all-features` passed: 30 tests passed
- `cargo test -p labby protected_ --all-features` passed: 39 tests passed
- `cargo test -p labby mcp_app_sibling_lookup --all-features` passed: 2 tests passed
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed
- `cargo nextest run --workspace --all-features` passed: `1950 tests run: 1950 passed, 27 skipped`

Known warning during Rust builds:
- `apps/gateway-admin/out not found — embedding empty web assets`, pre-existing/expected in this worktree without building the web bundle.
