### PR TITLE
fix(snippets): bound executable code, not whole tutorial body

### DIFF
--- a/crates/lab/src/dispatch/snippets/store.rs
+++ b/crates/lab/src/dispatch/snippets/store.rs
@@ -844,10 +844,13 @@ mod tests {
                 .expect("builtin snippet file stem");
             let body = fs::read_to_string(&path).expect("read builtin snippet");
             // Mirror `collect_snippets`' builtin discovery rule: a markdown file
-            // without frontmatter (e.g. the directory README) is not treated as
-            // a snippet, so it is not held to the snippet contract.
-            if path.extension().and_then(|e| e.to_str()) == Some("md")
-                && frontmatter(&body).ok().flatten().is_none()
+            // with no frontmatter at all (e.g. the directory README) is not a
+            // snippet, so it is not held to the snippet contract. A file that
+            // *opens* frontmatter (`---`) but fails to parse is a broken builtin
+            // and must fail loudly — so skip only on genuine absence and let the
+            // `frontmatter(body)?` inside `validate_snippet_body` surface parse
+            // errors, rather than collapsing both cases with `.ok().flatten()`.
+            if path.extension().and_then(|e| e.to_str()) == Some("md") && !body.starts_with("---\n")
             {
                 continue;
             }
@@ -883,6 +886,51 @@ mod tests {
         let error = validate_snippet_body("demo", &body)
             .expect_err("oversized code block should be rejected");
         assert!(format!("{error}").contains("snippet code exceeds"));
+    }
+
+    #[test]
+    fn validate_snippet_body_bounds_bare_code_without_fences() {
+        // A bare snippet body (no frontmatter, no fences) is its own code, so
+        // the code bound governs the whole body directly.
+        let small = "async () => ({ ok: true })";
+        assert!(validate_snippet_body("demo", small).is_ok());
+
+        let big = format!("async () => {{\n{}\nreturn 1;\n}}", "// pad\n".repeat(4096));
+        assert!(big.len() > MAX_SNIPPET_CODE_BYTES);
+        let error = validate_snippet_body("demo", &big)
+            .expect_err("oversized bare code should be rejected");
+        assert!(format!("{error}").contains("snippet code exceeds"));
+    }
+
+    #[test]
+    fn validate_snippet_body_code_bound_is_exclusive_at_the_limit() {
+        // Pin the strict `>` comparison: code of exactly MAX_SNIPPET_CODE_BYTES
+        // passes, one byte over fails. Guards against a `>` -> `>=` drift.
+        let prefix = "async () => { return \"";
+        let suffix = "\"; }";
+        let pad = MAX_SNIPPET_CODE_BYTES - prefix.len() - suffix.len();
+        let at_limit = format!("{prefix}{}{suffix}", "x".repeat(pad));
+        assert_eq!(at_limit.len(), MAX_SNIPPET_CODE_BYTES);
+        assert!(validate_snippet_body("demo", &at_limit).is_ok());
+
+        let over_limit = format!("{prefix}{}{suffix}", "x".repeat(pad + 1));
+        assert_eq!(over_limit.len(), MAX_SNIPPET_CODE_BYTES + 1);
+        let error = validate_snippet_body("demo", &over_limit)
+            .expect_err("code one byte over the limit should be rejected");
+        assert!(format!("{error}").contains("snippet code exceeds"));
+    }
+
+    #[test]
+    fn validate_snippet_body_rejects_oversized_file() {
+        // A file larger than MAX_SNIPPET_FILE_BYTES is rejected before parsing,
+        // even though its extracted code would be tiny.
+        let prose = "x".repeat(MAX_SNIPPET_FILE_BYTES + 1);
+        let body = format!(
+            "---\nname: demo\ndescription: Demo snippet\ntags: []\n---\n\n{prose}\n\n```js\nasync () => ({{ ok: true }})\n```\n"
+        );
+        let error =
+            validate_snippet_body("demo", &body).expect_err("oversized file should be rejected");
+        assert!(format!("{error}").contains("snippet file exceeds"));
     }
 
     #[test]

--- a/crates/lab/src/dispatch/snippets/store.rs
+++ b/crates/lab/src/dispatch/snippets/store.rs
@@ -9,7 +9,18 @@ use serde_json::{Map, Value};
 use crate::dispatch::error::ToolError;
 
 const SNIPPET_EXTENSIONS: &[&str] = &["md", "js"];
-const MAX_SNIPPET_BYTES: usize = 24 * 1024;
+
+/// Maximum size of a snippet's *executable* code — the extracted ```js block,
+/// or the whole file for bare `.js` snippets. This is what actually runs in
+/// code-mode, so it mirrors `CODE_MODE_CLI_MAX_SOURCE_BYTES` in `cli/gateway.rs`.
+const MAX_SNIPPET_CODE_BYTES: usize = 20 * 1024;
+
+/// Generous upper bound on the whole snippet markdown file (frontmatter + prose
+/// + fenced code). Tutorial-format snippets carry substantial prose that never
+/// executes, so the file bound is intentionally loose; only the extracted code
+/// is held to `MAX_SNIPPET_CODE_BYTES`. The file bound exists purely to reject
+/// pathological inputs before they are read fully into memory and parsed.
+const MAX_SNIPPET_FILE_BYTES: usize = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -364,9 +375,9 @@ fn io_error(action: &str, path: &Path, error: std::io::Error) -> ToolError {
 }
 
 pub fn validate_snippet_body(name: &str, body: &str) -> Result<(), ToolError> {
-    if body.len() > MAX_SNIPPET_BYTES {
+    if body.len() > MAX_SNIPPET_FILE_BYTES {
         return Err(ToolError::InvalidParam {
-            message: format!("snippet body exceeds {MAX_SNIPPET_BYTES} bytes"),
+            message: format!("snippet file exceeds {MAX_SNIPPET_FILE_BYTES} bytes"),
             param: "body".to_string(),
         });
     }
@@ -386,6 +397,12 @@ pub fn validate_snippet_body(name: &str, body: &str) -> Result<(), ToolError> {
     } else {
         body.trim().to_string()
     };
+    if code.len() > MAX_SNIPPET_CODE_BYTES {
+        return Err(ToolError::InvalidParam {
+            message: format!("snippet code exceeds {MAX_SNIPPET_CODE_BYTES} bytes"),
+            param: "body".to_string(),
+        });
+    }
     validate_snippet_code(&code)
 }
 
@@ -805,6 +822,67 @@ mod tests {
 
         assert!(code.contains("github::search_issues"));
         assert!(!code.contains("github::list_workflow_runs"));
+    }
+
+    #[test]
+    fn all_builtin_snippets_satisfy_the_size_and_format_contract() {
+        // Guards against the failure mode that silently broke `docs generate`:
+        // a built-in tutorial snippet whose body violated the size contract.
+        // `collect_snippets` skips invalid snippets silently, so without this
+        // test an oversized built-in only surfaces as a `docs generate` abort.
+        let dir = builtin_snippet_dir();
+        let entries = fs::read_dir(&dir).expect("read builtin snippets directory");
+        let mut checked = 0usize;
+        for entry in entries {
+            let path = entry.expect("builtin snippet dir entry").path();
+            if !path.is_file() || !has_snippet_extension(&path) {
+                continue;
+            }
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .expect("builtin snippet file stem");
+            let body = fs::read_to_string(&path).expect("read builtin snippet");
+            // Mirror `collect_snippets`' builtin discovery rule: a markdown file
+            // without frontmatter (e.g. the directory README) is not treated as
+            // a snippet, so it is not held to the snippet contract.
+            if path.extension().and_then(|e| e.to_str()) == Some("md")
+                && frontmatter(&body).ok().flatten().is_none()
+            {
+                continue;
+            }
+            validate_snippet_body(stem, &body).unwrap_or_else(|error| {
+                panic!(
+                    "builtin snippet `{}` violates the size/format contract: {error}",
+                    path.display()
+                )
+            });
+            checked += 1;
+        }
+        assert!(checked > 0, "expected at least one builtin snippet");
+    }
+
+    #[test]
+    fn validate_snippet_body_bounds_executable_code_not_prose() {
+        // A large prose body with a small code block must pass: only the
+        // extracted JS is held to MAX_SNIPPET_CODE_BYTES.
+        let code = "async () => ({ ok: true })";
+        let prose = "x".repeat(MAX_SNIPPET_CODE_BYTES + 4096);
+        let body = format!(
+            "---\nname: demo\ndescription: Demo snippet\ntags: []\n---\n\n{prose}\n\n```js\n{code}\n```\n"
+        );
+        assert!(body.len() > MAX_SNIPPET_CODE_BYTES);
+        assert!(validate_snippet_body("demo", &body).is_ok());
+
+        // A code block that itself exceeds the code limit must fail.
+        let big_code = format!("async () => {{\n{}\nreturn 1;\n}}", "// pad\n".repeat(4096));
+        assert!(big_code.len() > MAX_SNIPPET_CODE_BYTES);
+        let body = format!(
+            "---\nname: demo\ndescription: Demo snippet\ntags: []\n---\n\n```js\n{big_code}\n```\n"
+        );
+        let error = validate_snippet_body("demo", &body)
+            .expect_err("oversized code block should be rejected");
+        assert!(format!("{error}").contains("snippet code exceeds"));
     }
 
     #[test]

--- a/crates/lab/tests/deploy_runner.rs
+++ b/crates/lab/tests/deploy_runner.rs
@@ -19,7 +19,6 @@
 //! correctly and respects the concurrency/abort knobs.
 
 #![cfg(feature = "deploy")]
-#![allow(clippy::panic)]
 #![allow(unused_qualifications)]
 
 use std::collections::HashMap;

--- a/crates/lab/tests/gateway_stdio_spawn.rs
+++ b/crates/lab/tests/gateway_stdio_spawn.rs
@@ -11,7 +11,6 @@
     clippy::unnested_or_patterns
 )]
 //! Integration test: real stdio MCP child-process spawn + reaping.
-#![allow(clippy::panic)]
 //!
 //! These tests are `#[ignore]` (local-only, per repo convention) because they
 //! spawn real child processes and require the `labby` binary compiled into


### PR DESCRIPTION
## Problem

\`just docs-generate\` / \`docs-check\` (and CI's \`docs-check\` job) aborted on built-in tutorial-format snippets:

\`\`\`
invalid built-in snippet docs/snippets/axon-fanout.md: snippet body exceeds … bytes
\`\`\`

The snippet size contract measured the **entire markdown file** (prose + frontmatter + fenced code), but only the extracted JS block ever executes in code-mode. A tutorial whose prose pushed the file over the limit aborted \`docs generate\` even though its executable code was well under budget. (HEAD already carried a fragile 24 KiB stopgap — ~2 KiB of headroom and no guard.)

## Fix (intent-aligned)

Verified the execution path: \`execute_snippet → code_for_snippet → extract_javascript_block\`, so only the extracted JS block reaches code-mode; the full tutorial body is never executed. The broker enforces no source-byte cap, and \`CODE_MODE_CLI_MAX_SOURCE_BYTES\` governs only the separate \`gateway code-mode --file\` path.

- Split \`MAX_SNIPPET_BYTES\` into:
  - **\`MAX_SNIPPET_CODE_BYTES\` (20 KiB)** — bounds the extracted JS block, mirroring \`CODE_MODE_CLI_MAX_SOURCE_BYTES\` (what actually runs).
  - **\`MAX_SNIPPET_FILE_BYTES\` (256 KiB)** — loose sanity bound on the whole file to reject pathological inputs.
- \`validate_snippet_body\` checks the file bound up front, the code bound after extraction.

## Guard

Added \`all_builtin_snippets_satisfy_the_size_and_format_contract\` — walks \`docs/snippets/\`, skips non-snippet files (markdown without frontmatter, mirroring \`collect_snippets\`' discovery rule), and asserts every built-in passes \`validate_snippet_body\`. An oversized/malformed built-in now fails nextest/CI loudly instead of silently breaking \`docs generate\`. Plus a focused test proving large-prose+small-code passes while an oversized code block fails.

## Verification
- \`cargo nextest -p labby --all-features snippets::store\` → 7/7 pass
- \`cargo clippy -p labby --all-features\` → clean
- \`just docs-generate\` → exit 0, 15 artifacts, no diff
- \`just docs-check\` → "15 docs artifacts: fresh"

Note: investigation showed the \`deploy.plan\`/\`setup.bootstrap\` dotted aliases referenced in the original task never existed in source; the generated catalogs were already fresh (no diff). Bare verbs are intentional for single-resource services — not changed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes docs generation by sizing snippets on the runnable JS block, not the whole tutorial. Adds clear code/file limits, strengthens CI guards, and cleans up a duplicated clippy allow in tests.

- **Bug Fixes**
  - Split limits: MAX_SNIPPET_CODE_BYTES = 20 KiB (extracted JS) and MAX_SNIPPET_FILE_BYTES = 256 KiB (whole file). `validate_snippet_body` checks file first, then code.
  - Hardened CI guard: validates all built-in snippets and skips only when markdown truly lacks frontmatter (`---`). Adds tests for bare `.js` bodies, exact code-size boundary, file-size rejection, and large-prose+small-code vs oversized code.

- **Refactors**
  - Removed duplicated `clippy::panic` allow attributes in integration tests to silence a duplicated attribute warning.

<sup>Written for commit 2af1e5bb44517d37680c3d5e822d744c9cb625c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

