### PR TITLE
Snippets tutorial-size test + dev adb mount portability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,3 +182,10 @@ TEI_URL=http://localhost:8080
 
 # Override the tracing filter set in config/config.toml.
 # RUST_LOG=lab=debug,warn
+
+# Opt-in: host adb client bind-mounted into labby:dev for the claude-in-mobile
+# MCP server (it shells out to adb, talking to the host adb server at
+# 172.19.0.1:5037). Set this to the host's adb binary so the in-container client
+# version matches the host server's. Leave unset on hosts without the Android SDK
+# — the mount defaults to a harmless /dev/null no-op.
+# ADB_PATH=/home/youruser/Android/Sdk/platform-tools/adb

--- a/.env.example
+++ b/.env.example
@@ -184,8 +184,9 @@ TEI_URL=http://localhost:8080
 # RUST_LOG=lab=debug,warn
 
 # Opt-in: host adb client bind-mounted into labby:dev for the claude-in-mobile
-# MCP server (it shells out to adb, talking to the host adb server at
-# 172.19.0.1:5037). Set this to the host's adb binary so the in-container client
-# version matches the host server's. Leave unset on hosts without the Android SDK
-# — the mount defaults to a harmless /dev/null no-op.
+# MCP server (it shells out to adb, talking to the host adb server configured in
+# config.toml as ANDROID_ADB_SERVER_ADDRESS=172.19.0.1 + ANDROID_ADB_SERVER_PORT=5037).
+# Set this to the host's adb binary so the in-container client version matches the
+# host server's. Leave unset on hosts without the Android SDK — the mount defaults
+# to a harmless /dev/null no-op.
 # ADB_PATH=/home/youruser/Android/Sdk/platform-tools/adb

--- a/.env.example
+++ b/.env.example
@@ -184,9 +184,10 @@ TEI_URL=http://localhost:8080
 # RUST_LOG=lab=debug,warn
 
 # Opt-in: host adb client bind-mounted into labby:dev for the claude-in-mobile
-# MCP server (it shells out to adb, talking to the host adb server configured in
-# config.toml as ANDROID_ADB_SERVER_ADDRESS=172.19.0.1 + ANDROID_ADB_SERVER_PORT=5037).
-# Set this to the host's adb binary so the in-container client version matches the
-# host server's. Leave unset on hosts without the Android SDK — the mount defaults
-# to a harmless /dev/null no-op.
+# MCP server (it shells out to adb, talking to the host adb server via the
+# host.docker.internal alias — see extra_hosts in docker-compose.yml — configured
+# in config.toml as ANDROID_ADB_SERVER_ADDRESS=host.docker.internal +
+# ANDROID_ADB_SERVER_PORT=5037). Set this to the host's adb binary so the
+# in-container client version matches the host server's. Leave unset on hosts
+# without the Android SDK — the mount defaults to a harmless /dev/null no-op.
 # ADB_PATH=/home/youruser/Android/Sdk/platform-tools/adb

--- a/crates/lab/src/dispatch/snippets.rs
+++ b/crates/lab/src/dispatch/snippets.rs
@@ -198,6 +198,27 @@ async () => ({ ok: true })
     }
 
     #[test]
+    fn list_keeps_tutorial_sized_builtin_snippets() {
+        let temp = tempfile::tempdir().unwrap();
+        let lab_home = temp.path().join("lab-home");
+        let builtin_dir = temp.path().join("builtins");
+        fs::create_dir_all(&builtin_dir).unwrap();
+        let tutorial = "This tutorial explains the selected tools and schemas.\n".repeat(450);
+        fs::write(
+            builtin_dir.join("tutorial.md"),
+            format!(
+                "---\nname: tutorial\ndescription: Tutorial snippet\ntags: [docs]\n---\n\n# Tutorial\n\n{tutorial}\n```js\nasync () => ({{ ok: true }})\n```\n"
+            ),
+        )
+        .unwrap();
+
+        let snippets = list_snippets(&lab_home, &builtin_dir).unwrap();
+
+        assert_eq!(snippets.len(), 1);
+        assert_eq!(snippets[0].name, "tutorial");
+    }
+
+    #[test]
     fn frontmatter_inputs_merge_defaults_and_validate_params() {
         let temp = tempfile::tempdir().unwrap();
         let lab_home = temp.path().join("lab-home");

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,16 @@ services:
     init: true
     working_dir: /workspace/lab
 
+    # Stable alias for "the host" reachable from inside the container. On Linux
+    # Docker Engine this is not auto-provided, so we map it to the special
+    # `host-gateway` value (Docker substitutes the current host gateway IP across
+    # whichever bridge the container is on). Lets config.toml reference host
+    # services by name — the adb server and the LM Studio/Ollama/TEI endpoints on
+    # :52000 — instead of a hardcoded, IPAM-assigned bridge IP. The dev override
+    # inherits this via `extends`.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
     ports:
       # LAB_HOST_PORT lets you remap the host-side port without editing this file.
       - "${LAB_HOST_PORT:-8765}:8765"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,17 +21,23 @@ services:
       # Hot-swap the locally built binary into the dev runtime.
       - ./bin/labby:/usr/local/bin/labby
       # adb client for the in-container claude-in-mobile MCP server. claude-in-mobile
-      # is configured (config.toml: ANDROID_ADB_SERVER_ADDRESS=172.19.0.1:5037) to
-      # talk to the host's adb SERVER over the docker bridge gateway, so it only
+      # is configured (config.toml: ANDROID_ADB_SERVER_ADDRESS=172.19.0.1 +
+      # ANDROID_ADB_SERVER_PORT=5037) to talk to the host's adb SERVER, so it only
       # needs a client binary on PATH to enumerate host-booted emulators
-      # (emulator-5554). We bind-mount the HOST's adb (not an apt-installed one) so
-      # the client version matches the host server's exactly — a mismatched client
-      # would kill+restart the host adb server and drop its live emulator sessions.
+      # (emulator-5554). 172.19.0.1 is the gateway of the shared axon/jakenet bridge
+      # the service also attaches to (see docker-compose.prod.yml), NOT the `lab`
+      # bridge defined below; it's an IPAM assignment, so re-check with
+      # `docker network inspect jakenet` if adb can't reach the host.
+      #
+      # We bind-mount the HOST's adb (not an apt-installed one) so the client version
+      # matches the host server's exactly — a mismatched client would kill+restart
+      # the host adb server and drop its live emulator sessions.
       #
       # Opt-in: set ADB_PATH in the repo .env to the host's adb (e.g.
-      # ${HOME}/Android/Sdk/platform-tools/adb). The default /dev/null is a no-op
-      # mount that exists on every host, so hosts without the Android SDK don't trip
-      # on a missing path (Docker would otherwise create a phantom directory there).
+      # ${HOME}/Android/Sdk/platform-tools/adb). The default /dev/null is a real
+      # device present on every host; without it, an unset ADB_PATH would leave
+      # Docker to auto-create an empty directory at the (missing) source path and
+      # shadow the adb binary with a directory.
       - ${ADB_PATH:-/dev/null}:/usr/local/bin/adb:ro
     environment:
       # Serve frontend assets from the bind-mounted workspace so `pnpm build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,19 @@ services:
     volumes:
       # Hot-swap the locally built binary into the dev runtime.
       - ./bin/labby:/usr/local/bin/labby
+      # adb client for the in-container claude-in-mobile MCP server. claude-in-mobile
+      # is configured (config.toml: ANDROID_ADB_SERVER_ADDRESS=172.19.0.1:5037) to
+      # talk to the host's adb SERVER over the docker bridge gateway, so it only
+      # needs a client binary on PATH to enumerate host-booted emulators
+      # (emulator-5554). We bind-mount the HOST's adb (not an apt-installed one) so
+      # the client version matches the host server's exactly — a mismatched client
+      # would kill+restart the host adb server and drop its live emulator sessions.
+      #
+      # Opt-in: set ADB_PATH in the repo .env to the host's adb (e.g.
+      # ${HOME}/Android/Sdk/platform-tools/adb). The default /dev/null is a no-op
+      # mount that exists on every host, so hosts without the Android SDK don't trip
+      # on a missing path (Docker would otherwise create a phantom directory there).
+      - ${ADB_PATH:-/dev/null}:/usr/local/bin/adb:ro
     environment:
       # Serve frontend assets from the bind-mounted workspace so `pnpm build`
       # changes are reflected immediately without a binary rebuild.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,14 +39,8 @@ services:
       # Docker to auto-create an empty directory at the (missing) source path and
       # shadow the adb binary with a directory.
       - ${ADB_PATH:-/dev/null}:/usr/local/bin/adb:ro
-    # Stable alias for "the host" reachable from inside the container. On Linux
-    # Docker Engine this is not auto-provided, so we map it to the special
-    # `host-gateway` value (Docker substitutes the current host gateway IP across
-    # whichever bridge the container is on). Lets config.toml reference host
-    # services by name (adb server, LM Studio/Ollama/TEI on :52000) instead of a
-    # hardcoded, IPAM-assigned bridge IP.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # extra_hosts (host.docker.internal:host-gateway) is inherited from
+    # docker-compose.prod.yml via `extends` above — see the comment there.
     environment:
       # Serve frontend assets from the bind-mounted workspace so `pnpm build`
       # changes are reflected immediately without a binary rebuild.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,13 +21,13 @@ services:
       # Hot-swap the locally built binary into the dev runtime.
       - ./bin/labby:/usr/local/bin/labby
       # adb client for the in-container claude-in-mobile MCP server. claude-in-mobile
-      # is configured (config.toml: ANDROID_ADB_SERVER_ADDRESS=172.19.0.1 +
-      # ANDROID_ADB_SERVER_PORT=5037) to talk to the host's adb SERVER, so it only
-      # needs a client binary on PATH to enumerate host-booted emulators
-      # (emulator-5554). 172.19.0.1 is the gateway of the shared axon/jakenet bridge
-      # the service also attaches to (see docker-compose.prod.yml), NOT the `lab`
-      # bridge defined below; it's an IPAM assignment, so re-check with
-      # `docker network inspect jakenet` if adb can't reach the host.
+      # talks to the host's adb SERVER (config.toml: ANDROID_ADB_SERVER_ADDRESS +
+      # ANDROID_ADB_SERVER_PORT=5037), so it only needs a client binary on PATH to
+      # enumerate host-booted emulators (emulator-5554). Point the address at the
+      # `host.docker.internal` alias provided by extra_hosts below rather than a
+      # hardcoded bridge IP — Docker resolves it to the current host gateway on any
+      # network. The host adb server must listen on a non-loopback interface
+      # (`ADB_SERVER_SOCKET=tcp:0.0.0.0:5037` / `adb -a` on the host).
       #
       # We bind-mount the HOST's adb (not an apt-installed one) so the client version
       # matches the host server's exactly — a mismatched client would kill+restart
@@ -39,6 +39,14 @@ services:
       # Docker to auto-create an empty directory at the (missing) source path and
       # shadow the adb binary with a directory.
       - ${ADB_PATH:-/dev/null}:/usr/local/bin/adb:ro
+    # Stable alias for "the host" reachable from inside the container. On Linux
+    # Docker Engine this is not auto-provided, so we map it to the special
+    # `host-gateway` value (Docker substitutes the current host gateway IP across
+    # whichever bridge the container is on). Lets config.toml reference host
+    # services by name (adb server, LM Studio/Ollama/TEI on :52000) instead of a
+    # hardcoded, IPAM-assigned bridge IP.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       # Serve frontend assets from the bind-mounted workspace so `pnpm build`
       # changes are reflected immediately without a binary rebuild.

--- a/docs/sessions/2026-06-13-snippets-markdown-render-deploy.md
+++ b/docs/sessions/2026-06-13-snippets-markdown-render-deploy.md
@@ -1,0 +1,185 @@
+---
+date: 2026-06-13 23:56:58 EST
+repo: git@github.com:jmagar/lab.git
+branch: codex/snippets-cli-mcp
+head: 4defbcee
+session id: 98d0dcb0-f6be-4dee-8f5e-146c5a7c4a5a
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-lab/98d0dcb0-f6be-4dee-8f5e-146c5a7c4a5a.jsonl
+working directory: /home/jmagar/workspace/lab
+worktree: /home/jmagar/workspace/lab 4defbcee [codex/snippets-cli-mcp]
+---
+
+# Snippets markdown rendering, review, merge, and deployment
+
+## User Request
+
+The session started with a request to debug a Google MCP re-authentication hang, then pivoted to a direct Labby push/deploy flow and a follow-up request to turn the repo-status GitHub command chain into a reusable snippet. The user later asked to do the snippet work in a new worktree, dispatch PR review toolkit agents, merge to `main`, redeploy the binary to PATH and the container, and finally save this session to markdown.
+
+## Session Overview
+
+Implemented a built-in `repo-status-gh-pulse` snippet and changed the Labby snippets UI so tutorial markdown renders as markdown instead of plain text. The feature was reviewed by four PR review toolkit agents, fixed based on their findings, committed on `codex/snippets-markdown-render`, merged into `main`, pushed, built as a release binary, linked into PATH, and deployed into the `labby` container.
+
+The original Google MCP re-authentication hang was not diagnosed because the user redirected the session to the snippet, merge, and deploy workflow.
+
+## Sequence of Events
+
+1. Created isolated worktree `/home/jmagar/workspace/lab/.worktrees/snippets-markdown-render` on branch `codex/snippets-markdown-render`.
+2. Added the built-in GitHub repo-status snippet and updated snippet documentation.
+3. Added a shared safe markdown renderer and refactored chat/snippets surfaces to use it.
+4. Ran focused frontend, Rust, CLI snippet, and execution tests.
+5. Dispatched four PR review toolkit agents and addressed their blocking findings.
+6. Merged feature commit `068963ab` into `main` as merge commit `ce38827c`, then pushed `main`.
+7. Ran `just dev` from the clean main worktree to build web assets, build the release binary, install/link `labby`, and restart the container.
+8. Verified the PATH binary, container binary, container health, `/snippets` route, and built-in snippet validation.
+9. Performed the save-session maintenance pass and removed only the clean, merged `snippets-markdown-render` worktree/branch.
+
+## Key Findings
+
+- The GitHub workflow-run MCP route originally considered for the snippet was unavailable, so the final snippet uses `github::search_issues` and reports workflow-run status as a shell-only evidence gap.
+- Snippet tutorials were displayed as plain text before this session; the UI now renders them through a shared safe markdown component.
+- Failed snippet action receipts needed stricter handling for `valid:false`, `passed:false`, and `result.ok:false`.
+- `codex/snippets-markdown-render` was clean and merged into `origin/main`; `git merge-base --is-ancestor 068963ab main` returned `0`.
+- The deploy worktree `/home/jmagar/workspace/lab/.worktrees/save-session-mcpjam-inspector` was intentionally left in place because `/home/jmagar/.local/bin/labby` resolves to its `target/release/labby`.
+
+## Technical Decisions
+
+- Chose a shared `SafeMarkdown` component in `apps/gateway-admin/components/markdown/safe-markdown.tsx` so chat messages and snippets share the same markdown safety rules.
+- Disabled raw HTML/images and restricted links to http, https, mailto, and relative URLs in rendered markdown.
+- Kept the snippet Code Mode implementation on available GitHub MCP search calls and did not invent a workflow-runs MCP call that the live catalog did not expose.
+- Used a merge commit into `main` instead of a squash so the feature commit remained directly traceable.
+- Used `just dev` for deployment because it performs the repo's expected web build, release build, binary install/link, and Docker restart sequence.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `apps/gateway-admin/components/chat/message-bubble.tsx` | - | Reused the shared safe markdown renderer in chat message rendering. | `git show --name-status 068963ab` |
+| created | `apps/gateway-admin/components/markdown/safe-markdown.tsx` | - | Added safe markdown rendering rules for Labby UI content. | `git show --name-status 068963ab` |
+| modified | `apps/gateway-admin/components/snippets/snippets-page-content.test.tsx` | - | Covered snippet detail loading, markdown tutorial rendering, and failed action receipts. | `git show --name-status 068963ab` |
+| modified | `apps/gateway-admin/components/snippets/snippets-page-content.tsx` | - | Loaded selected snippet details and rendered tutorial markdown instead of plain text. | `git show --name-status 068963ab` |
+| modified | `crates/lab/src/dispatch/snippets/store.rs` | - | Added coverage for built-in snippet discovery and executable code extraction. | `git show --name-status 068963ab` |
+| modified | `docs/snippets/README.md` | - | Documented the new built-in snippet/tutorial workflow. | `git show --name-status 068963ab` |
+| created | `docs/snippets/repo-status-gh-pulse.md` | - | Added the reusable repo-status GitHub pulse snippet. | `git show --name-status 068963ab` |
+| created | `docs/sessions/2026-06-13-snippets-markdown-render-deploy.md` | - | Captured this session. | current save-to-md step |
+
+## Beads Activity
+
+No bead activity observed for this session. `bd list --all --sort updated --reverse --limit 100 --json` returned broad historical Lab issues, and a narrower snippet/markdown search produced only older or unrelated Lab/code-mode entries. No bead create, claim, edit, close, or comment command was run for the snippet markdown feature in the observed transcript or current shell history.
+
+## Repository Maintenance
+
+### Plans
+
+- Checked `docs/plans/` with `find docs/plans -maxdepth 2 -type f`; observed `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` and `docs/plans/fleet-ws-plan-lab-n07n.md`.
+- Did not move `docs/plans/fleet-ws-plan-lab-n07n.md` because it was not clearly part of this session and completion was not verified.
+- Observed recent `docs/superpowers/plans/` files, including dirty marketplace-stash-integration planning files in the current worktree; left them untouched as unrelated user WIP.
+
+### Beads
+
+- Ran broad and narrowed bead reads before writing the note.
+- No directly relevant bead updates were made because no current session bead was identified with enough evidence to safely edit or close.
+
+### Worktrees And Branches
+
+- Inspected `git worktree list --porcelain`, `git branch -vv`, and `git branch -r -vv`.
+- Removed `/home/jmagar/workspace/lab/.worktrees/snippets-markdown-render` and deleted local branch `codex/snippets-markdown-render` after proving commit `068963ab` was merged into `main`.
+- Left `/home/jmagar/workspace/lab/.worktrees/save-session-mcpjam-inspector` because it is the clean `main` worktree used for deployment and currently backs `/home/jmagar/.local/bin/labby`.
+- Left `/home/jmagar/workspace/lab/.worktrees/marketplace-stash-integration` because it is a separate active branch, even though its worktree was clean.
+- Left the current worktree dirty files untouched: `docs/contracts/marketplace-stash-integration.md`, `docs/superpowers/plans/2026-06-13-marketplace-stash-integration.md`, `docs/superpowers/specs/2026-06-13-marketplace-stash-integration-spec.md`, and `plugins/vibin/skills/creating-snippets/`.
+
+### Stale Docs
+
+- The feature updated `docs/snippets/README.md` and added `docs/snippets/repo-status-gh-pulse.md`.
+- No additional stale docs were changed during the save pass because the remaining dirty docs belong to unrelated marketplace-stash-integration work.
+
+## Tools and Skills Used
+
+- **Skills.** Used `vibin:save-to-md` for this artifact, `superpowers:using-git-worktrees` for isolated implementation, `superpowers:receiving-code-review` for review follow-up, `superpowers:finishing-a-development-branch` for merge/deploy closure, and `build-web-apps:react-best-practices` for frontend changes.
+- **Shell commands.** Used Git, Cargo, pnpm, Docker, curl, `just`, `bd`, `gh`, `ps`, and standard file inspection commands for implementation, verification, and deployment.
+- **File tools.** Used patch-based file edits for code/docs changes and generated this session artifact as a path-limited docs file.
+- **Subagents/agents.** Dispatched four PR review toolkit agents: Code Reviewer, Type Design Analyzer, PR Test Analyzer, and Silent Failure Hunter.
+- **External CLIs.** Used `labby` CLI for snippet validation/execution and deploy verification; used Docker CLI for container status and in-container version checks.
+- **Browser tools.** No browser automation was used in the observed final deploy/save pass.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `pnpm --dir apps/gateway-admin exec eslint components/markdown/safe-markdown.tsx components/chat/message-bubble.tsx components/snippets/snippets-page-content.tsx components/snippets/snippets-page-content.test.tsx` | Passed. |
+| `pnpm --dir apps/gateway-admin exec tsx --test components/snippets/snippets-page-content.test.tsx components/chat/message-bubble.test.tsx` | Passed; later rerun on main with 23 tests passing. |
+| `cargo test -p labby --all-features dispatch::snippets::store::tests::repo_status_gh_pulse_builtin_is_discoverable_and_executable` | Passed in the feature worktree and after merge in the main worktree. |
+| `cargo run -p labby --all-features -- snippets validate repo-status-gh-pulse --json` | Passed with `valid:true`. |
+| `cargo run -p labby --all-features -- snippets exec repo-status-gh-pulse --param include_workflow_runs=false --param pr_limit=1 --json` | Passed and returned `ok:true`. |
+| `git merge codex/snippets-markdown-render` | Created merge commit `ce38827c` on `main`. |
+| `git push origin main` | Pushed `main` to GitHub. |
+| `just dev` | Built web assets, built release binary, installed `bin/labby`, linked PATH binary, and restarted the `labby` container. |
+| `./bin/labby --version && labby --version` | Both reported `labby 0.25.0`. |
+| `docker exec labby /usr/local/bin/labby --version` | Reported `labby 0.25.0`. |
+| `curl -fsS http://localhost:8765/health` | Returned `{"status":"ok","mode":"master","pid":7,...}`. |
+| `curl -fsS -o /tmp/labby-snippets.html -w '%{http_code} %{content_type}\n' http://localhost:8765/snippets` | Returned `200 text/html; charset=utf-8`. |
+| `git worktree remove /home/jmagar/workspace/lab/.worktrees/snippets-markdown-render && git branch -d codex/snippets-markdown-render` | Removed the clean merged feature worktree and local branch. |
+
+## Errors Encountered
+
+- The first planned workflow-run snippet path was not available in the live GitHub MCP surface, so the snippet was changed to use `github::search_issues` and document workflow runs as shell-only evidence.
+- PR review agents found blocking issues in the first pass, including unavailable tool assumptions and failure-state rendering gaps; these were fixed before merge.
+- `just dev` spent about 15 minutes in the optimized all-features release build. Process checks showed `rustc` was CPU-active, so the build was allowed to finish.
+- A narrowed `bd` query using `jq` hit a null-string match error for some older bead records; the safe outcome was to avoid mutating beads and document the lack of directly relevant bead evidence.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Snippet tutorials | Tutorial markdown displayed as plain text. | Tutorial content renders as markdown through `SafeMarkdown`. |
+| Built-in snippets | No built-in repo-status GitHub pulse snippet existed. | `repo-status-gh-pulse` is discoverable and validates successfully. |
+| Snippet action receipts | Some failed responses could render like normal output. | `valid:false`, `passed:false`, and `result.ok:false` render as failed action receipts. |
+| Labby deployment | Running container and PATH binary pointed at the pre-merge build. | PATH and container binaries report `labby 0.25.0` from the post-merge release build. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `pnpm --dir apps/gateway-admin exec eslint ...` | Frontend lint passes. | Passed. | pass |
+| `pnpm --dir apps/gateway-admin exec tsx --test ...` | Snippets/chat tests pass. | Passed; main rerun reported 23 tests. | pass |
+| `cargo test -p labby --all-features dispatch::snippets::store::tests::repo_status_gh_pulse_builtin_is_discoverable_and_executable` | Built-in snippet discovery/extraction test passes. | Passed. | pass |
+| `cargo run -p labby --all-features -- snippets validate repo-status-gh-pulse --json` | Snippet validates. | `valid:true`. | pass |
+| `cargo run -p labby --all-features -- snippets exec repo-status-gh-pulse --param include_workflow_runs=false --param pr_limit=1 --json` | Snippet executes without requiring unavailable workflow-run tools. | `ok:true`. | pass |
+| `just dev` | Build, install/link binary, restart container. | Finished release build, installed `bin/labby`, linked PATH, restarted container. | pass |
+| `labby --version` | PATH binary is current release. | `labby 0.25.0`. | pass |
+| `docker exec labby /usr/local/bin/labby --version` | Container binary is current release. | `labby 0.25.0`. | pass |
+| `curl -fsS http://localhost:8765/health` | Labby health endpoint returns ok. | `{"status":"ok","mode":"master","pid":7,"uptime_s":10}`. | pass |
+| `curl -fsS -o /tmp/labby-snippets.html -w '%{http_code} %{content_type}\n' http://localhost:8765/snippets` | Snippets route serves HTML. | `200 text/html; charset=utf-8`. | pass |
+
+## Risks and Rollback
+
+- The deploy path uses a release binary inside `/home/jmagar/workspace/lab/.worktrees/save-session-mcpjam-inspector/target/release/labby`; do not remove that worktree until PATH deployment is repointed elsewhere.
+- Rollback for the feature is `git revert ce38827c` on `main`, then rerun `just dev` from the deployment worktree.
+- Rollback for only the PATH/container deployment is to relink `/home/jmagar/.local/bin/labby` to a known previous binary and restart the `labby` container with the previous mounted binary.
+
+## Decisions Not Taken
+
+- Did not continue the Google MCP re-authentication debugging after the session pivoted.
+- Did not implement a backend-provided `tutorial_markdown` field; the UI was made robust enough to render the current snippet detail content safely.
+- Did not remove the clean `main` deployment worktree because the PATH binary symlink depends on it.
+- Did not mutate unrelated marketplace-stash-integration dirty files or branches.
+
+## References
+
+- Feature commit: `068963ab feat(snippets): render tutorials as markdown`
+- Merge commit: `ce38827c Merge branch 'codex/snippets-markdown-render'`
+- Deployed route: `http://localhost:8765/snippets`
+- Health endpoint: `http://localhost:8765/health`
+- Transcript checked: `/home/jmagar/.claude/projects/-home-jmagar-workspace-lab/98d0dcb0-f6be-4dee-8f5e-146c5a7c4a5a.jsonl`
+
+## Open Questions
+
+- The Google MCP re-authentication hang shown at the beginning of the session remains unresolved.
+- The current worktree still contains unrelated marketplace-stash-integration dirty files and an untracked `plugins/vibin/skills/creating-snippets/` directory.
+- `docs/plans/fleet-ws-plan-lab-n07n.md` remains outside `docs/plans/complete/` because this pass did not verify that it is complete.
+
+## Next Steps
+
+- For the Google MCP hang: reproduce the OAuth waiting state, inspect Labby gateway auth logs, verify upstream OAuth subject/token state, and test the Google MCP endpoints independently.
+- For snippet follow-up: consider adding a backend `tutorial_markdown` field if the UI parsing contract becomes fragile.
+- For deployment hygiene: if the team wants to delete `/home/jmagar/workspace/lab/.worktrees/save-session-mcpjam-inspector`, first copy or relink the release binary so `/home/jmagar/.local/bin/labby` does not point into a removed worktree.
+- For repo hygiene: finish or separately save the unrelated marketplace-stash-integration WIP before broad branch/worktree cleanup.

--- a/docs/sessions/2026-06-14-marketplace-stash-review-merge.md
+++ b/docs/sessions/2026-06-14-marketplace-stash-review-merge.md
@@ -1,0 +1,232 @@
+---
+date: 2026-06-14 10:15:58 EST
+repo: git@github.com:jmagar/lab.git
+branch: codex/snippets-cli-mcp
+head: a12d9663
+working directory: /home/jmagar/workspace/lab
+worktree: /home/jmagar/workspace/lab  a12d966 [codex/snippets-cli-mcp]
+pr: "#123 Wire marketplace artifact forks into stash https://github.com/jmagar/lab/pull/123"
+beads: lab-tw72d, lab-tw72d.1, lab-tw72d.2, lab-tw72d.3, lab-tw72d.4, lab-tw72d.5, lab-tw72d.6, lab-tw72d.7, lab-tw72d.8
+---
+
+# Marketplace stash review merge and binary sync
+
+## User Request
+
+The user asked whether the dispatched agent fixed all PR review issues, and if so to merge the marketplace/stash integration back into `main`, rebuild the release binary, and sync it to PATH and the running container so it no longer pointed at a worktree binary. The user then asked to save the session to markdown.
+
+## Session Overview
+
+The marketplace/stash review branch was verified, committed, fast-forwarded into `main`, pushed, and confirmed merged as PR #123. The release `labby` binary was rebuilt from merged `main`, copied into PATH as a regular file, copied to the canonical repo `bin/labby` used by the dev container bind mount, and the `labby-master` container was restarted and verified healthy.
+
+## Sequence of Events
+
+1. Rechecked the PR worktree and confirmed the agent had modified nine review-fix files.
+2. Confirmed all eight review child beads under `lab-tw72d` were closed while the parent bead remained open.
+3. Committed the review fixes on `codex/marketplace-stash-integration` as `506d0fa0`.
+4. Created a clean temporary `main` worktree at `/home/jmagar/workspace/lab/.worktrees/main-merge-marketplace-stash` because the primary worktree and an existing auxiliary worktree contained unrelated dirty changes.
+5. Fast-forwarded `main` to `506d0fa0`, pushed both the feature branch and `main`, and confirmed PR #123 was merged.
+6. Built a full all-features release binary from merged `main`, replaced the PATH binary, copied the binary to the canonical repo `bin/labby`, restarted the container, and verified matching hashes.
+7. Closed parent bead `lab-tw72d` after PR merge and verification.
+8. Ran the `vibin:save-to-md` workflow and wrote this session artifact.
+
+## Key Findings
+
+- The review agent had addressed all eight child findings listed under `lab-tw72d`.
+- `/home/jmagar/.local/bin/labby` was initially a symlink to `/home/jmagar/workspace/lab/.worktrees/marketplace-stash-integration/target/release/labby`.
+- The canonical container bind mount uses `/home/jmagar/workspace/lab/bin/labby`, so that file also needed to be overwritten with the merged release binary.
+- The release build emitted the known warning that `apps/gateway-admin/out` was missing, so the Rust binary embedded empty web assets. The running dev container still uses repo bind mounts.
+- A concurrent cargo/test process briefly overwrote `/home/jmagar/.local/bin/labby` after the first copy; PATH was recopied after checking active builder processes.
+
+## Technical Decisions
+
+- Used a fresh temporary `main` worktree for the merge because the primary checkout was on `codex/snippets-cli-mcp` with unrelated dirty docs and an untracked skill directory.
+- Used a fast-forward merge because local `main` and `origin/main` were both at `ce38827c` before integration and the feature branch descended from that base.
+- Replaced `/home/jmagar/.local/bin/labby` with a regular executable file instead of another symlink, directly addressing the user's concern about dangling or worktree-pointing binaries.
+- Synced `/home/jmagar/workspace/lab/bin/labby` because the running Docker Compose service mounts that path into `/usr/local/bin/labby`.
+- Left dirty or ambiguous worktrees and branches in place rather than deleting anything with unclear ownership.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `apps/gateway-admin/components/marketplace/plugin-files-panel.tsx` | - | Frontend fork-to-stash state hardening | Merged in PR #123 |
+| modified | `apps/gateway-admin/components/marketplace/plugin-files-panel.test.tsx` | - | UI regression coverage | Merged in PR #123 |
+| created | `apps/gateway-admin/lib/api/marketplace-artifacts.test.ts` | - | Marketplace artifact API coverage | Merged in PR #123 |
+| modified | `apps/gateway-admin/lib/api/marketplace-client.ts` | - | Artifact API client support | Merged in PR #123 |
+| modified | `apps/gateway-admin/lib/dev/preview-mode.test.ts` | - | Dev preview allowlist coverage | Merged in PR #123 |
+| modified | `apps/gateway-admin/lib/dev/preview-mode.ts` | - | Added `artifact.list` dev-preview allowance | Merged in PR #123 |
+| modified | `crates/lab-apis/src/stash.rs` | - | Stash API model exposure | Merged in PR #123 |
+| modified | `crates/lab-apis/src/stash/types.rs` | - | Stash data contract expansion | Merged in PR #123 |
+| modified | `crates/lab/src/api/openapi.rs` | - | API schema updates | Merged in PR #123 |
+| modified | `crates/lab/src/api/services/marketplace.rs` | - | Marketplace REST admin gate/catalog alignment | Merged in PR #123 |
+| modified | `crates/lab/src/api/services/stash.rs` | - | Stash REST admin gate/catalog alignment | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/marketplace.rs` | - | Dispatch integration for stash bridge | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/marketplace/catalog.rs` | - | Catalog/admin policy changes | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/marketplace/fork.rs` | - | Artifact fork behavior | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/marketplace/params.rs` | - | Artifact parameter models | Merged in PR #123 |
+| created | `crates/lab/src/dispatch/marketplace/stash_bridge.rs` | - | Marketplace-to-stash bridge implementation and tests | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/marketplace/update.rs` | - | Preview rebuild and artifact update behavior | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/setup/catalog.rs` | - | Generated/catalog alignment | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/snippets/store.rs` | - | Store behavior touched by integration | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/catalog.rs` | - | Stash catalog actions | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/client.rs` | - | Stash client support | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/dispatch.rs` | - | Stash dispatch support | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/export.rs` | - | Stash export support | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/import.rs` | - | Stash import support | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/params.rs` | - | Stash action parameter models | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/revision.rs` | - | Stash revision support | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/service.rs` | - | Stash service behavior | Merged in PR #123 |
+| modified | `crates/lab/src/dispatch/stash/store.rs` | - | Stash store behavior | Merged in PR #123 |
+| modified | `crates/lab/src/mcp/context.rs` | - | MCP context support for integration | Merged in PR #123 |
+| modified | `crates/lab/src/mcp/context/tests.rs` | - | MCP context coverage | Merged in PR #123 |
+| modified | `docs/contracts/marketplace-stash-integration.md` | - | Integration contract updates | Merged in PR #123 |
+| modified | `docs/coverage/stash.md` | - | Stash coverage notes | Merged in PR #123 |
+| modified | `docs/features/artifact-diffs.md` | - | Artifact diff documentation | Merged in PR #123 |
+| modified | `docs/generated/action-catalog.json` | - | Generated action catalog | Merged in PR #123 |
+| modified | `docs/generated/action-catalog.md` | - | Generated action catalog docs | Merged in PR #123 |
+| modified | `docs/generated/cli-help.md` | - | Generated CLI help | Merged in PR #123 |
+| modified | `docs/generated/mcp-help.json` | - | Generated MCP help | Merged in PR #123 |
+| modified | `docs/generated/mcp-help.md` | - | Generated MCP help docs | Merged in PR #123 |
+| modified | `docs/generated/openapi.json` | - | Generated OpenAPI document | Merged in PR #123 |
+| created | `docs/sessions/2026-06-13-marketplace-stash-integration-work-it.md` | - | Prior work-it session note | Merged in PR #123 |
+| modified | `docs/superpowers/plans/2026-06-13-marketplace-stash-integration.md` | - | Plan updates | Merged in PR #123 |
+| modified | `docs/superpowers/specs/2026-06-13-marketplace-stash-integration-spec.md` | - | Spec updates | Merged in PR #123 |
+| created | `docs/sessions/2026-06-14-marketplace-stash-review-merge.md` | - | This session log | Created by save-to-md workflow |
+| modified | `/home/jmagar/.local/bin/labby` | - | PATH release binary copy | Hash `58e046b4edb54c8598b876325920e4fa5a851df77500f5ba4c0d3d70a10ebf1a` |
+| modified | `/home/jmagar/workspace/lab/bin/labby` | - | Canonical container-mounted release binary | Hash `58e046b4edb54c8598b876325920e4fa5a851df77500f5ba4c0d3d70a10ebf1a` |
+
+## Beads Activity
+
+| bead | title | action(s) | final status | why it mattered |
+|---|---|---|---|---|
+| `lab-tw72d` | Review PR #123 marketplace stash integration findings | Read, verified child state, closed | Closed | Parent tracker for all PR #123 review findings |
+| `lab-tw72d.1` | `artifact.reset` applies requested paths to every fork for a plugin | Verified closed | Closed | Ensured reset targets only matching artifact forks |
+| `lab-tw72d.2` | `artifact.update.apply` drops `artifact_path` when rebuilding missing preview | Verified closed | Closed | Ensured missing preview fallback preserves artifact identity |
+| `lab-tw72d.3` | Marketplace stash bridge performs blocking filesystem work on async handlers | Verified closed | Closed | Ensured heavy sync work moved off async handlers |
+| `lab-tw72d.4` | `artifact.unfork` can leave stale sidecar state after component deletion | Verified closed | Closed | Ensured sidecar cleanup happens before component deletion |
+| `lab-tw72d.5` | Fork to Stash UI allows overlapping fork requests after file switch | Verified closed | Closed | Ensured frontend request state prevents overlap |
+| `lab-tw72d.6` | Fork to Stash completion can update stale panel state | Verified closed | Closed | Ensured stale UI completions do not overwrite current panel state |
+| `lab-tw72d.7` | `artifact.list` is missing from dev-preview read-only allowlist | Verified closed | Closed | Ensured dev preview can read artifact listings |
+| `lab-tw72d.8` | REST admin gates duplicate catalog `requires_admin` policy | Verified closed | Closed | Ensured REST gates use catalog policy |
+
+## Repository Maintenance
+
+### Plans
+
+- Checked `docs/plans`; observed `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` and `docs/plans/fleet-ws-plan-lab-n07n.md`.
+- No plan files were moved. `fleet-ws-plan-lab-n07n.md` was not proven complete during this session.
+
+### Beads
+
+- Read `lab-tw72d` and confirmed all children were closed.
+- Closed `lab-tw72d` only after PR #123 was merged, `origin/main` was updated, and runtime binary sync was verified.
+
+### Worktrees and branches
+
+- Inspected registered worktrees and branch tracking.
+- Left `/home/jmagar/workspace/lab` untouched because it contains unrelated dirty docs and an untracked skill directory on `codex/snippets-cli-mcp`.
+- Left `/home/jmagar/workspace/lab/.claude/worktrees/focused-buck-91e0b8` untouched because it had many unrelated dirty files and was behind `origin/main`.
+- Left `/home/jmagar/workspace/lab/.worktrees/marketplace-stash-integration` in place because it is the PR branch worktree and now matches `origin/codex/marketplace-stash-integration`.
+- Left `/home/jmagar/workspace/lab/.worktrees/main-merge-marketplace-stash` in place because it is a clean `main` worktree at `506d0fa0` and was used as the release build source.
+
+### Stale docs
+
+- The PR included docs, generated catalogs, OpenAPI, plan, spec, and contract updates.
+- No additional stale docs were edited during the save pass because no new stale-doc contradiction was proven.
+
+## Tools and Skills Used
+
+- **Skills.** Used `vibin:save-to-md` for the session artifact workflow.
+- **Subagents.** Used dispatched agent `019ec5b7-d461-72a2-81bb-73f384bd2da8` (Popper) earlier in the session to address PR review findings.
+- **Shell and Git.** Used `git status`, `git diff`, `git worktree`, `git merge --ff-only`, `git push`, and log/status commands to inspect and integrate work safely.
+- **GitHub CLI.** Used `gh pr view` to confirm PR #123 state, head SHA, base, title, URL, and merge time.
+- **Beads CLI.** Used `bd show`, `bd list`, and `bd close` to verify and close review tracking.
+- **Rust and Node tooling.** Used `cargo test`, `cargo build --workspace --all-features --release`, and `pnpm --dir apps/gateway-admin exec tsx --test` for targeted and release verification.
+- **Docker Compose.** Used `docker compose ps`, `docker compose restart labby-master`, and `docker compose exec` to sync and verify the running dev container.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git status --short --branch && git diff --stat` | Confirmed nine review-fix files modified in the PR worktree before commit |
+| `bd show lab-tw72d` | Confirmed all eight child review beads were closed and parent was open |
+| `git add ... && git commit -m "fix(marketplace): address stash integration review findings"` | Created commit `506d0fa0` |
+| `git worktree add /home/jmagar/workspace/lab/.worktrees/main-merge-marketplace-stash main` | Created clean temporary main worktree |
+| `git merge --ff-only codex/marketplace-stash-integration` | Fast-forwarded `main` to `506d0fa0` |
+| `cargo build --workspace --all-features --release` | Built release successfully in 12m16s |
+| `install -D -m 755 target/release/labby /home/jmagar/.local/bin/labby` | Replaced PATH binary with a regular file |
+| `install -D -m 755 target/release/labby /home/jmagar/workspace/lab/bin/labby` | Replaced canonical container-mounted binary |
+| `docker compose restart labby-master` | Restarted the dev container |
+| `docker compose exec -T labby-master sh -lc 'labby --version && sha256sum /usr/local/bin/labby'` | Verified container binary version and hash |
+| `git push origin codex/marketplace-stash-integration && git push origin main` | Pushed PR branch and fast-forwarded `origin/main` |
+| `gh pr view 123 --json ...` | Confirmed PR #123 was merged at `2026-06-14T13:14:54Z` |
+| `bd close lab-tw72d --reason ...` | Closed parent review bead |
+
+## Errors Encountered
+
+- `just build-release` failed in the temporary main worktree because mise did not trust that worktree's `.mise.toml`. The release build was rerun directly with `cargo build --workspace --all-features --release`.
+- The release build warned that `apps/gateway-admin/out` was missing, causing empty web assets to be embedded in the Rust binary. This was documented and not treated as blocking for the dev container binary sync.
+- `gh pr view` failed in the temporary worktree for the same mise trust reason. The command was rerun from the canonical repo context successfully.
+- A concurrent cargo/test process overwrote `/home/jmagar/.local/bin/labby` after the first release copy. Active builder processes were checked and PATH was recopied from the merged release artifact.
+- A first wait loop used `pgrep -f` with a pattern that matched its own shell command. That helper process was killed and replaced by a PID-safe final check.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Marketplace artifact reset | Review found reset could target every fork for a plugin | Reset targets matching artifact forks only |
+| Marketplace update apply | Review found missing-preview fallback could drop `artifact_path` | Missing preview fallback preserves selected artifact path |
+| Stash bridge async behavior | Review found blocking filesystem work in async handlers | Heavy sync work moved behind blocking boundary |
+| Artifact unfork | Review found stale sidecar state risk | Sidecar cleanup happens before component deletion |
+| Frontend Fork to Stash | Review found overlapping and stale completion issues | UI state guards request overlap and stale completion updates |
+| Dev preview | `artifact.list` missing from read-only allowlist | `artifact.list` allowed in dev preview |
+| REST admin gates | Gates duplicated policy | Gates derive policy from catalog `requires_admin` |
+| PATH binary | `/home/jmagar/.local/bin/labby` pointed into a worktree symlink | PATH binary is a regular file copied from merged release artifact |
+| Container binary | Container used prior canonical mounted binary | Container uses hash-matched merged release binary and is healthy |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `pnpm --dir apps/gateway-admin exec tsx --test lib/dev/preview-mode.test.ts components/marketplace/plugin-files-panel.test.tsx` | Frontend targeted tests pass | 13/13 tests passed | pass |
+| `cargo test -p labby reset_with_` | Reset-target tests pass | Targeted reset tests passed | pass |
+| `cargo test -p labby update_apply_rebuilds_missing_preview_for_selected_artifact_fork` | Update fallback test passes | Test passed | pass |
+| `cargo test -p labby catalog_admin_actions_drive_rest_gate` | REST gate tests pass | Marketplace and stash catalog gate tests passed | pass |
+| `cargo build --workspace --all-features --release` | Release build succeeds | Finished release profile in 12m16s | pass |
+| `sha256sum /home/jmagar/.local/bin/labby /home/jmagar/workspace/lab/bin/labby /usr/local/bin/labby` | All hashes match | All were `58e046b4edb54c8598b876325920e4fa5a851df77500f5ba4c0d3d70a10ebf1a` | pass |
+| `docker compose ps --format json` | `labby-master` healthy | Status `Up ... (healthy)` | pass |
+| `gh pr view 123 --json number,state,mergedAt,headRefOid,baseRefName,url` | PR merged into main | State `MERGED`, head `506d0fa0`, base `main` | pass |
+| `git status --short --branch` in main merge worktree | Clean and tracking origin/main | `## main...origin/main` | pass |
+
+## Risks and Rollback
+
+- The release binary was built without frontend assets embedded because `apps/gateway-admin/out` was absent. For a production release artifact, build the frontend bundle first and rebuild the release binary.
+- `/home/jmagar/.local/bin/labby` is now a regular file, not a symlink. If the repo convention should return to symlinked PATH binaries later, run the normal install/link workflow from the intended checkout.
+- Rollback for the code merge is `git revert 506d0fa0` on `main` plus a rebuild and container restart. Rollback for the local binary sync is copying a previous known-good `labby` binary back to `/home/jmagar/.local/bin/labby` and `/home/jmagar/workspace/lab/bin/labby`, then restarting `labby-master`.
+
+## Decisions Not Taken
+
+- Did not trust the temporary worktree with mise just to run `just build-release`; direct cargo build avoided changing trust state.
+- Did not clean or remove dirty worktrees because ownership was unclear and unrelated changes were present.
+- Did not force-push or rewrite branch history; both pushes were normal fast-forward updates.
+- Did not run broad `git add .` or include unrelated primary-worktree dirty docs in any commit.
+
+## References
+
+- PR #123: https://github.com/jmagar/lab/pull/123
+- Parent bead: `lab-tw72d`
+- Release source worktree: `/home/jmagar/workspace/lab/.worktrees/main-merge-marketplace-stash`
+- Feature worktree: `/home/jmagar/workspace/lab/.worktrees/marketplace-stash-integration`
+
+## Open Questions
+
+- Whether the temporary clean `main` worktree should be removed after the user no longer needs it.
+- Whether the embedded web assets warning should be handled immediately by building `apps/gateway-admin/out` and rebuilding the release artifact.
+- Whether the existing unrelated dirty docs and `plugins/vibin/skills/creating-snippets/` in the primary worktree should be committed, revised, or discarded in a separate task.
+
+## Next Steps
+
+- If a production-style binary is needed, run the frontend build first, then rerun the release build and binary/container sync.
+- Clean up the temporary merge worktree only after confirming no one needs its build artifacts.
+- Continue the separate `codex/snippets-cli-mcp` work without mixing it with the already-merged marketplace/stash PR.

--- a/plugins/testing/skills/claude-in-mobile/SKILL.md
+++ b/plugins/testing/skills/claude-in-mobile/SKILL.md
@@ -62,6 +62,54 @@ Run `claude-in-mobile doctor` first when setup is uncertain. It checks common
 dependencies such as ADB, Android SDK paths, Xcode/simctl, Appium/WDA, JDK,
 audb-client, and Chrome.
 
+## Android Via Labby
+
+When using the Labby gateway, do not conclude that `claude-in-mobile` is broken
+just because the first `device list` shows no Android target. The gateway may
+have a working `claude-in-mobile` server while no device is attached yet, or
+while host ADB is bound only to loopback.
+
+Use this recovery sequence before giving up:
+
+```bash
+# 1. Confirm the upstream is connected.
+labby gateway list | rg -i 'claude-in-mobile|mobile'
+
+# 2. Ask claude-in-mobile what it can see through Labby.
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.device({ action: "list" })'
+
+# 3. If Android is missing or system info reports ADB connection refused to
+#    172.19.0.1:5037, restart host ADB so gateway/container clients can reach it.
+adb kill-server
+adb -a start-server
+ss -ltnp | rg ':5037'
+
+# 4. If no Android device is attached, boot an emulator instead of stopping.
+avdmanager list avd
+/path/to/Android/Sdk/emulator/emulator -avd <name> \
+  -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu off -camera-back none -camera-front none
+
+# 5. Wait for the emulator, then re-check both ADB and Labby.
+adb devices -l
+adb -s emulator-5554 shell getprop sys.boot_completed
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.device({ action: "list" })'
+```
+
+Important details:
+- Labby-hosted `claude-in-mobile` may reach the host ADB daemon through a Docker
+  bridge address such as `172.19.0.1:5037`; host ADB listening on
+  `127.0.0.1:5037` is not enough. `adb -a start-server` binds it for gateway
+  access.
+- If an AVD appears to exit immediately, rerun the emulator in the foreground
+  with `-verbose` and headless-safe flags instead of assuming the emulator is
+  unavailable. A successful headless launch should eventually show
+  `control console listening on port 5554, ADB on port 5555`.
+- After Labby sees `emulator-5554`, use the MCP app/system tools to install,
+  launch, capture screenshots, and collect crash logs.
+
 ## Core Tool Families
 
 - `device`: list devices, set/get active target, and enable/disable modules.

--- a/plugins/testing/skills/claude-in-mobile/references/tooling.md
+++ b/plugins/testing/skills/claude-in-mobile/references/tooling.md
@@ -38,6 +38,86 @@ claude-in-mobile setup codex --global
 - Aurora OS: install `audb-client`, enable SSH on the device, and install Python
   on device for tap/swipe support.
 
+### Labby + Android Device Recovery
+
+When `claude-in-mobile` is exposed through Labby, the MCP server can be healthy
+while Android still reports `no device`. Do not stop there. First distinguish
+tool availability from target availability.
+
+```bash
+# Confirm the upstream and helper namespace.
+labby gateway list | rg -i 'claude-in-mobile|mobile'
+labby gateway code exec --json --code \
+  'async () => Object.keys(codemode.claude_in_mobile)'
+
+# List targets through Labby.
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.device({ action: "list" })'
+```
+
+If the Android system call fails with an ADB error such as:
+
+```text
+failed to connect to '172.19.0.1:5037': Connection refused
+cannot start server on remote host
+```
+
+then the gateway can see the host, but host ADB is only listening on loopback.
+Restart ADB with remote binding:
+
+```bash
+adb kill-server
+adb -a start-server
+ss -ltnp | rg ':5037'   # should show *:5037, not only 127.0.0.1:5037
+```
+
+If no device is connected, create or boot an emulator rather than reporting
+that claude-in-mobile cannot test Android:
+
+```bash
+sdkmanager --list_installed | rg 'emulator|platform-tools|system-images;android'
+avdmanager list avd
+
+# Create one if needed, using an installed system image.
+echo no | avdmanager create avd \
+  -n mobile_debug \
+  -k 'system-images;android-35-ext15;google_apis;x86_64' \
+  -d pixel_6 --force
+
+# Headless launch that works well under agent sessions.
+/home/$USER/Android/Sdk/emulator/emulator -avd mobile_debug \
+  -no-window -no-audio -no-boot-anim -no-snapshot \
+  -gpu off -camera-back none -camera-front none -verbose
+```
+
+In another shell, wait for boot and re-check Labby:
+
+```bash
+for i in $(seq 1 120); do
+  serial=$(adb devices | awk '/^emulator-[0-9]+[[:space:]]+device/{print $1; exit}')
+  if [ -n "$serial" ]; then
+    boot=$(adb -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+    echo "serial=$serial boot=$boot"
+    [ "$boot" = "1" ] && break
+  fi
+  sleep 2
+done
+
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.device({ action: "list" })'
+```
+
+Once Android appears, continue with install, launch, screenshots, UI tree, and
+crash logs:
+
+```bash
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.app({ action: "install", path: "/tmp/app.apk" })'
+labby gateway code exec --json --code \
+  'async () => await codemode.claude_in_mobile.app({ action: "launch", package: "com.example.app" })'
+adb -s emulator-5554 logcat -d -b crash
+```
+
 ## Coordinate Rule
 
 Raw `input` coordinates come from the most recent screenshot pixel space and can

--- a/plugins/vibin/skills/creating-snippets/SKILL.md
+++ b/plugins/vibin/skills/creating-snippets/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: creating-snippets
+description: Use when creating, editing, validating, testing, running, explaining, or removing Labby Code Mode snippets; when a user wants a reusable workflow made from gateway MCP tools; or when building schema-backed snippets from upstream tool ids, JSON schemas, params, inputs, defaults, artifacts, and MCP/CLI snippet actions.
+---
+
+# Creating Snippets
+
+## Overview
+
+Labby snippets are saved Code Mode workflows: pick gateway MCP tools, fill their schema-typed params, call them from one async JavaScript arrow function, and return structured JSON. Keep snippet business logic in the snippet body; use Labby's snippets dispatch/CLI/MCP actions to store, validate, test, and execute it.
+
+## First Checks
+
+Use `vibin:mcp-gateway-tools` before authoring any snippet that calls upstream tools. Search the live catalog and copy the returned `id`, `schema`, `output_schema`, `signature`, and `dts`; never guess tool ids or params.
+
+Useful local references:
+
+- `/home/jmagar/workspace/lab/docs/snippets/README.md`
+- `/home/jmagar/workspace/lab/docs/snippets/*.md`
+- `/home/jmagar/workspace/lab/crates/lab/src/dispatch/snippets/`
+
+## Snippet Shape
+
+Use Markdown for reusable snippets. The filename stem is the id, and frontmatter `name` must match it.
+
+````markdown
+---
+name: my-workflow
+description: Brief human-readable purpose
+tags: [research, readonly]
+inputs:
+  topic:
+    type: string
+    required: true
+    description: Topic to search
+  limit:
+    type: integer
+    default: 5
+    required: false
+tools:
+  - axon::axon
+  - github::search_issues
+---
+
+## Tutorial: How This Snippet Is Built
+
+Explain the selected tools, params, validation, execution order, and output.
+
+```js
+async (input) => {
+  const topic = input.topic;
+  const limit = input.limit ?? 5;
+  const axon = (params) => callTool("axon::axon", params);
+
+  const timed = async (label, fn) => {
+    const started = Date.now();
+    try {
+      return { label, ok: true, ms: Date.now() - started, result: await fn() };
+    } catch (error) {
+      return { label, ok: false, ms: Date.now() - started, error: String(error) };
+    }
+  };
+
+  const results = await Promise.all([
+    timed("web-search", () => axon({ action: "search", query: topic, limit })),
+    timed("rag-query", () => axon({ action: "query", query: topic, limit }))
+  ]);
+
+  return { snippet: "my-workflow", input: { topic, limit }, results };
+}
+```
+````
+
+Raw JavaScript is allowed, but Markdown with frontmatter and a tutorial is preferred.
+
+## Inputs And Defaults
+
+Use frontmatter `inputs` for user-configurable values. Supported types are `string`, `integer`, `number`, `boolean`, `object`, `array`, and `json`.
+
+Rules:
+
+- Give optional inputs defaults when possible so snippets still run with sparse params.
+- Mark genuinely required values with `required: true`.
+- Keep unknown input rejection useful: declared inputs cause `snippets.exec` to reject unexpected caller params.
+- Mirror upstream schemas in the generated call params. Snippet inputs describe user-facing knobs; upstream schemas validate each MCP tool call.
+
+## Authoring Workflow
+
+1. List existing snippets: `labby snippets list --json`.
+2. Search gateway tools with `search` and inspect schemas/signatures.
+3. Pick tools and decide parallel vs chained execution.
+4. Draft Markdown with frontmatter, tutorial text, declared inputs, and one `js`/`javascript` fenced block.
+5. Validate without saving: `labby snippets validate my-workflow --file draft.md`.
+6. Save as a user snippet: `labby snippets create my-workflow --file draft.md --description "..."`.
+7. Smoke-test execution: `labby snippets test my-workflow --param topic="mcp-ui rust"`.
+8. Run normally: `labby snippets exec my-workflow --param topic="mcp-ui rust" --max-tool-calls 10`.
+
+Use `--force` only when intentionally replacing a user snippet.
+
+## MCP And Dispatch Actions
+
+Snippets are also available through the shared dispatch layer and MCP/API service:
+
+```json
+{ "action": "snippets.list", "params": {} }
+{ "action": "snippets.get", "params": { "name": "my-workflow" } }
+{ "action": "snippets.validate", "params": { "name": "my-workflow", "body": "..." } }
+{ "action": "snippets.create", "params": { "name": "my-workflow", "body": "...", "description": "...", "force": false } }
+{ "action": "snippets.exec", "params": { "name": "my-workflow", "params": { "topic": "mcp-ui rust" }, "max_tool_calls": 10 } }
+{ "action": "snippets.test", "params": { "name": "my-workflow", "params": { "topic": "mcp-ui rust" } } }
+{ "action": "snippets.test", "params": { "all": true } }
+{ "action": "snippets.remove", "params": { "name": "my-workflow" } }
+```
+
+`remove` is destructive and only removes user snippets. Built-ins are read-only.
+
+## Execution Patterns
+
+- Use `Promise.all` only for independent calls.
+- Chain calls when later params depend on earlier results.
+- Wrap each call with timing and error capture.
+- Return stable JSON fields: `snippet`, `input`, `summary`, `results`, `evidence`, `gaps`, `followup_calls`, `timings`.
+- Keep responses compact; large Markdown, tables, screenshots, or manifests should be written with `writeArtifact("relative/path.md", content, { contentType })`.
+- Include enough ids, URLs, labels, and raw evidence handles for follow-up verification.
+
+## Validation Checklist
+
+Before calling the work done:
+
+- `name` is slug-like and matches filename/frontmatter.
+- Description is non-empty.
+- Body contains exactly the intended async arrow function.
+- All upstream tool ids came from live gateway `search`.
+- Tool params match upstream schemas.
+- Optional inputs have defaults or code fallbacks.
+- Required inputs fail fast with clear validation.
+- Fan-out is bounded by limits and `max_tool_calls`.
+- `labby snippets validate` passes.
+- `labby snippets test` passes for one snippet, or `labby snippets test --all` passes when changing shared built-ins.

--- a/plugins/vibin/skills/creating-snippets/agents/openai.yaml
+++ b/plugins/vibin/skills/creating-snippets/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Creating Snippets"
+  short_description: "Build Labby Code Mode snippets from gateway tools and schemas."
+  default_prompt: "Help me create a Labby snippet from available gateway tools."


### PR DESCRIPTION
## Summary

This branch was rebased onto `main` after most of the snippets CLI/MCP work landed via cherry-picks; what remains is a small, additive set of changes (566 insertions, 0 deletions across the original 4 commits) plus two follow-ups from this session.

### Changes
- **`fix(snippets)`** — preserve the `list_keeps_tutorial_sized_builtin_snippets` backend test. The frontend/store portions of the original commit were superseded by `main`'s evolved versions (key-based selection, better `tutorialText`, split `MAX_SNIPPET_CODE_BYTES`/`MAX_SNIPPET_FILE_BYTES`); only the new test was kept and it passes against main's loosened 256K file bound.
- **`docs(testing)`** — document mobile emulator recovery for the claude-in-mobile skill.
- **`feat(vibin)`** — add the `creating-snippets` skill.
- **`fix(dev)`** — make the claude-in-mobile adb bind-mount opt-in via `ADB_PATH` (default `/dev/null` no-op). Previously hardcoded `${HOME}/Android/Sdk/platform-tools/adb`, which mounted a phantom directory on hosts without the Android SDK. The host binary is mounted (not apt-installed) to keep the in-container adb client version in lockstep with the host adb server and avoid a kill+restart of the host daemon.
- Two `docs: save session log` commits.

## Test
- `cargo nextest run --manifest-path crates/lab/Cargo.toml --all-features -E 'test(list_keeps_tutorial_sized_builtin_snippets)'` → **1 passed**.
- `docker compose config` validated the adb mount resolves to the real path with `ADB_PATH` set and to `/dev/null` without it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps tutorial-sized built-in snippets visible and improves dev ADB portability by making the bind-mount opt-in and using a stable `host.docker.internal` alias across stacks. Adds a `creating-snippets` skill and expands Android recovery docs for the `claude-in-mobile` flow.

- **New Features**
  - Added `creating-snippets` skill with authoring workflow and agent config.
  - Expanded `claude-in-mobile` Android emulator recovery docs when used via Labby.

- **Bug Fixes**
  - Snippets: kept tutorial-sized built-ins in listing; added test `list_keeps_tutorial_sized_builtin_snippets`.
  - Dev: ADB client bind-mount is opt-in via `ADB_PATH` (defaults to `/dev/null`) to prevent phantom mounts and keep client/server versions in sync.
  - Dev: Replaced hardcoded bridge IP with `host.docker.internal`; defined the alias in `docker-compose.prod.yml` (inherited by dev) so both stacks reliably reach host ADB and local LLM services; clarified `ANDROID_ADB_SERVER_ADDRESS`/`ANDROID_ADB_SERVER_PORT` and the need for `adb -a` on the host.

<sup>Written for commit dde1ef0e8757cdfb9a458b7b89ff4ce893e25589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

