### PR TITLE
fix(dispatch): make path handling cross-platform for Windows CI

### DIFF
--- a/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/artifacts.rs
@@ -479,8 +479,7 @@ fn normalize_artifact_path(raw: &str) -> Result<String, ToolError> {
     // real `../` separators that escape the jail. Converting first makes the
     // guards see exactly the separators the filesystem will.
     let normalized = trimmed.replace('\\', "/");
-    let path = Path::new(&normalized);
-    if path.is_absolute() {
+    if is_rooted_or_drive_absolute(&normalized) {
         return Err(ToolError::InvalidParam {
             message: "artifact path must be a relative path".to_string(),
             param: "path".to_string(),
@@ -488,4 +487,27 @@ fn normalize_artifact_path(raw: &str) -> Result<String, ToolError> {
     }
     reject_path_traversal(&normalized)?;
     Ok(normalized)
+}
+
+/// Cross-platform "is this artifact path rooted or absolute?" check.
+///
+/// `Path::is_absolute()` is platform-dependent: on Windows a POSIX-rooted path
+/// like `/etc/evil` (or `\etc\evil`, which we normalize to `/etc/evil`) is NOT
+/// absolute because it lacks a drive prefix, so it would slip past the guard and
+/// only later be caught — with the wrong error kind — by `reject_path_traversal`.
+/// We operate on the already-`\`->`/`-normalized string so the rule is identical
+/// on every OS: reject a leading `/`, a Windows drive prefix (`C:`), or anything
+/// the current platform already considers absolute.
+fn is_rooted_or_drive_absolute(normalized: &str) -> bool {
+    normalized.starts_with('/')
+        || has_windows_drive_prefix(normalized)
+        || Path::new(normalized).is_absolute()
+}
+
+/// True when the path begins with a Windows drive-letter prefix such as `C:` —
+/// covering both drive-absolute (`C:/foo`) and drive-relative (`C:foo`) forms,
+/// neither of which is a valid jailed relative artifact path on any platform.
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }

--- a/crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs
@@ -191,9 +191,25 @@ impl PooledRunner {
     /// the pool's lease / free-list / recycle / eviction bookkeeping and PID
     /// reuse without needing the real labby binary (`current_exe()` in a lib
     /// unit test is the test harness, not the runner).
+    ///
+    /// The stand-in program must exist on the test host AND resolve under the
+    /// `env_clear()` in `spawn_stub_command` (no inherited `PATH`). On Unix `cat`
+    /// satisfies both; on Windows `cat`/`sleep` don't exist, so we use System32
+    /// built-ins, which `CreateProcess` finds via its default search order even
+    /// with an empty environment. `findstr` reads stdin and parks until EOF,
+    /// mirroring `cat`.
     #[cfg(test)]
     pub(in crate::dispatch::gateway::code_mode) fn spawn_stub() -> Result<Self, ToolError> {
-        Self::spawn_stub_command("cat", &[])
+        #[cfg(not(windows))]
+        {
+            Self::spawn_stub_command("cat", &[])
+        }
+        #[cfg(windows)]
+        {
+            // `findstr ^` matches every line and reads stdin until EOF, so it
+            // parks on an open-but-idle stdin pipe just like `cat`.
+            Self::spawn_stub_command("findstr", &["^"])
+        }
     }
 
     /// Test-only: a stub that consumes nothing on stdout and stays alive for a
@@ -201,9 +217,21 @@ impl PooledRunner {
     /// parent-side wall-clock timeout path in `drive_runner`.
     #[cfg(test)]
     pub(in crate::dispatch::gateway::code_mode) fn spawn_stub_silent() -> Result<Self, ToolError> {
-        // `sleep` ignores stdin and emits nothing on stdout, so the drive loop's
-        // `lines.next()` pends until the wall-clock deadline fires.
-        Self::spawn_stub_command("sleep", &["3600"])
+        // The program ignores stdin and emits nothing on stdout, so the drive
+        // loop's `lines.next()` pends until the wall-clock deadline fires.
+        #[cfg(not(windows))]
+        {
+            Self::spawn_stub_command("sleep", &["3600"])
+        }
+        #[cfg(windows)]
+        {
+            // `timeout` refuses redirected stdin; `powershell -Command Start-Sleep`
+            // is silent, ignores stdin, and resolves from System32 under env_clear.
+            Self::spawn_stub_command(
+                "powershell",
+                &["-NoProfile", "-Command", "Start-Sleep -Seconds 3600"],
+            )
+        }
     }
 
     #[cfg(test)]

--- a/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/tests_runtime.rs
@@ -700,6 +700,32 @@ async fn write_code_mode_artifact_rejects_backslash_absolute_path() {
     );
 }
 
+#[tokio::test]
+async fn write_code_mode_artifact_rejects_windows_drive_paths() {
+    // Regression: a Windows drive prefix (`C:/foo` drive-absolute or `C:foo`
+    // drive-relative) is NOT caught by `Path::is_absolute()` on Unix, and its
+    // `C:` segment parses as a plain `Normal` component there — so without the
+    // explicit `has_windows_drive_prefix` guard it would slip past the jail and
+    // only later (if at all) be mislabeled by the traversal check. Both forms
+    // must be rejected as `invalid_param` on every platform.
+    let root = TempDir::new().expect("temp root");
+    for raw in ["C:/Windows/evil", "C:foo"] {
+        let request = CodeModeArtifactWrite {
+            path: raw.to_string(),
+            content: "# nope".to_string(),
+            content_type: None,
+        };
+        let err = write_code_mode_artifact(root.path(), &request, TEST_MAX_BYTES)
+            .await
+            .expect_err("drive-prefixed path must be rejected");
+        assert_eq!(err.kind(), "invalid_param", "path `{raw}`");
+        assert!(
+            err.to_string().contains("relative path"),
+            "error should explain relative path requirement for `{raw}`: {err}"
+        );
+    }
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn write_code_mode_artifact_rejects_symlinked_ancestor() {

--- a/crates/lab/src/dispatch/marketplace/stash_bridge.rs
+++ b/crates/lab/src/dispatch/marketplace/stash_bridge.rs
@@ -856,14 +856,12 @@ fn relative_file_paths(root: &Path, current: &Path) -> Result<Vec<String>, ToolE
         if file_type.is_dir() {
             out.extend(relative_file_paths(root, &entry.path())?);
         } else {
-            out.push(
-                entry
-                    .path()
-                    .strip_prefix(root)
-                    .map_err(crate::dispatch::marketplace::client::io_internal)?
-                    .to_string_lossy()
-                    .into_owned(),
-            );
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .map_err(crate::dispatch::marketplace::client::io_internal)?
+                .to_path_buf();
+            out.push(crate::dispatch::path_safety::rel_to_unix_string(&relative));
         }
     }
     Ok(out)

--- a/crates/lab/src/dispatch/marketplace/update.rs
+++ b/crates/lab/src/dispatch/marketplace/update.rs
@@ -1311,12 +1311,8 @@ fn collect_text_paths(
             continue;
         }
         if std::fs::read_to_string(&path).is_ok() {
-            out.insert(
-                path.strip_prefix(root)
-                    .unwrap_or(&path)
-                    .to_string_lossy()
-                    .into_owned(),
-            );
+            let relative = path.strip_prefix(root).unwrap_or(&path);
+            out.insert(crate::dispatch::path_safety::rel_to_unix_string(relative));
         }
     }
     Ok(())

--- a/crates/lab/src/dispatch/path_safety.rs
+++ b/crates/lab/src/dispatch/path_safety.rs
@@ -239,6 +239,21 @@ fn reject_existing_symlink(path: &Path) -> Result<(), ToolError> {
     }
 }
 
+/// Render a relative path with `/` separators on every platform so the logical
+/// artifact keys stashes and updates emit are stable across Unix and Windows.
+///
+/// `Path::to_string_lossy()` uses the platform separator (`\` on Windows), which
+/// would make the same artifact key differ by OS and break equality with the
+/// forward-slash keys callers and snapshots expect. Iterating `components()`
+/// only rewrites the real `MAIN_SEPARATOR`; a literal backslash inside a Unix
+/// filename stays intact because it is part of a single `Normal` component.
+pub fn rel_to_unix_string(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn normalize_lexical(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for comp in path.components() {

--- a/crates/lab/src/dispatch/path_safety.rs
+++ b/crates/lab/src/dispatch/path_safety.rs
@@ -283,6 +283,26 @@ mod tests {
     }
 
     #[test]
+    fn rel_to_unix_string_joins_components_with_forward_slash() {
+        // Multi-component relative path renders with `/` on every platform —
+        // this is what keeps artifact keys stable across the Windows runner and
+        // Linux. Build via `join` so the input uses the platform separator.
+        let path = Path::new("skills").join("demo").join("SKILL.md");
+        assert_eq!(rel_to_unix_string(&path), "skills/demo/SKILL.md");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rel_to_unix_string_preserves_backslash_in_unix_filename() {
+        // On Unix a `\` is an ordinary filename byte, not a separator, so it must
+        // survive as part of a single component rather than being rewritten.
+        assert_eq!(
+            rel_to_unix_string(Path::new(r"weird\name.txt")),
+            r"weird\name.txt"
+        );
+    }
+
+    #[test]
     fn reject_symlink_accepts_directory() {
         let dir = tempdir().unwrap();
         assert!(reject_symlink(dir.path()).is_ok());

--- a/crates/lab/src/dispatch/snippets/store.rs
+++ b/crates/lab/src/dispatch/snippets/store.rs
@@ -425,8 +425,17 @@ pub fn validate_snippet_code(code: &str) -> Result<(), ToolError> {
     Ok(())
 }
 
+/// Strip the opening `---` frontmatter delimiter line, tolerating both LF and
+/// CRLF endings. Windows checkouts (and Windows-authored user snippets) carry
+/// `---\r\n`, which a bare `strip_prefix("---\n")` would miss — silently
+/// dropping the snippet's frontmatter and making built-ins undiscoverable.
+fn strip_frontmatter_open(body: &str) -> Option<&str> {
+    body.strip_prefix("---\n")
+        .or_else(|| body.strip_prefix("---\r\n"))
+}
+
 pub fn frontmatter(body: &str) -> Result<Option<SnippetFrontmatter>, ToolError> {
-    let Some(rest) = body.strip_prefix("---\n") else {
+    let Some(rest) = strip_frontmatter_open(body) else {
         return Ok(None);
     };
     let Some(raw) = frontmatter_block(rest) else {
@@ -496,7 +505,7 @@ fn frontmatter_block(rest: &str) -> Option<String> {
 }
 
 fn has_frontmatter(body: &str) -> bool {
-    body.starts_with("---\n")
+    strip_frontmatter_open(body).is_some()
 }
 
 fn required_frontmatter_field(value: Option<String>, field: &str) -> Result<String, ToolError> {
@@ -850,8 +859,7 @@ mod tests {
             // and must fail loudly — so skip only on genuine absence and let the
             // `frontmatter(body)?` inside `validate_snippet_body` surface parse
             // errors, rather than collapsing both cases with `.ok().flatten()`.
-            if path.extension().and_then(|e| e.to_str()) == Some("md") && !body.starts_with("---\n")
-            {
+            if path.extension().and_then(|e| e.to_str()) == Some("md") && !has_frontmatter(&body) {
                 continue;
             }
             validate_snippet_body(stem, &body).unwrap_or_else(|error| {

--- a/crates/lab/src/dispatch/snippets/store.rs
+++ b/crates/lab/src/dispatch/snippets/store.rs
@@ -811,6 +811,24 @@ mod tests {
     }
 
     #[test]
+    fn frontmatter_tolerates_crlf_line_endings() {
+        // Regression guard for the Windows-checkout failure: a `---\r\n` opening
+        // delimiter must be recognized just like `---\n`, otherwise built-in
+        // snippets carry no frontmatter and become undiscoverable. Without this
+        // test a dropped CRLF arm in `strip_frontmatter_open` would pass on both
+        // CI platforms (Cargo never rewrites these string literals).
+        let body = "---\r\nname: demo\r\ndescription: Demo snippet\r\ntags: []\r\n---\r\n\r\n```js\r\nasync () => ({ ok: true })\r\n```\r\n";
+
+        assert!(has_frontmatter(body), "CRLF frontmatter must be detected");
+        let meta = frontmatter(body)
+            .expect("CRLF frontmatter must parse")
+            .expect("CRLF frontmatter must be present");
+        assert_eq!(meta.name, "demo");
+        assert_eq!(meta.description, "Demo snippet");
+        assert!(validate_snippet_body("demo", body).is_ok());
+    }
+
+    #[test]
     fn repo_status_gh_pulse_builtin_is_discoverable_and_executable() {
         let lab_home = tempfile::tempdir().expect("temp lab home");
         let builtin_dir = builtin_snippet_dir();

--- a/crates/lab/src/dispatch/stash/params.rs
+++ b/crates/lab/src/dispatch/stash/params.rs
@@ -276,12 +276,21 @@ mod tests {
 
     use super::*;
 
+    // `required_absolute_path` uses OS-semantic `Path::is_absolute()`, which is
+    // correct for real host paths: a Unix `/tmp/demo` is not absolute on Windows
+    // (no drive prefix). Use a platform-appropriate absolute path so the test
+    // exercises the accept/reject contract on every OS.
+    #[cfg(windows)]
+    const ABS_PATH: &str = r"C:\tmp\demo";
+    #[cfg(not(windows))]
+    const ABS_PATH: &str = "/tmp/demo";
+
     #[test]
     fn parse_adopt_rejects_relative_origin_local_path() {
         let error = match parse_adopt_params(&json!({
             "kind": "skill",
             "name": "demo",
-            "source_path": "/tmp/demo",
+            "source_path": ABS_PATH,
             "origin": {
                 "kind": "local_path",
                 "source_path": "relative/demo"
@@ -299,14 +308,14 @@ mod tests {
         let params = parse_adopt_params(&json!({
             "kind": "skill",
             "name": "demo",
-            "source_path": "/tmp/demo",
+            "source_path": ABS_PATH,
             "origin": {
                 "kind": "local_path",
-                "source_path": "/tmp/demo"
+                "source_path": ABS_PATH
             }
         }))
         .unwrap();
 
-        assert_eq!(params.source_path, PathBuf::from("/tmp/demo"));
+        assert_eq!(params.source_path, PathBuf::from(ABS_PATH));
     }
 }


### PR DESCRIPTION
## Why

The `Test (windows self-hosted)` CI job has been red on `main` while every Linux job passes. Eight tests fail on three distinct platform-dependent path bugs.

## Failing tests (all Windows-only)

| Test | Root cause |
|---|---|
| `code_mode::…::write_code_mode_artifact_rejects_absolute_paths` | `Path::is_absolute()` is false for POSIX-rooted `/tmp/…` on Windows |
| `code_mode::…::write_code_mode_artifact_rejects_backslash_absolute_path` | same |
| `marketplace::stash_bridge::…::replace_workspace_from_base_resets_whole_plugin_tree` | `to_string_lossy()` emits `\` separators |
| `marketplace::stash_bridge::…::reset_one_path_from_base_handles_directory_artifacts` | same |
| `marketplace::update::…::collect_versions_expands_directory_artifact_paths` | same |
| `snippets::store::…::all_builtin_snippets_satisfy_the_size_and_format_contract` | CRLF checkout → frontmatter `---\r\n` missed |
| `snippets::store::…::repo_status_gh_pulse_builtin_is_discoverable_and_executable` | same |
| `stash::params::…::parse_adopt_accepts_absolute_origin_local_path` | test hardcoded a Unix-only absolute path |

## What changed

- **code_mode artifacts** — `is_rooted_or_drive_absolute()` operates on the `\`→`/`-normalized string (leading `/`, Windows drive prefix, or OS `is_absolute`) so the sandbox jail rejects rooted paths identically on every OS, with the correct `invalid_param` kind.
- **stash_bridge + marketplace update** — new `path_safety::rel_to_unix_string()` builds relative artifact keys with `/` separators on all platforms (iterates `components()`, so a literal `\` inside a Unix filename is preserved).
- **snippets store** — `strip_frontmatter_open()` accepts both `---\n` and `---\r\n`, so Windows checkouts/authoring no longer silently drop frontmatter and hide built-in snippets.
- **stash params test** — uses a platform-appropriate absolute path; production `required_absolute_path` correctly keeps OS-semantic `is_absolute()` for real host paths.

## Verification

Linux: `cargo build --all-features`, `cargo clippy --all-features --all-targets`, `cargo fmt --check` all clean. The 8 formerly-Windows-red tests plus their module neighbours (30 total) pass on Linux with no regression. Windows behaviour is verified by this PR's self-hosted CI run.

Closes lab-78yia

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-platform path handling to restore the Windows self-hosted CI tests. Align absolute-path checks, relative path rendering, snippet frontmatter parsing, and make pool test stubs resolve on Windows. Closes lab-78yia.

- **Bug Fixes**
  - Artifacts: replace `Path::is_absolute()` with `is_rooted_or_drive_absolute()` on normalized `/` strings to reject leading `/` and `C:` drive paths with the correct error.
  - Stable keys: add `path_safety::rel_to_unix_string()` and use it in stash bridge and marketplace update to always emit `/` separators (preserves literal backslashes in filenames).
  - Snippets: accept both `---\n` and `---\r\n` via `strip_frontmatter_open()` so Windows checkouts don’t drop frontmatter.
  - Tests: add regression tests for drive-prefixed paths, CRLF frontmatter, and forward-slash rendering; update stash params to use a platform-appropriate absolute path; use Windows-native stub runners in pool tests (`findstr ^` for “cat”, `powershell -NoProfile -Command Start-Sleep` for “sleep”).

<sup>Written for commit 21e3133c2cde5dcb8bced2d62ebcb1914220c833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

