### PR TITLE
fix: stop recurring npx/uvx cache corruption + dedupe OAuth URL output

### DIFF
--- a/crates/lab/src/cli/gateway.rs
+++ b/crates/lab/src/cli/gateway.rs
@@ -972,7 +972,12 @@ async fn run_gateway_oauth_start(
         "dispatch ok"
     );
 
-    crate::output::print(&value, format)?;
+    // In JSON mode emit the structured payload to stdout for scripting. In human
+    // mode the friendly "Open this URL to authorize" hint below already renders the
+    // URL, so printing the structured value here too would show it twice.
+    if format.is_json() {
+        crate::output::print(&value, format)?;
+    }
 
     let start_view: GatewayOauthStartView =
         serde_json::from_value(value.clone()).map_err(|error| {

--- a/crates/lab/src/dispatch/upstream/pool.rs
+++ b/crates/lab/src/dispatch/upstream/pool.rs
@@ -37,6 +37,7 @@ mod prompts_list;
 mod registration;
 mod resources_list;
 mod resources_read;
+mod spawn_lock;
 #[cfg(test)]
 mod testsupport;
 mod tools;

--- a/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
+++ b/crates/lab/src/dispatch/upstream/pool/connect_stdio.rs
@@ -44,6 +44,18 @@ pub(super) async fn connect_stdio_upstream(
     use std::process::Stdio;
     use tokio::process::Command;
 
+    // Cross-process spawn lock: stdio servers launched via `npx -y`/`uvx` install
+    // into a shared package cache on first cold spawn; two processes installing
+    // the same package at once corrupt it. Hold an advisory file lock (keyed on
+    // the command + args) for the whole connect — spawn, handshake, and the
+    // `list_tools` below — so identical commands serialize across every process.
+    // Best-effort: a `None` guard means locking was unavailable and we proceed.
+    // The guard borrows `spawn_lock`, so both are held as locals here; the guard
+    // is declared second so it drops first (unlock before the file handle closes)
+    // at the end of this function.
+    let mut spawn_lock = super::spawn_lock::open(command, args);
+    let _spawn_guard = super::spawn_lock::acquire(spawn_lock.as_mut()).await;
+
     // SECURITY (S1): never inherit labby's full environment — it holds
     // LAB_OAUTH_ENCRYPTION_KEY and every upstream credential. Start from a
     // scrubbed allowlist of runtime essentials (so npx/uvx/docker/etc. can still

--- a/crates/lab/src/dispatch/upstream/pool/spawn_lock.rs
+++ b/crates/lab/src/dispatch/upstream/pool/spawn_lock.rs
@@ -1,0 +1,168 @@
+//! Cross-process spawn lock for stdio upstreams.
+//!
+//! stdio MCP servers launched via `npx -y <pkg>` / `uvx <pkg>` install into a
+//! SHARED package cache (`~/.npm/_npx`, `~/.cache/uv`) on first cold spawn. When
+//! two processes install the *same* package concurrently — the gateway daemon
+//! racing a reconnect/probe attempt, or a separate `labby gateway test` / `mcp
+//! enable` CLI process racing the daemon — they write the same cache directory
+//! at once and corrupt it (partial `node_modules`, e.g. a missing peer dep),
+//! after which the server crashes on startup before completing the MCP
+//! handshake.
+//!
+//! The pool's in-process `lazy_connect_lock` (a `tokio::Mutex`) only serializes
+//! connects WITHIN one process, so it cannot prevent the cross-process race.
+//! This module adds an advisory **file lock** (`fd-lock`, the workspace's file
+//! locking crate) keyed on a hash of the spawn command + args, held for the
+//! entire connect (spawn → handshake → `list_tools`, the window during which the
+//! install runs). Identical commands serialize across every process on the host;
+//! once the cache is warm, each later acquire is a fast cache hit. Distinct
+//! commands hash to distinct lock files and never contend, so the parallel
+//! warmup stays parallel.
+//!
+//! It is deliberately keyed on the command itself, not on a hardcoded package
+//! list — every current and future `npx`/`uvx`/binary stdio server is covered
+//! automatically. Acquisition is best-effort: any filesystem/locking failure
+//! logs at debug and proceeds without the lock rather than blocking a spawn.
+//!
+//! `fd-lock`'s `RwLockWriteGuard` borrows its `RwLock`, so the two cannot live
+//! in one returnable struct. Callers therefore [`open`] the lock (a value they
+//! own for the connect's duration) and pass `&mut` to [`acquire`]; the returned
+//! guard is held as a sibling local and releases on drop. Declare the guard
+//! AFTER the `RwLock` so it drops first (unlock before the file handle closes).
+
+use fd_lock::{RwLock, RwLockWriteGuard};
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{File, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+
+/// How long to wait for a contended lock before giving up and proceeding
+/// without it. Generous enough to cover a slow cold `npm`/`uv` install.
+const SPAWN_LOCK_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Poll interval while the lock is held by another process.
+const SPAWN_LOCK_POLL: Duration = Duration::from_millis(100);
+
+/// Open (but do not yet lock) the per-command lock file. Returns `None` on any
+/// filesystem error so the caller proceeds best-effort without a lock. The
+/// returned `RwLock` must outlive the guard returned by [`acquire`].
+pub(super) fn open(command: &str, args: &[String]) -> Option<RwLock<File>> {
+    let mut hasher = DefaultHasher::new();
+    command.hash(&mut hasher);
+    args.hash(&mut hasher);
+    let key = format!("{:016x}", hasher.finish());
+
+    let dir = std::env::temp_dir().join("labby-spawn-locks");
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        tracing::debug!(
+            service = "upstream.pool",
+            action = "upstream.spawn_lock",
+            %error,
+            "spawn lock dir create failed; proceeding without lock"
+        );
+        return None;
+    }
+    let path = dir.join(format!("{key}.lock"));
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+    {
+        Ok(file) => Some(RwLock::new(file)),
+        Err(error) => {
+            tracing::debug!(
+                service = "upstream.pool",
+                action = "upstream.spawn_lock",
+                %error,
+                "spawn lock file open failed; proceeding without lock"
+            );
+            None
+        }
+    }
+}
+
+/// Acquire the exclusive cross-process lock, polling until the holder releases
+/// it or [`SPAWN_LOCK_TIMEOUT`] elapses. Returns `None` (proceed best-effort) if
+/// `lock` is absent, on timeout, or on any locking error — never blocks a spawn.
+pub(super) async fn acquire(lock: Option<&mut RwLock<File>>) -> Option<RwLockWriteGuard<'_, File>> {
+    let lock = lock?;
+    let deadline = Instant::now() + SPAWN_LOCK_TIMEOUT;
+
+    // Wait until the lock looks free (or we time out), releasing the probe lock
+    // between attempts. The probe guard is a temporary scoped to the `if`
+    // condition, so it drops before the loop body runs. Keeping the final
+    // acquisition OUTSIDE the loop avoids returning a borrow across the loop
+    // back-edge (which the borrow checker rejects).
+    let mut waited = false;
+    while Instant::now() < deadline {
+        // The probe guard is a temporary scoped to this `if` condition, so it
+        // drops (releasing the lock) before the loop body runs.
+        if lock.try_write().is_ok() {
+            break;
+        }
+        waited = true;
+        tokio::time::sleep(SPAWN_LOCK_POLL).await;
+    }
+
+    match lock.try_write() {
+        Ok(guard) => {
+            if waited {
+                tracing::debug!(
+                    service = "upstream.pool",
+                    action = "upstream.spawn_lock",
+                    "acquired contended spawn lock"
+                );
+            }
+            Some(guard)
+        }
+        Err(error) => {
+            tracing::warn!(
+                service = "upstream.pool",
+                action = "upstream.spawn_lock",
+                %error,
+                timeout_secs = SPAWN_LOCK_TIMEOUT.as_secs(),
+                "spawn lock unavailable (contended past timeout or errored); proceeding without lock"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn acquire_then_release_allows_reacquire() {
+        // Distinct command per test avoids cross-test contention on the shared
+        // temp lock directory.
+        let mut lock = super::open("labby-spawn-lock-test-bin", &["--unit-test".to_string()])
+            .expect("open lock file");
+
+        {
+            let guard = super::acquire(Some(&mut lock)).await;
+            assert!(guard.is_some(), "first acquire should succeed");
+        } // guard dropped here, releasing the flock
+
+        let again = super::acquire(Some(&mut lock)).await;
+        assert!(again.is_some(), "reacquire after release should succeed");
+    }
+
+    #[tokio::test]
+    async fn distinct_commands_open_distinct_locks() {
+        let mut a = super::open("labby-spawn-lock-test-a", &[]).expect("open a");
+        let mut b = super::open("labby-spawn-lock-test-b", &[]).expect("open b");
+        let ga = super::acquire(Some(&mut a)).await;
+        let gb = super::acquire(Some(&mut b)).await;
+        assert!(
+            ga.is_some() && gb.is_some(),
+            "different commands hash to different lock files and must not block each other"
+        );
+    }
+
+    #[tokio::test]
+    async fn absent_lock_yields_no_guard() {
+        let guard = super::acquire(None).await;
+        assert!(guard.is_none(), "None input must proceed without a guard");
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,16 @@ services:
     volumes:
       # Hot-swap the locally built binary into the dev runtime.
       - ./bin/labby:/usr/local/bin/labby
+      # Persist the npm/uv package caches across container recreates. stdio MCP
+      # upstreams are launched via `npx -y <pkg>` / `uvx <pkg>`, which install
+      # into these caches on first cold spawn. Without persistence the caches
+      # live in the container's writable layer and are wiped on every recreate,
+      # forcing a fresh concurrent re-download each boot — the window in which
+      # the install race (see pool/spawn_lock.rs) corrupts a package. A named
+      # volume makes the clean install permanent: every later spawn is a cache
+      # hit, so the race never runs again.
+      - npm-cache:/home/lab/.npm
+      - uv-cache:/home/lab/.cache
       # adb client for the in-container claude-in-mobile MCP server. claude-in-mobile
       # talks to the host's adb SERVER (config.toml: ANDROID_ADB_SERVER_ADDRESS +
       # ANDROID_ADB_SERVER_PORT=5037), so it only needs a client binary on PATH to
@@ -50,6 +60,10 @@ services:
 
 volumes:
   labby-data:
+    driver: local
+  npm-cache:
+    driver: local
+  uv-cache:
     driver: local
 
 networks:


### PR DESCRIPTION
## Summary

Two fixes that came out of investigating why the **repomix** MCP upstream and the **Google** MCP upstreams stopped exposing tools through the Labby gateway.

### 1. Stop recurring npx/uvx package-cache corruption (the main fix)

**Root cause.** stdio MCP upstreams are launched via `npx -y <pkg>` / `uvx <pkg>`, which install into a shared package cache (`~/.npm/_npx`, `~/.cache/uv`) on first cold spawn. When two processes install the *same* package concurrently — the gateway daemon racing a reconnect/probe attempt, or a separate `labby gateway test` / `mcp enable` CLI process racing the daemon — they write the same cache directory at once and corrupt it (partial `node_modules`, e.g. a missing `ajv` peer dep). The server then crashes on startup before completing the MCP handshake, surfacing as `Broken pipe ... when send initialize request` or `connection closed: initialize response`. repomix was hitting exactly this.

The pool already has a per-upstream `lazy_connect_lock`, but it's an in-process `tokio::Mutex` — it can't coordinate across separate `labby` processes, which is where the race actually happens.

**Fix.** New `pool/spawn_lock.rs`: an advisory **file lock** (`fs4`, already a dep) keyed on a hash of `command + args`, held for the whole connect (spawn → handshake → `list_tools` — the window in which the install runs). Wired into the single stdio spawn chokepoint in `connect_stdio.rs`.

- Keyed on the command, **not a hardcoded package list** — every current and future `npx`/`uvx`/binary stdio server is covered automatically.
- Distinct commands hash to distinct lock files and never contend, so the 16-way parallel warmup stays parallel; only *identical* concurrent spawns serialize.
- Best-effort: any lock/fs failure logs at debug and proceeds — it never blocks a spawn. 120s timeout with 100ms polling.

Also persist the npm/uv caches as named volumes (`npm-cache`, `uv-cache`) in `docker-compose.yml`. Previously these lived in the container's writable layer and were wiped on every recreate, forcing a fresh concurrent re-download each boot. With a named volume the clean install is permanent: every later spawn is a cache hit and the race never reopens.

### 2. Print the upstream OAuth authorization URL once

`labby gateway mcp auth start` printed the authorization URL twice in human mode — once via the structured `output::print` of the dispatch result, and again via the "Open this URL to authorize" hint. Gate the structured print behind `--json` so human mode shows the URL a single time, while `--json` still emits clean machine output on stdout for scripting.

## Testing

- `cargo check --all-features` ✅
- New `spawn_lock` unit tests (acquire/release/reacquire, distinct-commands-don't-contend) pass ✅
- `cargo fmt --check` ✅, `cargo clippy --all-features --lib` clean (0 warnings) ✅
- `docker compose config` validates; cache volumes resolve to `lab_npm-cache` / `lab_uv-cache` ✅
- Double-print fix verified against the built binary: 1 URL in human mode, clean single-line JSON under `--json`.

## Reviewer notes

- The spawn lock holds for the full connect (through `list_tools`), bounded by the existing `DISCOVERY_TIMEOUT`; the lock's own wait is bounded at 120s and falls back to proceeding without the lock.
- Activating the cache volumes requires a `docker compose up -d` recreate (not just restart). The spawn-lock change ships in the labby binary and works on the existing ephemeral cache too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops recurring `npx`/`uvx` package-cache corruption by serializing identical stdio MCP spawns across processes and persisting caches. Also prints the upstream OAuth authorization URL only once.

- **Bug Fixes**
  - Added cross-process file lock (via `fd-lock`) keyed on `command + args` to serialize identical stdio spawns during connect; prevents shared cache clobbering in `~/.npm/_npx` and `~/.cache/uv`.
  - Persisted npm/uv caches as named volumes in `docker-compose.yml` (`npm-cache`, `uv-cache`) so cold installs survive container recreates.
  - Gated structured print in `labby gateway mcp auth start` behind `--json` to avoid duplicate authorization URLs in human mode.

- **Migration**
  - Recreate containers to attach the new cache volumes: `docker compose up -d`.

<sup>Written for commit 0a1464f9e1662fb9c7e139adef08e54085150af4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate output in `gateway mcp auth start` command when not using JSON format.
  * Improved stability by adding cross-process locking to prevent race conditions during concurrent operations.

* **Chores**
  * Optimized Docker setup with persistent package manager caches to reduce reinstall time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->