### PR TITLE
fix(build): make all product feature-slices compile standalone

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -19,6 +19,7 @@ Every push and PR to `main` must pass all jobs:
 | actionlint | `go run github.com/rhysd/actionlint/cmd/actionlint@latest` |
 | frontend-assets | `pnpm install --frozen-lockfile && pnpm build` in `apps/gateway-admin` |
 | check | `cargo check --workspace --all-features` |
+| feature-slices | `cargo check -p labby --no-default-features --features <slice>` per slice (`gateway`/`marketplace`/`fs`/`deploy`/`acp_registry`) — catches cross-slice coupling (a shared module unconditionally referencing a feature-gated one). Gates compilation only; overrides the global `-D warnings` because per-slice dead-code warnings are expected. |
 | fmt | `cargo fmt --all -- --check` |
 | clippy | `cargo clippy --workspace --all-features -- -D warnings` |
 | deny | `cargo deny check` (via `EmbarkStudios/cargo-deny-action`) |
@@ -36,7 +37,10 @@ is not viable because aws-lc-sys requires a real Windows C toolchain even under
 `cargo check`). Windows breakage therefore surfaces on the post-merge main run,
 not in the PR.
 
-`RUSTFLAGS: -D warnings` is set globally — zero warnings permitted.
+`RUSTFLAGS: -D warnings` is set globally — zero warnings permitted. The lone
+exception is the `feature-slices` job, which overrides it to `""` because
+per-slice dead-code warnings are an inherent, expected consequence of disabling
+features; that job gates compilation, not warning-cleanliness.
 
 ## Release Build Matrix (release.yml)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,16 +102,16 @@ jobs:
     needs: frontend-assets
     # CLAUDE.md's intent is that each standalone product slice compiles on its
     # own (--no-default-features --features <slice>) to catch cross-slice
-    # coupling. This job runs that check but is ADVISORY: shared MCP/security
-    # infra (mcp/call_tool.rs, mcp/context.rs, dispatch/security/ssrf.rs,
-    # dispatch/setup/dispatch.rs) currently references the gateway / upstream /
-    # acp_registry feature-gated modules unconditionally, so no single slice
-    # builds standalone yet. Feature-gating that core plumbing (~55 references)
-    # is its own change; the authoritative signal remains the all-features
-    # `check`/`test` jobs above. Until the slices build clean, a failure is
-    # downgraded to a `::warning::` annotation so this advisory gate does not
-    # block the PR. Drop the `|| { ... }` wrapper once the slices compile.
-    # `stash` has no feature flag (always-on) so it is absent.
+    # coupling — a shared module referencing a feature-gated one unconditionally.
+    # This is a hard gate on COMPILATION (errors), not warning-cleanliness:
+    # per-slice dead-code warnings are an inherent, expected consequence of
+    # disabling features (a service module is compiled but its registration is
+    # gated off), so this job overrides the global `-D warnings`. The
+    # all-features `check`/`clippy`/`test` jobs above remain the authoritative
+    # warning-clean signal. `stash` has no feature flag (always-on) so it is
+    # absent.
+    env:
+      RUSTFLAGS: ""
     strategy:
       fail-fast: false
       matrix:
@@ -124,10 +124,7 @@ jobs:
           path: apps/gateway-admin/out
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@v2
-      - run: |
-          cargo check -p labby --no-default-features --features ${{ matrix.slice }} --locked || {
-            echo "::warning title=feature-slice::slice '${{ matrix.slice }}' does not yet build standalone (pre-existing cross-slice coupling in shared MCP/security infra)"
-          }
+      - run: cargo check -p labby --no-default-features --features ${{ matrix.slice }} --locked
 
   docs-check:
     name: Generated docs

--- a/crates/lab-apis/src/acp_registry.rs
+++ b/crates/lab-apis/src/acp_registry.rs
@@ -8,8 +8,11 @@
 pub mod client;
 pub mod error;
 pub mod installer;
-pub mod ssrf;
 pub mod types;
+
+/// The canonical SSRF guard now lives in `crate::core::ssrf`; re-exported here so
+/// existing `acp_registry::ssrf` / `super::ssrf` paths keep working unchanged.
+pub use crate::core::ssrf;
 
 pub use client::AcpRegistryClient;
 pub use error::AcpRegistryError;

--- a/crates/lab-apis/src/core.rs
+++ b/crates/lab-apis/src/core.rs
@@ -28,6 +28,12 @@ pub mod traits;
 /// `deploy`.
 pub mod ssh;
 
+/// Canonical SSRF preflight guards for externally supplied HTTPS URLs. Lives in
+/// `core` (not under a feature-gated service module) because it is a shared
+/// security primitive used by always-compiled `lab` dispatch code as well as
+/// the feature-gated `acp_registry` installer.
+pub mod ssrf;
+
 // Convenience re-exports so service modules can `use crate::core::{Auth, HttpClient, ApiError, ...}`.
 pub use action::{ActionSpec, ParamSpec};
 pub use auth::Auth;

--- a/crates/lab-apis/src/core/ssrf.rs
+++ b/crates/lab-apis/src/core/ssrf.rs
@@ -9,9 +9,9 @@
 //!
 //! It is a *preflight* guard, not a complete DNS-rebinding defense. Any code
 //! that performs an outbound request must still avoid unsafe redirects and
-//! must re-validate the connected peer where it can (see
-//! [`super::installer`], which pins a single validated address and re-checks
-//! the peer IP post-connect).
+//! must re-validate the connected peer where it can (see the ACP installer in
+//! `crate::acp_registry::installer`, which pins a single validated address and
+//! re-checks the peer IP post-connect).
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -19,7 +19,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 ///
 /// Carries no caller secrets — messages are built from already-redacted URL
 /// forms / bare host strings. Wrapped into surface error types (`ToolError`,
-/// [`AcpInstallerError`](super::installer::AcpInstallerError)) by callers; the
+/// `AcpInstallerError`) by callers; the
 /// stable error `kind` for all variants is `ssrf_blocked` except
 /// [`SsrfError::InvalidUrl`] which is `invalid_param`.
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
+++ b/crates/lab/src/dispatch/marketplace/acp_dispatch.rs
@@ -660,8 +660,8 @@ mod tests {
     // NB: The deep download/verify/extract/install guard tests (SSRF address
     // filtering, mandatory SHA-256, size cap, zip-slip/symlink rejection,
     // setuid strip, atomic install, peer re-validation) moved with the
-    // primitive into `lab_apis::acp_registry::installer` and
-    // `lab_apis::acp_registry::ssrf`. They are exercised there. The tests
+    // primitive into `lab_apis::acp_registry::installer` and the SSRF guard in
+    // `lab_apis::core::ssrf`. They are exercised there. The tests
     // below cover the orchestrator's remaining responsibilities.
 
     // The integrity-missing fail-closed gate stays in dispatch because it

--- a/crates/lab/src/dispatch/security/ssrf.rs
+++ b/crates/lab/src/dispatch/security/ssrf.rs
@@ -5,7 +5,7 @@
 //! must not claim that validation-time DNS pins the final connection target.
 //!
 //! The host/IP allow-deny policy itself is **not** defined here — it lives in
-//! `lab_apis::acp_registry::ssrf` (the canonical single source of truth, since
+//! `lab_apis::core::ssrf` (the canonical single source of truth, since
 //! `lab-apis` cannot depend back on `dispatch`). This module owns only the
 //! `lab`-side concerns: DNS resolution, the async `spawn_blocking` wrapper,
 //! the concurrency semaphore, and conversion of `SsrfError` into `ToolError`.
@@ -16,7 +16,7 @@ use std::net::{IpAddr, ToSocketAddrs};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use lab_apis::acp_registry::ssrf as shared;
+use lab_apis::core::ssrf as shared;
 
 use crate::dispatch::error::ToolError;
 use tokio::sync::Semaphore;

--- a/crates/lab/src/dispatch/setup/dispatch.rs
+++ b/crates/lab/src/dispatch/setup/dispatch.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use crate::config::env_merge::{self, EnvEntry, MergeRequest, snapshot_mtime};
 use crate::config::{config_toml_path, patch_built_in_upstream_apis_enabled};
+#[cfg(feature = "gateway")]
 use crate::dispatch::gateway::current_gateway_manager;
 
 /// Maximum elapsed time for the inline doctor.audit.full call inside
@@ -376,6 +377,10 @@ fn settings_update_action(params: &Value) -> Result<Value, ToolError> {
 
 fn refresh_built_in_upstream_registry(enabled: bool) {
     crate::registry::set_runtime_built_in_upstream_apis_enabled(enabled);
+    // Notify the live gateway manager so upstream discovery reflects the change.
+    // The gateway manager only exists with the gateway feature; without it there
+    // is nothing to refresh.
+    #[cfg(feature = "gateway")]
     if let Some(manager) = current_gateway_manager() {
         manager.set_builtin_service_registry(crate::registry::filter_built_in_upstream_apis(
             crate::registry::build_default_registry(),

--- a/crates/lab/src/mcp/call_tool.rs
+++ b/crates/lab/src/mcp/call_tool.rs
@@ -24,9 +24,13 @@ use rmcp::service::RequestContext;
 use serde_json::Value;
 
 use crate::dispatch::error::ToolError;
+#[cfg(feature = "gateway")]
 use crate::dispatch::gateway::manager::CallbackToolLookup;
+#[cfg(feature = "gateway")]
 use crate::dispatch::upstream::types::UpstreamTool;
+#[cfg(feature = "gateway")]
 use crate::mcp::call_tool_upstream::PreResolvedUpstreamTool;
+#[cfg(feature = "gateway")]
 use crate::mcp::catalog::{CODE_MODE_SEARCH_TOOL_NAME, TOOL_EXECUTE_TOOL_NAME};
 use crate::mcp::context::{
     auth_context_from_extensions, tool_execute_builtin_action_allowed, tool_execute_scope_allowed,
@@ -39,6 +43,7 @@ use crate::mcp::result_format::{
 };
 use crate::mcp::server::LabMcpServer;
 
+#[cfg(feature = "gateway")]
 enum WidgetCallbackGate {
     Allowed {
         resolved: Box<PreResolvedUpstreamTool>,
@@ -240,7 +245,13 @@ impl LabMcpServer {
             )]));
         }
 
+        // Upstream widget-callback resolution is a gateway-only concern (it
+        // proxies to upstream MCP tools). Without the gateway feature there are
+        // no upstream tools, so this resolution and the upstream tail below are
+        // both compiled out.
+        #[cfg(feature = "gateway")]
         let mut resolved_upstream_tool = None;
+        #[cfg(feature = "gateway")]
         if self.code_mode_visibility().await.hides_raw_tools() {
             let widget_callback = if svc.is_none() {
                 match self.resolve_widget_callback_gate(&service, &context).await {
@@ -459,20 +470,39 @@ impl LabMcpServer {
 
         // Fall through to upstream proxy dispatch (raw + subject-scoped +
         // no-dispatcher-wired fallback). The helper returns unconditionally.
-        self.call_tool_upstream_impl(
-            &service,
-            &action,
-            raw_arguments,
-            resolved_upstream_tool,
-            start,
-            &subject,
-            actor_key,
-            &context,
-        )
-        .await
+        // The upstream proxy only exists with the gateway feature; without it an
+        // unresolved service name is simply not found.
+        #[cfg(feature = "gateway")]
+        {
+            self.call_tool_upstream_impl(
+                &service,
+                &action,
+                raw_arguments,
+                resolved_upstream_tool,
+                start,
+                &subject,
+                actor_key,
+                &context,
+            )
+            .await
+        }
+        #[cfg(not(feature = "gateway"))]
+        {
+            let _ = (raw_arguments, actor_key, start);
+            let envelope = build_error(
+                &service,
+                &action,
+                "not_found",
+                &format!("service `{service}` not found"),
+            );
+            Ok(CallToolResult::error(vec![Content::text(
+                envelope.to_string(),
+            )]))
+        }
     }
 }
 
+#[cfg(feature = "gateway")]
 impl LabMcpServer {
     async fn resolve_widget_callback_gate(
         &self,
@@ -549,6 +579,7 @@ impl LabMcpServer {
     }
 }
 
+#[cfg(feature = "gateway")]
 fn classify_widget_callback_candidates(
     route: &'static str,
     hidden_sibling: bool,


### PR DESCRIPTION
## Summary

Makes every standalone product feature-slice compile on its own
(`cargo check -p labby --no-default-features --features <slice>`). Previously
**no** slice built standalone because shared, always-compiled infrastructure
referenced feature-gated modules unconditionally — the pre-existing cross-slice
coupling flagged when the feature-slice CI job was first added (#130, where it was
left advisory).

## Two coupling classes fixed

**1. SSRF (broke `gateway` / `marketplace` / `fs` / `deploy`)**
The canonical SSRF preflight guard was filed under the `acp_registry` feature in
`lab-apis` (`acp_registry/ssrf.rs`), but the always-compiled
`dispatch::security::ssrf` used it unconditionally. It's a shared security
primitive, not an acp_registry concern, so it now lives in `lab-apis` **core**
(`core/ssrf.rs`, always available), re-exported from `acp_registry` for
back-compat. No behavior change.

**2. `gateway` / `upstream` (broke `marketplace` / `fs` / `deploy` / `acp_registry`)**
The MCP upstream-proxy + widget-callback machinery in `mcp/call_tool.rs` and the
gateway-manager notification in `dispatch/setup/dispatch.rs` referenced the
`gateway`/`upstream` feature-gated modules unconditionally. Feature-gated behind
`#[cfg(feature = "gateway")]`:
- the upstream/widget-callback imports, the `WidgetCallbackGate` enum, and the
  `resolve_widget_callback_gate` / `classify_widget_callback_candidates` helpers
- the two gateway-only sections of `call_tool_impl` (widget-callback resolution +
  the upstream proxy tail), with a clean non-gateway `not_found` fallback
- the gateway-manager refresh in `setup/dispatch.rs`

The auth/scope functions (`tool_execute_builtin_action_allowed`,
`auth_context_from_extensions`, …) stay **ungated** — admin-scope enforcement on
builtin actions is unchanged in minimal builds, so there is no security regression.

## CI

The `feature-slices` job becomes a **real (non-advisory) compile gate** — the
`|| warning` swallow is removed. It overrides the global `-D warnings` because
per-slice dead-code warnings (a service module compiled but its registration
gated off) are an inherent, expected consequence of disabling features; the
all-features `check` / `clippy -D warnings` / `test` jobs remain the authoritative
warning-clean signal.

## Verification
- All 5 slices (`gateway`/`marketplace`/`fs`/`deploy`/`acp_registry`) compile — 0 errors.
- All-features `cargo check` + `cargo clippy --all-features -- -D warnings` clean.
- `cargo nextest run --workspace --all-features` — **2121 passed**.
- `docs check`, `cargo deny check`, `cargo fmt --check` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make each product feature-slice compile on its own by removing cross-slice coupling and gating gateway-only code. Also makes the `feature-slices` CI job a strict compile gate.

- **Refactors**
  - Moved the SSRF preflight guard to `lab-apis` `core/ssrf` (always available) and re-exported from `acp_registry::ssrf`; updated dispatch to use `lab_apis::core::ssrf`. No behavior change.
  - Gated gateway/upstream code in `mcp/call_tool.rs` and `dispatch/setup/dispatch.rs` behind `#[cfg(feature = "gateway")]`; non-gateway builds now return "not_found" for unresolved services.

- **CI**
  - `feature-slices`: now required; runs `cargo check -p labby --no-default-features --features <slice>` per slice.
  - Overrides global `-D warnings` (`RUSTFLAGS: ""`) to ignore expected per-slice dead-code warnings; docs updated in `.github/CLAUDE.md`.

<sup>Written for commit 52d9cacc28539bd7f94eb9823d06bf6f4e64479b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

