### PR TITLE
fix: Google MCP upstreams — refresh keeps client secret + capability probe non-fatal

### DIFF
--- a/crates/lab/src/dispatch/gateway/oauth_lifecycle.rs
+++ b/crates/lab/src/dispatch/gateway/oauth_lifecycle.rs
@@ -338,9 +338,18 @@ impl GatewayManager {
                 discovered_tool_count = summary.discovered_tool_count;
                 exposed_tool_count = summary.exposed_tool_count;
             }
-            if let Some(error) = pool.upstream_last_error(upstream).await {
+            // Only a TOOL discovery failure marks the upstream as failed —
+            // tool routing is gated solely on tool health (see
+            // `UpstreamPool::healthy_tools`). A resources/prompts capability
+            // probe that errors (e.g. an upstream whose endpoint returns HTTP
+            // 400 for `resources/list` instead of a clean "unsupported" reply)
+            // must NOT hide tools that discovered fine; surface it as a
+            // non-fatal diagnostic and keep the connection authenticated.
+            if let Some(error) = pool.upstream_tool_last_error(upstream).await {
                 discovery_error = Some(error);
                 state = UpstreamOauthConnectionState::DiscoveryFailed;
+            } else if let Some(error) = pool.upstream_last_error(upstream).await {
+                discovery_error = Some(error);
             }
         }
         let authenticated = matches!(

--- a/crates/lab/src/oauth/upstream/manager.rs
+++ b/crates/lab/src/oauth/upstream/manager.rs
@@ -583,6 +583,32 @@ impl UpstreamOauthManager {
             )));
         }
 
+        // rmcp's `initialize_from_store()` reconfigures the OAuth client via
+        // `configure_client_id()`, which hardcodes `client_secret: None` and so
+        // discards the secret that `configured_authorization_manager` just set.
+        // Confidential upstreams (e.g. Google, which requires `client_secret` on
+        // the refresh_token grant) then fail refresh with "client_secret is
+        // missing". Re-apply the resolved client config — including the secret —
+        // now that stored credentials and metadata are loaded. `refresh_token()`
+        // reads the refresh token from the credential store, not the client
+        // config, so re-configuring the client does not disturb it. For public
+        // clients `resolve_client_config` yields no secret, so this is a no-op.
+        let scopes_owned = self.oauth_config()?.scopes.clone().unwrap_or_default();
+        let scopes: Vec<&str> = scopes_owned.iter().map(String::as_str).collect();
+        let client_cfg = self
+            .resolve_client_config(
+                &mut manager,
+                subject,
+                &scopes,
+                DynamicClientRegistrationUse::StoredCredentials,
+            )
+            .await?;
+        manager.configure_client(client_cfg).map_err(|e| {
+            OauthError::Internal(format!(
+                "re-configure client with credentials after store init: {e}"
+            ))
+        })?;
+
         manager.refresh_token().await.map_err(map_auth_error)?;
         tracing::info!(
             upstream = %self.upstream.name,


### PR DESCRIPTION
## Summary

Two real bugs behind "the Google MCP servers won't stay connected / expose no tools," found while investigating why all four (`google-drive`, `google-gmail`, `google-calendar`, `google-people`) drop offline ~1h after authorizing. Replaces the workaround of gating `proxy_resources = false` with actual fixes.

### 1. Token refresh dropped the client secret → all four upstreams die on refresh

After the initial authorization, every proactive refresh failed with `invalid_request: client_secret is missing`, flipping the upstream to `refresh_failed` once the access token expired. Re-authing fixed it only until the next refresh.

**Root cause** is an interaction with rmcp's `AuthorizationManager`:
- `refresh_auth_client` configures the client **with** the secret (via `configured_authorization_manager`), then calls `initialize_from_store()` to load stored credentials.
- `initialize_from_store()` reconfigures the client through `configure_client_id()`, which **hardcodes `client_secret: None`** (rmcp `auth.rs`), discarding the secret right before `refresh_token()` builds the grant.
- The initial `authorization_code` **exchange** never calls `initialize_from_store()`, which is exactly why exchange worked but refresh always failed.

**Fix:** re-apply the resolved client config (including the secret) after `initialize_from_store()` and before `refresh_token()`. The refresh token is read from the credential store, not the client config, so re-configuring the client doesn't disturb it. For public clients `resolve_client_config` yields no secret, so it's a no-op.

### 2. A resources/list probe error marked the whole upstream `DiscoveryFailed`

`google-drive` discovered its 8 tools fine but was reported failed (and tools hidden from the status view) because its endpoint returns **HTTP 400 for `resources/list`** — it's tools-only and doesn't implement the resources primitive, and the 400 isn't the clean `-32601` "unsupported" reply the gateway already tolerates.

The OAuth status path keyed `DiscoveryFailed` on the aggregate `upstream_last_error` (tools **or** resources **or** prompts). But tool routing is gated **solely** on tool health (`UpstreamPool::healthy_tools` → `tool_health.is_routable()`), so a resources/prompts probe error has no bearing on whether tools work.

**Fix:** gate `DiscoveryFailed` on `upstream_tool_last_error` (tools only); surface a non-tool capability error as a non-fatal `discovery_error` diagnostic without flipping state or authentication.

## Testing

- `cargo check --workspace --all-features --locked` ✅ (exact CI command)
- `cargo nextest run -E 'test(upstream_oauth)'` — 17/17 pass, including the existing public-client refresh lifecycle test (no regression) ✅
- `cargo clippy --all-features --lib --tests` clean (0 warnings) ✅, `cargo fmt --check` ✅

**Note on test coverage:** an automated confidential-client refresh test would need to inject a `client_secret` via the `client_secret_env` indirection, i.e. `std::env::set_var` — which is `unsafe` in edition 2024 and rejected by the crate's `forbid(unsafe_code)`. The fix is covered by the unchanged public-client path tests plus live verification against the Google upstreams. If we want automated coverage, a small non-env seam on `Preregistered` (e.g. an inline secret for tests) would let us assert the refresh body carries `client_secret`.

## Reviewer notes

- Fix #1 touches the security-sensitive upstream OAuth path; the change is additive (re-applies an already-resolved config) and bounded to `refresh_auth_client`.
- Fix #2 only changes the OAuth **status** classification + the diagnostic surfaced; it does not change routing, which was already tool-health-gated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues that caused Google MCP upstreams to drop after ~1h and hide tools unnecessarily. Keeps confidential-client refresh working and makes non-tool capability probe errors non-fatal.

- **Bug Fixes**
  - OAuth refresh: preserve `client_secret` for confidential clients by re-applying the resolved client config after loading stored credentials, preventing `invalid_request: client_secret is missing` and `refresh_failed`.
  - Discovery status: only mark `DiscoveryFailed` on tool errors; treat resources/prompts probe failures as a non-fatal `discovery_error` so tools remain visible (e.g., `google-drive` returning HTTP 400 for `resources/list`).

<sup>Written for commit f4c6861cdc3c095dd48bc3ef817b62cf808b0f9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

