### PR TITLE
fix(code-mode): show reduced search results in the inspector

### DIFF
--- a/apps/gateway-admin/components/code-mode-app/code-mode-inspector.test.tsx
+++ b/apps/gateway-admin/components/code-mode-app/code-mode-inspector.test.tsx
@@ -96,6 +96,28 @@ test('renders search truncation count metadata', async () => {
   await unmount()
 })
 
+test('renders reduced search result shape and value when no tool rows match', async () => {
+  installChatTestDom()
+  const { container, unmount } = await renderClient(
+    <CodeModeInspector
+      initialTrace={{
+        kind: 'code_mode_search_trace',
+        query_kind: 'catalog_filter',
+        match_count: 0,
+        matches: [],
+        result_shape: { type: 'object', key_count: 2, keys: ['total', 'upstreams'] },
+        result: { total: 398, upstreams: 42 },
+      }}
+    />,
+  )
+
+  assert.match(container.textContent ?? '', /Search result/)
+  assert.match(container.textContent ?? '', /reduced value/)
+  assert.match(container.textContent ?? '', /keys: total, upstreams/)
+  assert.match(container.textContent ?? '', /398/)
+  await unmount()
+})
+
 test('renders history rows and flattened nested calls', async () => {
   installChatTestDom()
   const { container, unmount } = await renderClient(

--- a/apps/gateway-admin/components/code-mode-app/code-mode-inspector.tsx
+++ b/apps/gateway-admin/components/code-mode-app/code-mode-inspector.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/aurora/tokens'
 import {
   type CodeModeTrace,
+  describeResultShape,
   flattenTraceRows,
   parseCodeModeTrace,
   stringifyRedactedParams,
@@ -250,6 +251,10 @@ export function CodeModeInspector({ initialTrace }: CodeModeInspectorProps) {
           </Panel>
         ) : null}
 
+        {trace?.kind === 'code_mode_search_trace' && rows.matches.length === 0 ? (
+          <SearchResultPanel trace={trace} />
+        ) : null}
+
         {rows.history.length > 0 ? (
           <Panel title="Recent history" count={rows.history.length}>
             <div className="grid gap-2">
@@ -456,6 +461,46 @@ function SearchRow({ match }: { match: ReturnType<typeof flattenTraceRows>['matc
         </div>
       </div>
     </article>
+  )
+}
+
+function SearchResultPanel({
+  trace,
+}: {
+  trace: Extract<CodeModeTrace, { kind: 'code_mode_search_trace' }>
+}) {
+  const shape = trace.result_shape
+  const headline =
+    shape?.type === 'array'
+      ? trace.match_count > 0
+        ? `Search returned ${trace.match_count} array items, but none are tool-entry objects.`
+        : 'Search returned an empty list — no tools matched.'
+      : 'Search returned a reduced value, not a tool list — the matches panel only lists tool-entry objects.'
+  const shapeLabel = describeResultShape(shape)
+  const resultJson = stringifyRedactedParams(trace.result)
+
+  return (
+    <Panel title="Search result" count={shape?.type ?? 'empty'}>
+      <article className={cn('p-2.5 sm:p-3', AURORA_MESSAGE_SURFACE)}>
+        <div className="flex items-center gap-2">
+          <Search className="size-4 text-aurora-accent-primary" />
+          <p className="text-sm font-medium text-aurora-text-primary">{headline}</p>
+        </div>
+        {shapeLabel ? (
+          <p className="mt-1 font-mono text-xs text-aurora-text-muted">{shapeLabel}</p>
+        ) : null}
+        {resultJson ? (
+          <details className="mt-1.5 rounded-md border border-aurora-border-default bg-aurora-panel-strong sm:mt-3 sm:rounded-aurora-2">
+            <summary className="cursor-pointer px-2.5 py-1 text-xs font-semibold text-aurora-accent-strong sm:px-3 sm:py-2">
+              Returned value
+            </summary>
+            <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 pb-2.5 font-mono text-xs text-aurora-text-primary sm:px-3 sm:pb-3">
+              {resultJson}
+            </pre>
+          </details>
+        ) : null}
+      </article>
+    </Panel>
   )
 }
 

--- a/apps/gateway-admin/lib/code-mode-app/trace.test.ts
+++ b/apps/gateway-admin/lib/code-mode-app/trace.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { flattenTraceRows, parseCodeModeTrace, stringifyRedactedParams } from './trace'
+import {
+  describeResultShape,
+  flattenTraceRows,
+  parseCodeModeTrace,
+  stringifyRedactedParams,
+} from './trace'
 
 test('parses execute traces with redacted params', () => {
   const trace = parseCodeModeTrace({
@@ -45,6 +50,36 @@ test('parses search traces with matched tools', () => {
 
   assert.equal(trace?.kind, 'code_mode_search_trace')
   assert.equal(flattenTraceRows(trace).matches[0].tool, 'ask')
+})
+
+test('parses search traces that carry a reduced result value', () => {
+  const trace = parseCodeModeTrace({
+    kind: 'code_mode_search_trace',
+    query_kind: 'catalog_filter',
+    match_count: 0,
+    matches: [],
+    result_shape: { type: 'object', key_count: 2, keys: ['total', 'upstreams'] },
+    result: { total: 398, upstreams: 42 },
+  })
+
+  assert.equal(trace?.kind, 'code_mode_search_trace')
+  assert.equal(flattenTraceRows(trace).matches.length, 0)
+  assert.deepEqual(
+    trace?.kind === 'code_mode_search_trace' ? trace.result : undefined,
+    { total: 398, upstreams: 42 },
+  )
+})
+
+test('describes result shapes for the no-match search view', () => {
+  assert.equal(
+    describeResultShape({ type: 'object', key_count: 2, keys: ['total', 'upstreams'] }),
+    'object · 2 keys — keys: total, upstreams',
+  )
+  assert.equal(
+    describeResultShape({ type: 'array', length: 3, item_types: ['string'] }),
+    'array · 3 items — items: string',
+  )
+  assert.equal(describeResultShape(undefined), '')
 })
 
 test('parses history traces and flattens nested execute calls', () => {

--- a/apps/gateway-admin/lib/code-mode-app/trace.ts
+++ b/apps/gateway-admin/lib/code-mode-app/trace.ts
@@ -20,6 +20,13 @@ export interface CodeModeSearchTrace {
   truncated?: boolean
   matches: CodeModeSearchMatch[]
   result_shape?: ResultShape
+  /**
+   * Present when no tool rows were summarized (the snippet returned a
+   * reduced/aggregate value, or an array of non-entry items). Carries the
+   * bounded actual return value so the inspector can show what the search
+   * produced instead of a bare "No matches".
+   */
+  result?: unknown
   warnings?: CodeModeTraceWarning[]
 }
 
@@ -131,8 +138,37 @@ function parseSearchTrace(value: Record<string, unknown>): CodeModeSearchTrace |
     truncated: booleanOptional(value.truncated),
     matches: matches.items,
     result_shape: parseResultShape(value.result_shape),
+    result: 'result' in value ? value.result : undefined,
     warnings: droppedWarning(matches.dropped, 'search match'),
   }
+}
+
+/**
+ * Human-readable one-line description of a result shape, used by the inspector
+ * when a search returned a value with no summarizable tool rows. Returns an
+ * empty string when no shape is available.
+ */
+export function describeResultShape(shape: ResultShape | undefined): string {
+  if (!shape?.type) return ''
+  const parts: string[] = [shape.type]
+  if (shape.type === 'object' && shape.key_count !== undefined) {
+    parts.push(`${shape.key_count} key${shape.key_count === 1 ? '' : 's'}`)
+  }
+  if (shape.type === 'array' && shape.length !== undefined) {
+    parts.push(`${shape.length} item${shape.length === 1 ? '' : 's'}`)
+  }
+  if (shape.type === 'string' && shape.length !== undefined) {
+    parts.push(`${shape.length} chars`)
+  }
+  if (shape.size_bytes !== undefined) parts.push(`${shape.size_bytes} B`)
+  let label = parts.join(' · ')
+  if (shape.type === 'object' && shape.keys?.length) {
+    label += ` — keys: ${shape.keys.join(', ')}`
+  }
+  if (shape.type === 'array' && shape.item_types?.length) {
+    label += ` — items: ${shape.item_types.join(', ')}`
+  }
+  return label
 }
 
 function parseHistoryTrace(value: Record<string, unknown>): CodeModeHistoryTrace | null {

--- a/crates/lab/src/dispatch/gateway/code_mode/trace.rs
+++ b/crates/lab/src/dispatch/gateway/code_mode/trace.rs
@@ -14,6 +14,11 @@ const MAX_DEPTH: usize = 16;
 const MAX_COLLECTION_ITEMS: usize = 64;
 const MAX_STRING_CHARS: usize = 512;
 const DEFAULT_PARAM_BYTES: usize = 4096;
+/// Byte cap for the actual search return value embedded in the trace when no
+/// tool rows can be summarized. Larger than `DEFAULT_PARAM_BYTES` because this
+/// is a display aid for the inspector (not a secret-bearing param channel), but
+/// still bounded so a reduced aggregate stays compact in the widget payload.
+const SEARCH_RESULT_DISPLAY_BYTES: usize = 8192;
 
 #[must_use]
 pub(in crate::dispatch::gateway::code_mode) fn redact_trace_params(
@@ -61,7 +66,7 @@ pub(crate) fn code_mode_search_trace(response: &Value, elapsed_ms: u128) -> Valu
         .unwrap_or_default();
     let match_count = response.as_array().map_or(0, Vec::len);
     let displayed_count = matches.len();
-    json!({
+    let mut trace = json!({
         "kind": "code_mode_search_trace",
         "query_kind": "catalog_filter",
         "elapsed_ms": elapsed_ms,
@@ -70,7 +75,26 @@ pub(crate) fn code_mode_search_trace(response: &Value, elapsed_ms: u128) -> Valu
         "truncated": match_count > displayed_count,
         "matches": matches,
         "result_shape": compact_result_shape(response),
-    })
+    });
+    // When no tool rows were summarized — the snippet returned a reduced/aggregate
+    // value, or an array whose items aren't catalog entries — the inspector would
+    // otherwise show a bare "No matches" even though the search ran and produced
+    // data. Embed the bounded *actual* return value so the widget can show WHAT
+    // the search produced. Skipped when real matches exist: the `matches` array
+    // already carries the data, and re-embedding the full catalog array would
+    // bloat the trace (and re-expose the per-entry `dts`/`signature` blobs the
+    // match summary deliberately drops). Mirrors `code_mode_execute_trace`, which
+    // embeds its `result` verbatim; here the value is bounded by
+    // `redact_trace_value` since search results are not budget-capped upstream.
+    if displayed_count == 0
+        && let Some(object) = trace.as_object_mut()
+    {
+        object.insert(
+            "result".to_string(),
+            redact_trace_value(response, SEARCH_RESULT_DISPLAY_BYTES),
+        );
+    }
+    trace
 }
 
 fn search_match_summary(value: &Value) -> Option<Value> {

--- a/crates/lab/src/mcp/assets/code_mode_app.html
+++ b/crates/lab/src/mcp/assets/code_mode_app.html
@@ -139,6 +139,7 @@ const stats=document.getElementById("stats");
 function esc(value){return String(value??"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
 function json(value){try{return JSON.stringify(value,null,2)}catch{return String(value)}}
 function shape(s){if(!s)return"";return [s.type,s.key_count&&`${s.key_count} keys`,s.length&&`${s.length} items`].filter(Boolean).join(" / ")}
+function shapeDetail(s){if(!s||!s.type)return"";const parts=[s.type];if(s.type==="object"&&s.key_count!=null)parts.push(`${s.key_count} key${s.key_count===1?"":"s"}`);if(s.type==="array"&&s.length!=null)parts.push(`${s.length} item${s.length===1?"":"s"}`);if(s.type==="string"&&s.length!=null)parts.push(`${s.length} chars`);if(s.size_bytes!=null)parts.push(`${s.size_bytes} B`);let label=parts.join(" · ");if(s.type==="object"&&Array.isArray(s.keys)&&s.keys.length)label+=` — keys: ${s.keys.join(", ")}`;if(s.type==="array"&&Array.isArray(s.item_types)&&s.item_types.length)label+=` — items: ${s.item_types.join(", ")}`;return label;}
 function card(body){return `<article class="card">${body}</article>`}
 function panel(title,count,body,meta=""){return `<section class="panel"><div class="panel-head"><div class="panel-title">${esc(title)}</div><div class="row"><span class="pill info">${esc(count)}</span>${meta?`<span class="pill err">${esc(meta)}</span>`:""}</div></div><div class="panel-body">${body}</div></section>`}
 function compactStatLabel(label){return String(label).replace("Execute calls","Calls").replace("Catalog matches","Matches").replace("History entries","History")}
@@ -165,7 +166,30 @@ function render(trace){
   const t=trace&&trace.structuredContent?trace.structuredContent:trace;
   if(!t||!t.kind){clearStats();content.innerHTML=card('<div class="meta">Run Code Mode search or execute to populate the inspector.</div>');return false;}
   if(t.kind==="code_mode_execute_trace"){const rows=(t.calls||[]).map(callRow).join("")||card('<div class="meta">No calls were made.</div>');summary.textContent=`${t.call_count||0} calls captured`;renderStats([["Execute calls",t.call_count||0],["Catalog matches",0],["History entries",0]]);content.innerHTML=panel("Execute calls",t.call_count||0,rows);return true;}
-  if(t.kind==="code_mode_search_trace"){const count=searchCount(t);const shown=`${(t.matches||[]).length} shown`;const rows=(t.matches||[]).map(matchRow).join("")||card('<div class="meta">No matches.</div>');summary.textContent=t.truncated?"Search matches truncated to the current display window":"Search matches from current search";renderStats([["Execute calls",0],["Catalog matches",count],["History entries",0]]);content.innerHTML=panel("Search matches",t.truncated?shown:count,rows);return true;}
+  if(t.kind==="code_mode_search_trace"){
+    const matchRows=(t.matches||[]);
+    if(matchRows.length>0){
+      const count=searchCount(t);
+      const shown=`${matchRows.length} shown`;
+      summary.textContent=t.truncated?"Search matches truncated to the current display window":"Search matches from current search";
+      renderStats([["Execute calls",0],["Catalog matches",count],["History entries",0]]);
+      content.innerHTML=panel("Search matches",t.truncated?shown:count,matchRows.map(matchRow).join(""));
+      return true;
+    }
+    // No tool rows summarized: the snippet returned a reduced/aggregate value
+    // (or an array of non-entry items). Show WHAT it returned instead of a bare
+    // "No matches" — the encouraged "reduce inside the sandbox" pattern lands here.
+    const s=t.result_shape;
+    const headline=s&&s.type==="array"
+      ?(t.match_count>0?`Search returned ${t.match_count} array items, but none are tool-entry objects.`:"Search returned an empty list — no tools matched.")
+      :"Search returned a reduced value, not a tool list — the matches panel only lists tool-entry objects.";
+    const detail=shapeDetail(s);
+    const value=t.result!==undefined?`<details><summary>Returned value</summary><pre>${esc(json(t.result))}</pre></details>`:"";
+    summary.textContent="Search returned a value with no tool rows to list";
+    renderStats([["Execute calls",0],["Catalog matches",searchCount(t)],["History entries",0]]);
+    content.innerHTML=panel("Search result",(s&&s.type)||"empty",card(`<div class="name">${esc(headline)}</div>${detail?`<div class="meta">${esc(detail)}</div>`:""}${value}`));
+    return true;
+  }
   if(t.kind==="code_mode_history"){const rows=(t.entries||[]).map(historyRow).join("")||card('<div class="meta">History is empty.</div>');summary.textContent=`${(t.entries||[]).length} bounded history entries`;renderStats([["Execute calls",0],["Catalog matches",0],["History entries",(t.entries||[]).length]]);content.innerHTML=panel("Recent history",(t.entries||[]).length,rows);return true;}
   clearStats();content.innerHTML=card(`<pre>${esc(json(t))}</pre>`);return false;
 }
@@ -214,11 +238,31 @@ if (window.openai) {
   // MCP Apps bridge (Claude): live search/execute traces arrive via ontoolresult.
   const app = new App({ name: "LabCodeModeInspector", version: "1.0.0" }, {});
   app.onhostcontextchanged = (ctx) => { if (ctx && ctx.theme) { document.documentElement.classList.toggle("dark", ctx.theme === "dark"); } };
-  app.ontoolresult = (result) => render(result && result.structuredContent ? result.structuredContent : result);
-  try { state.textContent = "connected"; state.classList.add("connected"); } catch (_) {}
-  // Fire-and-forget per the MCP Apps spec — resolves async after the host
-  // postMessage handshake, which may be delayed or unavailable.
-  app.connect().catch(() => { try { state.textContent = "read only"; state.classList.remove("connected"); } catch (_) {} });
+  let hydrated = false;
+  const setState = (label, connected) => {
+    try { state.textContent = label; state.classList.toggle("connected", connected); } catch (_) {}
+  };
+  app.ontoolresult = (result) => {
+    // Recognized trace -> connected; non-null-but-unrecognized -> "malformed"
+    // (parity with the OpenAI branch / React inspector) rather than passing a
+    // raw JSON dump off as a healthy render.
+    const recognized = render(result && result.structuredContent ? result.structuredContent : result);
+    hydrated = true;
+    setState(recognized ? "connected" : "malformed", recognized);
+  };
+  // Do NOT claim "connected" up front — the handshake has not resolved yet and
+  // no trace has arrived. Show "connecting" until either the postMessage
+  // handshake resolves or a tool result renders, so an unconnected widget is
+  // never indistinguishable from a connected one. Mirrors the React inspector's
+  // connect()-gated bridge state.
+  setState("connecting", false);
+  app
+    .connect()
+    // Fire-and-forget per the MCP Apps spec — resolves async after the host
+    // postMessage handshake, which may be delayed or unavailable. A tool result
+    // may have already rendered by then (don't downgrade a live trace).
+    .then(() => { if (!hydrated) setState("connected", true); })
+    .catch(() => { if (!hydrated) setState("read only", false); });
 }
 })();
 </script>

--- a/crates/lab/src/mcp/call_tool_codemode/tests.rs
+++ b/crates/lab/src/mcp/call_tool_codemode/tests.rs
@@ -235,4 +235,47 @@ fn search_trace_reports_display_truncation() {
     assert_eq!(trace["displayed_count"], json!(50));
     assert_eq!(trace["truncated"], json!(true));
     assert_eq!(trace["matches"].as_array().expect("matches").len(), 50);
+    // Matches were summarized, so the lean trace must NOT also embed the raw
+    // catalog array (which would re-expose the dropped per-entry blobs).
+    assert!(
+        trace.get("result").is_none(),
+        "matched searches keep the trace lean and omit the raw result"
+    );
+}
+
+#[test]
+fn search_trace_embeds_reduced_result_when_no_matches() {
+    // A reduced/aggregate return (the encouraged Code Mode pattern) is not a
+    // catalog-entry array, so no tool rows can be summarized. The trace must
+    // still carry the actual returned value so the inspector shows WHAT the
+    // search produced instead of a bare "No matches".
+    let response = json!({
+        "total": 398,
+        "upstreams": 42,
+        "heavy_hitters": { "github": 48, "notebooklm": 30 },
+    });
+
+    let trace = code_mode_search_trace(&response, 9);
+    assert_eq!(trace["kind"], json!("code_mode_search_trace"));
+    assert_eq!(trace["match_count"], json!(0));
+    assert_eq!(trace["displayed_count"], json!(0));
+    assert_eq!(trace["matches"], json!([]));
+    assert_eq!(trace["result_shape"]["type"], json!("object"));
+    // The bounded actual return value is embedded for the inspector.
+    assert_eq!(trace["result"]["total"], json!(398));
+    assert_eq!(trace["result"]["heavy_hitters"]["github"], json!(48));
+}
+
+#[test]
+fn search_trace_embeds_result_for_non_entry_array() {
+    // An array whose items aren't catalog entries: `match_count` reflects the
+    // array length, but no rows summarize, so the raw (bounded) array is embedded.
+    let response = json!(["github", "axon", "unraid"]);
+
+    let trace = code_mode_search_trace(&response, 3);
+    assert_eq!(trace["match_count"], json!(3));
+    assert_eq!(trace["displayed_count"], json!(0));
+    assert_eq!(trace["matches"], json!([]));
+    assert_eq!(trace["result_shape"]["type"], json!("array"));
+    assert_eq!(trace["result"], json!(["github", "axon", "unraid"]));
 }

--- a/crates/lab/src/mcp/handlers_resources.rs
+++ b/crates/lab/src/mcp/handlers_resources.rs
@@ -1118,4 +1118,33 @@ mod tests {
             "inline app must use result_shape.length"
         );
     }
+
+    #[test]
+    fn code_mode_app_html_renders_reduced_search_result_fallback() {
+        // The bundle is hand-maintained vanilla JS with no test harness, so guard
+        // the no-match search path that shows the returned value/shape instead of
+        // a bare "No matches" when the snippet returned a reduced/aggregate value.
+        let html = code_mode_app_html(CODE_MODE_SEARCH_APP_URI, None).expect("search resource");
+        assert!(
+            html.contains("Search result"),
+            "bundle must render the reduced-result panel for matchless searches"
+        );
+        assert!(
+            html.contains("shapeDetail"),
+            "bundle must describe the returned value's shape"
+        );
+        assert!(
+            html.contains("t.result"),
+            "bundle must embed the actual returned value when no rows match"
+        );
+        // Status must not be claimed "connected" before the bridge resolves.
+        assert!(
+            html.contains("\"connecting\""),
+            "MCP Apps branch must start from a 'connecting' state, not optimistic 'connected'"
+        );
+        assert!(
+            html.contains("if (!hydrated) setState(\"connected\", true)"),
+            "MCP Apps branch must gate 'connected' on the connect() handshake"
+        );
+    }
 }


### PR DESCRIPTION
## What & why

Investigated a screenshot where the **Code Mode trace** inspector showed `Matches: 0` / **"No matches"** even though the search had clearly returned real data (a "398 tools across 42 upstreams" summary).

### Root cause

The `code_search` tool runs an arbitrary JS snippet over the catalog and returns the snippet's value **verbatim** (`search.rs:104`). The inspector's `code_mode_search_trace` only extracts `matches` when that value is a **top-level array of catalog-entry objects** (`trace.rs:51-74`). The moment a snippet *aggregates* — returns a count, a grouped object, or an array of non-entry items — `match_count`/`matches` come out empty and the widget renders "No matches."

This is the common case, because Code Mode explicitly tells the model to *"reduce data inside the sandbox before returning — that is the point of Code Mode."* So doing the encouraged thing blanked the inspector.

It was **not** a bridge failure: the widget was genuinely connected and a trace did arrive — just one whose return shape the match-extraction couldn't summarize.

A secondary finding: the MCP Apps (Claude) branch set the status pill to `"connected"` *optimistically and synchronously*, before the postMessage handshake even resolved — unlike the OpenAI branch and the React component, which gate on the actual connection.

### Fix

1. **Surface the actual result.** `code_mode_search_trace` now embeds the **bounded actual return value** (`result`, capped + redacted via `redact_trace_value`) when no tool rows can be summarized — mirroring `code_mode_execute_trace`. Skipped when real matches exist, so matched searches stay lean and don't re-expose the dropped per-entry `dts`/`signature` blobs. *(`result_shape` was already emitted and parsed end-to-end — both frontends just ignored it; now they render it too.)*
2. **Render it in both inspectors.** The bundled MCP App HTML widget and the gateway-admin React component now show a **"Search result"** panel with a human headline, the result shape, and the returned value whenever a search has no tool matches.
3. **Honest status pill.** The Claude/MCP-Apps branch starts at `"connecting"` and only claims `"connected"` once `connect()` resolves or a tool result renders — matching the React inspector.

## Testing

- Rust (`--all-features`): 4 `search_trace` unit tests (2 new: reduced-object + non-entry-array), 3 `code_mode_app_html` HTML guard tests (1 new), clippy clean, `cargo fmt --check` clean.
- TS: `trace.test.ts` (2 new: result passthrough + `describeResultShape`), `code-mode-inspector.test.tsx` (1 new: reduced-result render), `tsc --noEmit` clean, eslint clean on changed files (the 2 reported `no-this-alias` errors pre-date this branch).

No backend wire-protocol or error-kind changes; the new `result` field is additive and only present when there are zero matches.


---
_Generated by [Claude Code](https://claude.ai/code/session_019sMXH2Bif7U5yyFBodWKji)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Code Mode inspector showing “Matches: 0” for reduced search results by displaying the actual returned value and its shape when no tool rows can be summarized. Also makes the MCP Apps status pill reflect real connection state.

- **Bug Fixes**
  - Backend: `code_mode_search_trace` now embeds a bounded `result` when `matches` is empty; skipped when matches exist to keep traces lean.
  - UI: React inspector and the bundled MCP App render a “Search result” panel with a brief headline, result shape, and the returned value.
  - Bridge: MCP Apps status pill starts at “connecting” and only switches to “connected” after `connect()` resolves or a tool result renders.

<sup>Written for commit e7d419e5494ff94f8b8fdee321d24e318fff6c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

