### PR TITLE
chore(labby): mount host ssh binary for zsnoop-mcp fleet access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       # Docker to auto-create an empty directory at the (missing) source path and
       # shadow the adb binary with a directory.
       - ${ADB_PATH:-/dev/null}:/usr/local/bin/adb:ro
+      # ssh client for zsnoop-mcp and other upstreams that need to reach fleet hosts.
+      - /usr/bin/ssh:/usr/local/bin/ssh:ro
     # extra_hosts (host.docker.internal:host-gateway) is inherited from
     # docker-compose.prod.yml via `extends` above — see the comment there.
     environment:

--- a/plugins/labby/CHANGELOG.md
+++ b/plugins/labby/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added the `creating-snippets` skill for Labby Code Mode snippet authoring.
 - **Removed the bundled `labby` binary** (previously shipped via Git LFS at
   `bin/labby`). The plugin is now skills + MCP config only. Install the binary
   explicitly: `curl -fsSL https://raw.githubusercontent.com/jmagar/lab/main/scripts/install.sh | sh`,

--- a/plugins/labby/README.md
+++ b/plugins/labby/README.md
@@ -6,6 +6,7 @@ This plugin does **not** bundle the `labby` binary and does not auto-install
 or auto-repair anything. It ships:
 
 - the `using-labby` skill,
+- the `creating-snippets` skill for Labby Code Mode snippet authoring,
 - an HTTP MCP server entry pointing at a running `labby serve`
   (`${user_config.server_url}/mcp` — remote machines never need a local binary),
 - advisory hooks: SessionStart reports setup status via

--- a/plugins/labby/skills/creating-snippets/CHANGELOG.md
+++ b/plugins/labby/skills/creating-snippets/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to the `creating-snippets` skill are recorded here.
+
+## 2026-06-15
+
+### Added
+
+- Added packaging documentation so the skill has a README and changelog alongside `SKILL.md`.

--- a/plugins/labby/skills/creating-snippets/README.md
+++ b/plugins/labby/skills/creating-snippets/README.md
@@ -1,0 +1,14 @@
+# Creating Snippets
+
+Use when creating, editing, validating, testing, running, explaining, or removing Labby Code Mode snippets.
+
+## Usage
+
+Invoke this skill when the user request matches the trigger conditions in `SKILL.md`. The skill body is the source of truth for workflow steps, safety rules, and operational constraints.
+
+## Files
+
+- `SKILL.md` - agent workflow and trigger guidance
+- `agents/` - OpenAI runtime metadata
+- `README.md` - packaging overview
+- `CHANGELOG.md` - packaging change history

--- a/plugins/labby/skills/creating-snippets/SKILL.md
+++ b/plugins/labby/skills/creating-snippets/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: creating-snippets
+description: Use when creating, editing, validating, testing, running, explaining, or removing Labby Code Mode snippets; when a user wants a reusable workflow made from gateway MCP tools; or when building schema-backed snippets from upstream tool ids, JSON schemas, params, inputs, defaults, artifacts, and MCP/CLI snippet actions.
+---
+
+# Creating Snippets
+
+## Overview
+
+Labby snippets are saved Code Mode workflows: pick gateway MCP tools, fill their schema-typed params, call them from one async JavaScript arrow function, and return structured JSON. Keep snippet business logic in the snippet body; use Labby's snippets dispatch/CLI/MCP actions to store, validate, test, and execute it.
+
+## First Checks
+
+Use `using-labby` before authoring any snippet that calls upstream tools. Search the live catalog and copy the returned `id`, `schema`, `output_schema`, `signature`, and `dts`; never guess tool ids or params.
+
+Useful local references when the Lab checkout is present on the current host:
+
+- `/home/jmagar/workspace/lab/docs/snippets/README.md`
+- `/home/jmagar/workspace/lab/docs/snippets/*.md`
+- `/home/jmagar/workspace/lab/crates/lab/src/dispatch/snippets/`
+
+If those paths are unavailable, treat the live gateway and `labby snippets --help` as the source of
+truth. Do not invent snippet actions, flags, tool ids, or schemas from memory.
+
+## Snippet Shape
+
+Use Markdown for reusable snippets. The filename stem is the id, and frontmatter `name` must match it.
+
+````markdown
+---
+name: my-workflow
+description: Brief human-readable purpose
+tags: [research, readonly]
+inputs:
+  topic:
+    type: string
+    required: true
+    description: Topic to search
+  limit:
+    type: integer
+    default: 5
+    required: false
+tools:
+  - axon::axon
+  - github::search_issues
+---
+
+## Tutorial: How This Snippet Is Built
+
+Explain the selected tools, params, validation, execution order, and output.
+
+```js
+async (input) => {
+  const topic = input.topic;
+  const limit = input.limit ?? 5;
+  const axon = (params) => callTool("axon::axon", params);
+
+  const timed = async (label, fn) => {
+    const started = Date.now();
+    try {
+      return { label, ok: true, ms: Date.now() - started, result: await fn() };
+    } catch (error) {
+      return { label, ok: false, ms: Date.now() - started, error: String(error) };
+    }
+  };
+
+  const results = await Promise.all([
+    timed("web-search", () => axon({ action: "search", query: topic, limit })),
+    timed("rag-query", () => axon({ action: "query", query: topic, limit }))
+  ]);
+
+  return { snippet: "my-workflow", input: { topic, limit }, results };
+}
+```
+````
+
+Raw JavaScript is allowed, but Markdown with frontmatter and a tutorial is preferred.
+
+## Inputs And Defaults
+
+Use frontmatter `inputs` for user-configurable values. Supported types are `string`, `integer`, `number`, `boolean`, `object`, `array`, and `json`.
+
+Rules:
+
+- Give optional inputs defaults when possible so snippets still run with sparse params.
+- Mark genuinely required values with `required: true`.
+- Keep unknown input rejection useful: declared inputs cause `snippets.exec` to reject unexpected caller params.
+- Mirror upstream schemas in the generated call params. Snippet inputs describe user-facing knobs; upstream schemas validate each MCP tool call.
+
+## Authoring Workflow
+
+1. List existing snippets: `labby snippets list --json`.
+2. Search gateway tools with `search` and inspect schemas/signatures. If `labby` is not on `PATH`,
+   locate the active Labby CLI before continuing instead of guessing command syntax.
+3. Pick tools and decide parallel vs chained execution.
+4. Draft Markdown with frontmatter, tutorial text, declared inputs, and one `js`/`javascript` fenced block.
+5. Validate without saving: `labby snippets validate my-workflow --file draft.md`.
+6. Save as a user snippet: `labby snippets create my-workflow --file draft.md --description "..."`.
+7. Smoke-test execution: `labby snippets test my-workflow --param topic="mcp-ui rust"`.
+8. Run normally: `labby snippets exec my-workflow --param topic="mcp-ui rust" --max-tool-calls 10`.
+
+Use `--force` only when intentionally replacing a user snippet.
+
+## MCP And Dispatch Actions
+
+Snippets are also available through the shared dispatch layer and MCP/API service:
+
+```json
+{ "action": "snippets.list", "params": {} }
+{ "action": "snippets.get", "params": { "name": "my-workflow" } }
+{ "action": "snippets.validate", "params": { "name": "my-workflow", "body": "..." } }
+{ "action": "snippets.create", "params": { "name": "my-workflow", "body": "...", "description": "...", "force": false } }
+{ "action": "snippets.exec", "params": { "name": "my-workflow", "params": { "topic": "mcp-ui rust" }, "max_tool_calls": 10 } }
+{ "action": "snippets.test", "params": { "name": "my-workflow", "params": { "topic": "mcp-ui rust" } } }
+{ "action": "snippets.test", "params": { "all": true } }
+{ "action": "snippets.remove", "params": { "name": "my-workflow" } }
+```
+
+`remove` is destructive and only removes user snippets. Built-ins are read-only.
+
+## Execution Patterns
+
+- Use `Promise.all` only for independent calls.
+- Chain calls when later params depend on earlier results.
+- Wrap each call with timing and error capture.
+- Return stable JSON fields: `snippet`, `input`, `summary`, `results`, `evidence`, `gaps`, `followup_calls`, `timings`.
+- Keep responses compact; large Markdown, tables, screenshots, or manifests should be written with `writeArtifact("relative/path.md", content, { contentType })`.
+- Include enough ids, URLs, labels, and raw evidence handles for follow-up verification.
+
+## Validation Checklist
+
+Before calling the work done:
+
+- `name` is slug-like and matches filename/frontmatter.
+- Description is non-empty.
+- Body contains exactly the intended async arrow function.
+- All upstream tool ids came from live gateway `search`.
+- Tool params match upstream schemas.
+- Optional inputs have defaults or code fallbacks.
+- Required inputs fail fast with clear validation.
+- Fan-out is bounded by limits and `max_tool_calls`.
+- `labby snippets validate` passes.
+- `labby snippets test` passes for one snippet, or `labby snippets test --all` passes when changing shared built-ins.

--- a/plugins/labby/skills/creating-snippets/agents/openai.yaml
+++ b/plugins/labby/skills/creating-snippets/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Creating Snippets"
+  short_description: "Build Labby Code Mode snippets from gateway tools and schemas."
+  default_prompt: "Help me create a Labby snippet from available gateway tools."


### PR DESCRIPTION
## Summary

- Bind-mounts `/usr/bin/ssh` from the host into the container at `/usr/local/bin/ssh`
- Required by `zsnoop-mcp` upstream to SSH into fleet hosts (squirts, shart, tootie, dookie) for ZFS snapshot exploration
- Follows the same pattern as the existing `adb` mount

## Test plan

- [ ] `zsnoop::list_pools` and `zsnoop::list_snapshots` work via Labby Code Mode against fleet hosts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind-mounted the host `ssh` client into the Labby container for `zsnoop-mcp` fleet access, and added the `creating-snippets` skill for Labby Code Mode snippet authoring.

- **New Features**
  - Docker: mounted `/usr/bin/ssh` to `/usr/local/bin/ssh` (read-only), matching the existing `adb` pattern, so `zsnoop-mcp` can SSH into fleet hosts for ZFS snapshot exploration.
  - Labby plugin: added the `creating-snippets` skill with `SKILL.md`, packaging docs, and agent metadata; updated plugin README/CHANGELOG to list it.

- **Migration**
  - Rebuild/restart the Labby container to pick up the new bind mount; verify `zsnoop::list_pools` and `zsnoop::list_snapshots` via Code Mode.

<sup>Written for commit 3dfe77499db33f1cb627dc167bcfbbff82920087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

