### PR TITLE
Keep Labby root list_tools nonblocking

### DIFF
--- a/crates/lab/src/mcp/handlers_tools.rs
+++ b/crates/lab/src/mcp/handlers_tools.rs
@@ -139,27 +139,12 @@ impl LabMcpServer {
             gateway_tool_count += 1;
         }
 
-        // Merge upstream tools (healthy only, filtered for collisions with built-in services).
-        #[cfg(feature = "gateway")]
-        if hide_raw_tools
-            && let Some(manager) = self.gateway_manager.as_ref()
-            && let Err(error) = manager
-                .code_mode_catalog_tools_allowed(
-                    true,
-                    None,
-                    oauth_subject.as_deref(),
-                    self.route_scope.allowed_upstreams(),
-                )
-                .await
-        {
-            tracing::warn!(
-                surface = "mcp",
-                service = "labby",
-                action = "list_tools",
-                error = %error,
-                "failed to warm upstream catalog before listing MCP App tools"
-            );
-        }
+        // Merge upstream tools from the already-healthy catalog only. Root
+        // `list_tools` must never cold-connect upstreams: a single slow or
+        // unhealthy server can otherwise stall the host's tool refresh and make
+        // Labby's synthetic Code Mode tool appear to disappear. Code Mode
+        // execution/search still performs cold discovery through the gateway
+        // manager when the caller actually asks for upstream catalog data.
         #[cfg(feature = "gateway")]
         if let Some(pool) = self.current_upstream_pool().await {
             let upstream_tools = if hide_raw_tools {

--- a/crates/lab/src/mcp/handlers_tools.rs
+++ b/crates/lab/src/mcp/handlers_tools.rs
@@ -59,9 +59,6 @@ impl LabMcpServer {
         let hide_raw_tools = visibility.hides_raw_tools();
         let visibility_mode = visibility.mode_label();
         let auth = auth_context_from_extensions(&context.extensions);
-        #[cfg(feature = "gateway")]
-        let oauth_subject =
-            oauth_upstream_subject_for_request(auth, self.request_subject(&context));
         let mut builtin_names = Vec::new();
         for svc in self.registry.services() {
             if self.route_scope.allows_service(svc.name)
@@ -177,6 +174,8 @@ impl LabMcpServer {
                     upstream_tool_count += 1;
                 }
             }
+            let oauth_subject =
+                oauth_upstream_subject_for_request(auth, self.request_subject(&context));
             if !hide_raw_tools && let Some(oauth_subject) = oauth_subject.as_ref() {
                 let configs = self.route_scoped_oauth_upstream_configs().await;
                 for (_, upstream_tools) in pool

--- a/crates/lab/src/mcp/handlers_tools.rs
+++ b/crates/lab/src/mcp/handlers_tools.rs
@@ -53,6 +53,10 @@ impl LabMcpServer {
         let mut gateway_tool_count = 0usize;
         let mut upstream_ui_tool_count = 0usize;
         let mut suppressed_builtin_tool_count = 0usize;
+        let mut pool_present = false;
+        let mut catalog_upstream_count = 0usize;
+        let mut upstream_tool_error_count = 0usize;
+        let mut open_upstream_count = 0usize;
         let visibility = self.code_mode_visibility().await;
         let manager_code_mode_enabled = visibility.exposes_synthetic_tools();
         let process_code_mode_enabled = crate::config::process_code_mode_enabled();
@@ -136,14 +140,21 @@ impl LabMcpServer {
             gateway_tool_count += 1;
         }
 
-        // Merge upstream tools from the already-healthy catalog only. Root
-        // `list_tools` must never cold-connect upstreams: a single slow or
-        // unhealthy server can otherwise stall the host's tool refresh and make
-        // Labby's synthetic Code Mode tool appear to disappear. Code Mode
-        // execution/search still performs cold discovery through the gateway
-        // manager when the caller actually asks for upstream catalog data.
+        // Merge upstream tools from the already-healthy catalog only. The
+        // hidden-raw-tools path must never cold-connect upstreams: a single
+        // slow or unhealthy server can otherwise stall the host's tool refresh
+        // and make Labby's synthetic Code Mode tool appear to disappear. Code
+        // Mode execution/search still performs cold discovery through the
+        // gateway manager when the caller asks for upstream catalog data.
         #[cfg(feature = "gateway")]
         if let Some(pool) = self.current_upstream_pool().await {
+            pool_present = true;
+            let upstream_status = pool.upstream_status().await;
+            catalog_upstream_count = upstream_status.len();
+            open_upstream_count = upstream_status
+                .iter()
+                .filter(|(_, health)| health.is_open())
+                .count();
             let upstream_tools = if hide_raw_tools {
                 pool.healthy_ui_tools_allowed(self.route_scope.allowed_upstreams())
                     .await
@@ -194,6 +205,11 @@ impl LabMcpServer {
                     }
                 }
             }
+            for (upstream, _) in &upstream_status {
+                if pool.upstream_tool_last_error(upstream).await.is_some() {
+                    upstream_tool_error_count += 1;
+                }
+            }
         }
 
         let elapsed_ms = start.elapsed().as_millis();
@@ -209,6 +225,16 @@ impl LabMcpServer {
             upstream_ui_tool_count,
             subject_scoped_tool_count,
             suppressed_builtin_tool_count,
+            pool_present,
+            cold_discovery_skipped = hide_raw_tools,
+            upstream_catalog_source = if pool_present {
+                "cached"
+            } else {
+                "not_initialized"
+            },
+            catalog_upstream_count,
+            open_upstream_count,
+            upstream_tool_error_count,
             manager_code_mode_enabled,
             process_code_mode_enabled,
             hide_raw_tools,

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -440,14 +440,11 @@ async fn list_tools_does_not_cold_connect_code_mode_catalog() {
         .list_tools_impl(None, context)
         .await
         .expect("list tools");
-    let names = result
-        .tools
-        .iter()
-        .map(|tool| tool.name.as_ref())
-        .collect::<Vec<_>>();
-
     assert!(
-        names.contains(&CODE_MODE_TOOL_NAME),
+        result
+            .tools
+            .iter()
+            .any(|tool| tool.name.as_ref() == CODE_MODE_TOOL_NAME),
         "root list_tools must keep advertising Code Mode"
     );
 

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -412,6 +412,58 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
 }
 
 #[tokio::test]
+async fn list_tools_does_not_cold_connect_code_mode_catalog() {
+    let pool = Arc::new(UpstreamPool::new());
+    let manager =
+        code_mode_manager_with_pool(true, fixture_upstream_config("cold-apps"), Arc::clone(&pool))
+            .await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = running
+        .service()
+        .list_tools_impl(None, context)
+        .await
+        .expect("list tools");
+    let names = result
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert!(
+        names.contains(&CODE_MODE_TOOL_NAME),
+        "root list_tools must keep advertising Code Mode"
+    );
+    assert!(
+        !names.contains(&"cold_widget"),
+        "cold upstream tools must not be discovered by root list_tools"
+    );
+
+    let summary = pool.cached_upstream_summary("cold-apps").await;
+    assert!(
+        summary.is_none(),
+        "root list_tools must not cold-connect or populate a lazy upstream catalog"
+    );
+    assert!(
+        pool.upstream_tool_last_error("cold-apps").await.is_none(),
+        "skipping cold discovery should not mark the upstream failed"
+    );
+}
+
+#[tokio::test]
 async fn list_tools_skips_upstream_ui_tools_that_collide_with_synthetic_names() {
     let upstream_name: Arc<str> = Arc::from("apps");
     let colliding_tool = fixture_upstream_tool(

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -450,10 +450,6 @@ async fn list_tools_does_not_cold_connect_code_mode_catalog() {
         names.contains(&CODE_MODE_TOOL_NAME),
         "root list_tools must keep advertising Code Mode"
     );
-    assert!(
-        !names.contains(&"cold_widget"),
-        "cold upstream tools must not be discovered by root list_tools"
-    );
 
     let summary = pool.cached_upstream_summary("cold-apps").await;
     assert!(

--- a/crates/lab/src/mcp/handlers_tools/tests.rs
+++ b/crates/lab/src/mcp/handlers_tools/tests.rs
@@ -414,9 +414,12 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
 #[tokio::test]
 async fn list_tools_does_not_cold_connect_code_mode_catalog() {
     let pool = Arc::new(UpstreamPool::new());
-    let manager =
-        code_mode_manager_with_pool(true, fixture_upstream_config("cold-apps"), Arc::clone(&pool))
-            .await;
+    let manager = code_mode_manager_with_pool(
+        true,
+        fixture_upstream_config("cold-apps"),
+        Arc::clone(&pool),
+    )
+    .await;
     let server = test_server(
         completion_test_registry(),
         Some(manager),

--- a/docs/sessions/2026-06-19-nonblocking-root-list-tools.md
+++ b/docs/sessions/2026-06-19-nonblocking-root-list-tools.md
@@ -1,0 +1,156 @@
+---
+date: 2026-06-19 23:21:25 EDT
+repo: git@github.com:jmagar/lab.git
+branch: fix/nonblocking-root-list-tools
+head: dfbf4751
+plan: docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
+working directory: /home/jmagar/workspace/lab/.worktrees/nonblocking-root-list-tools
+worktree: /home/jmagar/workspace/lab/.worktrees/nonblocking-root-list-tools
+pr: "#143 Keep Labby root list_tools nonblocking https://github.com/jmagar/lab/pull/143"
+beads: lab-114y1, lab-sgh5a
+---
+
+# Nonblocking root list tools session
+
+## User Request
+
+Merge the plan into main, execute `docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md` in a worktree, run the Lavra and PR review loops, fix all findings, verify lint/tests/CI, and create a PR.
+
+## Session Overview
+
+Implemented the nonblocking `list_tools` fix for Labby Code Mode catalog discovery, opened PR #143, addressed Lavra, simplifier, and PR-toolkit findings, created a follow-up bead for the pre-existing raw OAuth path, and verified the PR through local gates plus green CI.
+
+## Sequence of Events
+
+1. Added the implementation plan to `main` in commit `2674901d`.
+2. Created worktree `/home/jmagar/workspace/lab/.worktrees/nonblocking-root-list-tools` on branch `fix/nonblocking-root-list-tools`.
+3. Created and claimed bead `lab-114y1`.
+4. Dispatched an implementation worker, which added the regression test and removed the root `list_tools` Code Mode catalog warmup.
+5. Opened PR #143 and pushed follow-up review commits.
+6. Ran Lavra, three simplifier passes, and PR review toolkit agents; fixed every introduced finding they reported.
+7. Created follow-up bead `lab-sgh5a` for the pre-existing raw OAuth `list_tools` blocking path.
+8. Verified local gates and waited for all PR CI checks to pass.
+9. Closed `lab-114y1`.
+
+## Key Findings
+
+- Root `list_tools` had synchronously called `code_mode_catalog_tools_allowed(true, ...)`, so slow or unhealthy upstream initialization could hide Labby's synthetic Code Mode tool.
+- Removing that warmup keeps the hidden-raw-tools path on already-healthy cached catalog data only.
+- The raw-tools OAuth subject-scoped path can still connect during root `list_tools`; this was pre-existing and filed as `lab-sgh5a`.
+- The initial plan text referenced a nonexistent `runtime_metadata_for_upstream`; the shipped test uses `cached_upstream_summary` and `upstream_tool_last_error`.
+
+## Technical Decisions
+
+- Kept cold discovery in Code Mode execution/search and direct tool resolution paths, where the caller explicitly asks for upstream catalog/tool data.
+- Added structured `list_tools` success log fields for cached catalog source, pool presence, open upstream count, and cached upstream tool-error count instead of reintroducing blocking discovery.
+- Kept test setup consistent with nearby `handlers_tools` tests rather than extracting a broader helper.
+- Treated CodeRabbit's docstring coverage warning as non-actionable for this focused PR because it was a repo-wide advisory, not an introduced inline finding.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `crates/lab/src/mcp/handlers_tools.rs` | - | Remove root Code Mode catalog warmup and add nonblocking catalog observability fields. | PR diff and commit `dfbf4751` |
+| modified | `crates/lab/src/mcp/handlers_tools/tests.rs` | - | Add regression test proving root `list_tools` does not cold-connect or populate lazy upstream catalog. | `list_tools_does_not_cold_connect_code_mode_catalog` passed |
+| created | `docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md` | - | Checked-in implementation plan. | Commit `2674901d`; later updated for shipped helper names |
+| created | `docs/sessions/2026-06-19-nonblocking-root-list-tools.md` | - | Session closeout artifact. | This commit |
+
+## Beads Activity
+
+| bead | title | actions | final status | why |
+|---|---|---|---|---|
+| `lab-114y1` | Keep Labby root list_tools nonblocking | Created, claimed, worked, closed. | closed | Tracked this implementation and review loop. |
+| `lab-sgh5a` | Make raw OAuth root list_tools nonblocking | Created. | open | Captures pre-existing review finding outside this PR's hidden-raw-tools scope. |
+
+## Repository Maintenance
+
+### Plans
+
+The active plan lives under `docs/superpowers/plans/`, not `docs/plans/`; no completed plan move was performed.
+
+### Beads
+
+`lab-114y1` was closed after local verification and CI passed. `lab-sgh5a` remains open as follow-up work for the pre-existing raw OAuth path.
+
+### Worktrees and branches
+
+`git worktree list --porcelain` showed the main worktree, two detached Codex worktrees, the long-lived `marketplace-no-mcp` worktree, and this active PR worktree. No worktrees or branches were removed because the PR branch is active and the other worktrees were outside this task.
+
+### Stale docs
+
+The plan document was updated to replace stale helper names, remove the dead `cold_widget` assertion, and clarify that `labby gateway code status --json` is a gateway sanity check rather than an MCP `list_tools` latency proof.
+
+## Tools and Skills Used
+
+- `vibin:work-it`: drove the isolated worktree, PR, review, and save-session workflow.
+- `lavra:lavra-review`: ran multi-agent review and finding synthesis.
+- `vibin:save-to-md`: followed for this session artifact structure and path-limited commit rule.
+- Lumen semantic search: used as first-pass code discovery where applicable; indexing was sometimes incomplete, so exact-symbol shell reads were used after known names were identified.
+- Multi-agent reviewers: implementation worker, Lavra reviewers, simplifier passes, and PR review toolkit roles.
+- GitHub CLI and GitHub MCP connector: created PR, watched CI, checked PR comments and review threads.
+- `bd`: created/closed beads and filed pre-existing review follow-up.
+- Cargo and git: local verification, formatting, diff checks, commits, and pushes.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture` | pass |
+| `cargo test -p labby --all-features list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden -- --nocapture` | pass |
+| `cargo fmt --all --check` | pass |
+| `git diff --check` | pass |
+| `cargo check --workspace --all-features` | pass; emitted existing `apps/gateway-admin/out` warning |
+| `gh pr create --base main --head fix/nonblocking-root-list-tools ...` | created PR #143 |
+| `gh pr checks 143 --watch --interval 20` | all required CI checks passed |
+| `bd close lab-114y1 --reason ...` | closed `lab-114y1` |
+
+## Errors Encountered
+
+- Cargo rejected multi-filter test commands from the plan; tests were run as separate focused commands.
+- Several review agents attempted Cargo tests concurrently and caused artifact-directory lock waits; duplicate reviewer-side checks were stopped or ignored, and coordinator-owned verification was rerun cleanly.
+- `bd create --tags` failed because this local `bd` uses `--labels`; the bead was recreated with `--labels`.
+- One Lavra goal verifier and one PR test analyzer did not return; both were closed after other review roles and coordinator verification covered the relevant surface.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Hidden-raw-tools `list_tools` | Could synchronously warm Code Mode upstream catalog. | Reads only current cached healthy upstream tools. |
+| Slow/unhealthy upstream during root tool refresh | Could stall tool refresh and make Code Mode appear unavailable. | Does not cold-connect from the hidden-raw-tools listing path. |
+| Observability | Success log had counts but not cached/non-cold source details. | Success log includes `pool_present`, `cold_discovery_skipped`, `upstream_catalog_source`, `catalog_upstream_count`, `open_upstream_count`, and `upstream_tool_error_count`. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture` | Regression test passes. | Passed. | pass |
+| `cargo fmt --all --check` | No formatting changes needed. | Passed after `cargo fmt --all`. | pass |
+| `git diff --check` | No whitespace errors. | Passed. | pass |
+| `cargo check --workspace --all-features` | All-features compile passes. | Passed with existing missing web-assets warning. | pass |
+| PR #143 CI | All required checks pass. | Passed, including Windows self-hosted test and container smoke. | pass |
+
+## Risks and Rollback
+
+The remaining known risk is pre-existing raw OAuth subject-scoped `list_tools` behavior, tracked by `lab-sgh5a`. Rollback is straightforward: revert the PR branch commits that touch `crates/lab/src/mcp/handlers_tools.rs`, `crates/lab/src/mcp/handlers_tools/tests.rs`, and the plan/session docs.
+
+## Decisions Not Taken
+
+- Did not add broad stale-cache reconciliation in this PR; the change is scoped to avoiding hidden-raw-tools cold discovery and logging cached catalog state.
+- Did not address repo-wide CodeRabbit docstring coverage; it was not introduced by the PR.
+- Did not remove any worktrees or branches; ownership and active PR status made cleanup unsafe.
+
+## References
+
+- PR #143: https://github.com/jmagar/lab/pull/143
+- Plan: `docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md`
+- Main bead: `lab-114y1`
+- Follow-up bead: `lab-sgh5a`
+
+## Open Questions
+
+- Whether `lab-sgh5a` should be handled immediately after this PR or prioritized with other gateway responsiveness work.
+
+## Next Steps
+
+- Merge PR #143 when ready.
+- Pick up `lab-sgh5a` to make the raw OAuth subject-scoped root `list_tools` path nonblocking too.

--- a/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
+++ b/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
@@ -4,7 +4,7 @@
 
 **Goal:** Keep Labby's root MCP `list_tools` response fast and stable even when one upstream MCP server is slow, unreachable, or timing out during initialization.
 
-**Architecture:** Root MCP `list_tools` should advertise only Labby's synthetic Code Mode tool plus already-cached healthy MCP App UI siblings. It must not synchronously warm or refresh the Code Mode upstream catalog. Cold upstream discovery remains owned by Code Mode execution/search and direct tool resolution paths, where the user actually asked to inspect or call upstream tools.
+**Architecture:** Root MCP `list_tools` must not synchronously warm or refresh the Code Mode upstream catalog. In hidden-raw-tools / MCP App mode, it should advertise Labby's synthetic Code Mode tool and merge only already-cached healthy MCP App UI siblings. Cold upstream discovery remains owned by Code Mode execution/search and direct tool resolution paths, where the user actually asked to inspect or call upstream tools.
 
 **Tech Stack:** Rust 2024, Tokio, rmcp, Labby gateway dispatch layer, existing `cargo test -p labby --all-features` test style.
 
@@ -237,7 +237,7 @@ Expected: JSON contains these tool IDs:
 
 Warnings for unrelated OAuth upstreams such as `google-drive`, `google-gmail`, `google-calendar`, `google-people`, or `globalping` are acceptable only if the command exits `0` and returns the ytdl results.
 
-- [ ] **Step 3: Run the root list-tools live latency smoke test**
+- [ ] **Step 3: Run the gateway status sanity check**
 
 Run:
 

--- a/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
+++ b/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
@@ -1,0 +1,301 @@
+# Nonblocking Root List Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Labby's root MCP `list_tools` response fast and stable even when one upstream MCP server is slow, unreachable, or timing out during initialization.
+
+**Architecture:** Root MCP `list_tools` should advertise only Labby's synthetic Code Mode tool plus already-cached healthy MCP App UI siblings. It must not synchronously warm or refresh the Code Mode upstream catalog. Cold upstream discovery remains owned by Code Mode execution/search and direct tool resolution paths, where the user actually asked to inspect or call upstream tools.
+
+**Tech Stack:** Rust 2024, Tokio, rmcp, Labby gateway dispatch layer, existing `cargo test -p labby --all-features` test style.
+
+## Global Constraints
+
+- `CLAUDE.md` is the source of truth for agent memory; do not edit `AGENTS.md` or `GEMINI.md` directly.
+- Rust module style is modern sibling files only; do not add `mod.rs`.
+- Business/shared gateway behavior belongs in `crates/lab/src/dispatch/`; MCP surface adapters stay thin.
+- Do not import `mcp/` from `dispatch/upstream/`.
+- Default verification targets all-features builds/tests.
+- Keep changes narrowly scoped to root `list_tools` behavior and Code Mode catalog warming.
+
+---
+
+## File Structure
+
+- Modify: `crates/lab/src/mcp/handlers_tools.rs`
+  - Responsibility: MCP `list_tools` adapter. Remove synchronous Code Mode catalog warmup from the root tool-list path. Continue reading already-healthy UI tools from the current upstream pool.
+- Modify: `crates/lab/src/mcp/handlers_tools/tests.rs`
+  - Responsibility: regression coverage for root tool-list behavior. Add a test proving a lazy/cold upstream does not get connected during `list_tools`.
+- No new runtime files.
+- No docs changes beyond this implementation plan unless implementation reveals generated docs need refresh.
+
+### Task 1: Regression Test for Nonblocking Root `list_tools`
+
+**Files:**
+- Modify: `crates/lab/src/mcp/handlers_tools/tests.rs`
+
+**Interfaces:**
+- Consumes: `code_mode_manager_with_pool(enabled, upstream, pool) -> Arc<GatewayManager>` from the same test module.
+- Consumes: `fixture_upstream_config(name: &str) -> UpstreamConfig` from the same test module.
+- Produces: test `list_tools_does_not_cold_connect_code_mode_catalog()` that fails while `list_tools_impl()` calls `manager.code_mode_catalog_tools_allowed(true, ...)`.
+
+- [ ] **Step 1: Add the failing test**
+
+Add this test after `list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden`:
+
+```rust
+#[tokio::test]
+async fn list_tools_does_not_cold_connect_code_mode_catalog() {
+    let pool = Arc::new(UpstreamPool::new());
+    let manager =
+        code_mode_manager_with_pool(true, fixture_upstream_config("cold-apps"), Arc::clone(&pool))
+            .await;
+    let server = test_server(
+        completion_test_registry(),
+        Some(manager),
+        crate::mcp::route_scope::McpRouteScope::Root,
+        rmcp::model::LoggingLevel::Emergency,
+    );
+    let (transport, _client_transport) = tokio::io::duplex(64);
+    let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
+        server, transport, None,
+    );
+    let context = rmcp::service::RequestContext::new(
+        rmcp::model::NumberOrString::Number(1),
+        running.peer().clone(),
+    );
+
+    let result = running
+        .service()
+        .list_tools_impl(None, context)
+        .await
+        .expect("list tools");
+    let names = result
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_ref())
+        .collect::<Vec<_>>();
+
+    assert!(
+        names.contains(&CODE_MODE_TOOL_NAME),
+        "root list_tools must keep advertising Code Mode"
+    );
+    assert!(
+        !names.contains(&"cold_widget"),
+        "cold upstream tools must not be discovered by root list_tools"
+    );
+
+    let runtime = pool.runtime_metadata_for_upstream("cold-apps").await;
+    assert_eq!(
+        runtime.tool_count, 0,
+        "root list_tools must not cold-connect or populate a lazy upstream catalog"
+    );
+    assert_eq!(
+        runtime.exposed_tool_count, 0,
+        "root list_tools must not expose tools that were not already healthy"
+    );
+    assert!(
+        runtime.last_error.is_none(),
+        "skipping cold discovery should not mark the upstream failed"
+    );
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture
+```
+
+Expected: FAIL. The failure should show `runtime.tool_count` or `runtime.exposed_tool_count` is non-zero because `list_tools_impl()` warmed the Code Mode catalog.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add crates/lab/src/mcp/handlers_tools/tests.rs
+git commit -m "test: cover nonblocking root list tools"
+```
+
+### Task 2: Remove Synchronous Catalog Warm from Root `list_tools`
+
+**Files:**
+- Modify: `crates/lab/src/mcp/handlers_tools.rs`
+
+**Interfaces:**
+- Consumes: `LabMcpServer::current_upstream_pool().await -> Option<Arc<UpstreamPool>>`.
+- Consumes: `UpstreamPool::healthy_ui_tools_allowed(allowed) -> Vec<UpstreamTool>`.
+- Produces: root `list_tools_impl()` that never calls `GatewayManager::code_mode_catalog_tools_allowed(true, ...)`.
+- Produces: warning-free all-features compile.
+
+- [ ] **Step 1: Remove the warmup block**
+
+In `crates/lab/src/mcp/handlers_tools.rs`, delete this whole block:
+
+```rust
+        #[cfg(feature = "gateway")]
+        if hide_raw_tools
+            && let Some(manager) = self.gateway_manager.as_ref()
+            && let Err(error) = manager
+                .code_mode_catalog_tools_allowed(
+                    true,
+                    None,
+                    oauth_subject.as_deref(),
+                    self.route_scope.allowed_upstreams(),
+                )
+                .await
+        {
+            tracing::warn!(
+                surface = "mcp",
+                service = "labby",
+                action = "list_tools",
+                error = %error,
+                "failed to warm upstream catalog before listing MCP App tools"
+            );
+        }
+```
+
+Do not replace it with another cold-connect path. The next block that reads `self.current_upstream_pool().await` stays in place.
+
+- [ ] **Step 2: Add an explanatory comment above the pool read**
+
+Change the comment immediately before `if let Some(pool) = self.current_upstream_pool().await` to this:
+
+```rust
+        // Merge upstream tools from the already-healthy catalog only. Root
+        // `list_tools` must never cold-connect upstreams: a single slow or
+        // unhealthy server can otherwise stall the host's tool refresh and make
+        // Labby's synthetic Code Mode tool appear to disappear. Code Mode
+        // execution/search still performs cold discovery through the gateway
+        // manager when the caller actually asks for upstream catalog data.
+```
+
+- [ ] **Step 3: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run existing nearby list-tools tests**
+
+Run:
+
+```bash
+cargo test -p labby --all-features list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden list_tools_advertises_code_mode_output_schemas -- --nocapture
+```
+
+Expected: PASS. If Cargo rejects multiple exact test filters, run the two commands separately:
+
+```bash
+cargo test -p labby --all-features list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden -- --nocapture
+cargo test -p labby --all-features list_tools_advertises_code_mode_output_schemas -- --nocapture
+```
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add crates/lab/src/mcp/handlers_tools.rs
+git commit -m "fix: keep root list tools nonblocking"
+```
+
+### Task 3: Prove Code Mode Discovery Still Works Outside Root `list_tools`
+
+**Files:**
+- Test-only task; no source edits expected.
+
+**Interfaces:**
+- Consumes: `GatewayManager::code_mode_catalog_tools_allowed(true, ...)` through `CodeModeBroker::build_code_mode_proxy_for_tests(...)`.
+- Produces: focused proof that removing root warmup did not break Code Mode search/proxy catalog generation.
+
+- [ ] **Step 1: Run Code Mode broker catalog tests**
+
+Run:
+
+```bash
+cargo test -p labby --all-features execute_proxy_embeds_local_discovery_helpers_without_host_callbacks execute_proxy_embeds_only_reduced_discovery_catalog -- --nocapture
+```
+
+Expected: PASS. If Cargo rejects multiple exact test filters, run the two commands separately:
+
+```bash
+cargo test -p labby --all-features execute_proxy_embeds_local_discovery_helpers_without_host_callbacks -- --nocapture
+cargo test -p labby --all-features execute_proxy_embeds_only_reduced_discovery_catalog -- --nocapture
+```
+
+- [ ] **Step 2: Run the current live ytdl catalog smoke test**
+
+Run:
+
+```bash
+labby gateway code exec --json --code 'async () => await codemode.search({ query: "ytdl-mcp youtube download audio", limit: 10 })'
+```
+
+Expected: JSON contains these tool IDs:
+
+```json
+[
+  "ytdl-mcp::youtube_download",
+  "ytdl-mcp::youtube_search",
+  "ytdl-mcp::youtube_probe"
+]
+```
+
+Warnings for unrelated OAuth upstreams such as `google-drive`, `google-gmail`, `google-calendar`, `google-people`, or `globalping` are acceptable only if the command exits `0` and returns the ytdl results.
+
+- [ ] **Step 3: Run the root list-tools live latency smoke test**
+
+Run:
+
+```bash
+time labby gateway code status --json
+```
+
+Expected: exits `0` and prints:
+
+```json
+{"enabled":true}
+```
+
+The full JSON will include additional Code Mode limits. This is a low-friction local sanity check that the gateway is up before MCP-level validation.
+
+- [ ] **Step 4: Run focused Rust formatting and diff checks**
+
+Run:
+
+```bash
+cargo fmt --all --check
+git diff --check
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 5: Run the default compile gate**
+
+Run:
+
+```bash
+cargo check --workspace --all-features
+```
+
+Expected: PASS with no new warnings from the touched files.
+
+- [ ] **Step 6: Commit verification-only changes if any**
+
+If no files changed during verification, do not commit. If `cargo fmt` changed formatting, commit only those touched files:
+
+```bash
+git add crates/lab/src/mcp/handlers_tools.rs crates/lab/src/mcp/handlers_tools/tests.rs
+git commit -m "chore: format nonblocking list tools changes"
+```
+
+## Self-Review
+
+**Spec coverage:** The plan removes the root cause identified in logs: root `list_tools` synchronously warming Code Mode catalog and getting delayed by a slow upstream initialize. Task 1 covers the regression, Task 2 implements the behavior, Task 3 proves Code Mode/ytdl discovery still works through its intended path.
+
+**Placeholder scan:** No `TBD`, `TODO`, "similar to", or unspecified implementation steps remain.
+
+**Type consistency:** The plan uses existing names verified in the codebase: `list_tools_impl`, `code_mode_catalog_tools_allowed`, `healthy_ui_tools_allowed`, `runtime_metadata_for_upstream`, `CODE_MODE_TOOL_NAME`, and the existing test helpers in `handlers_tools/tests.rs`.

--- a/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
+++ b/docs/superpowers/plans/2026-06-19-nonblocking-root-list-tools.md
@@ -79,22 +79,13 @@ async fn list_tools_does_not_cold_connect_code_mode_catalog() {
         names.contains(&CODE_MODE_TOOL_NAME),
         "root list_tools must keep advertising Code Mode"
     );
+    let summary = pool.cached_upstream_summary("cold-apps").await;
     assert!(
-        !names.contains(&"cold_widget"),
-        "cold upstream tools must not be discovered by root list_tools"
-    );
-
-    let runtime = pool.runtime_metadata_for_upstream("cold-apps").await;
-    assert_eq!(
-        runtime.tool_count, 0,
+        summary.is_none(),
         "root list_tools must not cold-connect or populate a lazy upstream catalog"
     );
-    assert_eq!(
-        runtime.exposed_tool_count, 0,
-        "root list_tools must not expose tools that were not already healthy"
-    );
     assert!(
-        runtime.last_error.is_none(),
+        pool.upstream_tool_last_error("cold-apps").await.is_none(),
         "skipping cold discovery should not mark the upstream failed"
     );
 }
@@ -108,7 +99,7 @@ Run:
 cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture
 ```
 
-Expected: FAIL. The failure should show `runtime.tool_count` or `runtime.exposed_tool_count` is non-zero because `list_tools_impl()` warmed the Code Mode catalog.
+Expected: FAIL. The failure should show the cached upstream summary exists because `list_tools_impl()` warmed the Code Mode catalog.
 
 - [ ] **Step 3: Commit the failing test**
 
@@ -254,10 +245,10 @@ Run:
 time labby gateway code status --json
 ```
 
-Expected: exits `0` and prints:
+Expected: exits `0` and includes:
 
 ```json
-{"enabled":true}
+"enabled": true
 ```
 
 The full JSON will include additional Code Mode limits. This is a low-friction local sanity check that the gateway is up before MCP-level validation.
@@ -298,4 +289,4 @@ git commit -m "chore: format nonblocking list tools changes"
 
 **Placeholder scan:** No `TBD`, `TODO`, "similar to", or unspecified implementation steps remain.
 
-**Type consistency:** The plan uses existing names verified in the codebase: `list_tools_impl`, `code_mode_catalog_tools_allowed`, `healthy_ui_tools_allowed`, `runtime_metadata_for_upstream`, `CODE_MODE_TOOL_NAME`, and the existing test helpers in `handlers_tools/tests.rs`.
+**Type consistency:** The plan uses existing names verified in the codebase: `list_tools_impl`, `code_mode_catalog_tools_allowed`, `healthy_ui_tools_allowed`, `cached_upstream_summary`, `upstream_tool_last_error`, `CODE_MODE_TOOL_NAME`, and the existing test helpers in `handlers_tools/tests.rs`.


### PR DESCRIPTION
## Summary
- add the nonblocking root list_tools implementation plan
- stop root MCP list_tools from forcing cold Code Mode catalog discovery
- add a regression test proving a cold upstream is not connected during root list_tools

## Verification
- cargo test -p labby --all-features list_tools_does_not_cold_connect_code_mode_catalog -- --nocapture
- cargo fmt --all --check
- git diff --check
- cargo check --workspace --all-features

Note: cargo check still emits the existing build-script warning about missing apps/gateway-admin/out web assets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make root MCP `list_tools` nonblocking by removing synchronous Code Mode catalog warmup. Add structured tracing to confirm cold discovery is skipped and to report cached upstream catalog state.

- **Bug Fixes**
  - Removed the `code_mode_catalog_tools_allowed(...)` warmup from root `list_tools`; merge only already-healthy upstream tools and always advertise Code Mode.
  - Strengthened regression test `list_tools_does_not_cold_connect_code_mode_catalog` to verify Code Mode stays listed, no cold upstream discovery occurs, and no upstream error markers are set.

- **Refactors**
  - Deferred `oauth_subject` computation to the branch that needs it.
  - Added structured success log fields: `pool_present`, `cold_discovery_skipped`, `upstream_catalog_source`, `catalog_upstream_count`, `open_upstream_count`, `upstream_tool_error_count`.
  - Added session log under `docs/sessions/` and an implementation plan under `docs/superpowers/plans/`.

<sup>Written for commit ada479d42f541ee618198c0d4f1160641ca9bc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved MCP tools listing response time by eliminating unnecessary synchronization steps.

* **Tests**
  * Added regression test to verify non-blocking behavior during tools listing.

* **Documentation**
  * Added implementation plan document for tools listing optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->