### PR TITLE
fix(deps): bump dompurify 3.4.9 → 3.4.11 (GHSA-cmwh-pvxp-8882)

### DIFF
--- a/apps/gateway-admin/package.json
+++ b/apps/gateway-admin/package.json
@@ -112,7 +112,7 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "dompurify": "3.4.9",
+      "dompurify": "3.4.11",
       "esbuild": "^0.28.1",
       "lodash": "4.18.0",
       "mermaid": "11.15.0",

--- a/apps/gateway-admin/pnpm-lock.yaml
+++ b/apps/gateway-admin/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   esbuild: ^0.28.1
   lodash: 4.18.0
   mermaid: 11.15.0
@@ -2436,8 +2436,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
@@ -5843,7 +5843,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6516,7 +6516,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0


### PR DESCRIPTION
## What

Resolves **Dependabot alert [#72](https://github.com/jmagar/lab/security/dependabot/72)** (medium severity, `GHSA-cmwh-pvxp-8882`).

DOMPurify `<= 3.4.10` has a stored-XSS hole: when an app uses the persistent-config API `setConfig()` together with an `uponSanitizeAttribute` hook, the 3.4.7 clone-guard is bypassed and a hook's `ALLOWED_ATTR` mutation permanently pollutes the shared allowlist. First patched in **3.4.11**.

## Root cause in this repo

`dompurify` is a **transitive** dependency of `mermaid@11.15.0` (pulled in via `streamdown` for markdown diagram rendering) in `apps/gateway-admin`. It surfaced as a direct concern because the `pnpm.overrides` block force-pinned it to the vulnerable **3.4.9** (originally to clear the earlier 3.4.7 advisory). That pin now sits inside the new vulnerable range.

## Change

- `apps/gateway-admin/package.json`: `pnpm.overrides.dompurify` `3.4.9` → `3.4.11`
- `apps/gateway-admin/pnpm-lock.yaml`: regenerated (`pnpm install`) so the `--frozen-lockfile` CI install stays in sync

Surgical diff — only the dompurify version + integrity hash changed; no incidental package drift. `mermaid` still resolves it correctly.

## Verification

| Gate | Result |
|------|--------|
| `pnpm install --frozen-lockfile` (CI `frontend-assets` step 1) | ✅ Lockfile up to date |
| `pnpm build` / `next build` (CI `frontend-assets` step 2) | ✅ Full static export |
| Bundled dompurify version | ✅ `3.4.11` |
| `just deny` (cargo-deny advisory gate) | ✅ advisories ok, bans ok, licenses ok, sources ok |
| `just build` (all-features; embeds `out/` via `include_dir!`) | ✅ Finished |
| `just test` (all-features nextest) | ✅ 2176 passed, 0 failed, 14 skipped |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `dompurify` to 3.4.11 to patch a stored XSS vulnerability (GHSA-cmwh-pvxp-8882). Resolves Dependabot alert #72 in `apps/gateway-admin`, where `dompurify` is pulled transitively via `mermaid`.

- **Dependencies**
  - Update `pnpm.overrides.dompurify` from `3.4.9` to `3.4.11`.
  - Regenerate `pnpm-lock.yaml` to keep CI installs in sync.

<sup>Written for commit dcd8de65b874638b5dd630f25cd3318070f0b89a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

