### PR TITLE
docs: session log — resolve Dependabot alert #72 (dompurify)

### DIFF
--- a/docs/sessions/2026-06-21-dompurify-dependabot-72.md
+++ b/docs/sessions/2026-06-21-dompurify-dependabot-72.md
@@ -1,0 +1,143 @@
+---
+date: 2026-06-21 08:42:29 EST
+repo: git@github.com:jmagar/lab.git
+branch: main
+head: ada2332c
+session id: 0fafde31-29f1-4842-935c-453156e75ec1
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-lab/0fafde31-29f1-4842-935c-453156e75ec1.jsonl
+working directory: /home/jmagar/workspace/lab
+pr: "#144 fix(deps): bump dompurify 3.4.9 → 3.4.11 (GHSA-cmwh-pvxp-8882) — https://github.com/jmagar/lab/pull/144"
+beads: lab-958j6
+---
+
+# Resolve Dependabot alert #72 — dompurify stored-XSS
+
+## User Request
+
+Investigate and resolve the 1 moderate-severity Dependabot vulnerability on the default
+branch of `jmagar/lab` (alert #72): identify the affected dependency, bump to a patched
+version, verify with the repo's all-features path, and open a PR to `main` without touching
+the protected `marketplace-no-mcp` branch.
+
+## Session Overview
+
+Resolved Dependabot alert #72 (`GHSA-cmwh-pvxp-8882`, medium-severity stored XSS in
+DOMPurify `<= 3.4.10`). The dependency turned out to be an **npm/pnpm** package — not a
+Cargo crate as the brief assumed. `dompurify` is a transitive dependency of `mermaid@11.15.0`
+(via `streamdown`) in `apps/gateway-admin`, but the app's `pnpm.overrides` block force-pinned
+it to the vulnerable `3.4.9`. Bumped the override to `3.4.11` (first patched + latest),
+regenerated the lockfile, verified the full CI gate locally, opened [PR #144](https://github.com/jmagar/lab/pull/144),
+confirmed all CI green, squash-merged, and confirmed the alert auto-closed to `fixed`.
+
+## Sequence of Events
+
+1. Pulled alert #72 via `gh api` — identified `dompurify` (npm), transitive, runtime, manifest `apps/gateway-admin/pnpm-lock.yaml`, vulnerable `<= 3.4.10`, first patched `3.4.11`.
+2. Explored `apps/gateway-admin/` — found `pnpm.overrides.dompurify: "3.4.9"` as the root cause; traced the transitive path to `mermaid@11.15.0` in the lockfile.
+3. Confirmed `3.4.11` is the latest published version, only this one app references dompurify, and CI's `frontend-assets` job (`pnpm install --frozen-lockfile` → `pnpm build`) is the real gate.
+4. Created/claimed tracking bead `lab-958j6`, branched `fix/dompurify-ghsa-cmwh-pvxp-8882`.
+5. Edited the override `3.4.9 → 3.4.11`, ran `pnpm install` to regenerate the lockfile (surgical 6-line diff across the two files).
+6. Verified locally: frozen install in sync, `next build` OK, bundled version `3.4.11`, `just deny` OK, all-features `just build`, `just test` (2176 passed).
+7. Committed (path-limited), pushed, opened PR #144 against `main`, noted PR on the bead and closed it.
+8. Monitored CI to completion — all 19 checks green (1 neutral skip), `MERGEABLE/CLEAN`.
+9. Squash-merged with `--delete-branch`, synced local `main`, deleted the stale local branch, confirmed alert #72 is now `state=fixed`.
+
+## Key Findings
+
+- The advisory dependency is npm `dompurify`, not Rust — the Cargo-oriented steps in the brief (`cargo tree -i`, `cargo update`) did not apply. Fix path was a pnpm override bump.
+- Root cause: `apps/gateway-admin/package.json:115` pinned `pnpm.overrides.dompurify` to `3.4.9` (originally to clear the earlier 3.4.7 advisory); that pin had drifted into the new vulnerable range.
+- Transitive source: `mermaid@11.15.0` → `dompurify` (`apps/gateway-admin/pnpm-lock.yaml`, mermaid snapshot ~line 6519); mermaid is itself in `pnpm.overrides`.
+- CI couples the frontend to the Rust build: the `lab` crate embeds `apps/gateway-admin/out` via `include_dir!`, and every Rust CI job `needs: frontend-assets`. So the frontend build is the gating step; `out/`/`.next/` are gitignored and not committed.
+
+## Technical Decisions
+
+- **Bump the override to `3.4.11`** (not remove it): mermaid still wants dompurify and the override is the only lever that controls the resolved version; `3.4.11` is both the first patched and latest release.
+- **Regenerate `pnpm-lock.yaml`** with a normal `pnpm install`: CI runs `--frozen-lockfile`, which fails if `package.json` and the lockfile disagree, so both must change together.
+- **Squash-merge**: the PR was a single well-formed conventional commit; squash keeps `main` history clean and matches the repo's commit style.
+- **Ran the full Rust all-features build/test** even though a JS dep cannot change Rust behavior, because the regenerated `out/` is embedded into the Rust binary — confirming the embed still compiles closed the loop.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | apps/gateway-admin/package.json | — | `pnpm.overrides.dompurify` `3.4.9` → `3.4.11` | `git diff --numstat` → `1 1` |
+| modified | apps/gateway-admin/pnpm-lock.yaml | — | regenerated lockfile (dompurify version + integrity, mermaid dep) | `git diff` → 6 lines, dompurify only |
+| created | docs/sessions/2026-06-21-dompurify-dependabot-72.md | — | this session log | save-to-md artifact |
+
+## Beads Activity
+
+| id | title | actions | final status | why it mattered |
+|---|---|---|---|---|
+| lab-958j6 | Fix Dependabot alert #72: bump dompurify 3.4.9 → 3.4.11 (GHSA-cmwh-pvxp-8882) | created, claimed, noted (PR #144 + verification), closed | CLOSED | Tracked the security fix per repo convention; note records the PR and the verification evidence. |
+
+## Repository Maintenance
+
+- **Plans**: Checked `docs/plans/`. No plan was touched by this session. `docs/plans/fleet-ws-plan-lab-n07n.md` remains active (unrelated) and was left alone; `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` is already filed under `complete/`. No moves needed.
+- **Beads**: Created and closed `lab-958j6` (see above). `bd show lab-958j6` confirms CLOSED with the PR note. No other beads relevant; no follow-up beads needed (work fully landed).
+- **Worktrees/branches**: My fix branch `fix/dompurify-ghsa-cmwh-pvxp-8882` was deleted on both remote (via `gh pr merge --delete-branch`) and local (`git branch -D`, was `dcd8de65`). Left alone, with reasons: `marketplace-no-mcp` + its worktree `/home/jmagar/workspace/_no_mcp_worktrees/lab` (protected per CLAUDE.md); `claude/crazy-ride-fcc2d4` and `claude/dazzling-heyrovsky-7d3fe0` worktrees at `407819ba` (active Claude Code worktrees from other sessions, unclear ownership / possible uncommitted work — not safe to delete despite being an ancestor of `main`).
+- **Stale docs**: This was a dependency-version bump; no documentation describes the dompurify pin, so nothing was contradicted. No doc updates required.
+- **Transparency**: All cleanup decisions above are backed by the merge output, `git worktree list`, and the injected branch/worktree snapshot. No destructive action taken beyond deleting my own merged fix branch.
+
+## Tools and Skills Used
+
+- **GitHub CLI (`gh`)**: alert inspection (`gh api .../dependabot/alerts/72`), CI monitoring (`gh pr checks`, `gh pr view`), PR create + squash-merge. No issues.
+- **Shell / build tooling**: `pnpm` (install, frozen install, `next build`, `pnpm view`), `just` (`deny`, `build`, `test`), `git`, `grep`/`sed`/`python3` for inspection. No issues; all green.
+- **File tools**: `Read` + `Edit` for the one-line `package.json` change; `Write` for this log.
+- **beads (`bd`)**: created/claimed/noted/closed `lab-958j6`. No issues.
+- **Skill**: `vibin:save-to-md` (this artifact).
+- **No** MCP servers, subagents, or browser tools were used.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `gh api repos/jmagar/lab/dependabot/alerts/72` | dompurify npm, transitive, `<= 3.4.10`, patched `3.4.11` |
+| `pnpm view dompurify version` | `3.4.11` (latest = first patched) |
+| `pnpm install` (gateway-admin) | lockfile updated to dompurify 3.4.11 |
+| `pnpm install --frozen-lockfile` | `Lockfile is up to date` |
+| `pnpm build` | full Next.js static export |
+| `just deny` | `advisories ok, bans ok, licenses ok, sources ok` |
+| `just build` | `Finished dev profile in 2m 25s` |
+| `just test` | `2176 tests run: 2176 passed, 14 skipped` |
+| `gh pr merge 144 --squash --delete-branch` | merged, sha `ada2332c` |
+| `gh api .../dependabot/alerts/72` (post-merge) | `state=fixed` |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `grep dompurify pnpm-lock.yaml` | `3.4.11`, no `3.4.9/3.4.10` | `3.4.11`; none vulnerable | pass |
+| `pnpm install --frozen-lockfile` | lockfile/manifest in sync | `Lockfile is up to date` | pass |
+| `pnpm build` | static export succeeds | full export, all routes | pass |
+| installed dompurify version | `3.4.11` | `3.4.11` | pass |
+| `just deny` | advisories ok | advisories/bans/licenses/sources ok | pass |
+| `just build` (all-features) | compiles with embedded `out/` | Finished (2m25s) | pass |
+| `just test` (all-features) | tests pass | 2176 passed, 0 failed, 14 skipped | pass |
+| `gh pr checks 144` | all checks green | 19 SUCCESS, 1 neutral (skip), 0 fail | pass |
+| alert #72 state post-merge | fixed | `state=fixed` | pass |
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| gateway-admin dompurify | resolved `3.4.9` (vulnerable to GHSA-cmwh-pvxp-8882) | resolved `3.4.11` (patched) |
+| Dependabot alert #72 | open (moderate) on default branch | fixed (auto-closed on merge) |
+
+## Risks and Rollback
+
+- Low risk: a patch-level bump within the same DOMPurify minor; mermaid's declared range still resolves it, and the full all-features test suite + frontend build passed.
+- Rollback: revert merge commit `ada2332c` (or re-set `pnpm.overrides.dompurify` to a prior version and re-run `pnpm install`).
+
+## Decisions Not Taken
+
+- **Removing the `dompurify` override** entirely — rejected: mermaid pulls it transitively and the override is the resolution lever; dropping it could let a future transitive bump regress. Pinning to the patched version is the minimal, intentional fix.
+- **Re-triggering `@coderabbitai review`** after its rate-limit notice — offered to the user, not done unilaterally (no findings were raised; change already verified + CI-green).
+
+## References
+
+- Dependabot alert #72: https://github.com/jmagar/lab/security/dependabot/72
+- Advisory GHSA-cmwh-pvxp-8882: https://github.com/cure53/DOMPurify/security/advisories/GHSA-cmwh-pvxp-8882
+- PR #144: https://github.com/jmagar/lab/pull/144
+
+## Next Steps
+
+- None required — the fix is merged to `main`, CI is green, and alert #72 is `fixed`. No follow-on or blocked work from this session.


### PR DESCRIPTION
Session log for the work in [PR #144](https://github.com/jmagar/lab/pull/144) (dompurify `3.4.9 → 3.4.11`, Dependabot alert #72 → `fixed`).

Adds `docs/sessions/2026-06-21-dompurify-dependabot-72.md` — docs-only, no code changes. Routed through a branch + PR rather than a direct push to `main` per the repo's branch-first convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log documenting the resolution of Dependabot alert #72 (stored XSS) by upgrading `dompurify` 3.4.9 → 3.4.11. Documentation only; records the steps and CI verification, no code changes.

<sup>Written for commit 9828dd844047b9d482d9bf31641b0d2cbd2952ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

