### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-06-21-retire-bundled-marketplace.md
+++ b/docs/sessions/2026-06-21-retire-bundled-marketplace.md
@@ -1,0 +1,136 @@
+---
+date: 2026-06-21 16:34:40 EST
+repo: git@github.com:jmagar/lab.git
+branch: claude/recursing-murdock-2f9d6b
+head: 5bfbdd3f
+working directory: /home/jmagar/workspace/lab/.claude/worktrees/recursing-murdock-2f9d6b
+worktree: /home/jmagar/workspace/lab/.claude/worktrees/recursing-murdock-2f9d6b
+pr: 146 — chore: retire lab's bundled marketplace (migrated to dendrite) — https://github.com/jmagar/lab/pull/146 (merged as 304080a0)
+---
+
+# Retire lab's bundled plugin marketplace (migrated to dendrite)
+
+## User Request
+"i thought we removed all the plugins from the repo except plugins/labby ...?" — which became: confirm the migration, delete the stale duplicate plugins + marketplace catalogs, remove the catalog generator, open a PR, review it, and merge.
+
+## Session Overview
+Confirmed that the Lab/Labby plugin marketplace was migrated to a dedicated repo (`github.com/jmagar/dendrite`), leaving stale duplicates in `lab`. Deleted 23 migrated plugin directories, both the Claude and Codex marketplace catalogs, and the `labby marketplace generate` machinery; kept `plugins/labby` + `plugins/scripts` and the marketplace browse/install dispatch service. Updated affected docs, opened PR #146, ran a four-agent review, fixed the one real finding plus the non-blocking suggestions, and squash-merged to `main` (`304080a0`) with full CI green.
+
+## Sequence of Events
+1. Investigated the opening question: the `cortex` SessionStart hook is from a **global** install (`~/.claude/plugins/data/cortex-dendrite-no-mcp`), not the repo — the repo has no `cortex` dir. Found 24 plugin dirs still tracked on `main`/branch, not just `labby`.
+2. User clarified the plugins were moved to `../dendrite`. Verified `~/workspace/dendrite` is a real repo and a superset; classified all 22 shared plugins (dendrite newer/superset) and surfaced exceptions: `vibin` had lab-only skills (`mcpjam-inspector`, `summarize`) and `bitwarden` was never migrated.
+3. User resolved exceptions (`creating-snippets` lives in `labby`; aurora/ytdl have their own source repos; `mcpjam-inspector`/`summarize`/`bitwarden` safe to delete).
+4. Deleted 23 plugin dirs + `.claude-plugin/marketplace.json` (Claude) + `.agents/plugins/marketplace.json` (Codex); kept `labby` + `scripts`.
+5. Removed `labby marketplace generate` (`generator.rs` + CLI subcommand + Justfile recipe); repointed `docs/PLUGINS.md` and `docs/services/MONITORS.md` at dendrite; regenerated `docs/generated/cli-help.md`.
+6. Verified, committed, pushed, opened PR #146; ran four `pr-review-toolkit` agents (code, comments, errors, tests) in parallel.
+7. Fixed the one real finding (`docs/coverage/PLUGINS.md` stale), then the two non-blocking suggestions (CHANGELOG entry, supersede note on `core-plugin-setup.md`); saved a project memory.
+8. Confirmed all CI checks green and squash-merged PR #146 to `main`.
+
+## Key Findings
+- The `cortex` hook noise was a **global** plugin install, unrelated to the repo (repo `plugins/` never contained `cortex`).
+- `dendrite` is the dedicated marketplace repo and a superset (76 entries); it references `plugins/labby` via a `git-subdir` source pointing at `lab.git`, so `labby` stays in `lab` but is cataloged by dendrite.
+- `bitwarden` was never migrated to dendrite — deleted during the split (change survives only in a dendrite stash), 0 marketplace entries.
+- `crates/lab/build.rs` embeds `apps/gateway-admin/out` (the frontend), **not** plugins/catalogs — so the deletions touch zero files in the compile graph.
+- The marketplace **generator** (`crates/lab/src/cli/marketplace/generator.rs`) only produced lab's own catalog and was isolated to the `Generate` CLI subcommand; the marketplace **dispatch service** (`crates/lab/src/dispatch/marketplace/`) is a separate consumer feature and stays.
+- Review surfaced a second, missed live operator doc: `docs/coverage/PLUGINS.md` (documented all 23 deleted plugins; earlier grep missed it because it lists plugins by `## heading`, not by path).
+
+## Technical Decisions
+- Distinguished marketplace **generator** (removed) from marketplace **service** (kept — powers the Labby web UI, MCP Registry, ACP agents).
+- Verified build-safety **structurally** (build.rs target, no `include_*` of plugins, temp-dir tests) rather than running a cold ~10-min `cargo build`, since no compile-graph file changed; still ran `clippy --all-features -D warnings`, `fmt --check`, and `labby docs check`.
+- Squash-merged (matches the repo's `(#N)` single-commit convention).
+- Left historical records as point-in-time: `CHANGELOG.md` history line untouched; `docs/features/core-plugin-setup.md` kept but annotated with a "Superseded in part" note.
+
+## Files Changed
+| status | path | previous path | purpose | evidence |
+|--------|------|---------------|---------|----------|
+| deleted | `.claude-plugin/marketplace.json` | — | remove Claude catalog (superseded by dendrite) | `git rm`; 0 `marketplace.json` left in repo |
+| deleted | `.agents/plugins/marketplace.json` | — | remove Codex catalog (superseded by dendrite) | git-tracked, confirmed dendrite has its own |
+| deleted | `crates/lab/src/cli/marketplace/generator.rs` | — | remove obsolete catalog generator | clippy green after removal |
+| deleted | `plugins/{acp,adguard,agent-os,arrs,bitwarden,bytestash,dozzle,immich,linkding,loggifly,memos,navidrome,neo4j,notebooklm,plexus,qdrant,radicale,scrutiny,swag,tei,testing,uptime-kuma,vibin}/**` | — | 23 migrated plugin dirs (stale duplicates) | each verified present in dendrite (bulk: 596 files in first commit) |
+| modified | `crates/lab/src/cli/marketplace.rs` | — | drop `Generate` subcommand; preserve dispatch path | smoke: `marketplace help` ok, `marketplace generate` rejected |
+| modified | `Justfile` | — | remove `marketplace` recipe that ran the generator | no remaining `marketplace` refs |
+| modified | `docs/PLUGINS.md` | — | "Generated marketplace tree" → "Marketplace distribution" (dendrite) | comment-analyzer verified accurate |
+| modified | `docs/services/MONITORS.md` | — | repoint stale plugin-monitor examples at dendrite; keep `labby deploy monitor` docs | comment-analyzer verified accurate |
+| modified | `docs/generated/cli-help.md` | — | regenerated (drops the `generate` subcommand) | `labby docs check` FRESH |
+| modified | `docs/coverage/PLUGINS.md` | — | prune to surviving `labby`+`scripts`; point rest at dendrite; add labby `creating-snippets` | review-critical fix |
+| modified | `CHANGELOG.md` | — | `[Unreleased] → Removed` entry | review follow-up |
+| modified | `docs/features/core-plugin-setup.md` | — | "Superseded in part" note on the generator sections | review follow-up |
+| created | `docs/sessions/2026-06-21-retire-bundled-marketplace.md` | — | this session log | — |
+| created | `~/.claude/projects/-home-jmagar-workspace-lab/memory/marketplace-migrated-to-dendrite.md` | — | durable memory: dendrite is the marketplace home (outside repo) | indexed in `MEMORY.md` |
+
+## Beads Activity
+No bead activity observed. The session was driven by direct user instruction and a GitHub PR, not the `bd` tracker; the injected `Beads recent issues` are historical, and no bead was created, claimed, edited, commented on, or closed.
+
+## Repository Maintenance
+- **Plans:** `docs/plans/fleet-ws-plan-lab-n07n.md` remains active (untouched by this session); `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` already complete. No plan was completed this session, so no moves. Evidence: `ls docs/plans/`.
+- **Beads:** none — see Beads Activity.
+- **Worktrees/branches:** the session branch `claude/recursing-murdock-2f9d6b` is now merged into `main` via squash (`304080a0`). It was **not** deleted because it is this session's active worktree (`git worktree list` shows it live). Other worktrees/branches (`crazy-ride`, `dazzling-heyrovsky`, `keen-hugle`, `cm-*`, `worktree-agent-*`, the protected `marketplace-no-mcp`) are unrelated to this session and were left alone (active/unclear ownership). Evidence: injected `git worktree list` + `git branch -vv`.
+- **Stale docs:** handled in-session. All plugin/marketplace docs touched or contradicted by the change were updated (`PLUGINS.md`, `coverage/PLUGINS.md`, `MONITORS.md`, `core-plugin-setup.md`, `CHANGELOG.md`, regenerated `cli-help.md`). No remaining live operator doc references the deleted plugins/catalogs/generator (review sweep confirmed historical-only leftovers in `CHANGELOG` history and session logs).
+
+## Tools and Skills Used
+- **Shell (Bash):** `git`, `gh`, `cargo` (clippy/fmt/run), `jq`, `rg`, `fd`, `ls`, `diff`, `target/debug/labby` — investigation, deletion, build/lint verification, PR + merge. Issue: a `for p in $plugins` loop did not word-split under zsh (ran once over the whole string); fixed with an explicit literal list.
+- **File tools:** `Read`, `Write`, `Edit` for code + docs. Issue: first `Justfile` `Edit` failed ("File has not been read yet"); resolved by `Read`-ing it first.
+- **Subagents:** four `pr-review-toolkit` agents (`code-reviewer`, `comment-analyzer`, `silent-failure-hunter`, `pr-test-analyzer`) run in parallel against PR #146.
+- **Skills:** `pr-review-toolkit:review-pr` (review orchestration), `vibin:save-to-md` (this log).
+- **Interactive:** `AskUserQuestion` used twice (vibin exception handling, marketplace.json scope) — both dismissed by the user, who answered in prose instead.
+- **Memory:** `Write` to the project memory dir + `MEMORY.md` index.
+- No MCP servers or browser tools were used.
+
+## Commands Executed
+| command | result |
+|---------|--------|
+| `git ls-files plugins/ \| awk -F/ '{print $2}' \| sort -u` | 24 tracked plugin dirs (not just labby) |
+| `ls -1 ~/.claude/plugins/data/` | confirmed `cortex-dendrite-no-mcp` etc. are global installs |
+| `diff -rq plugins/<p> $DEN/plugins/<p>` (×22) | dendrite superset; only `vibin` had lab-only files |
+| `git rm -r <23 dirs> .claude-plugin/marketplace.json` + `git rm .agents/plugins/marketplace.json` | 598 deletions staged |
+| `cargo clippy --workspace --all-features -- -D warnings` | exit 0 |
+| `cargo fmt --all --check` | exit 0 |
+| `target/debug/labby docs check` | FRESH (exit 0) |
+| `cargo run -- docs generate` | regenerated `cli-help.md` (clean diff) |
+| `gh pr create ... ; gh pr merge 146 --squash` | PR #146 opened then MERGED (`304080a0`) |
+| `gh pr checks 146` | all checks pass (exit 0) |
+
+## Errors Encountered
+- **zsh word-splitting:** `for p in $plugins` iterated once over the whole string. Root cause: zsh does not split unquoted parameters like bash. Fixed by iterating an explicit literal plugin list.
+- **Edit before Read:** the first `Justfile` edit errored ("File has not been read yet"). Fixed by `Read`-ing the relevant lines first.
+- **AskUserQuestion dismissed (×2):** not a failure — the user preferred to answer in prose; proceeded on their typed answers.
+
+## Behavior Changes (Before/After)
+| area | before | after |
+|------|--------|-------|
+| `labby marketplace generate` | generated a Claude/Codex marketplace tree | removed — `--out` now errors "unexpected argument" |
+| `labby marketplace <action>` | browse/install dispatch service | unchanged (service intact) |
+| `lab` repo marketplace | shipped `.claude-plugin/` + `.agents/plugins/` catalogs + 24 plugins | ships only `plugins/labby` + `plugins/scripts`, no catalogs |
+| `just marketplace` | built the marketplace tree | recipe removed |
+
+## Verification Evidence
+| command | expected | actual | status |
+|---------|----------|--------|--------|
+| `cargo clippy --workspace --all-features -- -D warnings` | exit 0 | exit 0 | pass |
+| `cargo fmt --all --check` | exit 0 | exit 0 | pass |
+| `target/debug/labby docs check` | FRESH | FRESH | pass |
+| `target/debug/labby marketplace help` | dispatches | action catalog shown | pass |
+| `target/debug/labby marketplace generate --out /tmp/x` | rejected | "unexpected argument '--out'" | pass |
+| `gh pr checks 146` | all green | Clippy/Test/feature slices/Windows/docs/deny/gitleaks all pass | pass |
+
+## Risks and Rollback
+- Low risk: deletions are migrated duplicates verified present in dendrite; the only non-deletion code change (`cli/marketplace.rs`) is an isolated CLI-subcommand removal with the dispatch path preserved.
+- Rollback: revert squash commit `304080a0` on `main`. Deleted content is recoverable from git history and from the dendrite repo.
+
+## Decisions Not Taken
+- Did **not** remove the marketplace dispatch service — only the generator (the service is a separate consumer feature).
+- Did **not** scrub `bitwarden` from history or add a new CHANGELOG release section — kept history immutable.
+- Did **not** touch the long-lived `marketplace-no-mcp` branch (protected; keeps its own catalog copy).
+- Did **not** run a full cold `cargo build`/`nextest` locally — relied on structural analysis + clippy + the test-analyzer's `nextest --no-run` (all targets compile) + CI.
+
+## References
+- PR: https://github.com/jmagar/lab/pull/146 (merged `304080a0`)
+- Marketplace repo: https://github.com/jmagar/dendrite
+- Memory: `marketplace-migrated-to-dendrite.md` (project memory)
+
+## Open Questions
+- The three `generator.rs` unit tests were removed with the file; the test-analyzer suggested carrying them into the dendrite repo if the generator lives there. Out of scope for `lab`.
+
+## Next Steps
+- Nothing pending in `lab` — PR #146 is merged and CI is green.
+- Optional follow-ups: (1) confirm/port the generator's tests in dendrite if dendrite owns a generator; (2) clean up the now-merged `claude/recursing-murdock-2f9d6b` worktree/branch when convenient (left intact here as the active worktree).


### PR DESCRIPTION
Session log for the marketplace-retirement work (PR #146). Docs only — adds one file under docs/sessions/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add session log documenting the retirement of the bundled plugin marketplace and the migration to `github.com/jmagar/dendrite`, summarizing the changes merged in PR #146.
Docs-only; adds `docs/sessions/2026-06-21-retire-bundled-marketplace.md`.

<sup>Written for commit 386941562a5013b9b17473708504dc5b81b6af1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/lab/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

