### PR TITLE
Run Labby gateway as host service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ env:
   # .cargo/config.toml sets rustc-wrapper = "scripts/cargo-rustc-wrapper" for
   # local dev (sccache delegation + labby binary sync). The wrapper is a shell
   # script: Windows runners cannot exec it (os error 193) and its side effects
-  # are pointless in CI, so disable it for all CI jobs.
+  # are pointless in CI, so clear ambient wrappers and override Cargo's
+  # build.rustc-wrapper for all jobs.
   RUSTC_WRAPPER: ""
   CARGO_BUILD_RUSTC_WRAPPER: ""
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ env:
   RUSTFLAGS: -D warnings
   # .cargo/config.toml sets rustc-wrapper = "scripts/cargo-rustc-wrapper" for
   # local dev. The wrapper is a shell script: Windows runners cannot exec it
-  # (os error 193) and the cross/aarch64 container cannot either, so disable
-  # it for all release jobs (mirrors ci.yml).
+  # (os error 193) and the cross/aarch64 container cannot either, so clear
+  # ambient wrappers and override Cargo's build.rustc-wrapper for all release
+  # jobs (mirrors ci.yml).
   RUSTC_WRAPPER: ""
   CARGO_BUILD_RUSTC_WRAPPER: ""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,13 +329,18 @@ Default verification targets the all-features build. If you run a reduced featur
 - **`labby doctor`** — comprehensive health audit: checks env vars, reachability, auth, version for every enabled service. Emits human-readable table by default, `--json` for CI. Exit code reflects worst severity.
 - **`bin/health-check`** — repo-level shell helper for CI/CD smoke tests.
 
-### Docker dev container
+### Host Labby gateway
 
-`docker-compose.yml` runs `labby:dev` with the host's `~/.lab/`, `~/.gemini/`, the repo workspace, the locally built `bin/labby`, and frontend assets bind-mounted in. The image at `config/Dockerfile.fast` pre-installs the three ACP adapters (`claude-agent-acp`, `codex-acp`, `gemini`) into `/opt/acp-adapters/node_modules` and symlinks them into `/usr/local/bin/`, so each chat session spawn calls a deterministic local binary instead of paying the `npx -y` round-trip. The provider config at `config/acp-providers.docker.json` therefore uses `command: "claude-agent-acp"` (etc.) directly.
+The normal local/dookie Labby gateway should run on the host as
+`systemd --user` service `labby.service`, executing `~/.local/bin/labby serve`.
+This is preferred over the Docker dev container because the gateway launches
+stdio MCP tools and depends on host SSH config, agent credentials, local
+binaries, and user caches. Use `just host-service-install` once, then
+`just host-sync` after Rust changes.
 
-The Claude SDK is held forward of `claude-agent-acp`'s pinned version via an `overrides` entry in `/opt/acp-adapters/package.json` (currently `^0.2.131`). The bundled Claude Code binary version must match credential format expectations from the host's `claude` CLI, otherwise the underlying binary `SIGILL`s on session start. Bump both when upgrading.
-
-`just dev-debug` rebuilds the labby binary with nightly + cranelift codegen and hot-swaps it into the running container without rebuilding the Docker image. Image rebuilds are only needed when changing `Dockerfile.fast` or the pre-installed package set.
+The Docker Compose stack is still supported for prod-like image smoke and
+Docker-specific ACP adapter work. Use `just dev-container` or
+`just dev-container-debug` explicitly when testing that path.
 
 ### Bearer auth in dev (driving the UI with agent-browser)
 

--- a/Justfile
+++ b/Justfile
@@ -97,9 +97,8 @@ host-sync:
     install -D -m 755 "$LABBY_BIN" ~/.local/bin/labby.new
     mv ~/.local/bin/labby.new ~/.local/bin/labby
     if systemctl --user is-enabled --quiet labby.service; then
-      systemctl --user restart labby.service
+      ~/.local/bin/labby setup host-service restart -y
       ~/.local/bin/labby setup host-service status --json
-      curl -fsS http://127.0.0.1:8765/ready >/dev/null
     else
       echo "labby.service is not installed; run: just host-service-install"
     fi
@@ -112,7 +111,7 @@ host-service-install:
 
 host-service-restart:
     ~/.local/bin/labby setup host-service restart -y
-    curl -fsS http://127.0.0.1:8765/ready >/dev/null
+    ~/.local/bin/labby setup host-service status --json
 
 host-service-status:
     ~/.local/bin/labby setup host-service status --json

--- a/Justfile
+++ b/Justfile
@@ -54,9 +54,19 @@ build-release:
     install -D -m 755 target/release/labby bin/labby
     just link-bin
 
-# Symlink the compiled binary into PATH.
+# Copy the compiled binary into PATH.
 # Called automatically by `just build-release` and `just install`.
 link-bin profile="release":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if systemctl --user is-active --quiet labby.service 2>/dev/null; then
+      echo "error: labby.service is active; use 'just host-sync' so the service restarts onto the new binary" >&2
+      exit 1
+    fi
+    profile="{{profile}}"
+    just _install-labby-bin "$profile"
+
+_install-labby-bin profile:
     #!/usr/bin/env bash
     set -euo pipefail
     profile="{{profile}}"
@@ -70,7 +80,11 @@ link-bin profile="release":
       exit 1
     fi
     mkdir -p ~/.local/bin
-    ln -sf "$LABBY_BIN" ~/.local/bin/labby
+    if [ -x ~/.local/bin/labby ]; then
+      cp -f ~/.local/bin/labby ~/.local/bin/labby.prev
+    fi
+    install -D -m 755 "$LABBY_BIN" ~/.local/bin/labby.new
+    mv ~/.local/bin/labby.new ~/.local/bin/labby
     echo "labby → $LABBY_BIN"
 
 # Build release-fast binary, copy it to the durable host path, and restart the
@@ -79,34 +93,29 @@ link-bin profile="release":
 host-sync:
     #!/usr/bin/env bash
     set -euo pipefail
-    repo="$(pwd)"
     profile="{{local_release_profile}}"
     if command -v mold >/dev/null 2>&1; then
       export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
     fi
-    LAB_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
-    case "$LAB_TARGET_DIR" in
-      /*) LABBY_BIN="$LAB_TARGET_DIR/$profile/labby" ;;
-      *)  LABBY_BIN="$repo/$LAB_TARGET_DIR/$profile/labby" ;;
-    esac
     CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
-    mkdir -p ~/.local/bin
-    if [ -x ~/.local/bin/labby ]; then
-      cp -f ~/.local/bin/labby ~/.local/bin/labby.prev
-    fi
-    install -D -m 755 "$LABBY_BIN" ~/.local/bin/labby.new
-    mv ~/.local/bin/labby.new ~/.local/bin/labby
-    if systemctl --user is-enabled --quiet labby.service; then
+    just _install-labby-bin "$profile"
+    if systemctl --user is-active --quiet labby.service; then
       ~/.local/bin/labby setup host-service restart -y
       ~/.local/bin/labby setup host-service status --json
     else
-      echo "labby.service is not installed; run: just host-service-install"
+      echo "error: labby.service is not active; run: just host-service-install" >&2
+      exit 1
     fi
 
 host-service-install:
     #!/usr/bin/env bash
     set -euo pipefail
-    just host-sync
+    profile="{{local_release_profile}}"
+    if command -v mold >/dev/null 2>&1; then
+      export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
+    fi
+    CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
+    just _install-labby-bin "$profile"
     ~/.local/bin/labby setup host-service install -y
 
 host-service-restart:

--- a/Justfile
+++ b/Justfile
@@ -73,8 +73,67 @@ link-bin profile="release":
     ln -sf "$LABBY_BIN" ~/.local/bin/labby
     echo "labby → $LABBY_BIN"
 
-# Build local release-fast binary when stale, sync PATH/container bind binary,
-# rebuild the dev image only when runtime inputs changed, and restart container.
+# Build release-fast binary, copy it to the durable host path, and restart the
+# host user service. This is the preferred Labby gateway workflow because stdio
+# MCP tools, SSH config, agent caches, and credentials live on the host.
+host-sync:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    repo="$(pwd)"
+    profile="{{local_release_profile}}"
+    if command -v mold >/dev/null 2>&1; then
+      export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
+    fi
+    LAB_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+    case "$LAB_TARGET_DIR" in
+      /*) LABBY_BIN="$LAB_TARGET_DIR/$profile/labby" ;;
+      *)  LABBY_BIN="$repo/$LAB_TARGET_DIR/$profile/labby" ;;
+    esac
+    CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
+    mkdir -p ~/.local/bin
+    if [ -x ~/.local/bin/labby ]; then
+      cp -f ~/.local/bin/labby ~/.local/bin/labby.prev
+    fi
+    install -D -m 755 "$LABBY_BIN" ~/.local/bin/labby.new
+    mv ~/.local/bin/labby.new ~/.local/bin/labby
+    if systemctl --user is-enabled --quiet labby.service; then
+      systemctl --user restart labby.service
+      ~/.local/bin/labby setup host-service status --json
+      curl -fsS http://127.0.0.1:8765/ready >/dev/null
+    else
+      echo "labby.service is not installed; run: just host-service-install"
+    fi
+
+host-service-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just host-sync
+    ~/.local/bin/labby setup host-service install -y
+
+host-service-restart:
+    ~/.local/bin/labby setup host-service restart -y
+    curl -fsS http://127.0.0.1:8765/ready >/dev/null
+
+host-service-status:
+    ~/.local/bin/labby setup host-service status --json
+
+# Explicit container compatibility path. Prefer host-sync for normal gateway
+# development; this remains useful for prod-like image smoke and Docker-specific
+# ACP adapter changes.
+dev-container: web-build build-release
+    docker compose -f docker-compose.yml restart
+
+dev-container-debug:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nightly_rustc=$(rustup which --toolchain nightly rustc)
+    RUSTC="$nightly_rustc" RUSTC_WRAPPER="" RUSTFLAGS="-C link-arg=-fuse-ld=mold -Z codegen-backend=cranelift" \
+        cargo build -p labby --all-features
+    install -D -m 755 target/debug/labby bin/labby
+    docker compose -f docker-compose.yml restart
+
+# Explicit container sync path. The normal gateway workflow is host-sync.
+# Rebuilds the dev image only when runtime inputs changed, then restarts Docker.
 sync-container:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -149,24 +208,16 @@ install: build-release
 ensure-host-dirs:
     scripts/ensure-host-dirs
 
-# Start the dev container for the first time (or after docker-compose changes)
+# Start the explicit Docker compatibility container path for the first time (or
+# after docker-compose changes).
 dev-up: ensure-host-dirs
     docker compose -f docker-compose.yml up -d
 
-# Release build + web assets → hot-swap into running dev container (no image rebuild)
-dev: web-build build-release
-    docker compose -f docker-compose.yml restart
+# Backward-compatible alias for explicit Docker compatibility smoke.
+dev: dev-container
 
-# Debug build with Cranelift codegen (fastest compile) → hot-swap into running dev container.
-# Uses nightly toolchain — RUSTFLAGS explicitly includes mold since env var overrides config.toml.
-dev-debug:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    nightly_rustc=$(rustup which --toolchain nightly rustc)
-    RUSTC="$nightly_rustc" RUSTC_WRAPPER="" RUSTFLAGS="-C link-arg=-fuse-ld=mold -Z codegen-backend=cranelift" \
-        cargo build -p labby --all-features
-    install -D -m 755 target/debug/labby bin/labby
-    docker compose -f docker-compose.yml restart
+# Backward-compatible alias for explicit Docker debug smoke.
+dev-debug: dev-container-debug
 
 # Verify Docker ACP provider config, provider health, and a minimal Codex ACP prompt.
 acp-smoke *ARGS:

--- a/README.md
+++ b/README.md
@@ -381,13 +381,18 @@ just lint             # skill drift + cargo wrapper smoke + clippy -D warnings +
 just deny             # cargo deny check
 just build            # cargo build --workspace --all-features
 just build-release    # release build, bin/labby install, ~/.local/bin symlink
+just host-service-install # install/start labby.service under systemd --user
+just host-sync        # release-fast rebuild + install ~/.local/bin/labby + restart host service
+just host-service-status # inspect the host Labby gateway service
+just dev-container    # explicit Docker compatibility/prod-like smoke path
+just dev-container-debug # explicit Docker debug binary path
 just web-build        # cd apps/gateway-admin && pnpm build
 just web-watch        # rebuild web assets when frontend files change
 just run -- help      # cargo run --all-features -- <args>
 just chat-local       # local Labby chat workflow with browser auth disabled
-just dev-up           # start the trusted local Docker dev stack
-just dev              # web build + release rebuild + dev-container restart
-just dev-debug        # nightly/cranelift debug rebuild + dev-container restart
+just dev-up           # start the explicit Docker compatibility stack
+just dev              # alias for just dev-container
+just dev-debug        # alias for just dev-container-debug
 just install          # build-release + symlink ~/.local/bin/labby
 just prod-run         # local prod-like image smoke on port 18765
 just mcp-token        # rotate LAB_MCP_HTTP_TOKEN in .env
@@ -407,6 +412,16 @@ only for narrow local slices or when a tool specifically requires it.
 
 Frontend changes should also run the relevant `pnpm` scripts under
 `apps/gateway-admin`, and `just web-build` when exported assets matter.
+
+### Host Gateway Runtime
+
+The default local and dookie gateway runtime is the host user service:
+`~/.local/bin/labby serve` managed by `systemd --user` as `labby.service`.
+This keeps stdio MCP tools, SSH config, local binaries, agent caches, and
+credentials in the same namespace as the gateway. Use `just host-service-install`
+once, then `just host-sync` for ordinary Rust changes. Docker remains available
+for prod-like image smoke and adapter-container work, but it is no longer the
+preferred agent gateway runtime.
 
 ### Dev Container
 

--- a/crates/labby-codemode/Cargo.toml
+++ b/crates/labby-codemode/Cargo.toml
@@ -44,6 +44,7 @@ boa_parser = "0.21.1"
 nix = { version = "0.31", default-features = false, features = [
   "signal",
   "process",
+  "user",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/labby-codemode/src/lib.rs
+++ b/crates/labby-codemode/src/lib.rs
@@ -30,6 +30,7 @@ mod preamble;
 mod protocol;
 mod runner;
 mod runner_drive;
+mod runner_exe;
 mod runner_io;
 mod schema;
 mod shape;

--- a/crates/labby-codemode/src/pool.rs
+++ b/crates/labby-codemode/src/pool.rs
@@ -45,10 +45,7 @@ pub struct RunnerSpawn {
 
 impl RunnerSpawn {
     pub fn try_default() -> Result<Self, ToolError> {
-        let program = std::env::current_exe().map_err(|err| ToolError::Sdk {
-            sdk_kind: "internal_error".to_string(),
-            message: format!("failed to resolve current executable for Code Mode runner: {err}"),
-        })?;
+        let program = super::runner_exe::resolve_runner_exe()?;
         Ok(Self {
             program,
             args: vec!["internal".to_string(), "code-mode-runner".to_string()],

--- a/crates/labby-codemode/src/pool/runner_handle.rs
+++ b/crates/labby-codemode/src/pool/runner_handle.rs
@@ -158,7 +158,10 @@ impl PooledRunner {
 
         let mut child = cmd.spawn().map_err(|err| ToolError::Sdk {
             sdk_kind: "internal_error".to_string(),
-            message: format!("failed to spawn Code Mode runner: {err}"),
+            message: format!(
+                "failed to spawn Code Mode runner from `{}`: {err}",
+                spawn.program.display()
+            ),
         })?;
         let child_pid = child.id();
 

--- a/crates/labby-codemode/src/runner_exe.rs
+++ b/crates/labby-codemode/src/runner_exe.rs
@@ -119,6 +119,10 @@ fn reject_untrusted_permissions(path: &Path) -> Result<(), ToolError> {
             });
         }
     }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
     Ok(())
 }
 

--- a/crates/labby-codemode/src/runner_exe.rs
+++ b/crates/labby-codemode/src/runner_exe.rs
@@ -1,0 +1,200 @@
+//! Resolve the executable used to spawn `labby internal code-mode-runner`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::ToolError;
+
+pub(super) fn resolve_runner_exe() -> Result<PathBuf, ToolError> {
+    let current = std::env::current_exe().map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to locate current executable for Code Mode runner: {err}"),
+    })?;
+    let override_exe = std::env::var_os("LAB_CODE_MODE_RUNNER_EXE").map(PathBuf::from);
+    resolve_runner_exe_from(current, override_exe)
+}
+
+pub(super) fn resolve_runner_exe_from(
+    current_exe: PathBuf,
+    override_exe: Option<PathBuf>,
+) -> Result<PathBuf, ToolError> {
+    if let Some(path) = override_exe {
+        let path = validate_operator_override(path)?;
+        tracing::warn!(
+            runner_exe = %path.display(),
+            "using LAB_CODE_MODE_RUNNER_EXE override for Code Mode runner"
+        );
+        return Ok(path);
+    }
+
+    if is_usable_exe(&current_exe) {
+        return Ok(current_exe);
+    }
+
+    Err(ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!(
+            "Code Mode runner executable is stale or unavailable: `{}`; restart labby.service or set LAB_CODE_MODE_RUNNER_EXE to a validated labby binary",
+            current_exe.display()
+        ),
+    })
+}
+
+fn validate_operator_override(path: PathBuf) -> Result<PathBuf, ToolError> {
+    if !path.is_absolute() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: "LAB_CODE_MODE_RUNNER_EXE must be an absolute path".to_string(),
+        });
+    }
+    let canonical = std::fs::canonicalize(&path).map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!(
+            "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but it cannot be resolved: {err}",
+            path.display()
+        ),
+    })?;
+    if !is_usable_exe(&canonical) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!(
+                "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but that file is not executable",
+                canonical.display()
+            ),
+        });
+    }
+    reject_untrusted_permissions(&canonical)?;
+    Ok(canonical)
+}
+
+fn is_usable_exe(path: &Path) -> bool {
+    if path.to_string_lossy().ends_with(" (deleted)") {
+        return false;
+    }
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn reject_untrusted_permissions(path: &Path) -> Result<(), ToolError> {
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path).map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to inspect `{}`: {err}", path.display()),
+        })?;
+        if meta.mode() & 0o022 != 0 {
+            return Err(ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: format!(
+                    "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but the file is group/world writable",
+                    path.display()
+                ),
+            });
+        }
+        let current_uid = nix::unistd::Uid::current().as_raw();
+        if meta.uid() != current_uid && meta.uid() != 0 {
+            return Err(ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: format!(
+                    "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but the file is not owned by the current user or root",
+                    path.display()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn uses_current_exe_when_it_is_usable() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("labby");
+        std::fs::write(&current, b"binary").unwrap();
+        #[cfg(unix)]
+        make_executable(&current);
+
+        let resolved = resolve_runner_exe_from(current.clone(), None).unwrap();
+
+        assert_eq!(resolved, current);
+    }
+
+    #[test]
+    fn deleted_current_exe_without_override_reports_restart_guidance() {
+        let err = resolve_runner_exe_from(PathBuf::from("/usr/local/bin/labby (deleted)"), None)
+            .unwrap_err();
+
+        assert_eq!(err.kind(), "internal_error");
+        assert!(err.to_string().contains("restart labby.service"));
+    }
+
+    #[test]
+    fn override_must_be_absolute() {
+        let err = resolve_runner_exe_from(
+            PathBuf::from("/usr/local/bin/labby"),
+            Some(PathBuf::from("target/debug/labby")),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn override_must_point_to_usable_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing-labby");
+
+        let err = resolve_runner_exe_from(PathBuf::from("/usr/local/bin/labby"), Some(missing))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), "internal_error");
+        assert!(err.to_string().contains("LAB_CODE_MODE_RUNNER_EXE"));
+        assert!(err.to_string().contains("missing-labby"));
+    }
+
+    #[test]
+    fn explicit_override_is_used_after_validation() {
+        let temp = tempfile::tempdir().unwrap();
+        let override_path = temp.path().join("labby");
+        std::fs::write(&override_path, b"binary").unwrap();
+        #[cfg(unix)]
+        make_executable(&override_path);
+
+        let resolved = resolve_runner_exe_from(
+            PathBuf::from("/usr/local/bin/labby (deleted)"),
+            Some(override_path.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(resolved, std::fs::canonicalize(override_path).unwrap());
+    }
+}

--- a/crates/labby-codemode/src/runner_exe.rs
+++ b/crates/labby-codemode/src/runner_exe.rs
@@ -197,4 +197,24 @@ mod tests {
 
         assert_eq!(resolved, std::fs::canonicalize(override_path).unwrap());
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn override_rejects_group_or_world_writable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let override_path = temp.path().join("labby");
+        std::fs::write(&override_path, b"binary").unwrap();
+        let mut perms = std::fs::metadata(&override_path).unwrap().permissions();
+        perms.set_mode(0o777);
+        std::fs::set_permissions(&override_path, perms).unwrap();
+
+        let err =
+            resolve_runner_exe_from(PathBuf::from("/usr/local/bin/labby"), Some(override_path))
+                .unwrap_err();
+
+        assert_eq!(err.kind(), "internal_error");
+        assert!(err.to_string().contains("group/world writable"));
+    }
 }

--- a/crates/labby/Cargo.toml
+++ b/crates/labby/Cargo.toml
@@ -32,6 +32,7 @@ process-wrap = { version = "9.1.0", default-features = false, features = [
 nix = { version = "0.31", default-features = false, features = [
   "signal",
   "process",
+  "user",
 ] }
 sysinfo = { version = "0.38", default-features = false, features = [
   "system",

--- a/crates/labby/src/cli/setup.rs
+++ b/crates/labby/src/cli/setup.rs
@@ -13,10 +13,12 @@
 //! includes browser launch + headless detection; that wiring can land
 //! incrementally without breaking the CLI surface contract.
 
+use std::future::Future;
 use std::process::ExitCode;
 
 use anyhow::Result;
 use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::output::theme::CliTheme;
@@ -115,12 +117,13 @@ pub struct HostServiceArgs {
     pub command: HostServiceCommand,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, PartialEq, Eq, Subcommand)]
 pub enum HostServiceCommand {
     /// Print the user systemd unit that Labby would install.
     Unit,
     /// Install and start labby.service under systemd --user.
     Install {
+        /// Confirm installation and service start.
         #[arg(short = 'y', long, alias = "no-confirm")]
         yes: bool,
     },
@@ -128,11 +131,13 @@ pub enum HostServiceCommand {
     Status,
     /// Restart labby.service.
     Restart {
+        /// Confirm service restart.
         #[arg(short = 'y', long, alias = "no-confirm")]
         yes: bool,
     },
     /// Stop, disable, and remove labby.service.
     Uninstall {
+        /// Confirm service removal.
         #[arg(short = 'y', long, alias = "no-confirm")]
         yes: bool,
     },
@@ -358,8 +363,12 @@ async fn run_command(command: SetupCommand, format: OutputFormat) -> Result<Exit
 async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -> Result<()> {
     match args.command {
         HostServiceCommand::Unit => {
-            let value = crate::dispatch::setup::host_service::unit().await?;
-            print(&value, format)?;
+            run_host_service_logged(
+                "host_service.unit",
+                format,
+                crate::dispatch::setup::host_service::unit,
+            )
+            .await?;
         }
         HostServiceCommand::Install { yes } => {
             if !yes {
@@ -367,12 +376,20 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
                     "setup host-service install is destructive; pass -y/--yes to confirm"
                 );
             }
-            let value = crate::dispatch::setup::host_service::install().await?;
-            print(&value, format)?;
+            run_host_service_logged(
+                "host_service.install",
+                format,
+                crate::dispatch::setup::host_service::install,
+            )
+            .await?;
         }
         HostServiceCommand::Status => {
-            let value = crate::dispatch::setup::host_service::status().await?;
-            print(&value, format)?;
+            run_host_service_logged(
+                "host_service.status",
+                format,
+                crate::dispatch::setup::host_service::status,
+            )
+            .await?;
         }
         HostServiceCommand::Restart { yes } => {
             if !yes {
@@ -380,8 +397,12 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
                     "setup host-service restart is destructive; pass -y/--yes to confirm"
                 );
             }
-            let value = crate::dispatch::setup::host_service::restart().await?;
-            print(&value, format)?;
+            run_host_service_logged(
+                "host_service.restart",
+                format,
+                crate::dispatch::setup::host_service::restart,
+            )
+            .await?;
         }
         HostServiceCommand::Uninstall { yes } => {
             if !yes {
@@ -389,10 +410,41 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
                     "setup host-service uninstall is destructive; pass -y/--yes to confirm"
                 );
             }
-            let value = crate::dispatch::setup::host_service::uninstall().await?;
-            print(&value, format)?;
+            run_host_service_logged(
+                "host_service.uninstall",
+                format,
+                crate::dispatch::setup::host_service::uninstall,
+            )
+            .await?;
         }
     }
+    Ok(())
+}
+
+async fn run_host_service_logged<F, Fut, T>(
+    action: &'static str,
+    format: OutputFormat,
+    operation: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, crate::dispatch::error::ToolError>>,
+    T: Serialize,
+{
+    crate::cli::helpers::run_action_command(
+        "setup",
+        action.to_string(),
+        json!({}),
+        format,
+        |_action, _params| async move {
+            let value = operation().await?;
+            serde_json::to_value(value).map_err(|err| crate::dispatch::error::ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: err.to_string(),
+            })
+        },
+    )
+    .await?;
     Ok(())
 }
 
@@ -549,16 +601,43 @@ mod tests {
 
     #[test]
     fn parses_host_service_subcommands() {
-        for command in ["unit", "install", "status", "restart", "uninstall"] {
+        for (command, flag, expected) in [
+            ("unit", None, HostServiceCommand::Unit),
+            (
+                "install",
+                Some("-y"),
+                HostServiceCommand::Install { yes: true },
+            ),
+            ("status", None, HostServiceCommand::Status),
+            (
+                "restart",
+                Some("-y"),
+                HostServiceCommand::Restart { yes: true },
+            ),
+            (
+                "uninstall",
+                Some("-y"),
+                HostServiceCommand::Uninstall { yes: true },
+            ),
+            (
+                "restart",
+                Some("--no-confirm"),
+                HostServiceCommand::Restart { yes: true },
+            ),
+        ] {
             let mut args = vec!["labby", "setup", "host-service", command];
-            if matches!(command, "install" | "restart" | "uninstall") {
-                args.push("-y");
+            if let Some(flag) = flag {
+                args.push(flag);
             }
             let cli = crate::cli::Cli::try_parse_from(args).unwrap();
             let crate::cli::Command::Setup(args) = cli.command else {
                 panic!("expected setup command");
             };
-            assert!(matches!(args.command, Some(SetupCommand::HostService(_))));
+            let Some(SetupCommand::HostService(HostServiceArgs { command: actual })) = args.command
+            else {
+                panic!("expected setup host-service subcommand");
+            };
+            assert_eq!(actual, expected);
         }
     }
 }

--- a/crates/labby/src/cli/setup.rs
+++ b/crates/labby/src/cli/setup.rs
@@ -65,6 +65,8 @@ impl SetupModeArg {
 pub enum SetupCommand {
     /// Manage the local setup draft.
     Draft(DraftArgs),
+    /// Manage the host user systemd Labby gateway service.
+    HostService(HostServiceArgs),
     /// List installed Claude Code lab plugins.
     InstalledPlugins {
         /// Bypass the short in-process cache.
@@ -105,6 +107,35 @@ pub enum SetupCommand {
 pub struct DraftArgs {
     #[command(subcommand)]
     pub command: DraftCommand,
+}
+
+#[derive(Debug, Args)]
+pub struct HostServiceArgs {
+    #[command(subcommand)]
+    pub command: HostServiceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HostServiceCommand {
+    /// Print the user systemd unit that Labby would install.
+    Unit,
+    /// Install and start labby.service under systemd --user.
+    Install {
+        #[arg(short = 'y', long, alias = "no-confirm")]
+        yes: bool,
+    },
+    /// Read labby.service status.
+    Status,
+    /// Restart labby.service.
+    Restart {
+        #[arg(short = 'y', long, alias = "no-confirm")]
+        yes: bool,
+    },
+    /// Stop, disable, and remove labby.service.
+    Uninstall {
+        #[arg(short = 'y', long, alias = "no-confirm")]
+        yes: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -244,6 +275,9 @@ async fn run_command(command: SetupCommand, format: OutputFormat) -> Result<Exit
         SetupCommand::Draft(args) => {
             run_draft_command(args, format).await?;
         }
+        SetupCommand::HostService(args) => {
+            run_host_service_command(args, format).await?;
+        }
         SetupCommand::InstalledPlugins { force } => {
             let value =
                 crate::dispatch::setup::dispatch("plugins.installed", json!({ "force": force }))
@@ -319,6 +353,47 @@ async fn run_command(command: SetupCommand, format: OutputFormat) -> Result<Exit
         }
     }
     Ok(ExitCode::SUCCESS)
+}
+
+async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -> Result<()> {
+    match args.command {
+        HostServiceCommand::Unit => {
+            let value = crate::dispatch::setup::host_service::unit().await?;
+            print(&value, format)?;
+        }
+        HostServiceCommand::Install { yes } => {
+            if !yes {
+                anyhow::bail!(
+                    "setup host-service install is destructive; pass -y/--yes to confirm"
+                );
+            }
+            let value = crate::dispatch::setup::host_service::install().await?;
+            print(&value, format)?;
+        }
+        HostServiceCommand::Status => {
+            let value = crate::dispatch::setup::host_service::status().await?;
+            print(&value, format)?;
+        }
+        HostServiceCommand::Restart { yes } => {
+            if !yes {
+                anyhow::bail!(
+                    "setup host-service restart is destructive; pass -y/--yes to confirm"
+                );
+            }
+            let value = crate::dispatch::setup::host_service::restart().await?;
+            print(&value, format)?;
+        }
+        HostServiceCommand::Uninstall { yes } => {
+            if !yes {
+                anyhow::bail!(
+                    "setup host-service uninstall is destructive; pass -y/--yes to confirm"
+                );
+            }
+            let value = crate::dispatch::setup::host_service::uninstall().await?;
+            print(&value, format)?;
+        }
+    }
+    Ok(())
 }
 
 async fn run_draft_command(args: DraftArgs, format: OutputFormat) -> Result<()> {
@@ -470,5 +545,20 @@ mod tests {
             panic!("expected setup draft discard subcommand");
         };
         assert!(discard.yes);
+    }
+
+    #[test]
+    fn parses_host_service_subcommands() {
+        for command in ["unit", "install", "status", "restart", "uninstall"] {
+            let mut args = vec!["labby", "setup", "host-service", command];
+            if matches!(command, "install" | "restart" | "uninstall") {
+                args.push("-y");
+            }
+            let cli = crate::cli::Cli::try_parse_from(args).unwrap();
+            let crate::cli::Command::Setup(args) = cli.command else {
+                panic!("expected setup command");
+            };
+            assert!(matches!(args.command, Some(SetupCommand::HostService(_))));
+        }
     }
 }

--- a/crates/labby/src/cli/setup.rs
+++ b/crates/labby/src/cli/setup.rs
@@ -371,11 +371,7 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
             .await?;
         }
         HostServiceCommand::Install { yes } => {
-            if !yes {
-                anyhow::bail!(
-                    "setup host-service install is destructive; pass -y/--yes to confirm"
-                );
-            }
+            require_host_service_confirmation("install", yes)?;
             run_host_service_logged(
                 "host_service.install",
                 format,
@@ -392,11 +388,7 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
             .await?;
         }
         HostServiceCommand::Restart { yes } => {
-            if !yes {
-                anyhow::bail!(
-                    "setup host-service restart is destructive; pass -y/--yes to confirm"
-                );
-            }
+            require_host_service_confirmation("restart", yes)?;
             run_host_service_logged(
                 "host_service.restart",
                 format,
@@ -405,11 +397,7 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
             .await?;
         }
         HostServiceCommand::Uninstall { yes } => {
-            if !yes {
-                anyhow::bail!(
-                    "setup host-service uninstall is destructive; pass -y/--yes to confirm"
-                );
-            }
+            require_host_service_confirmation("uninstall", yes)?;
             run_host_service_logged(
                 "host_service.uninstall",
                 format,
@@ -419,6 +407,19 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
         }
     }
     Ok(())
+}
+
+fn require_host_service_confirmation(action: &str, yes: bool) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    let error = crate::dispatch::error::ToolError::ConfirmationRequired {
+        message: format!("setup host-service {action} is destructive; pass -y/--yes to confirm"),
+    };
+    Err(anyhow::anyhow!(
+        "{}",
+        serde_json::to_string(&error).unwrap_or_else(|_| error.to_string())
+    ))
 }
 
 async fn run_host_service_logged<F, Fut, T>(
@@ -638,6 +639,29 @@ mod tests {
                 panic!("expected setup host-service subcommand");
             };
             assert_eq!(actual, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn host_service_destructive_commands_require_confirmation_envelope() {
+        for command in [
+            HostServiceCommand::Install { yes: false },
+            HostServiceCommand::Restart { yes: false },
+            HostServiceCommand::Uninstall { yes: false },
+        ] {
+            let err = run_host_service_command(
+                HostServiceArgs { command },
+                OutputFormat::from_json_flag(
+                    true,
+                    crate::output::ColorPolicy::Plain,
+                    crate::output::RenderEnv::stdout(),
+                ),
+            )
+            .await
+            .unwrap_err();
+            let envelope: Value = serde_json::from_str(&err.to_string()).unwrap();
+
+            assert_eq!(envelope["kind"], "confirmation_required");
         }
     }
 }

--- a/crates/labby/src/dispatch/setup.rs
+++ b/crates/labby/src/dispatch/setup.rs
@@ -12,6 +12,7 @@ mod claude_plugins;
 mod client;
 mod dispatch;
 mod draft;
+pub(crate) mod host_service;
 mod params;
 mod plugin_hook;
 mod secret_mask;

--- a/crates/labby/src/dispatch/setup/dispatch.rs
+++ b/crates/labby/src/dispatch/setup/dispatch.rs
@@ -900,14 +900,26 @@ mod tests {
         assert!(
             ACTIONS
                 .iter()
-                .all(|action| !action.name.starts_with("host_service.")),
+                .all(|action| !action.name.starts_with("host_service.")
+                    && !action.name.starts_with("host-service.")),
             "host-service lifecycle commands must remain CLI-only"
         );
     }
 
     #[tokio::test]
     async fn setup_dispatch_does_not_route_host_service_actions() {
-        for action in ["host_service.restart", "host_service.uninstall"] {
+        for action in [
+            "host_service.unit",
+            "host_service.install",
+            "host_service.status",
+            "host_service.restart",
+            "host_service.uninstall",
+            "host-service.unit",
+            "host-service.install",
+            "host-service.status",
+            "host-service.restart",
+            "host-service.uninstall",
+        ] {
             let err = dispatch(action, Value::Null).await.unwrap_err();
             assert!(
                 matches!(err, ToolError::UnknownAction { .. }),

--- a/crates/labby/src/dispatch/setup/dispatch.rs
+++ b/crates/labby/src/dispatch/setup/dispatch.rs
@@ -896,6 +896,27 @@ mod tests {
     }
 
     #[test]
+    fn setup_catalog_does_not_expose_host_service_actions() {
+        assert!(
+            ACTIONS
+                .iter()
+                .all(|action| !action.name.starts_with("host_service.")),
+            "host-service lifecycle commands must remain CLI-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_dispatch_does_not_route_host_service_actions() {
+        for action in ["host_service.restart", "host_service.uninstall"] {
+            let err = dispatch(action, Value::Null).await.unwrap_err();
+            assert!(
+                matches!(err, ToolError::UnknownAction { .. }),
+                "{action} must not be reachable through setup dispatch"
+            );
+        }
+    }
+
+    #[test]
     fn plugin_lifecycle_actions_are_cataloged() {
         // Every loopback-gated name must have a catalog ActionSpec — otherwise
         // the unknown-action gate in the API surface would reject it before

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -26,6 +26,7 @@ pub(crate) struct HostServiceStatus {
     pub unit_path: PathBuf,
     pub process_exe: Option<PathBuf>,
     pub local_ready: Option<bool>,
+    pub ready_owned_by_service: Option<bool>,
     pub docker_labby_master_running: Option<bool>,
 }
 
@@ -93,7 +94,7 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
     let path = unit_path(&home);
     let installed = path.is_file();
     let docker_labby_master_running = docker_labby_master_running().await;
-    let local_ready = Some(check_ready().await.unwrap_or(false));
+    let ready_response = check_ready().await.unwrap_or(false);
     let mut load_state = None;
     let mut active_state = None;
     let mut sub_state = None;
@@ -121,6 +122,12 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
     }
 
     let process_exe = main_pid.and_then(process_exe);
+    let ready_owned_by_service = if ready_response {
+        Some(readiness_owner_matches(main_pid).await?)
+    } else {
+        Some(false)
+    };
+    let local_ready = Some(ready_response && ready_owned_by_service == Some(true));
 
     Ok(HostServiceStatus {
         installed,
@@ -132,6 +139,7 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
         unit_path: path,
         process_exe,
         local_ready,
+        ready_owned_by_service,
         docker_labby_master_running,
     })
 }
@@ -205,6 +213,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=%h/.local/bin/labby serve
 WorkingDirectory=%h
+Environment=PATH=%h/.local/bin:%h/.cargo/bin:%h/.local/share/mise/shims:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=-%h/.lab/.env
 Restart=on-failure
 RestartSec=3
@@ -294,10 +303,15 @@ async fn preflight_port_available(operation: &str) -> Result<(), ToolError> {
 }
 
 fn configured_local_port() -> u16 {
-    std::env::var("LAB_MCP_HTTP_PORT")
-        .ok()
+    let env_file_port = env_file_value("LAB_MCP_HTTP_PORT");
+    let process_port = std::env::var("LAB_MCP_HTTP_PORT").ok();
+    configured_local_port_from(env_file_port.as_deref(), process_port.as_deref())
+}
+
+fn configured_local_port_from(service_env: Option<&str>, process_env: Option<&str>) -> u16 {
+    service_env
         .and_then(|value| value.parse().ok())
-        .or_else(|| env_file_value("LAB_MCP_HTTP_PORT").and_then(|value| value.parse().ok()))
+        .or_else(|| process_env.and_then(|value| value.parse().ok()))
         .unwrap_or(8765)
 }
 
@@ -351,7 +365,27 @@ async fn holder_can_be_host_service(holder: &str) -> Result<bool, ToolError> {
     let Some(pid) = status.main_pid else {
         return Ok(false);
     };
-    Ok(holder.contains(&format!("pid={pid},")) || holder.contains(&format!("pid={pid}")))
+    Ok(holder_contains_pid(holder, pid))
+}
+
+async fn readiness_owner_matches(main_pid: Option<u32>) -> Result<bool, ToolError> {
+    let Some(pid) = main_pid else {
+        return Ok(false);
+    };
+    let Some(holder) = port_holder(configured_local_port()).await? else {
+        return Ok(false);
+    };
+    Ok(holder_contains_pid(&holder, pid))
+}
+
+fn holder_contains_pid(holder: &str, pid: u32) -> bool {
+    let needle = format!("pid={pid}");
+    holder.match_indices(&needle).any(|(start, _)| {
+        holder[start + needle.len()..]
+            .chars()
+            .next()
+            .is_none_or(|next| !next.is_ascii_digit())
+    })
 }
 
 async fn docker_labby_master_running() -> Option<bool> {
@@ -372,13 +406,33 @@ async fn poll_ready() -> Result<(), String> {
     let mut last_err = String::new();
     while tokio::time::Instant::now() < deadline {
         match check_ready().await {
-            Ok(true) => return Ok(()),
+            Ok(true) => match systemctl_main_pid().await {
+                Ok(main_pid) => match readiness_owner_matches(main_pid).await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => {
+                        last_err =
+                            "ready endpoint responded, but the listener is not labby.service"
+                                .to_string();
+                    }
+                    Err(err) => last_err = err.to_string(),
+                },
+                Err(err) => last_err = err.to_string(),
+            },
             Ok(false) => last_err = "ready endpoint returned non-success".to_string(),
             Err(err) => last_err = err,
         }
         tokio::time::sleep(READY_POLL_INTERVAL).await;
     }
     Err(last_err)
+}
+
+async fn systemctl_main_pid() -> Result<Option<u32>, ToolError> {
+    let output = run_systemctl(&["show", SERVICE_NAME, "--property=MainPID", "--no-pager"]).await?;
+    let props = parse_systemctl_show(&output.stdout);
+    Ok(non_empty_prop(&props, "MainPID").and_then(|value| {
+        let pid = value.parse::<u32>().ok()?;
+        (pid != 0).then_some(pid)
+    }))
 }
 
 async fn check_ready() -> Result<bool, String> {
@@ -424,7 +478,9 @@ async fn run_systemctl(args: &[&str]) -> Result<CommandCapture, ToolError> {
 
 async fn run_command(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
     let command_display = command_display(program, args);
-    let output = tokio::time::timeout(COMMAND_TIMEOUT, Command::new(program).args(args).output())
+    let mut command = Command::new(program);
+    command.args(args).kill_on_drop(true);
+    let output = tokio::time::timeout(COMMAND_TIMEOUT, command.output())
         .await
         .map_err(|_| ToolError::Sdk {
             sdk_kind: "internal_error".into(),
@@ -490,6 +546,7 @@ mod tests {
         assert!(unit.contains("Description=Labby host gateway"));
         assert!(unit.contains("ExecStart=%h/.local/bin/labby serve"));
         assert!(unit.contains("WorkingDirectory=%h"));
+        assert!(unit.contains("Environment=PATH=%h/.local/bin:%h/.cargo/bin:%h/.local/share/mise/shims:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin"));
         assert!(unit.contains("EnvironmentFile=-%h/.lab/.env"));
     }
 
@@ -533,5 +590,24 @@ mod tests {
             Some("active")
         );
         assert_eq!(non_empty_prop(&props, "MainPID").as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn service_env_port_wins_over_process_env_port() {
+        assert_eq!(configured_local_port_from(Some("9876"), Some("1234")), 9876);
+        assert_eq!(configured_local_port_from(None, Some("1234")), 1234);
+        assert_eq!(configured_local_port_from(Some("bad"), Some("1234")), 1234);
+        assert_eq!(
+            configured_local_port_from(Some("bad"), Some("also-bad")),
+            8765
+        );
+    }
+
+    #[test]
+    fn detects_port_holder_pid() {
+        let holder = r#"LISTEN 0 4096 127.0.0.1:8765 0.0.0.0:* users:(("labby",pid=12345,fd=17))"#;
+
+        assert!(holder_contains_pid(holder, 12345));
+        assert!(!holder_contains_pid(holder, 1234));
     }
 }

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -304,13 +304,25 @@ async fn preflight_port_available(operation: &str) -> Result<(), ToolError> {
 
 fn configured_local_port() -> u16 {
     let env_file_port = env_file_value("LAB_MCP_HTTP_PORT");
+    let config_port = crate::config::load_toml(&crate::config::toml_candidates())
+        .ok()
+        .and_then(|config| config.mcp.port);
     let process_port = std::env::var("LAB_MCP_HTTP_PORT").ok();
-    configured_local_port_from(env_file_port.as_deref(), process_port.as_deref())
+    configured_local_port_from(
+        env_file_port.as_deref(),
+        config_port,
+        process_port.as_deref(),
+    )
 }
 
-fn configured_local_port_from(service_env: Option<&str>, process_env: Option<&str>) -> u16 {
+fn configured_local_port_from(
+    service_env: Option<&str>,
+    config_port: Option<u16>,
+    process_env: Option<&str>,
+) -> u16 {
     service_env
         .and_then(|value| value.parse().ok())
+        .or(config_port)
         .or_else(|| process_env.and_then(|value| value.parse().ok()))
         .unwrap_or(8765)
 }
@@ -523,9 +535,7 @@ fn path_to_str(path: &Path) -> Result<&str, ToolError> {
 }
 
 fn command_not_found(err: &ToolError) -> bool {
-    err.to_string().contains("No such file or directory")
-        || err.to_string().contains("os error 2")
-        || err.to_string().contains("not found")
+    err.to_string().contains("No such file or directory") || err.to_string().contains("os error 2")
 }
 
 fn io_error(err: std::io::Error) -> ToolError {
@@ -594,11 +604,25 @@ mod tests {
 
     #[test]
     fn service_env_port_wins_over_process_env_port() {
-        assert_eq!(configured_local_port_from(Some("9876"), Some("1234")), 9876);
-        assert_eq!(configured_local_port_from(None, Some("1234")), 1234);
-        assert_eq!(configured_local_port_from(Some("bad"), Some("1234")), 1234);
         assert_eq!(
-            configured_local_port_from(Some("bad"), Some("also-bad")),
+            configured_local_port_from(Some("9876"), Some(7777), Some("1234")),
+            9876
+        );
+        assert_eq!(
+            configured_local_port_from(None, Some(7777), Some("1234")),
+            7777
+        );
+        assert_eq!(configured_local_port_from(None, None, Some("1234")), 1234);
+        assert_eq!(
+            configured_local_port_from(Some("bad"), Some(7777), Some("1234")),
+            7777
+        );
+        assert_eq!(
+            configured_local_port_from(Some("bad"), None, Some("1234")),
+            1234
+        );
+        assert_eq!(
+            configured_local_port_from(Some("bad"), None, Some("also-bad")),
             8765
         );
     }

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -111,9 +111,8 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
     let mut active_state = None;
     let mut sub_state = None;
     let mut main_pid = None;
-    let mut exec_main_status = None;
 
-    if installed {
+    let exec_main_status = if installed {
         let output = run_systemctl(&[
             "show",
             SERVICE_NAME,
@@ -126,9 +125,10 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
         active_state = non_empty_prop(&props, "ActiveState");
         sub_state = non_empty_prop(&props, "SubState");
         main_pid = parse_main_pid(&props);
-        exec_main_status =
-            non_empty_prop(&props, "ExecMainStatus").and_then(|value| value.parse().ok());
-    }
+        non_empty_prop(&props, "ExecMainStatus").and_then(|value| value.parse().ok())
+    } else {
+        None
+    };
 
     let process_exe = main_pid.and_then(process_exe);
     let ready_owned_by_service = match ready_response {
@@ -221,7 +221,7 @@ pub(crate) async fn uninstall() -> Result<HostServiceOutcome, ToolError> {
 }
 
 fn unit_text() -> String {
-    r#"[Unit]
+    r"[Unit]
 Description=Labby host gateway
 After=network-online.target
 Wants=network-online.target
@@ -240,7 +240,7 @@ KillSignal=SIGINT
 
 [Install]
 WantedBy=default.target
-"#
+"
     .to_string()
 }
 

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -26,8 +26,10 @@ pub(crate) struct HostServiceStatus {
     pub unit_path: PathBuf,
     pub process_exe: Option<PathBuf>,
     pub local_ready: Option<bool>,
+    pub local_ready_error: Option<String>,
     pub ready_owned_by_service: Option<bool>,
     pub docker_labby_master_running: Option<bool>,
+    pub docker_labby_master_error: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -67,9 +69,12 @@ pub(crate) async fn install() -> Result<HostServiceOutcome, ToolError> {
     let daemon = run_systemctl(&["daemon-reload"]).await?;
     stdout.push_str(&daemon.stdout);
     stderr.push_str(&daemon.stderr);
-    let enable = run_systemctl(&["enable", "--now", SERVICE_NAME]).await?;
+    let enable = run_systemctl(&["enable", SERVICE_NAME]).await?;
     stdout.push_str(&enable.stdout);
     stderr.push_str(&enable.stderr);
+    let restart = run_systemctl(&["restart", SERVICE_NAME]).await?;
+    stdout.push_str(&restart.stdout);
+    stderr.push_str(&restart.stderr);
     if let Err(err) = poll_ready().await {
         stderr.push_str(&format!("\nreadiness failed: {err}"));
         return Err(ToolError::Sdk {
@@ -93,8 +98,15 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
     let home = current_home()?;
     let path = unit_path(&home);
     let installed = path.is_file();
-    let docker_labby_master_running = docker_labby_master_running().await;
-    let ready_response = check_ready().await.unwrap_or(false);
+    let (docker_labby_master_running, docker_labby_master_error) =
+        match docker_labby_master_running().await {
+            Ok(value) => (value, None),
+            Err(err) => (None, Some(err.user_message().to_string())),
+        };
+    let (ready_response, mut local_ready_error) = match check_ready().await {
+        Ok(value) => (Some(value), None),
+        Err(err) => (None, Some(err)),
+    };
     let mut load_state = None;
     let mut active_state = None;
     let mut sub_state = None;
@@ -113,21 +125,24 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
         load_state = non_empty_prop(&props, "LoadState");
         active_state = non_empty_prop(&props, "ActiveState");
         sub_state = non_empty_prop(&props, "SubState");
-        main_pid = non_empty_prop(&props, "MainPID").and_then(|value| {
-            let pid = value.parse::<u32>().ok()?;
-            (pid != 0).then_some(pid)
-        });
+        main_pid = parse_main_pid(&props);
         exec_main_status =
             non_empty_prop(&props, "ExecMainStatus").and_then(|value| value.parse().ok());
     }
 
     let process_exe = main_pid.and_then(process_exe);
-    let ready_owned_by_service = if ready_response {
-        Some(readiness_owner_matches(main_pid).await?)
-    } else {
-        Some(false)
+    let ready_owned_by_service = match ready_response {
+        Some(true) => match readiness_owner_matches(main_pid).await {
+            Ok(value) => Some(value),
+            Err(err) => {
+                local_ready_error = Some(err.user_message().to_string());
+                None
+            }
+        },
+        Some(false) => Some(false),
+        None => None,
     };
-    let local_ready = Some(ready_response && ready_owned_by_service == Some(true));
+    let local_ready = ready_response.map(|ready| ready && ready_owned_by_service == Some(true));
 
     Ok(HostServiceStatus {
         installed,
@@ -139,8 +154,10 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
         unit_path: path,
         process_exe,
         local_ready,
+        local_ready_error,
         ready_owned_by_service,
         docker_labby_master_running,
+        docker_labby_master_error,
     })
 }
 
@@ -279,24 +296,49 @@ async fn append_optional_verify(
 }
 
 async fn preflight_port_available(operation: &str) -> Result<(), ToolError> {
-    if docker_labby_master_running().await == Some(true) {
-        return Err(ToolError::Sdk {
-            sdk_kind: "internal_error".into(),
+    let docker_running = docker_labby_master_running().await?;
+    let port = configured_local_port();
+    let holder = port_holder(port).await?;
+    let (active_state, main_pid) = if holder.is_some() {
+        systemctl_service_identity().await?
+    } else {
+        (None, None)
+    };
+    preflight_decision(
+        operation,
+        port,
+        docker_running,
+        holder.as_deref(),
+        active_state.as_deref(),
+        main_pid,
+    )
+}
+
+fn preflight_decision(
+    operation: &str,
+    port: u16,
+    docker_running: Option<bool>,
+    holder: Option<&str>,
+    active_state: Option<&str>,
+    main_pid: Option<u32>,
+) -> Result<(), ToolError> {
+    if docker_running == Some(true) {
+        return Err(ToolError::Conflict {
             message: format!(
                 "cannot {operation} {SERVICE_NAME}: Docker container `labby-master` is running; stop it before starting the host gateway"
             ),
+            existing_id: "labby-master".to_string(),
         });
     }
 
-    let port = configured_local_port();
-    if let Some(holder) = port_holder(port).await?
-        && !holder_can_be_host_service(&holder).await?
+    if let Some(holder) = holder
+        && !holder_can_be_host_service_from(holder, active_state, main_pid)
     {
-        return Err(ToolError::Sdk {
-            sdk_kind: "internal_error".into(),
+        return Err(ToolError::Conflict {
             message: format!(
                 "cannot {operation} {SERVICE_NAME}: local port {port} is already in use:\n{holder}"
             ),
+            existing_id: format!("127.0.0.1:{port}"),
         });
     }
     Ok(())
@@ -369,17 +411,6 @@ async fn port_holder(port: u16) -> Result<Option<String>, ToolError> {
     }
 }
 
-async fn holder_can_be_host_service(holder: &str) -> Result<bool, ToolError> {
-    let status = status().await?;
-    if status.active_state.as_deref() != Some("active") {
-        return Ok(false);
-    }
-    let Some(pid) = status.main_pid else {
-        return Ok(false);
-    };
-    Ok(holder_contains_pid(holder, pid))
-}
-
 async fn readiness_owner_matches(main_pid: Option<u32>) -> Result<bool, ToolError> {
     let Some(pid) = main_pid else {
         return Ok(false);
@@ -388,6 +419,22 @@ async fn readiness_owner_matches(main_pid: Option<u32>) -> Result<bool, ToolErro
         return Ok(false);
     };
     Ok(holder_contains_pid(&holder, pid))
+}
+
+fn holder_can_be_host_service_from(
+    holder: &str,
+    active_state: Option<&str>,
+    main_pid: Option<u32>,
+) -> bool {
+    active_state == Some("active") && main_pid.is_some_and(|pid| holder_contains_pid(holder, pid))
+}
+
+#[cfg(test)]
+fn readiness_owner_matches_from(main_pid: Option<u32>, holder: Option<&str>) -> bool {
+    let Some(pid) = main_pid else {
+        return false;
+    };
+    holder.is_some_and(|holder| holder_contains_pid(holder, pid))
 }
 
 fn holder_contains_pid(holder: &str, pid: u32) -> bool {
@@ -400,16 +447,17 @@ fn holder_contains_pid(holder: &str, pid: u32) -> bool {
     })
 }
 
-async fn docker_labby_master_running() -> Option<bool> {
+async fn docker_labby_master_running() -> Result<Option<bool>, ToolError> {
     match run_command(
         "docker",
         &["inspect", "-f", "{{.State.Running}}", "labby-master"],
     )
     .await
     {
-        Ok(output) => Some(output.stdout.trim() == "true"),
-        Err(err) if command_not_found(&err) => None,
-        Err(_) => Some(false),
+        Ok(output) => Ok(Some(output.stdout.trim() == "true")),
+        Err(err) if command_not_found(&err) => Ok(None),
+        Err(err) if docker_container_missing(&err) => Ok(Some(false)),
+        Err(err) => Err(err),
     }
 }
 
@@ -439,12 +487,22 @@ async fn poll_ready() -> Result<(), String> {
 }
 
 async fn systemctl_main_pid() -> Result<Option<u32>, ToolError> {
-    let output = run_systemctl(&["show", SERVICE_NAME, "--property=MainPID", "--no-pager"]).await?;
+    Ok(systemctl_service_identity().await?.1)
+}
+
+async fn systemctl_service_identity() -> Result<(Option<String>, Option<u32>), ToolError> {
+    let output = run_systemctl(&[
+        "show",
+        SERVICE_NAME,
+        "--property=ActiveState,MainPID",
+        "--no-pager",
+    ])
+    .await?;
     let props = parse_systemctl_show(&output.stdout);
-    Ok(non_empty_prop(&props, "MainPID").and_then(|value| {
-        let pid = value.parse::<u32>().ok()?;
-        (pid != 0).then_some(pid)
-    }))
+    Ok((
+        non_empty_prop(&props, "ActiveState"),
+        parse_main_pid(&props),
+    ))
 }
 
 async fn check_ready() -> Result<bool, String> {
@@ -480,6 +538,13 @@ fn non_empty_prop(props: &BTreeMap<String, String>, key: &str) -> Option<String>
         .get(key)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn parse_main_pid(props: &BTreeMap<String, String>) -> Option<u32> {
+    non_empty_prop(props, "MainPID").and_then(|value| {
+        let pid = value.parse::<u32>().ok()?;
+        (pid != 0).then_some(pid)
+    })
 }
 
 async fn run_systemctl(args: &[&str]) -> Result<CommandCapture, ToolError> {
@@ -535,7 +600,14 @@ fn path_to_str(path: &Path) -> Result<&str, ToolError> {
 }
 
 fn command_not_found(err: &ToolError) -> bool {
-    err.to_string().contains("No such file or directory") || err.to_string().contains("os error 2")
+    let message = err.to_string();
+    message.contains("failed to run `")
+        && (message.contains("No such file or directory") || message.contains("os error 2"))
+}
+
+fn docker_container_missing(err: &ToolError) -> bool {
+    let message = err.to_string();
+    message.contains("No such object: labby-master") || message.contains("No such container")
 }
 
 fn io_error(err: std::io::Error) -> ToolError {
@@ -600,6 +672,7 @@ mod tests {
             Some("active")
         );
         assert_eq!(non_empty_prop(&props, "MainPID").as_deref(), Some("123"));
+        assert_eq!(parse_main_pid(&props), Some(123));
     }
 
     #[test]
@@ -633,5 +706,57 @@ mod tests {
 
         assert!(holder_contains_pid(holder, 12345));
         assert!(!holder_contains_pid(holder, 1234));
+    }
+
+    #[test]
+    fn preflight_blocks_docker_labby_master() {
+        let err = preflight_decision("install", 8765, Some(true), None, None, None).unwrap_err();
+
+        assert_eq!(err.kind(), "conflict");
+        assert!(err.to_string().contains("labby-master"));
+    }
+
+    #[test]
+    fn preflight_blocks_foreign_port_holder() {
+        let holder = r#"LISTEN 0 4096 127.0.0.1:8765 0.0.0.0:* users:(("other",pid=54321,fd=17))"#;
+        let err = preflight_decision(
+            "restart",
+            8765,
+            Some(false),
+            Some(holder),
+            Some("active"),
+            Some(12345),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), "conflict");
+        assert!(
+            err.to_string()
+                .contains("local port 8765 is already in use")
+        );
+    }
+
+    #[test]
+    fn preflight_allows_active_service_pid_holder() {
+        let holder = r#"LISTEN 0 4096 127.0.0.1:8765 0.0.0.0:* users:(("labby",pid=12345,fd=17))"#;
+
+        preflight_decision(
+            "restart",
+            8765,
+            Some(false),
+            Some(holder),
+            Some("active"),
+            Some(12345),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn readiness_from_non_service_pid_is_not_owned() {
+        let holder = r#"LISTEN 0 4096 127.0.0.1:8765 0.0.0.0:* users:(("other",pid=54321,fd=17))"#;
+
+        assert!(!readiness_owner_matches_from(Some(12345), Some(holder)));
+        assert!(readiness_owner_matches_from(Some(54321), Some(holder)));
+        assert!(!readiness_owner_matches_from(None, Some(holder)));
     }
 }

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -1,0 +1,537 @@
+//! CLI-only management helpers for the host `systemd --user` Labby service.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio::process::Command;
+
+use crate::dispatch::error::ToolError;
+
+const SERVICE_NAME: &str = "labby.service";
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(300);
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceStatus {
+    pub installed: bool,
+    pub load_state: Option<String>,
+    pub active_state: Option<String>,
+    pub sub_state: Option<String>,
+    pub main_pid: Option<u32>,
+    pub exec_main_status: Option<i32>,
+    pub unit_path: PathBuf,
+    pub process_exe: Option<PathBuf>,
+    pub local_ready: Option<bool>,
+    pub docker_labby_master_running: Option<bool>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceOutcome {
+    pub ok: bool,
+    pub changed: bool,
+    pub message: String,
+    pub unit_path: PathBuf,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+struct CommandCapture {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+pub(crate) async fn unit() -> Result<String, ToolError> {
+    Ok(unit_text())
+}
+
+pub(crate) async fn install() -> Result<HostServiceOutcome, ToolError> {
+    preflight_port_available("install").await?;
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let text = unit_text();
+    std::fs::create_dir_all(unit_dir(&home)).map_err(io_error)?;
+    let changed = std::fs::read_to_string(&path).ok().as_deref() != Some(text.as_str());
+    if changed {
+        atomic_write(&path, text.as_bytes())?;
+    }
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    append_optional_verify(&path, &mut stdout, &mut stderr).await?;
+    let daemon = run_systemctl(&["daemon-reload"]).await?;
+    stdout.push_str(&daemon.stdout);
+    stderr.push_str(&daemon.stderr);
+    let enable = run_systemctl(&["enable", "--now", SERVICE_NAME]).await?;
+    stdout.push_str(&enable.stdout);
+    stderr.push_str(&enable.stderr);
+    if let Err(err) = poll_ready().await {
+        stderr.push_str(&format!("\nreadiness failed: {err}"));
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "installed {SERVICE_NAME}, but local readiness did not pass: {err}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            ),
+        });
+    }
+    Ok(HostServiceOutcome {
+        ok: true,
+        changed,
+        message: format!("{SERVICE_NAME} installed and running"),
+        unit_path: path,
+        stdout,
+        stderr,
+    })
+}
+
+pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let installed = path.is_file();
+    let docker_labby_master_running = docker_labby_master_running().await;
+    let local_ready = Some(check_ready().await.unwrap_or(false));
+    let mut load_state = None;
+    let mut active_state = None;
+    let mut sub_state = None;
+    let mut main_pid = None;
+    let mut exec_main_status = None;
+
+    if installed {
+        let output = run_systemctl(&[
+            "show",
+            SERVICE_NAME,
+            "--property=LoadState,ActiveState,SubState,MainPID,ExecMainStatus",
+            "--no-pager",
+        ])
+        .await?;
+        let props = parse_systemctl_show(&output.stdout);
+        load_state = non_empty_prop(&props, "LoadState");
+        active_state = non_empty_prop(&props, "ActiveState");
+        sub_state = non_empty_prop(&props, "SubState");
+        main_pid = non_empty_prop(&props, "MainPID").and_then(|value| {
+            let pid = value.parse::<u32>().ok()?;
+            (pid != 0).then_some(pid)
+        });
+        exec_main_status =
+            non_empty_prop(&props, "ExecMainStatus").and_then(|value| value.parse().ok());
+    }
+
+    let process_exe = main_pid.and_then(process_exe);
+
+    Ok(HostServiceStatus {
+        installed,
+        load_state,
+        active_state,
+        sub_state,
+        main_pid,
+        exec_main_status,
+        unit_path: path,
+        process_exe,
+        local_ready,
+        docker_labby_master_running,
+    })
+}
+
+pub(crate) async fn restart() -> Result<HostServiceOutcome, ToolError> {
+    preflight_port_available("restart").await?;
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let restart = run_systemctl(&["restart", SERVICE_NAME]).await?;
+    let mut stderr = restart.stderr;
+    if let Err(err) = poll_ready().await {
+        stderr.push_str(&format!("\nreadiness failed: {err}"));
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "restarted {SERVICE_NAME}, but local readiness did not pass: {err}\nstdout:\n{}\nstderr:\n{stderr}",
+                restart.stdout
+            ),
+        });
+    }
+    Ok(HostServiceOutcome {
+        ok: true,
+        changed: true,
+        message: format!("{SERVICE_NAME} restarted"),
+        unit_path: path,
+        stdout: restart.stdout,
+        stderr,
+    })
+}
+
+pub(crate) async fn uninstall() -> Result<HostServiceOutcome, ToolError> {
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if path.exists() {
+        let disable = run_systemctl(&["disable", "--now", SERVICE_NAME]).await?;
+        stdout.push_str(&disable.stdout);
+        stderr.push_str(&disable.stderr);
+        std::fs::remove_file(&path).map_err(io_error)?;
+        let daemon = run_systemctl(&["daemon-reload"]).await?;
+        stdout.push_str(&daemon.stdout);
+        stderr.push_str(&daemon.stderr);
+        Ok(HostServiceOutcome {
+            ok: true,
+            changed: true,
+            message: format!("{SERVICE_NAME} disabled and removed"),
+            unit_path: path,
+            stdout,
+            stderr,
+        })
+    } else {
+        Ok(HostServiceOutcome {
+            ok: true,
+            changed: false,
+            message: format!("{SERVICE_NAME} is not installed"),
+            unit_path: path,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+fn unit_text() -> String {
+    r#"[Unit]
+Description=Labby host gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/labby serve
+WorkingDirectory=%h
+EnvironmentFile=-%h/.lab/.env
+Restart=on-failure
+RestartSec=3
+StartLimitIntervalSec=60
+StartLimitBurst=5
+KillSignal=SIGINT
+
+[Install]
+WantedBy=default.target
+"#
+    .to_string()
+}
+
+fn unit_dir(home: &Path) -> PathBuf {
+    home.join(".config/systemd/user")
+}
+
+fn unit_path(home: &Path) -> PathBuf {
+    unit_dir(home).join(SERVICE_NAME)
+}
+
+fn current_home() -> Result<PathBuf, ToolError> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: "HOME is not set; cannot manage user systemd service".to_string(),
+        })
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), ToolError> {
+    let dir = path.parent().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "internal_error".into(),
+        message: format!("cannot determine parent directory for `{}`", path.display()),
+    })?;
+    let mut temp = tempfile::NamedTempFile::new_in(dir).map_err(io_error)?;
+    std::io::Write::write_all(&mut temp, bytes).map_err(io_error)?;
+    temp.as_file_mut().sync_all().map_err(io_error)?;
+    temp.persist(path).map_err(|err| io_error(err.error))?;
+    if let Ok(dir_file) = std::fs::File::open(dir) {
+        drop(dir_file.sync_all());
+    }
+    Ok(())
+}
+
+async fn append_optional_verify(
+    path: &Path,
+    stdout: &mut String,
+    stderr: &mut String,
+) -> Result<(), ToolError> {
+    match run_command("systemd-analyze", &["--user", "verify", path_to_str(path)?]).await {
+        Ok(output) => {
+            stdout.push_str(&output.stdout);
+            stderr.push_str(&output.stderr);
+            Ok(())
+        }
+        Err(err) if command_not_found(&err) => {
+            stderr.push_str("systemd-analyze not found; skipped unit verification\n");
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+async fn preflight_port_available(operation: &str) -> Result<(), ToolError> {
+    if docker_labby_master_running().await == Some(true) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "cannot {operation} {SERVICE_NAME}: Docker container `labby-master` is running; stop it before starting the host gateway"
+            ),
+        });
+    }
+
+    let port = configured_local_port();
+    if let Some(holder) = port_holder(port).await?
+        && !holder_can_be_host_service(&holder).await?
+    {
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "cannot {operation} {SERVICE_NAME}: local port {port} is already in use:\n{holder}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn configured_local_port() -> u16 {
+    std::env::var("LAB_MCP_HTTP_PORT")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .or_else(|| env_file_value("LAB_MCP_HTTP_PORT").and_then(|value| value.parse().ok()))
+        .unwrap_or(8765)
+}
+
+fn env_file_value(key: &str) -> Option<String> {
+    let path = current_home().ok()?.join(".lab/.env");
+    let text = std::fs::read_to_string(path).ok()?;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once('=')
+            && name.trim() == key
+        {
+            return Some(
+                value
+                    .trim()
+                    .trim_matches('"')
+                    .trim_matches('\'')
+                    .to_string(),
+            );
+        }
+    }
+    None
+}
+
+async fn port_holder(port: u16) -> Result<Option<String>, ToolError> {
+    match run_command("ss", &["-ltnp", &format!("sport = :{port}")]).await {
+        Ok(output) => {
+            let lines = output
+                .stdout
+                .lines()
+                .filter(|line| !line.trim().is_empty() && !line.starts_with("State"))
+                .collect::<Vec<_>>();
+            if lines.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(lines.join("\n")))
+            }
+        }
+        Err(err) if command_not_found(&err) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+async fn holder_can_be_host_service(holder: &str) -> Result<bool, ToolError> {
+    let status = status().await?;
+    if status.active_state.as_deref() != Some("active") {
+        return Ok(false);
+    }
+    let Some(pid) = status.main_pid else {
+        return Ok(false);
+    };
+    Ok(holder.contains(&format!("pid={pid},")) || holder.contains(&format!("pid={pid}")))
+}
+
+async fn docker_labby_master_running() -> Option<bool> {
+    match run_command(
+        "docker",
+        &["inspect", "-f", "{{.State.Running}}", "labby-master"],
+    )
+    .await
+    {
+        Ok(output) => Some(output.stdout.trim() == "true"),
+        Err(err) if command_not_found(&err) => None,
+        Err(_) => Some(false),
+    }
+}
+
+async fn poll_ready() -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    let mut last_err = String::new();
+    while tokio::time::Instant::now() < deadline {
+        match check_ready().await {
+            Ok(true) => return Ok(()),
+            Ok(false) => last_err = "ready endpoint returned non-success".to_string(),
+            Err(err) => last_err = err,
+        }
+        tokio::time::sleep(READY_POLL_INTERVAL).await;
+    }
+    Err(last_err)
+}
+
+async fn check_ready() -> Result<bool, String> {
+    let url = format!("http://127.0.0.1:{}/ready", configured_local_port());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .map_err(|err| err.to_string())?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    Ok(response.status().is_success())
+}
+
+fn process_exe(pid: u32) -> Option<PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+fn parse_systemctl_show(stdout: &str) -> BTreeMap<String, String> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+fn non_empty_prop(props: &BTreeMap<String, String>, key: &str) -> Option<String> {
+    props
+        .get(key)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+async fn run_systemctl(args: &[&str]) -> Result<CommandCapture, ToolError> {
+    let mut command_args = vec!["--user"];
+    command_args.extend_from_slice(args);
+    run_command("systemctl", &command_args).await
+}
+
+async fn run_command(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
+    let command_display = command_display(program, args);
+    let output = tokio::time::timeout(COMMAND_TIMEOUT, Command::new(program).args(args).output())
+        .await
+        .map_err(|_| ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!("command timed out after {COMMAND_TIMEOUT:?}: {command_display}"),
+        })?
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!("failed to run `{command_display}`: {err}"),
+        })?;
+    let captured = CommandCapture {
+        status: output.status,
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    };
+    if captured.status.success() {
+        Ok(captured)
+    } else {
+        Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "command failed: {command_display}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+                captured.status, captured.stdout, captured.stderr
+            ),
+        })
+    }
+}
+
+fn command_display(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().copied())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn path_to_str(path: &Path) -> Result<&str, ToolError> {
+    path.to_str().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "internal_error".into(),
+        message: format!("path is not valid UTF-8: `{}`", path.display()),
+    })
+}
+
+fn command_not_found(err: &ToolError) -> bool {
+    err.to_string().contains("No such file or directory")
+        || err.to_string().contains("os error 2")
+        || err.to_string().contains("not found")
+}
+
+fn io_error(err: std::io::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_uses_durable_host_binary_and_lab_env() {
+        let unit = unit_text();
+
+        assert!(unit.contains("Description=Labby host gateway"));
+        assert!(unit.contains("ExecStart=%h/.local/bin/labby serve"));
+        assert!(unit.contains("WorkingDirectory=%h"));
+        assert!(unit.contains("EnvironmentFile=-%h/.lab/.env"));
+    }
+
+    #[test]
+    fn unit_does_not_hard_code_public_bind_or_port() {
+        let unit = unit_text();
+
+        assert!(!unit.contains("--host 0.0.0.0"));
+        assert!(!unit.contains("--port 8765"));
+    }
+
+    #[test]
+    fn unit_contains_restart_limit_settings() {
+        let unit = unit_text();
+
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("RestartSec=3"));
+        assert!(unit.contains("StartLimitIntervalSec=60"));
+        assert!(unit.contains("StartLimitBurst=5"));
+        assert!(unit.contains("KillSignal=SIGINT"));
+    }
+
+    #[test]
+    fn unit_path_lives_under_user_systemd_dir() {
+        let home = Path::new("/home/example");
+
+        assert_eq!(
+            unit_path(home),
+            PathBuf::from("/home/example/.config/systemd/user/labby.service")
+        );
+    }
+
+    #[test]
+    fn parses_systemctl_show_properties() {
+        let props = parse_systemctl_show(
+            "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=123\n",
+        );
+
+        assert_eq!(
+            non_empty_prop(&props, "ActiveState").as_deref(),
+            Some("active")
+        );
+        assert_eq!(non_empty_prop(&props, "MainPID").as_deref(), Some("123"));
+    }
+}

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -651,6 +651,7 @@ Usage: setup [OPTIONS] [COMMAND]
 
 Commands:
   draft                Manage the local setup draft
+  host-service         Manage the host user systemd Labby gateway service
   installed-plugins    List installed Claude Code lab plugins
   services-status      Join service configuration, draft, and Claude plugin state
   plugin-hook          Run binary-owned local setup checks for Claude plugin hooks
@@ -746,6 +747,161 @@ Options:
 ```
 
 ## `labby setup draft help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: help [COMMAND]...
+
+Arguments:
+  [COMMAND]...
+          Print help for the subcommand(s)
+```
+
+## `labby setup host-service`
+
+```text
+Manage the host user systemd Labby gateway service
+
+Usage: host-service [OPTIONS] <COMMAND>
+
+Commands:
+  unit       Print the user systemd unit that Labby would install
+  install    Install and start labby.service under systemd --user
+  status     Read labby.service status
+  restart    Restart labby.service
+  uninstall  Stop, disable, and remove labby.service
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service unit`
+
+```text
+Print the user systemd unit that Labby would install
+
+Usage: unit [OPTIONS]
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service install`
+
+```text
+Install and start labby.service under systemd --user
+
+Usage: install [OPTIONS]
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+  -y, --yes
+
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service status`
+
+```text
+Read labby.service status
+
+Usage: status [OPTIONS]
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service restart`
+
+```text
+Restart labby.service
+
+Usage: restart [OPTIONS]
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+  -y, --yes
+
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service uninstall`
+
+```text
+Stop, disable, and remove labby.service
+
+Usage: uninstall [OPTIONS]
+
+Options:
+      --json
+          Emit JSON instead of human-readable tables
+
+  -y, --yes
+
+
+      --color <COLOR>
+          Control human-readable CLI styling
+
+          [default: auto]
+          [possible values: auto, plain, color]
+
+  -h, --help
+          Print help
+```
+
+## `labby setup host-service help`
 
 ```text
 Print this message or the help of the given subcommand(s)

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -820,7 +820,7 @@ Options:
           Emit JSON instead of human-readable tables
 
   -y, --yes
-
+          Confirm installation and service start
 
       --color <COLOR>
           Control human-readable CLI styling
@@ -865,7 +865,7 @@ Options:
           Emit JSON instead of human-readable tables
 
   -y, --yes
-
+          Confirm service restart
 
       --color <COLOR>
           Control human-readable CLI styling
@@ -889,7 +889,7 @@ Options:
           Emit JSON instead of human-readable tables
 
   -y, --yes
-
+          Confirm service removal
 
       --color <COLOR>
           Control human-readable CLI styling

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -70,13 +70,16 @@ Expected result includes:
 Also prove the public route is backed by the host service:
 
 ```bash
-pid=$(systemctl --user show labby.service --property=MainPID --value)
-readlink "/proc/$pid/exe"
-docker inspect -f '{{.State.Running}}' labby-master 2>/dev/null || true
+host_pid=$(systemctl --user show labby.service --property=MainPID --value)
+public_pid=$(curl -fsS https://lab.tootie.tv/health | jq -r .pid)
+test "$public_pid" = "$host_pid"
+readlink "/proc/$host_pid/exe"
+docker inspect -f '{{.State.Running}}' labby-master
 ```
 
-Expected: `/proc/$pid/exe` points at `/home/jmagar/.local/bin/labby`, and the
-Docker container is not the process answering the public route.
+Expected: the public health PID matches `labby.service` `MainPID`,
+`/proc/$host_pid/exe` points at `/home/jmagar/.local/bin/labby`, and the Docker
+container reports `false`.
 
 ## Roll Back To Docker
 
@@ -92,8 +95,7 @@ If Code Mode reports `failed to spawn Code Mode runner` after replacing a
 running binary, check:
 
 ```bash
-pid=$(pgrep -u "$USER" -f 'labby serve' | head -n1)
-readlink "/proc/$pid/exe"
+labby setup host-service status --json | jq -r .process_exe
 ```
 
 If the path ends in `(deleted)`, restart the service:

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -1,0 +1,93 @@
+# Host Labby Gateway
+
+The preferred Labby gateway runtime is a host user service:
+
+```bash
+~/.local/bin/labby serve
+```
+
+It runs as `labby.service` under `systemd --user`. Bind host, port, auth, and
+upstream gateway configuration continue to come from `~/.lab/.env` and Labby
+config. Do not bake public bind settings into the systemd unit.
+
+## Install
+
+```bash
+just host-service-install
+systemctl --user --no-pager --full status labby.service
+```
+
+## Migrate From The Docker Dev Container
+
+Stop the container before starting the host service because both runtimes bind
+port `8765`:
+
+```bash
+docker compose -f docker-compose.yml stop labby-master
+just host-service-install
+curl -fsS http://127.0.0.1:8765/ready
+labby gateway list
+```
+
+## Update The Running Host Gateway
+
+```bash
+just host-sync
+curl -fsS http://127.0.0.1:8765/ready
+labby gateway code exec --json --code 'async () => 1'
+```
+
+## Verify The Public MCP Route
+
+```bash
+TOKEN=$(awk -F= '/^LAB_MCP_HTTP_TOKEN=/{print $2}' ~/.lab/.env)
+curl -fsS -H "Authorization: Bearer $TOKEN" https://lab.tootie.tv/mcp
+```
+
+Then verify from Codex by calling the Labby Code Mode MCP tool through the
+public MCP route with:
+
+```javascript
+async () => 1
+```
+
+Expected result:
+
+```json
+{"result":1}
+```
+
+Also prove the public route is backed by the host service:
+
+```bash
+pid=$(systemctl --user show labby.service --property=MainPID --value)
+readlink "/proc/$pid/exe"
+docker inspect -f '{{.State.Running}}' labby-master 2>/dev/null || true
+```
+
+Expected: `/proc/$pid/exe` points at `/home/jmagar/.local/bin/labby`, and the
+Docker container is not the process answering the public route.
+
+## Roll Back To Docker
+
+```bash
+systemctl --user disable --now labby.service
+docker compose -f docker-compose.yml up -d labby-master --no-deps
+curl -fsS http://127.0.0.1:8765/ready
+```
+
+## Known Failure Mode: Deleted Executable
+
+If Code Mode reports `failed to spawn Code Mode runner` after replacing a
+running binary, check:
+
+```bash
+pid=$(pgrep -u "$USER" -f 'labby serve' | head -n1)
+readlink "/proc/$pid/exe"
+```
+
+If the path ends in `(deleted)`, restart the service:
+
+```bash
+systemctl --user restart labby.service
+```

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -33,25 +33,35 @@ labby gateway list
 
 ```bash
 just host-sync
-curl -fsS http://127.0.0.1:8765/ready
+labby setup host-service status --json
 labby gateway code exec --json --code 'async () => 1'
 ```
 
 ## Verify The Public MCP Route
 
 ```bash
-TOKEN=$(awk -F= '/^LAB_MCP_HTTP_TOKEN=/{print $2}' ~/.lab/.env)
-curl -fsS -H "Authorization: Bearer $TOKEN" https://lab.tootie.tv/mcp
+set -a
+. ~/.lab/.env
+set +a
+TOKEN="$LAB_MCP_HTTP_TOKEN"
+mcporter list https://lab.tootie.tv/mcp \
+  --header Authorization="Bearer $TOKEN" \
+  --status \
+  --exit-code
 ```
 
-Then verify from Codex by calling the Labby Code Mode MCP tool through the
-public MCP route with:
+Then call Code Mode through the same public MCP route:
 
-```javascript
-async () => 1
+```bash
+mcporter call \
+  --http-url https://lab.tootie.tv/mcp \
+  --header Authorization="Bearer $TOKEN" \
+  --tool codemode \
+  --args '{"code":"async () => 1"}' \
+  --output json
 ```
 
-Expected result:
+Expected result includes:
 
 ```json
 {"result":1}

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -20,12 +20,12 @@ systemctl --user --no-pager --full status labby.service
 ## Migrate From The Docker Dev Container
 
 Stop the container before starting the host service because both runtimes bind
-port `8765`:
+the configured local MCP HTTP port:
 
 ```bash
 docker compose -f docker-compose.yml stop labby-master
 just host-service-install
-curl -fsS http://127.0.0.1:8765/ready
+labby setup host-service status --json
 labby gateway list
 ```
 
@@ -99,5 +99,29 @@ readlink "/proc/$pid/exe"
 If the path ends in `(deleted)`, restart the service:
 
 ```bash
+systemctl --user restart labby.service
+```
+
+Advanced operators can point Code Mode at an alternate validated Labby binary
+before restarting the service. The path must be absolute, executable, owned by
+the current user or root, and not group/world-writable:
+
+```bash
+install -D -m 755 target/release-fast/labby ~/.local/bin/labby.next
+env_file="$HOME/.lab/.env"
+tmp="$(mktemp)"
+grep -v '^LAB_CODE_MODE_RUNNER_EXE=' "$env_file" > "$tmp"
+printf 'LAB_CODE_MODE_RUNNER_EXE=%s\n' "$HOME/.local/bin/labby.next" >> "$tmp"
+install -m 600 "$tmp" "$env_file"
+rm -f "$tmp"
+systemctl --user restart labby.service
+labby gateway code exec --json --code 'async () => 1'
+```
+
+Remove `LAB_CODE_MODE_RUNNER_EXE` from `~/.lab/.env` after the normal
+`~/.local/bin/labby` path is healthy again:
+
+```bash
+sed -i '/^LAB_CODE_MODE_RUNNER_EXE=/d' ~/.lab/.env
 systemctl --user restart labby.service
 ```

--- a/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
+++ b/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
@@ -1,0 +1,166 @@
+---
+date: 2026-06-22 11:04:07 EST
+repo: git@github.com:jmagar/lab.git
+branch: codex/host-gateway-work
+head: 22b1ef6f
+plan: docs/superpowers/plans/2026-06-22-host-labby-gateway.md
+working directory: /home/jmagar/workspace/lab/.worktrees/codex-host-gateway-work
+worktree: /home/jmagar/workspace/lab/.worktrees/codex-host-gateway-work
+pr: "#152 Run Labby gateway as host service (https://github.com/jmagar/labby/pull/152)"
+---
+
+# Host Labby Gateway Work Session
+
+## User Request
+
+Set up the host-first Labby gateway work using the writing-plans workflow, run engineering review, update the plan for the findings, then execute the full `vibin:work-it` review-and-fix loop.
+
+## Session Overview
+
+Implemented a host `labby.service` path for running the gateway outside the dev container, hardened Code Mode runner executable resolution for host operation, updated operator docs and generated CLI help, created PR #152, and iterated through independent review, simplifier, PR-toolkit, CodeRabbit, and local verification feedback.
+
+## Sequence of Events
+
+1. Created and worked inside `/home/jmagar/workspace/lab/.worktrees/codex-host-gateway-work` on `codex/host-gateway-work`.
+2. Added the host-gateway plan at `docs/superpowers/plans/2026-06-22-host-labby-gateway.md`.
+3. Implemented host-service CLI commands, systemd unit rendering/install/restart/status support, Justfile host-sync/install flows, and Code Mode runner executable validation.
+4. Opened PR #152 and pushed the initial implementation commit.
+5. Ran lavra review, three simplifier passes, PR-review-toolkit style sweeps, and CodeRabbit comment resolution, then pushed focused fix commits for each batch.
+6. Ran targeted and full verification locally, then saved this session artifact for the final docs-only commit.
+
+## Key Findings
+
+- Running the gateway inside the dev container made host-local process identity and Code Mode executable paths fragile; the implementation now treats the host service as the primary runtime.
+- Host-service lifecycle commands needed to remain CLI-only, not reachable through setup dispatch, MCP, or HTTP. Regression tests in `crates/lab/src/dispatch/setup/dispatch.rs` cover both underscore and hyphen action variants.
+- The Code Mode runner must fail closed when `/proc/self/exe` points at a deleted binary, and operator overrides need ownership, permission, absolute-path, canonicalization, and executable checks.
+- `host-sync` needed to refuse updates while no host service is active, otherwise it could quietly copy a binary and restart nothing.
+- Public MCP route proof should use `mcporter` and correlate the public `/health` process id with `systemctl --user show labby.service MainPID`.
+
+## Technical Decisions
+
+- Kept host-service implementation under `crates/lab/src/dispatch/setup/host_service.rs` because the plan and repo instructions route setup behavior through the setup dispatch area, while the CLI explicitly avoids exposing those actions through shared dispatch.
+- Used `systemctl --user enable` plus `restart` during install so changed units and env files take effect immediately.
+- Made Docker and port-holder preflights fail with structured conflict errors instead of silently assuming safety.
+- Kept live service/container mutation out of verification; the tests and docs prove the behavior without disrupting the current machine.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `CLAUDE.md` | - | Documented host-first gateway expectations. | `git diff --name-status main...HEAD` |
+| modified | `Justfile` | - | Added durable host binary copy, host install/sync recipes, and active-service guardrails. | `git diff --name-status main...HEAD` |
+| modified | `README.md` | - | Pointed operators at the host gateway runtime docs. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/Cargo.toml` | - | Added dependencies needed by host-service/runtime support. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/cli/setup.rs` | - | Added CLI-only host-service commands and confirmation handling. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/dispatch/gateway/code_mode.rs` | - | Wired runner executable resolver into Code Mode. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs` | - | Kept runner handle behavior aligned with host executable resolution. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs` | - | Drove Code Mode runner through the validated executable path. | `git diff --name-status main...HEAD` |
+| created | `crates/lab/src/dispatch/gateway/code_mode/runner_exe.rs` | - | Added deleted-executable and override validation logic with tests. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/dispatch/setup.rs` | - | Registered setup host-service module internally. | `git diff --name-status main...HEAD` |
+| modified | `crates/lab/src/dispatch/setup/dispatch.rs` | - | Added guards proving host-service actions are not dispatch/MCP/API actions. | `git diff --name-status main...HEAD` |
+| created | `crates/lab/src/dispatch/setup/host_service.rs` | - | Implemented unit rendering, install, status, restart, uninstall, preflight, and readiness helpers. | `git diff --name-status main...HEAD` |
+| modified | `docs/generated/cli-help.md` | - | Regenerated CLI help after adding host-service commands. | `just docs-check` |
+| created | `docs/runtime/HOST_GATEWAY.md` | - | Added host gateway operator runbook. | `git diff --name-status main...HEAD` |
+| created | `docs/superpowers/plans/2026-06-22-host-labby-gateway.md` | - | Captured the implementation plan and review-informed follow-up scope. | `git diff --name-status main...HEAD` |
+| created | `docs/sessions/2026-06-22-host-labby-gateway-work-it.md` | - | Captures this session closeout. | This file |
+
+## Beads Activity
+
+No bead activity observed for this host-gateway work. `bd list --all --sort updated --reverse --limit 50 --json` returned older closed Lab issues, and no directly matching active bead was observed during closeout.
+
+## Repository Maintenance
+
+### Plans
+
+Checked `docs/plans` and `docs/superpowers/plans`. The active host-gateway plan remains in `docs/superpowers/plans/2026-06-22-host-labby-gateway.md` because the PR is still open and should not be archived as complete before merge.
+
+### Beads
+
+Checked recent beads with `bd list --all --sort updated --reverse --limit 50 --json`. No directly relevant bead was found or changed.
+
+### Worktrees and Branches
+
+Checked `git worktree list --porcelain` and `git branch -vv`. Left all worktrees and branches intact because several are active PR/work-in-progress branches, `marketplace-no-mcp` is explicitly long-lived, and ownership of unrelated worktrees was outside this session.
+
+### Stale Docs
+
+Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/generated/cli-help.md` for the new host runtime and CLI surface. Broader historical plan cleanup was skipped because unrelated plan files predate this session and need separate ownership.
+
+## Tools and Skills Used
+
+- **Skills.** Used `superpowers:writing-plans`, `lavra:lavra-eng-review`, `vibin:work-it`, and `vibin:save-to-md` for planning, review, execution workflow, and session documentation.
+- **Shell and Git.** Used Cargo, Just, Git, GitHub CLI, system command probes, and Beads CLI reads for implementation, verification, PR state, and maintenance checks.
+- **MCP and Review Tooling.** Used Lumen for code discovery when available, plus lavra review, simplifier passes, PR review toolkit equivalents, and CodeRabbit PR feedback.
+- **External CLIs.** Used `gh` for PR creation/checks/review-thread evidence and `mcporter` guidance in docs for public route verification.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `cargo fmt --all` | Passed. |
+| `cargo test -p labby host_service --all-features` | Passed, 15 host-service tests. |
+| `cargo test -p labby host_service_destructive_commands_require_confirmation_envelope --all-features` | Passed. |
+| `cargo test -p labby runner_exe --all-features` | Passed, 6 runner executable tests. |
+| `just --summary >/dev/null` | Passed. |
+| `just docs-check` | Passed, 15 docs artifacts fresh. |
+| `cargo fmt --all --check` | Passed. |
+| `git diff --check` | Passed. |
+| `cargo check --workspace --all-features` | Passed. |
+| `cargo nextest run --workspace --all-features` | Passed, 2200 passed and 14 skipped. |
+| `gh api graphql ... reviewThreads` | Confirmed all CodeRabbit inline review threads resolved. |
+
+## Errors Encountered
+
+- Early review found generated CLI docs drift after adding commands. Regenerated docs and verified with `just docs-check`.
+- Review found host-service preflight and status paths were too lossy around Docker/port/readiness errors. Fixed with explicit conflict errors, probe error fields, and ownership checks.
+- Review found `command_not_found` matched generic `not found` text. Narrowed it to actual spawn failures.
+- Review found operator docs could hide public-route proof gaps. Replaced the generic public proof with `mcporter` and PID correlation guidance.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Gateway runtime | Dev-container gateway path was treated as the practical default. | Host `labby.service` has a documented install/sync/status/restart flow. |
+| Code Mode runner | Runner inherited the current process executable path, including stale deleted paths. | Runner path is resolved and validated, and deleted executables fail closed. |
+| Host sync | Could update a binary while no host service was active. | Requires active `labby.service` and uses `labby setup host-service restart -y`. |
+| Setup dispatch | Host lifecycle behavior risked being conflated with shared setup actions. | Host-service verbs are CLI-only and guarded by tests. |
+| Operator proof | Docs used basic health checks. | Docs require public route smoke via `mcporter` and process-id correlation. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo test -p labby host_service --all-features` | Host-service unit/status/preflight/CLI boundary tests pass. | 15 passed. | pass |
+| `cargo test -p labby host_service_destructive_commands_require_confirmation_envelope --all-features` | Destructive CLI commands require structured confirmation. | Passed. | pass |
+| `cargo test -p labby runner_exe --all-features` | Runner executable validation tests pass. | 6 passed. | pass |
+| `just docs-check` | Generated docs are fresh. | Passed, 15 artifacts fresh. | pass |
+| `cargo check --workspace --all-features` | Workspace compiles with all features. | Passed. | pass |
+| `cargo nextest run --workspace --all-features` | Full test suite is green. | 2200 passed, 14 skipped. | pass |
+| `gh api graphql ... reviewThreads` | No unresolved actionable CodeRabbit threads. | All 4 threads returned `isResolved: true`. | pass |
+
+## Risks and Rollback
+
+- The host-service install/restart paths intentionally mutate the user's systemd user service and were not run live during verification. Roll back by reverting PR #152 or removing the host unit with `labby setup host-service uninstall -y`.
+- `host-sync` now refuses to operate unless `labby.service` is active. If an operator wants a one-off binary replacement without the service running, they must use the lower-level install/copy path deliberately.
+
+## Decisions Not Taken
+
+- Did not move `host_service.rs` out of `dispatch/setup`; the implementation is CLI-only but still belongs to setup ownership per the plan and repo instructions.
+- Did not run live Docker/service migration commands during validation; avoiding disruption was more important than proving those destructive paths on this machine.
+- Did not archive older unrelated plans or clean unrelated worktrees; their ownership and merge state were outside this PR.
+
+## References
+
+- PR #152: https://github.com/jmagar/labby/pull/152
+- Plan: `docs/superpowers/plans/2026-06-22-host-labby-gateway.md`
+- Runtime docs: `docs/runtime/HOST_GATEWAY.md`
+
+## Open Questions
+
+- Final GitHub Actions checks for the last implementation push were still in progress when this note was written. They should be rechecked after the session-note commit as well.
+
+## Next Steps
+
+1. Commit only this session artifact with `docs: save session log`.
+2. Push `codex/host-gateway-work`.
+3. Wait for PR #152 checks after the final commit and fix any new CI or review findings before merge.

--- a/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
+++ b/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
@@ -27,7 +27,7 @@ Implemented a host `labby.service` path for running the gateway outside the dev 
 4. Opened PR #152 and pushed the initial implementation commit.
 5. Ran lavra review, three simplifier passes, PR-review-toolkit style sweeps, and CodeRabbit comment resolution, then pushed focused fix commits for each batch.
 6. Ran targeted and full verification locally, then saved this session artifact for the final docs-only commit.
-7. Fixed a Rust 1.94.1 CI-only Clippy failure in `host_service.rs`, re-ran local Clippy and focused host-service tests, and prepared the final push.
+7. Fixed Rust 1.94.1 CI-only Clippy failures in `host_service.rs`, then fixed a Windows-only unused-variable failure in `runner_exe.rs`, re-running local Clippy and focused tests after each patch.
 
 ## Key Findings
 
@@ -118,6 +118,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 - Review found `command_not_found` matched generic `not found` text. Narrowed it to actual spawn failures.
 - Review found operator docs could hide public-route proof gaps. Replaced the generic public proof with `mcporter` and PID correlation guidance.
 - Remote CI Clippy on Rust 1.94.1 failed for `needless_raw_string_hashes` and `useless_let_if_seq` in `crates/lab/src/dispatch/setup/host_service.rs`. Removed the needless raw-string hashes and rewrote the `ExecMainStatus` assignment as an expression.
+- Remote Windows self-hosted CI failed because `reject_untrusted_permissions(path: &Path)` used `path` only under `#[cfg(unix)]`. Added a non-Unix use so Windows no longer trips `unused_variables` under `-D warnings`.
 
 ## Behavior Changes (Before/After)
 
@@ -165,5 +166,5 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 
 ## Next Steps
 
-1. Push the final CI Clippy fix.
+1. Push the final CI fix.
 2. Wait for PR #152 checks after the final commit and fix any new CI or review findings before merge.

--- a/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
+++ b/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
@@ -28,6 +28,7 @@ Implemented a host `labby.service` path for running the gateway outside the dev 
 5. Ran lavra review, three simplifier passes, PR-review-toolkit style sweeps, and CodeRabbit comment resolution, then pushed focused fix commits for each batch.
 6. Ran targeted and full verification locally, then saved this session artifact for the final docs-only commit.
 7. Fixed Rust 1.94.1 CI-only Clippy failures in `host_service.rs`, then fixed a Windows-only unused-variable failure in `runner_exe.rs`, re-running local Clippy and focused tests after each patch.
+8. Investigated the Windows self-hosted runner failure, cleared an orphaned `Runner.Worker`/Cargo process tree after GitHub had already marked the job complete, reran the job, and fixed the workflow env override so CI disables the repo-local Cargo rustc wrapper through Cargo's config key.
 
 ## Key Findings
 
@@ -64,6 +65,8 @@ Implemented a host `labby.service` path for running the gateway outside the dev 
 | created | `docs/runtime/HOST_GATEWAY.md` | - | Added host gateway operator runbook. | `git diff --name-status main...HEAD` |
 | created | `docs/superpowers/plans/2026-06-22-host-labby-gateway.md` | - | Captured the implementation plan and review-informed follow-up scope. | `git diff --name-status main...HEAD` |
 | created | `docs/sessions/2026-06-22-host-labby-gateway-work-it.md` | - | Captures this session closeout. | This file |
+| modified | `.github/workflows/ci.yml` | - | Uses `CARGO_BUILD_RUSTC_WRAPPER` to disable the repo-local shell wrapper in CI, including Windows. | Manual Windows `cargo metadata` reproduction |
+| modified | `.github/workflows/release.yml` | - | Mirrors the CI wrapper override for release builds. | Manual Windows `cargo metadata` reproduction |
 
 ## Beads Activity
 
@@ -110,6 +113,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 | `cargo clippy --workspace --all-features --locked -- -D warnings` | Passed after fixing Rust 1.94.1 CI-only lints. |
 | `cargo nextest run --workspace --all-features` | Passed, 2200 passed and 14 skipped. |
 | `gh api graphql ... reviewThreads` | Confirmed all CodeRabbit inline review threads resolved. |
+| Windows `cargo metadata --format-version=1 --all-features --filter-platform x86_64-pc-windows-msvc --locked --no-deps` with `CARGO_BUILD_RUSTC_WRAPPER=""` | Passed on `agent-os`; confirmed the correct override for `.cargo/config.toml` `build.rustc-wrapper`. |
 
 ## Errors Encountered
 
@@ -119,6 +123,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 - Review found operator docs could hide public-route proof gaps. Replaced the generic public proof with `mcporter` and PID correlation guidance.
 - Remote CI Clippy on Rust 1.94.1 failed for `needless_raw_string_hashes` and `useless_let_if_seq` in `crates/lab/src/dispatch/setup/host_service.rs`. Removed the needless raw-string hashes and rewrote the `ExecMainStatus` assignment as an expression.
 - Remote Windows self-hosted CI failed because `reject_untrusted_permissions(path: &Path)` used `path` only under `#[cfg(unix)]`. Added a non-Unix use so Windows no longer trips `unused_variables` under `-D warnings`.
+- Remote Windows self-hosted CI then failed without a Rust diagnostic while compiling. The first attempt left an orphaned `Runner.Worker`/Cargo process tree after the job completed; after clearing it and rerunning, manual reproduction showed Cargo still reading `.cargo/config.toml` `build.rustc-wrapper = "scripts/cargo-rustc-wrapper"` when only `RUSTC_WRAPPER=""` was set. Setting `CARGO_BUILD_RUSTC_WRAPPER=""` made Windows `cargo metadata` succeed, so CI and release workflows now use the Cargo config override.
 
 ## Behavior Changes (Before/After)
 
@@ -142,6 +147,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 | `cargo clippy --workspace --all-features --locked -- -D warnings` | Matches CI Clippy gate. | Passed after CI lint fix. | pass |
 | `cargo nextest run --workspace --all-features` | Full test suite is green. | 2200 passed, 14 skipped. | pass |
 | `gh api graphql ... reviewThreads` | No unresolved actionable CodeRabbit threads. | All 4 threads returned `isResolved: true`. | pass |
+| Windows `cargo metadata` with `CARGO_BUILD_RUSTC_WRAPPER=""` | Cargo ignores the repo-local shell rustc wrapper on Windows. | Passed on `agent-os`. | pass |
 
 ## Risks and Rollback
 
@@ -166,5 +172,5 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 
 ## Next Steps
 
-1. Push the final CI fix.
+1. Push the final CI wrapper override fix.
 2. Wait for PR #152 checks after the final commit and fix any new CI or review findings before merge.

--- a/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
+++ b/docs/sessions/2026-06-22-host-labby-gateway-work-it.md
@@ -27,6 +27,7 @@ Implemented a host `labby.service` path for running the gateway outside the dev 
 4. Opened PR #152 and pushed the initial implementation commit.
 5. Ran lavra review, three simplifier passes, PR-review-toolkit style sweeps, and CodeRabbit comment resolution, then pushed focused fix commits for each batch.
 6. Ran targeted and full verification locally, then saved this session artifact for the final docs-only commit.
+7. Fixed a Rust 1.94.1 CI-only Clippy failure in `host_service.rs`, re-ran local Clippy and focused host-service tests, and prepared the final push.
 
 ## Key Findings
 
@@ -106,6 +107,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 | `cargo fmt --all --check` | Passed. |
 | `git diff --check` | Passed. |
 | `cargo check --workspace --all-features` | Passed. |
+| `cargo clippy --workspace --all-features --locked -- -D warnings` | Passed after fixing Rust 1.94.1 CI-only lints. |
 | `cargo nextest run --workspace --all-features` | Passed, 2200 passed and 14 skipped. |
 | `gh api graphql ... reviewThreads` | Confirmed all CodeRabbit inline review threads resolved. |
 
@@ -115,6 +117,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 - Review found host-service preflight and status paths were too lossy around Docker/port/readiness errors. Fixed with explicit conflict errors, probe error fields, and ownership checks.
 - Review found `command_not_found` matched generic `not found` text. Narrowed it to actual spawn failures.
 - Review found operator docs could hide public-route proof gaps. Replaced the generic public proof with `mcporter` and PID correlation guidance.
+- Remote CI Clippy on Rust 1.94.1 failed for `needless_raw_string_hashes` and `useless_let_if_seq` in `crates/lab/src/dispatch/setup/host_service.rs`. Removed the needless raw-string hashes and rewrote the `ExecMainStatus` assignment as an expression.
 
 ## Behavior Changes (Before/After)
 
@@ -135,6 +138,7 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 | `cargo test -p labby runner_exe --all-features` | Runner executable validation tests pass. | 6 passed. | pass |
 | `just docs-check` | Generated docs are fresh. | Passed, 15 artifacts fresh. | pass |
 | `cargo check --workspace --all-features` | Workspace compiles with all features. | Passed. | pass |
+| `cargo clippy --workspace --all-features --locked -- -D warnings` | Matches CI Clippy gate. | Passed after CI lint fix. | pass |
 | `cargo nextest run --workspace --all-features` | Full test suite is green. | 2200 passed, 14 skipped. | pass |
 | `gh api graphql ... reviewThreads` | No unresolved actionable CodeRabbit threads. | All 4 threads returned `isResolved: true`. | pass |
 
@@ -161,6 +165,5 @@ Updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and `docs/gene
 
 ## Next Steps
 
-1. Commit only this session artifact with `docs: save session log`.
-2. Push `codex/host-gateway-work`.
-3. Wait for PR #152 checks after the final commit and fix any new CI or review findings before merge.
+1. Push the final CI Clippy fix.
+2. Wait for PR #152 checks after the final commit and fix any new CI or review findings before merge.

--- a/docs/superpowers/plans/2026-06-22-host-labby-gateway.md
+++ b/docs/superpowers/plans/2026-06-22-host-labby-gateway.md
@@ -1,0 +1,1550 @@
+# Host Labby Gateway Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the primary Labby gateway runtime from the Docker dev container to a host-owned user service, while keeping Docker available only as an explicit prod-like/container smoke path.
+
+**Architecture:** Labby should run where its stdio MCP tools, host credentials, SSH config, local binaries, and agent caches already live: the host user session. The host runtime is owned by `systemd --user`, while Docker remains a compatibility path that never bind-mounts over the running executable as the default developer workflow. Code Mode runner spawning also gains a stable executable resolver so a replaced binary produces either a working fallback or a clear restart-needed error.
+
+**Tech Stack:** Rust 2024, Clap, Tokio, `systemctl --user`, Docker Compose, existing Lab setup dispatch layer, existing Code Mode runner pool.
+
+**Engineering review decisions applied:**
+- Host service lifecycle management is CLI-only for this change. Do not add `host_service.*` actions to the setup dispatch catalog, MCP, or HTTP API.
+- The host service binds through normal Labby config/env. The generated unit must not hard-code `--host 0.0.0.0 --port 8765`.
+- Code Mode runner resolution must not silently switch to another `labby` binary. Deleted/stale `current_exe()` returns clear restart guidance unless `LAB_CODE_MODE_RUNNER_EXE` is explicitly set and validated.
+- Service management helpers must preserve exact `systemctl`/journal diagnostics and use timeouts so a wedged user systemd bus does not hang an agent workflow.
+- Migration proof must verify the actual public MCP route and the host process backing it, not just `/health`.
+
+## Global Constraints
+
+- Preserve the current one-binary model: `labby serve` remains the hosted HTTP/API/MCP/Web runtime.
+- Keep `lab-apis` pure: no `clap`, `rmcp`, `axum`, `anyhow`, filesystem service management, or env loading there.
+- CLI files stay thin shims; host service behavior lives under `crates/lab/src/dispatch/setup/`.
+- Host service install/uninstall/restart commands are destructive and require explicit CLI confirmation.
+- Do not expose host service install, restart, uninstall, or status through MCP or HTTP in this implementation.
+- Do not remove Docker Compose support; demote it to explicit container smoke/dev-container workflows.
+- Validate with all-features Rust checks before completion.
+- Do not edit `AGENTS.md` or `GEMINI.md`; update `CLAUDE.md` if agent memory changes are needed.
+
+---
+
+## File Structure
+
+- Create: `crates/lab/src/dispatch/gateway/code_mode/runner_exe.rs`
+  - Resolves the executable used for `labby internal code-mode-runner`.
+  - Detects deleted/stale `current_exe()` paths.
+  - Honors an explicit `LAB_CODE_MODE_RUNNER_EXE` override.
+  - Does not fall back to unrelated Labby binaries automatically.
+- Modify: `crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs`
+  - Uses `runner_exe::resolve_runner_exe()` instead of calling `std::env::current_exe()` inline.
+- Modify: `crates/lab/src/dispatch/gateway/code_mode.rs`
+  - Declares the new `runner_exe` module.
+- Modify: `crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs`
+  - Improves the spawn error to include the attempted executable path.
+- Create: `crates/lab/src/dispatch/setup/host_service.rs`
+  - Generates and installs the `systemd --user` unit.
+  - Runs status/restart/uninstall operations through typed CLI-only helpers.
+  - Exposes serializable status and operation result types.
+- Modify: `crates/lab/src/dispatch/setup.rs`
+  - Declares `host_service`.
+- Modify: `crates/lab/src/cli/setup.rs`
+  - Adds `labby setup host-service ...` subcommands as thin CLI shims over `dispatch::setup::host_service`.
+- Modify: `Justfile`
+  - Adds host-first `host-sync`, `host-service-install`, `host-service-restart`, and `host-service-status`.
+  - Keeps container workflows under explicit names.
+- Modify: `README.md`
+  - Documents host gateway as the normal local/dookie runtime.
+  - Demotes the Docker dev container section.
+- Modify: `CLAUDE.md`
+  - Updates development instructions so agents prefer the host service for Labby gateway work.
+- Create: `docs/runtime/HOST_GATEWAY.md`
+  - Operator runbook for install, migration from container, rollback, verification, and known failure modes.
+
+---
+
+### Task 1: Code Mode Runner Executable Resolver
+
+**Files:**
+- Modify: `crates/lab/Cargo.toml`
+  - Enable the existing `nix` dependency's `user` feature if required for current-user ownership checks.
+- Create: `crates/lab/src/dispatch/gateway/code_mode/runner_exe.rs`
+- Modify: `crates/lab/src/dispatch/gateway/code_mode.rs`
+- Modify: `crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs`
+- Modify: `crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs`
+
+**Interfaces:**
+- Consumes: `ToolError::Sdk { sdk_kind, message }`
+- Produces: `pub(super) fn resolve_runner_exe() -> Result<std::path::PathBuf, ToolError>`
+- Produces for tests: `pub(super) fn resolve_runner_exe_from(current_exe: PathBuf, override_exe: Option<PathBuf>) -> Result<PathBuf, ToolError>`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Add this module to `crates/lab/src/dispatch/gateway/code_mode/runner_exe.rs` with the tests included first:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::dispatch::error::ToolError;
+
+pub(super) fn resolve_runner_exe() -> Result<PathBuf, ToolError> {
+    let current = std::env::current_exe().map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to locate current executable for Code Mode runner: {err}"),
+    })?;
+    let override_exe = std::env::var_os("LAB_CODE_MODE_RUNNER_EXE").map(PathBuf::from);
+    resolve_runner_exe_from(current, override_exe)
+}
+
+pub(super) fn resolve_runner_exe_from(
+    current_exe: PathBuf,
+    override_exe: Option<PathBuf>,
+) -> Result<PathBuf, ToolError> {
+    if let Some(path) = override_exe {
+        let path = validate_operator_override(path)?;
+        tracing::warn!(
+            runner_exe = %path.display(),
+            "using LAB_CODE_MODE_RUNNER_EXE override for Code Mode runner"
+        );
+        return Ok(path);
+    }
+
+    if is_usable_exe(&current_exe) {
+        return Ok(current_exe);
+    }
+
+    Err(ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!(
+            "Code Mode runner executable is stale or unavailable: `{}`; restart labby.service or set LAB_CODE_MODE_RUNNER_EXE to a validated labby binary",
+            current_exe.display()
+        ),
+    })
+}
+
+fn validate_operator_override(path: PathBuf) -> Result<PathBuf, ToolError> {
+    if !path.is_absolute() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: "LAB_CODE_MODE_RUNNER_EXE must be an absolute path".to_string(),
+        });
+    }
+    let canonical = std::fs::canonicalize(&path).map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!(
+            "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but it cannot be resolved: {err}",
+            path.display()
+        ),
+    })?;
+    if !is_usable_exe(&canonical) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!(
+                "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but that file is not executable",
+                canonical.display()
+            ),
+        });
+    }
+    reject_untrusted_permissions(&canonical)?;
+    Ok(canonical)
+}
+
+fn is_usable_exe(path: &Path) -> bool {
+    if path.to_string_lossy().ends_with(" (deleted)") {
+        return false;
+    }
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn reject_untrusted_permissions(path: &Path) -> Result<(), ToolError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path).map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to inspect `{}`: {err}", path.display()),
+        })?;
+        if meta.mode() & 0o022 != 0 {
+            return Err(ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: format!(
+                    "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but the file is group/world writable",
+                    path.display()
+                ),
+            });
+        }
+        let current_uid = nix::unistd::Uid::current().as_raw();
+        if meta.uid() != current_uid && meta.uid() != 0 {
+            return Err(ToolError::Sdk {
+                sdk_kind: "internal_error".to_string(),
+                message: format!(
+                    "LAB_CODE_MODE_RUNNER_EXE points at `{}`, but the file is not owned by the current user or root",
+                    path.display()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn uses_current_exe_when_it_is_usable() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("labby");
+        std::fs::write(&current, b"binary").unwrap();
+        #[cfg(unix)]
+        make_executable(&current);
+
+        let resolved = resolve_runner_exe_from(current.clone(), None).unwrap();
+
+        assert_eq!(resolved, current);
+    }
+
+    #[test]
+    fn deleted_current_exe_without_override_reports_restart_guidance() {
+        let err = resolve_runner_exe_from(PathBuf::from("/usr/local/bin/labby (deleted)"), None)
+            .unwrap_err();
+
+        assert_eq!(err.kind(), "internal_error");
+        assert!(err.to_string().contains("restart labby.service"));
+    }
+
+    #[test]
+    fn override_must_be_absolute() {
+        let err = resolve_runner_exe_from(
+            PathBuf::from("/usr/local/bin/labby"),
+            Some(PathBuf::from("target/debug/labby")),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn override_must_point_to_usable_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing-labby");
+
+        let err = resolve_runner_exe_from(
+            PathBuf::from("/usr/local/bin/labby"),
+            Some(missing),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), "internal_error");
+        assert!(err.to_string().contains("LAB_CODE_MODE_RUNNER_EXE"));
+    }
+
+    #[test]
+    fn explicit_override_is_used_after_validation() {
+        let temp = tempfile::tempdir().unwrap();
+        let override_path = temp.path().join("labby");
+        std::fs::write(&override_path, b"binary").unwrap();
+        #[cfg(unix)]
+        make_executable(&override_path);
+
+        let resolved = resolve_runner_exe_from(
+            PathBuf::from("/usr/local/bin/labby (deleted)"),
+            Some(override_path.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(resolved, std::fs::canonicalize(override_path).unwrap());
+    }
+}
+```
+
+Review note: automatic fallback to `/usr/local/bin/labby` or `~/.local/bin/labby`
+was rejected because it can mix parent and runner protocol versions after a
+failed restart. A future protocol/version handshake can be added if automatic
+fallback becomes necessary; this migration should prefer a loud restart-needed
+error over a silent stale-binary mismatch.
+
+- [ ] **Step 2: Run tests to verify the integration points fail**
+
+Run:
+
+```bash
+cargo test -p labby runner_exe --all-features
+```
+
+Expected before module wiring: compilation fails because `runner_exe` is not declared.
+
+- [ ] **Step 3: Wire the resolver into Code Mode**
+
+In `crates/lab/src/dispatch/gateway/code_mode.rs`, add the module declaration next to the other Code Mode submodules:
+
+```rust
+mod runner_exe;
+```
+
+In `crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs`, replace the inline `current_exe()` block with:
+
+```rust
+let exe = super::runner_exe::resolve_runner_exe()?;
+```
+
+In `crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs`, replace the spawn error message with:
+
+```rust
+let mut child = cmd.spawn().map_err(|err| ToolError::Sdk {
+    sdk_kind: "internal_error".to_string(),
+    message: format!(
+        "failed to spawn Code Mode runner from `{}`: {err}",
+        exe.display()
+    ),
+})?;
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run:
+
+```bash
+cargo test -p labby runner_exe --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing Code Mode runner tests**
+
+Run:
+
+```bash
+cargo nextest run -p labby --all-features code_mode_runner
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Verify diagnostics mention the executable path**
+
+Run the focused tests or an existing Code Mode runner smoke with a deliberately
+invalid override:
+
+```bash
+LAB_CODE_MODE_RUNNER_EXE=/tmp/missing-labby cargo test -p labby runner_exe --all-features
+```
+
+Expected: the failure message includes `LAB_CODE_MODE_RUNNER_EXE` and the
+attempted path. Do not leave the override in the environment after this check.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/lab/src/dispatch/gateway/code_mode.rs \
+  crates/lab/Cargo.toml \
+  crates/lab/src/dispatch/gateway/code_mode/runner_drive.rs \
+  crates/lab/src/dispatch/gateway/code_mode/runner_exe.rs \
+  crates/lab/src/dispatch/gateway/code_mode/pool/runner_handle.rs
+git commit -m "fix: resolve code mode runner executable robustly"
+```
+
+---
+
+### Task 2: Host Systemd Service CLI Only
+
+**Files:**
+- Create: `crates/lab/src/dispatch/setup/host_service.rs`
+- Modify: `crates/lab/src/dispatch/setup.rs`
+- Modify: `crates/lab/src/cli/setup.rs`
+- Modify only if tests reveal accidental exposure: `crates/lab/src/dispatch/setup/catalog.rs`, `crates/lab/src/dispatch/setup/dispatch.rs`, `crates/lab/src/api/services/setup.rs`
+
+**Interfaces:**
+- Consumes: local CLI invocation only.
+- Produces: `labby setup host-service unit`
+- Produces: `labby setup host-service install -y`
+- Produces: `labby setup host-service status`
+- Produces: `labby setup host-service restart -y`
+- Produces: `labby setup host-service uninstall -y`
+- Does not produce setup catalog actions, MCP actions, or HTTP API actions.
+
+Review note: this replaces the earlier dispatch-based Task 2. Host lifecycle
+management controls the process that serves the gateway and has access to host
+credentials, SSH config, and local agent caches. `requires_admin` is not a
+sufficient boundary for `systemctl --user` mutation on a service that can bind a
+public interface, so the lifecycle surface stays local CLI-only.
+
+- [ ] **Step 1: Add explicit non-exposure tests**
+
+Before implementing the CLI, add tests that fail if host-service actions are
+added to the shared setup action catalog:
+
+```rust
+#[test]
+fn setup_catalog_does_not_expose_host_service_actions() {
+    let catalog = crate::dispatch::setup::catalog::actions();
+    assert!(
+        catalog.iter().all(|action| !action.name.starts_with("host_service.")),
+        "host-service lifecycle commands must remain CLI-only"
+    );
+}
+```
+
+If there is already a route-level setup API test helper, add a companion test
+that a public `/v1/setup` request cannot call `host_service.restart` or
+`host_service.uninstall`. If such a helper does not exist, the catalog
+non-exposure test is the required guard for this plan.
+
+- [ ] **Step 2: Create the host service helper module with safe unit text**
+
+Create `crates/lab/src/dispatch/setup/host_service.rs`. Use
+`crate::dispatch::error::ToolError`, not `crate::mcp::error::ToolError`.
+
+Required unit behavior:
+- `ExecStart=%h/.local/bin/labby serve`
+- `EnvironmentFile=-%h/.lab/.env`
+- `WorkingDirectory=%h`
+- `Restart=on-failure`
+- `RestartSec=3`
+- `StartLimitIntervalSec=60`
+- `StartLimitBurst=5`
+- `KillSignal=SIGINT`
+- No hard-coded `--host` or `--port`; binding stays in `~/.lab/.env` or Labby config.
+
+Implement `unit_text()` as a fixed unit template instead of interpolating raw
+paths. The durable binary path is `%h/.local/bin/labby`; `host-sync` is
+responsible for copying that binary before restart.
+
+Add unit tests:
+- unit contains `ExecStart=%h/.local/bin/labby serve`
+- unit does not contain `--host 0.0.0.0` or `--port 8765`
+- unit contains `EnvironmentFile=-%h/.lab/.env`
+- unit contains restart limit settings
+- `unit_path(home)` resolves to `<home>/.config/systemd/user/labby.service`
+
+- [ ] **Step 3: Implement typed CLI-only service operations**
+
+In `host_service.rs`, implement:
+
+```rust
+pub(crate) async fn unit() -> Result<String, ToolError>;
+pub(crate) async fn install() -> Result<HostServiceOutcome, ToolError>;
+pub(crate) async fn status() -> Result<HostServiceStatus, ToolError>;
+pub(crate) async fn restart() -> Result<HostServiceOutcome, ToolError>;
+pub(crate) async fn uninstall() -> Result<HostServiceOutcome, ToolError>;
+```
+
+`HostServiceStatus` must be richer than `installed + active`:
+
+```rust
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceStatus {
+    pub installed: bool,
+    pub load_state: Option<String>,
+    pub active_state: Option<String>,
+    pub sub_state: Option<String>,
+    pub main_pid: Option<u32>,
+    pub exec_main_status: Option<i32>,
+    pub unit_path: PathBuf,
+    pub process_exe: Option<PathBuf>,
+    pub local_ready: Option<bool>,
+    pub docker_labby_master_running: Option<bool>,
+}
+```
+
+`HostServiceOutcome` must preserve diagnostics:
+
+```rust
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceOutcome {
+    pub ok: bool,
+    pub changed: bool,
+    pub message: String,
+    pub unit_path: PathBuf,
+    pub stdout: String,
+    pub stderr: String,
+}
+```
+
+System command rules:
+- Use `tokio::process::Command` or `tokio::task::spawn_blocking`; never block a Tokio worker with plain `std::process::Command` inside async code.
+- Wrap every `systemctl --user` call in `tokio::time::timeout`.
+- Return `ToolError::Sdk { sdk_kind: "internal_error", ... }` with the full command, exit status, stdout, and stderr on failure. Do not invent `systemctl_failed` unless `docs/dev/ERRORS.md` is updated in the same task.
+- Use atomic unit writes: write a temp sibling, `sync_all` if practical, then rename.
+- If `systemd-analyze --user verify <unit>` exists, run it before `daemon-reload`; if it is missing, skip with a diagnostic in the outcome.
+- `uninstall()` must fail when `disable --now` fails unless the unit is already absent.
+
+Readiness and port rules:
+- Before `install()` or `restart()`, detect the holder of the configured local port when possible. If another `labby` process or Docker `labby-master` owns it, return a diagnostic instead of entering a restart loop.
+- After `install()` and `restart()`, poll `http://127.0.0.1:8765/ready` with a deadline and include the last error in `stderr` if readiness fails.
+- `status()` should report `/proc/<pid>/exe` when `main_pid` is available and flag paths ending in ` (deleted)`.
+
+- [ ] **Step 4: Wire the module for local CLI use only**
+
+In `crates/lab/src/dispatch/setup.rs`, add:
+
+```rust
+pub(crate) mod host_service;
+```
+
+Do not add `host_service.*` entries to `setup/catalog.rs`.
+Do not add `host_service.*` arms to `setup/dispatch.rs`.
+Do not add MCP or HTTP routes for host service lifecycle.
+
+- [ ] **Step 5: Add CLI subcommands**
+
+In `crates/lab/src/cli/setup.rs`, add:
+
+```rust
+#[derive(Debug, Args)]
+pub struct HostServiceArgs {
+    #[command(subcommand)]
+    pub command: HostServiceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HostServiceCommand {
+    /// Print the user systemd unit that Labby would install.
+    Unit,
+    /// Install and start labby.service under systemd --user.
+    Install {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+    /// Read labby.service status.
+    Status,
+    /// Restart labby.service.
+    Restart {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+    /// Stop, disable, and remove labby.service.
+    Uninstall {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+}
+```
+
+The CLI match arm calls `crate::dispatch::setup::host_service::{unit, install,
+status, restart, uninstall}` directly and prints the returned serializable value
+through the existing output helpers.
+
+Destructive commands must require `-y/--yes` in the CLI shim:
+- `install -y`
+- `restart -y`
+- `uninstall -y`
+
+No `confirm` parameter is passed through JSON, because there is no dispatch
+action and no remote elicitation path.
+
+- [ ] **Step 6: Add parser, unit, and non-exposure tests**
+
+Run and make pass:
+
+```bash
+cargo test -p labby host_service --all-features
+cargo test -p labby parses_host_service_subcommands --all-features
+cargo test -p labby setup_catalog_does_not_expose_host_service_actions --all-features
+```
+
+Expected:
+- host service unit and helper tests PASS
+- CLI parser tests PASS
+- setup catalog non-exposure test PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/lab/src/dispatch/setup.rs \
+  crates/lab/src/dispatch/setup/host_service.rs \
+  crates/lab/src/cli/setup.rs
+git commit -m "feat: add local host labby service management"
+```
+
+---
+
+### Superseded Task 2 Draft: Do Not Implement
+
+This section is retained only as review context. It exposed host service
+lifecycle through shared setup dispatch actions, which engineering review
+rejected because the controls would become reachable through MCP or HTTP.
+
+<details>
+<summary>Superseded draft retained for context only</summary>
+
+**Files:**
+- Create: `crates/lab/src/dispatch/setup/host_service.rs`
+- Modify: `crates/lab/src/dispatch/setup.rs`
+- Modify: `crates/lab/src/dispatch/setup/catalog.rs`
+- Modify: `crates/lab/src/dispatch/setup/dispatch.rs`
+- Modify: `crates/lab/src/cli/setup.rs`
+
+**Interfaces:**
+- Consumes: `setup` dispatch action routing in `dispatch.rs`
+- Produces: `host_service::unit_text(bin_path: &Path, working_dir: &Path) -> String`
+- Produces dispatch actions:
+  - `host_service.unit`
+  - `host_service.install`
+  - `host_service.status`
+  - `host_service.restart`
+  - `host_service.uninstall`
+- Produces CLI:
+  - `labby setup host-service unit`
+  - `labby setup host-service install -y`
+  - `labby setup host-service status`
+  - `labby setup host-service restart -y`
+  - `labby setup host-service uninstall -y`
+
+- [ ] **Step 1: Write host service unit tests**
+
+Create `crates/lab/src/dispatch/setup/host_service.rs` with this initial content:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::mcp::error::ToolError;
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceStatus {
+    pub installed: bool,
+    pub active: Option<bool>,
+    pub unit_path: PathBuf,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct HostServiceOutcome {
+    pub ok: bool,
+    pub changed: bool,
+    pub message: String,
+    pub unit_path: PathBuf,
+}
+
+pub(crate) fn unit_text(bin_path: &Path, working_dir: &Path) -> String {
+    format!(
+        r#"[Unit]
+Description=Labby host gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={} serve --host 0.0.0.0 --port 8765
+WorkingDirectory={}
+EnvironmentFile=-%h/.lab/.env
+Restart=always
+RestartSec=2
+KillSignal=SIGINT
+
+[Install]
+WantedBy=default.target
+"#,
+        bin_path.display(),
+        working_dir.display()
+    )
+}
+
+pub(crate) fn unit_dir(home: &Path) -> PathBuf {
+    home.join(".config/systemd/user")
+}
+
+pub(crate) fn unit_path(home: &Path) -> PathBuf {
+    unit_dir(home).join("labby.service")
+}
+
+pub(crate) fn current_home() -> Result<PathBuf, ToolError> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: "HOME is not set; cannot manage user systemd service".to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_uses_host_binary_and_lab_env() {
+        let unit = unit_text(
+            Path::new("/home/jmagar/.local/bin/labby"),
+            Path::new("/home/jmagar/workspace/lab"),
+        );
+
+        assert!(unit.contains("Description=Labby host gateway"));
+        assert!(unit.contains("ExecStart=/home/jmagar/.local/bin/labby serve --host 0.0.0.0 --port 8765"));
+        assert!(unit.contains("WorkingDirectory=/home/jmagar/workspace/lab"));
+        assert!(unit.contains("EnvironmentFile=-%h/.lab/.env"));
+        assert!(unit.contains("Restart=always"));
+    }
+
+    #[test]
+    fn unit_path_lives_under_user_systemd_dir() {
+        let home = Path::new("/home/example");
+
+        assert_eq!(
+            unit_path(home),
+            PathBuf::from("/home/example/.config/systemd/user/labby.service")
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify the new unit helper passes**
+
+Run:
+
+```bash
+cargo test -p labby host_service --all-features
+```
+
+Expected: PASS for the local helper tests.
+
+- [ ] **Step 3: Implement install/status/restart/uninstall helpers**
+
+Append these functions to `host_service.rs`:
+
+```rust
+pub(crate) fn install(confirm: bool) -> Result<HostServiceOutcome, ToolError> {
+    if !confirm {
+        return Err(ToolError::Sdk {
+            sdk_kind: "confirmation_required".to_string(),
+            message: "host_service.install requires confirm=true".to_string(),
+        });
+    }
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let bin = home.join(".local/bin/labby");
+    let cwd = std::env::current_dir().map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to resolve current directory: {err}"),
+    })?;
+    let text = unit_text(&bin, &cwd);
+    std::fs::create_dir_all(unit_dir(&home)).map_err(io_error)?;
+    let changed = std::fs::read_to_string(&path).ok().as_deref() != Some(text.as_str());
+    if changed {
+        std::fs::write(&path, text).map_err(io_error)?;
+    }
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", "--now", "labby.service"])?;
+    Ok(HostServiceOutcome {
+        ok: true,
+        changed,
+        message: "labby.service installed and running".to_string(),
+        unit_path: path,
+    })
+}
+
+pub(crate) fn status() -> Result<HostServiceStatus, ToolError> {
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let installed = path.is_file();
+    let active = if installed {
+        Some(run_systemctl_status(&["is-active", "--quiet", "labby.service"])?)
+    } else {
+        None
+    };
+    Ok(HostServiceStatus {
+        installed,
+        active,
+        unit_path: path,
+    })
+}
+
+pub(crate) fn restart(confirm: bool) -> Result<HostServiceOutcome, ToolError> {
+    if !confirm {
+        return Err(ToolError::Sdk {
+            sdk_kind: "confirmation_required".to_string(),
+            message: "host_service.restart requires confirm=true".to_string(),
+        });
+    }
+    run_systemctl(&["restart", "labby.service"])?;
+    let home = current_home()?;
+    Ok(HostServiceOutcome {
+        ok: true,
+        changed: true,
+        message: "labby.service restarted".to_string(),
+        unit_path: unit_path(&home),
+    })
+}
+
+pub(crate) fn uninstall(confirm: bool) -> Result<HostServiceOutcome, ToolError> {
+    if !confirm {
+        return Err(ToolError::Sdk {
+            sdk_kind: "confirmation_required".to_string(),
+            message: "host_service.uninstall requires confirm=true".to_string(),
+        });
+    }
+    let home = current_home()?;
+    let path = unit_path(&home);
+    let _ = run_systemctl(&["disable", "--now", "labby.service"]);
+    let changed = if path.exists() {
+        std::fs::remove_file(&path).map_err(io_error)?;
+        true
+    } else {
+        false
+    };
+    run_systemctl(&["daemon-reload"])?;
+    Ok(HostServiceOutcome {
+        ok: true,
+        changed,
+        message: "labby.service uninstalled".to_string(),
+        unit_path: path,
+    })
+}
+
+fn run_systemctl(args: &[&str]) -> Result<(), ToolError> {
+    let output = std::process::Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .output()
+        .map_err(io_error)?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(ToolError::Sdk {
+        sdk_kind: "systemctl_failed".to_string(),
+        message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    })
+}
+
+fn run_systemctl_status(args: &[&str]) -> Result<bool, ToolError> {
+    let status = std::process::Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .status()
+        .map_err(io_error)?;
+    Ok(status.success())
+}
+
+fn io_error(err: std::io::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: err.to_string(),
+    }
+}
+```
+
+- [ ] **Step 4: Add dispatch actions**
+
+In `crates/lab/src/dispatch/setup.rs`, add:
+
+```rust
+pub(crate) mod host_service;
+```
+
+In `crates/lab/src/dispatch/setup/catalog.rs`, add these `ActionSpec` entries:
+
+```rust
+ActionSpec {
+    name: "host_service.unit",
+    description: "Render the user systemd unit for the host Labby gateway",
+    destructive: false,
+    requires_admin: false,
+    returns: "string",
+    params: &[],
+},
+ActionSpec {
+    name: "host_service.install",
+    description: "Install and start the host user systemd service for labby serve",
+    destructive: true,
+    requires_admin: true,
+    returns: "HostServiceOutcome",
+    params: &[ParamSpec {
+        name: "confirm",
+        ty: "boolean",
+        required: true,
+        description: "Must be true to install and start the service",
+    }],
+},
+ActionSpec {
+    name: "host_service.status",
+    description: "Read the host user systemd service status for labby.service",
+    destructive: false,
+    requires_admin: false,
+    returns: "HostServiceStatus",
+    params: &[],
+},
+ActionSpec {
+    name: "host_service.restart",
+    description: "Restart the host user systemd service for labby serve",
+    destructive: true,
+    requires_admin: true,
+    returns: "HostServiceOutcome",
+    params: &[ParamSpec {
+        name: "confirm",
+        ty: "boolean",
+        required: true,
+        description: "Must be true to restart the service",
+    }],
+},
+ActionSpec {
+    name: "host_service.uninstall",
+    description: "Disable and remove the host user systemd service for labby serve",
+    destructive: true,
+    requires_admin: true,
+    returns: "HostServiceOutcome",
+    params: &[ParamSpec {
+        name: "confirm",
+        ty: "boolean",
+        required: true,
+        description: "Must be true to stop and remove the service",
+    }],
+},
+```
+
+In `crates/lab/src/dispatch/setup/dispatch.rs`, add match arms:
+
+```rust
+"host_service.unit" => {
+    let home = super::host_service::current_home()?;
+    let unit = super::host_service::unit_text(
+        &home.join(".local/bin/labby"),
+        &std::env::current_dir().map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to resolve current directory: {err}"),
+        })?,
+    );
+    to_json(unit)
+}
+"host_service.install" => {
+    to_json(super::host_service::install(parse_required_confirm(&params)?)?)
+}
+"host_service.status" => to_json(super::host_service::status()?),
+"host_service.restart" => {
+    to_json(super::host_service::restart(parse_required_confirm(&params)?)?)
+}
+"host_service.uninstall" => {
+    to_json(super::host_service::uninstall(parse_required_confirm(&params)?)?)
+}
+```
+
+Add this helper near the other parse helpers:
+
+```rust
+fn parse_required_confirm(params: &Value) -> Result<bool, ToolError> {
+    let value = params.get("confirm").ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "missing_param".to_string(),
+        message: "missing required param `confirm`".to_string(),
+    })?;
+    parse_required_bool(value, "confirm")
+}
+```
+
+- [ ] **Step 5: Add CLI subcommands**
+
+In `crates/lab/src/cli/setup.rs`, add:
+
+```rust
+#[derive(Debug, Args)]
+pub struct HostServiceArgs {
+    #[command(subcommand)]
+    pub command: HostServiceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HostServiceCommand {
+    /// Print the user systemd unit that Labby would install.
+    Unit,
+    /// Install and start labby.service under systemd --user.
+    Install {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+    /// Read labby.service status.
+    Status,
+    /// Restart labby.service.
+    Restart {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+    /// Stop, disable, and remove labby.service.
+    Uninstall {
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+}
+```
+
+Add the enum variant:
+
+```rust
+/// Manage the host user systemd Labby gateway service.
+HostService(HostServiceArgs),
+```
+
+Add this match arm in `run_command`:
+
+```rust
+SetupCommand::HostService(args) => {
+    run_host_service_command(args, format).await?;
+}
+```
+
+Add this function:
+
+```rust
+async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -> Result<()> {
+    let (action, params) = match args.command {
+        HostServiceCommand::Unit => ("host_service.unit", json!({})),
+        HostServiceCommand::Install { yes } => {
+            if !yes {
+                anyhow::bail!("setup host-service install is destructive; pass -y/--yes to confirm");
+            }
+            ("host_service.install", json!({ "confirm": true }))
+        }
+        HostServiceCommand::Status => ("host_service.status", json!({})),
+        HostServiceCommand::Restart { yes } => {
+            if !yes {
+                anyhow::bail!("setup host-service restart is destructive; pass -y/--yes to confirm");
+            }
+            ("host_service.restart", json!({ "confirm": true }))
+        }
+        HostServiceCommand::Uninstall { yes } => {
+            if !yes {
+                anyhow::bail!("setup host-service uninstall is destructive; pass -y/--yes to confirm");
+            }
+            ("host_service.uninstall", json!({ "confirm": true }))
+        }
+    };
+    let value = crate::dispatch::setup::dispatch(action, params).await?;
+    print(&value, format)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Add parser and catalog tests**
+
+Extend `crates/lab/src/cli/setup.rs` tests:
+
+```rust
+#[test]
+fn parses_host_service_subcommands() {
+    for command in ["unit", "install", "status", "restart", "uninstall"] {
+        let mut args = vec!["labby", "setup", "host-service", command];
+        if matches!(command, "install" | "restart" | "uninstall") {
+            args.push("-y");
+        }
+        let cli = crate::cli::Cli::try_parse_from(args).unwrap();
+        let crate::cli::Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+        assert!(matches!(args.command, Some(SetupCommand::HostService(_))));
+    }
+}
+```
+
+Extend `setup_catalog_covers_dispatch_actions` in `crates/lab/src/dispatch/setup/dispatch.rs`:
+
+```rust
+"host_service.unit",
+"host_service.install",
+"host_service.status",
+"host_service.restart",
+"host_service.uninstall",
+```
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p labby setup::host_service --all-features
+cargo test -p labby parses_host_service_subcommands --all-features
+cargo test -p labby setup_catalog_covers_dispatch_actions --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/lab/src/dispatch/setup.rs \
+  crates/lab/src/dispatch/setup/host_service.rs \
+  crates/lab/src/dispatch/setup/catalog.rs \
+  crates/lab/src/dispatch/setup/dispatch.rs \
+  crates/lab/src/cli/setup.rs
+git commit -m "feat: add host labby service setup"
+```
+
+---
+
+</details>
+
+### Task 3: Host-First Developer Recipes And Documentation
+
+**Files:**
+- Modify: `Justfile`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+- Create: `docs/runtime/HOST_GATEWAY.md`
+
+**Interfaces:**
+- Consumes: `labby setup host-service ...` from Task 2.
+- Produces: host-first recipes:
+  - `just host-sync`
+  - `just host-service-install`
+  - `just host-service-restart`
+  - `just host-service-status`
+  - `just dev-container`
+  - `just dev-container-debug`
+
+- [ ] **Step 1: Update Justfile recipes**
+
+Modify `Justfile` so the host service is the default development gateway path:
+the host recipes must copy a durable binary to `~/.local/bin/labby`, not symlink
+to `target/` or the current worktree.
+
+```make
+# Build release-fast binary when stale, update ~/.local/bin/labby, and restart
+# the host user service. This is the preferred Labby gateway workflow because
+# stdio MCP tools, SSH config, agent caches, and credentials live on the host.
+host-sync:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    repo="$(pwd)"
+    profile="{{local_release_profile}}"
+    if command -v mold >/dev/null 2>&1; then
+      export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
+    fi
+    LAB_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+    case "$LAB_TARGET_DIR" in
+      /*) LABBY_BIN="$LAB_TARGET_DIR/$profile/labby" ;;
+      *)  LABBY_BIN="$repo/$LAB_TARGET_DIR/$profile/labby" ;;
+    esac
+    CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
+    mkdir -p ~/.local/bin
+    if [ -x ~/.local/bin/labby ]; then
+      cp -f ~/.local/bin/labby ~/.local/bin/labby.prev
+    fi
+    install -D -m 755 "$LABBY_BIN" ~/.local/bin/labby.new
+    mv ~/.local/bin/labby.new ~/.local/bin/labby
+    if systemctl --user is-enabled --quiet labby.service; then
+      systemctl --user restart labby.service
+      ~/.local/bin/labby setup host-service status --json
+      curl -fsS http://127.0.0.1:8765/ready >/dev/null
+    else
+      echo "labby.service is not installed; run: just host-service-install"
+    fi
+
+host-service-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just host-sync
+    ~/.local/bin/labby setup host-service install -y
+
+host-service-restart:
+    ~/.local/bin/labby setup host-service restart -y
+    curl -fsS http://127.0.0.1:8765/ready >/dev/null
+
+host-service-status:
+    ~/.local/bin/labby setup host-service status --json
+
+# Explicit container compatibility path. Prefer host-sync for normal gateway
+# development; this remains useful for prod-like image smoke and Docker-specific
+# ACP adapter changes.
+dev-container: web-build build-release
+    docker compose -f docker-compose.yml restart
+
+dev-container-debug:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nightly_rustc=$(rustup which --toolchain nightly rustc)
+    RUSTC="$nightly_rustc" RUSTC_WRAPPER="" RUSTFLAGS="-C link-arg=-fuse-ld=mold -Z codegen-backend=cranelift" \
+        cargo build -p labby --all-features
+    install -D -m 755 target/debug/labby bin/labby
+    docker compose -f docker-compose.yml restart
+```
+
+Keep `sync-container` and `container-sync` intact for now, but update comments so they are not described as the normal path.
+
+- [ ] **Step 2: Update README command table**
+
+In `README.md`, replace the dev command rows with:
+
+```markdown
+just host-service-install # install/start labby.service under systemd --user
+just host-sync            # release-fast rebuild + install ~/.local/bin/labby + restart host service
+just host-service-status  # inspect the host Labby gateway service
+just dev-container        # explicit Docker compatibility/prod-like smoke path
+just dev-container-debug  # explicit Docker debug binary path
+```
+
+Add this paragraph before the Dev Container section:
+
+```markdown
+### Host Gateway Runtime
+
+The default local and dookie gateway runtime is the host user service:
+`~/.local/bin/labby serve` managed by `systemd --user` as `labby.service`.
+This keeps stdio MCP tools, SSH config, local binaries, agent caches, and
+credentials in the same namespace as the gateway. Use `just host-service-install`
+once, then `just host-sync` for ordinary Rust changes. Docker remains available
+for prod-like image smoke and adapter-container work, but it is no longer the
+preferred agent gateway runtime.
+```
+
+- [ ] **Step 3: Update CLAUDE.md runtime guidance**
+
+In `CLAUDE.md`, replace the Docker-first development paragraph with:
+
+```markdown
+### Host Labby gateway
+
+The normal local/dookie Labby gateway should run on the host as
+`systemd --user` service `labby.service`, executing `~/.local/bin/labby serve`.
+This is preferred over the Docker dev container because the gateway launches
+stdio MCP tools and depends on host SSH config, agent credentials, local
+binaries, and user caches. Use `just host-service-install` once, then
+`just host-sync` after Rust changes.
+
+The Docker Compose stack is still supported for prod-like image smoke and
+Docker-specific ACP adapter work. Use `just dev-container` or
+`just dev-container-debug` explicitly when testing that path.
+```
+
+- [ ] **Step 4: Create host gateway runbook**
+
+Create `docs/runtime/HOST_GATEWAY.md`:
+
+```markdown
+# Host Labby Gateway
+
+The preferred Labby gateway runtime is a host user service:
+
+```bash
+~/.local/bin/labby serve
+```
+
+It runs as `labby.service` under `systemd --user`. Bind host, port, auth, and
+upstream gateway configuration continue to come from `~/.lab/.env` and Labby
+config. Do not bake public bind settings into the systemd unit.
+
+## Install
+
+```bash
+just host-service-install
+systemctl --user --no-pager --full status labby.service
+```
+
+## Migrate From The Docker Dev Container
+
+Stop the container before starting the host service because both runtimes bind
+port `8765`:
+
+```bash
+docker compose -f docker-compose.yml stop labby-master
+just host-service-install
+curl -fsS http://127.0.0.1:8765/ready
+labby gateway list
+```
+
+## Update The Running Host Gateway
+
+```bash
+just host-sync
+curl -fsS http://127.0.0.1:8765/ready
+labby gateway code exec --json --code 'async () => 1'
+```
+
+## Verify The Public MCP Route
+
+```bash
+TOKEN=$(awk -F= '/^LAB_MCP_HTTP_TOKEN=/{print $2}' ~/.lab/.env)
+curl -fsS -H "Authorization: Bearer $TOKEN" https://lab.tootie.tv/mcp
+```
+
+Then verify from Codex by calling the Labby Code Mode MCP tool through the
+public MCP route with:
+
+```javascript
+async () => 1
+```
+
+Expected result:
+
+```json
+{"result":1}
+```
+
+Also prove the public route is backed by the host service:
+
+```bash
+pid=$(systemctl --user show labby.service --property=MainPID --value)
+readlink "/proc/$pid/exe"
+docker inspect -f '{{.State.Running}}' labby-master 2>/dev/null || true
+```
+
+Expected: `/proc/$pid/exe` points at `/home/jmagar/.local/bin/labby`, and the
+Docker container is not the process answering the public route.
+
+## Roll Back To Docker
+
+```bash
+systemctl --user disable --now labby.service
+docker compose -f docker-compose.yml up -d labby-master --no-deps
+curl -fsS http://127.0.0.1:8765/ready
+```
+
+## Known Failure Mode: Deleted Executable
+
+If Code Mode reports `failed to spawn Code Mode runner` after replacing a
+running binary, check:
+
+```bash
+pid=$(pgrep -u "$USER" -f 'labby serve' | head -n1)
+readlink "/proc/$pid/exe"
+```
+
+If the path ends in `(deleted)`, restart the service:
+
+```bash
+systemctl --user restart labby.service
+```
+```
+
+- [ ] **Step 5: Run docs and recipe smoke**
+
+Run:
+
+```bash
+just --list | grep -E 'host-sync|host-service|dev-container'
+```
+
+Expected: all new recipes are listed.
+
+Run:
+
+```bash
+cargo test -p labby parses_host_service_subcommands --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Justfile README.md CLAUDE.md docs/runtime/HOST_GATEWAY.md
+git commit -m "docs: make host labby gateway the default"
+```
+
+---
+
+### Task 4: Live Migration And End-To-End Verification
+
+**Files:**
+- No source files required.
+- Uses: `~/.local/bin/labby`
+- Uses: `~/.lab/.env`
+- Uses: `~/.config/systemd/user/labby.service`
+- Uses: Codex config entry for `mcp_servers.labby.url = "https://lab.tootie.tv/mcp"`
+
+**Interfaces:**
+- Consumes: `just host-service-install`, `just host-sync`
+- Produces: live host service running Labby on port `8765`
+- Produces: verified Labby MCP Code Mode call through the public MCP route
+
+- [ ] **Step 1: Capture rollback and port preflight state**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml ps labby-master
+ss -ltnp 'sport = :8765' || true
+curl -fsS http://127.0.0.1:8765/ready || true
+```
+
+Expected: you know which process currently owns `8765`, and the container path
+can still be restored if the host install fails.
+
+- [ ] **Step 2: Stop the container runtime**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml stop labby-master
+```
+
+Expected: container stops and frees host port `8765`.
+
+- [ ] **Step 3: Install and start the host service**
+
+Run:
+
+```bash
+just host-service-install
+```
+
+Expected: `labby.service` installs, starts, and reports a passing local
+readiness check.
+
+- [ ] **Step 4: Verify local readiness**
+
+Run:
+
+```bash
+curl -fsS http://127.0.0.1:8765/ready
+```
+
+Expected: HTTP 200 readiness response.
+
+- [ ] **Step 5: Verify the running executable is the durable host binary**
+
+Run:
+
+```bash
+pid=$(systemctl --user show labby.service --property=MainPID --value)
+readlink "/proc/$pid/exe"
+```
+
+Expected: path is `/home/jmagar/.local/bin/labby` and does not end with
+` (deleted)`.
+
+- [ ] **Step 6: Verify Code Mode locally**
+
+Run:
+
+```bash
+labby gateway code exec --json --code 'async () => 1'
+```
+
+Expected:
+
+```json
+{"result":1,"calls":[],"logs":[]}
+```
+
+- [ ] **Step 7: Verify Synapse through Labby locally**
+
+Run:
+
+```bash
+labby gateway code exec --json --code 'async () => {
+  const result = await callTool("synapse::scout", { action: "nodes" });
+  return { count: result.hosts.length, names: result.hosts.map(h => h.name).sort() };
+}'
+```
+
+Expected: `count` is at least `1` and `names` includes `dookie`.
+
+- [ ] **Step 8: Verify the public MCP route**
+
+Use mcporter or an equivalent MCP client to initialize and call Code Mode
+through `https://lab.tootie.tv/mcp` with the bearer token from `~/.lab/.env`.
+Do not treat public `/health` as sufficient proof.
+
+Expected: MCP initialize succeeds, then the Code Mode call returns
+`{"result":1}`.
+
+- [ ] **Step 9: Verify Codex MCP tool path**
+
+From Codex, call the Labby MCP Code Mode tool with:
+
+```javascript
+async () => 1
+```
+
+Expected: the MCP result succeeds with `{"result":1}` instead of `failed to spawn Code Mode runner`.
+
+- [ ] **Step 10: Prove the public route is backed by the host service**
+
+Run:
+
+```bash
+pid=$(systemctl --user show labby.service --property=MainPID --value)
+readlink "/proc/$pid/exe"
+docker inspect -f '{{.State.Running}}' labby-master 2>/dev/null || true
+```
+
+Expected: the running Labby process is `/home/jmagar/.local/bin/labby`; the
+container is stopped or otherwise not serving the public MCP request.
+
+- [ ] **Step 11: Validate rollback path**
+
+Run the rollback commands from `docs/runtime/HOST_GATEWAY.md` in a controlled
+window, confirm Docker can answer `/ready`, then switch back to the host
+service. This proves the migration remains reversible before relying on it.
+
+- [ ] **Step 12: Run full verification**
+
+Run:
+
+```bash
+cargo check --workspace --all-features
+cargo nextest run --workspace --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit any final docs corrections**
+
+If live migration reveals a command or path correction, update `docs/runtime/HOST_GATEWAY.md` and commit:
+
+```bash
+git add docs/runtime/HOST_GATEWAY.md
+git commit -m "docs: record host gateway migration verification"
+```
+
+---
+
+## Engineering Review Coverage
+
+| Review finding | Plan response |
+|---|---|
+| Host service lifecycle was remotely reachable through setup dispatch | Task 2 is now CLI-only; setup catalog/dispatch/API/MCP exposure is explicitly forbidden and tested. |
+| New dispatch snippets imported MCP-layer `ToolError` | Task 1 and Task 2 now require `crate::dispatch::error::ToolError`. |
+| Code Mode fallback could spawn a stale or incompatible `labby` | Task 1 removed automatic fallback; only an explicit validated `LAB_CODE_MODE_RUNNER_EXE` override is allowed. |
+| Systemd unit hard-coded public host/port and mutable cwd | Task 2 unit uses `%h/.local/bin/labby serve`, `%h` working directory, and config/env-owned bind settings. |
+| `systemctl` calls could block async dispatch | Task 2 removes remote dispatch and requires async/timeout-wrapped process execution for CLI helpers. |
+| Service status was too lossy | Task 2 requires `LoadState`, `ActiveState`, `SubState`, `MainPID`, `ExecMainStatus`, process exe, readiness, and Docker state. |
+| Unit writes and path rendering were unsafe | Task 2 uses a fixed `%h` unit template and atomic writes, with optional `systemd-analyze --user verify`. |
+| `host-sync` could leave a deleted parent executable after failed restart | Task 3 copies a durable binary, keeps a previous binary, and makes restart/readiness visible. |
+| Public verification could pass while MCP was broken or still routed to Docker | Task 4 verifies MCP initialize/call through `https://lab.tootie.tv/mcp` and checks the host service process. |
+| Port conflicts and restart loops were under-specified | Task 2 and Task 4 add port-holder preflight, readiness polling, and systemd start-limit settings. |
+
+### Failure Modes To Prove
+
+| New path | Failure | Required rescue | User sees | Logged/returned |
+|---|---|---|---|---|
+| Code Mode runner resolver | Parent executable is deleted after `host-sync` but service restart failed | Restart `labby.service`; optional explicit override only after validation | Clear restart guidance instead of hang | Error includes stale path and `LAB_CODE_MODE_RUNNER_EXE` hint |
+| Host service install | Port `8765` is still owned by Docker or manual Labby | Stop owner or roll back to Docker | Install fails before restart loop | Port owner and systemctl/journal diagnostics |
+| Host service restart | Unit starts but `/ready` never passes | Restore previous binary or rollback to Docker | Restart command returns failure | Last readiness error plus service status |
+| Public MCP route | SWAG still targets container or stale backend | Fix proxy/backend, then retry MCP initialize | Public MCP call fails despite local ready | MCP client error plus host/container process check |
+| Uninstall/rollback | `systemctl --user disable --now` fails | Leave unit file intact and report failure | Rollback stops before deleting unit | Full `systemctl` stdout/stderr/status |
+
+### Not In Scope
+
+- Systemd sandboxing options such as `NoNewPrivileges` and `ProtectSystem`; add after compatibility testing.
+- Socket activation or `Type=notify` as the default. `Type=simple` remains acceptable unless the `systemd` feature becomes part of the normal build.
+- UI controls for host service status.
+- New remote scopes more granular than `lab:admin`; this plan avoids the remote lifecycle surface entirely.
+- Automatic runner fallback with protocol negotiation. The safer initial behavior is an explicit restart-needed error.
+
+---
+
+## Self-Review
+
+**Spec coverage:** The plan covers the observed MCP failure, host-first gateway setup, Docker demotion, operator migration, and end-to-end verification through both local CLI and Codex MCP paths.
+
+**Placeholder scan:** No placeholder markers or open-ended edge-case instructions remain.
+
+**Type consistency:** `HostServiceOutcome`, `HostServiceStatus`, `resolve_runner_exe`, and `resolve_runner_exe_from` are introduced before later tasks consume them. Host service lifecycle commands are CLI-only and intentionally do not have dispatch action names.


### PR DESCRIPTION
## Summary
- add a Code Mode runner executable resolver that rejects deleted/stale parent executables unless LAB_CODE_MODE_RUNNER_EXE is explicitly set and validated
- add CLI-only host systemd user-service management for labby.service, with tests proving it is not exposed through setup dispatch/catalog
- make host service workflows the default in Justfile/docs while preserving Docker as an explicit compatibility path

## Verification
- cargo fmt --all --check
- git diff --check
- just --list | grep -E 'host-sync|host-service|dev-container'\n- cargo test -p labby runner_exe --all-features\n- cargo test -p labby host_service --all-features\n- cargo test -p labby parses_host_service_subcommands --all-features\n- cargo test -p labby setup_catalog_does_not_expose_host_service_actions --all-features\n- cargo check --workspace --all-features\n- worker-reported: cargo nextest run --workspace --all-features (2192 passed, 14 skipped)\n\n## Notes\n- Live migration was not exercised in this commit because it mutates the active host/container gateway state. The runbook documents the controlled migration and rollback checks.\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Labby gateway as a host `systemd --user` service by default with CLI-only lifecycle management. Tightens safety checks (including UID/ownership) and makes upgrades safer; Docker is now an explicit compatibility path.

- **New Features**
  - `labby setup host-service {unit|install|status|restart|uninstall}` (CLI-only; not exposed via setup dispatch or MCP/API).
  - Safe `labby.service` unit running `~/.local/bin/labby serve` with `~/.lab/.env`, restart limits, and no hard-coded bind settings.
  - Hardened checks: detect port conflicts and active `labby-master` container; after install/restart, poll `http://127.0.0.1:8765/ready` and verify the responder PID and ownership match the service.
  - `status --json`: install state, load/active/sub states, PID, `ExecMainStatus`, unit path, process exe, and local readiness.
  - Code Mode runner resolver: validates UID/ownership, rejects stale/deleted parents, honors `LAB_CODE_MODE_RUNNER_EXE`, and includes the attempted path on spawn errors. 
  - Justfile: `host-service-install`, `host-sync`, `host-service-status`; `link-bin` blocks if the service is active and preserves `~/.local/bin/labby.prev`. Docker paths moved to `dev-container`/`dev-container-debug`.
  - Docs: new `docs/runtime/HOST_GATEWAY.md`, updated `README.md` and CLI help; added session log.
  - Windows: host-service code gated to Unix; no `systemd` path on Windows. CI/Release: clear ambient wrappers and set `CARGO_BUILD_RUSTC_WRAPPER=""` for all jobs.

- **Migration**
  - Run `just host-service-install` once, then `just host-sync` for updates.
  - Stop the Docker dev container before installing the host service to avoid port 8765 conflicts; use `just dev-container` or `just dev-container-debug` only when needed.
  - If Code Mode fails after a binary swap and `/proc/<pid>/exe` ends with “(deleted)”, restart with `labby setup host-service restart -y`.

<sup>Written for commit 3fde0c5dceb5688794a7ba683d9d1c7b4c76e184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new host-based local gateway workflow for faster day-to-day development.
  * Introduced simpler commands to install, sync, and check the running service.

* **Bug Fixes**
  * Improved startup reliability by handling stale or missing runner executables more safely.
  * Error messages now include more useful path details when a run fails.

* **Documentation**
  * Updated development guidance and added a new runtime guide for the host service setup, migration, and rollback steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->