### PR TITLE
Add Incus gateway provisioning

### DIFF
--- a/.github/workflows/sync-marketplace-no-mcp.yml
+++ b/.github/workflows/sync-marketplace-no-mcp.yml
@@ -66,16 +66,20 @@ jobs:
           echo "ahead_count=$ahead_count" >> "$GITHUB_OUTPUT"
           if [ "$ahead_count" = "0" ]; then
             echo "marketplace-no-mcp already up to date"
-            echo "committed=$committed" >> "$GITHUB_OUTPUT"
-            echo "pushed=$pushed" >> "$GITHUB_OUTPUT"
-            echo "new_no_mcp_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            {
+              echo "committed=$committed"
+              echo "pushed=$pushed"
+              echo "new_no_mcp_sha=$(git rev-parse HEAD)"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git push origin HEAD:marketplace-no-mcp
           pushed=true
-          echo "committed=$committed" >> "$GITHUB_OUTPUT"
-          echo "pushed=$pushed" >> "$GITHUB_OUTPUT"
-          echo "new_no_mcp_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          {
+            echo "committed=$committed"
+            echo "pushed=$pushed"
+            echo "new_no_mcp_sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify pushed no-MCP drift
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,22 +329,25 @@ Default verification targets the all-features build. If you run a reduced featur
 - **`labby doctor`** — comprehensive health audit: checks env vars, reachability, auth, version for every enabled service. Emits human-readable table by default, `--json` for CI. Exit code reflects worst severity.
 - **`bin/health-check`** — repo-level shell helper for CI/CD smoke tests.
 
-### Host Labby gateway
+### Labby gateway runtime
 
-The normal local/dookie Labby gateway should run on the host as
-`systemd --user` service `labby.service`, executing `~/.local/bin/labby serve`.
-This is preferred over the Docker dev container because the gateway launches
-stdio MCP tools and depends on host SSH config, agent credentials, local
-binaries, and user caches. The canonical service lifecycle is
-`labby setup host-service install --install-self -y`,
-`labby setup host-service restart --install-self -y`, and
-`labby setup host-service status --json`. In this checkout, `just host-sync`
-is only the developer shortcut that rebuilds from source before calling the
-CLI lifecycle.
+The primary supported self-hosted Labby gateway runtime is an amd64 Debian 13
+Incus system container. The host-side entrypoint is
+`scripts/incus-bootstrap.sh --version vX.Y.Z`; the in-box converger is
+`labby setup --provision`. The provision command is intentionally local
+CLI-only and must not be exposed through MCP, HTTP, Code Mode, or remote admin
+actions.
 
-The Docker Compose stack is still supported for prod-like image smoke and
-Docker-specific ACP adapter work. Use `just dev-container` or
-`just dev-container-debug` explicitly when testing that path.
+The default service is a hardened system unit at
+`/etc/systemd/system/labby.service`, running `User=lab`, `Group=lab`, and
+`ExecStart=/usr/local/bin/labby serve`. Do not reintroduce `systemd --user`,
+linger, `%h` unit paths, or `~/.local/bin/labby` as the supported self-hosted
+gateway service model. Preserve a user-service fallback only if it is explicit
+and clearly non-default.
+
+The Docker Compose stack is still supported only for explicit dev-container,
+prod-like image smoke, and Docker-specific ACP adapter work. Use
+`just dev-container` or `just dev-container-debug` when testing that path.
 
 ### Bearer auth in dev (driving the UI with agent-browser)
 

--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ lint: skill-drift test-cargo-wrapper
 
 # Check hand-authored skills for known stale or unsafe patterns
 skill-drift:
-    plugins/scripts/check-dozzle-skill
+    LAB_ALLOW_MISSING_DOZZLE=1 plugins/scripts/check-dozzle-skill
 
 # License and vulnerability audit
 deny:
@@ -59,7 +59,7 @@ build-release:
 link-bin profile="release":
     #!/usr/bin/env bash
     set -euo pipefail
-    if systemctl --user is-active --quiet labby.service 2>/dev/null; then
+    if systemctl is-active --quiet labby.service 2>/dev/null; then
       echo "error: labby.service is active; use 'just host-sync' so the service restarts onto the new binary" >&2
       exit 1
     fi
@@ -87,9 +87,9 @@ _install-labby-bin profile:
     mv ~/.local/bin/labby.new ~/.local/bin/labby
     echo "labby → $LABBY_BIN"
 
-# Build release-fast binary, copy it to the durable host path, and restart the
-# host user service. This is the preferred Labby gateway workflow because stdio
-# MCP tools, SSH config, agent caches, and credentials live on the host.
+# Build release-fast binary, copy it to the system service path, and restart the
+# system Labby gateway service. The primary self-hosted runtime is the Incus
+# system-container path; this source checkout shortcut assumes sudo access.
 host-sync:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -98,10 +98,11 @@ host-sync:
       export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
     fi
     CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
-    just _install-labby-bin "$profile"
-    if systemctl --user is-active --quiet labby.service; then
-      ~/.local/bin/labby setup host-service restart -y
-      ~/.local/bin/labby setup host-service status --json
+    LABBY_BIN="target/$profile/labby"
+    sudo install -D -m 755 "$LABBY_BIN" /usr/local/bin/labby
+    if systemctl is-active --quiet labby.service; then
+      sudo /usr/local/bin/labby setup host-service restart -y
+      sudo /usr/local/bin/labby setup host-service status --json
     else
       echo "error: labby.service is not active; run: just host-service-install" >&2
       exit 1
@@ -115,15 +116,20 @@ host-service-install:
       export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-fuse-ld=mold"
     fi
     CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-16}" cargo build --workspace --all-features --profile "$profile" --bin labby
-    just _install-labby-bin "$profile"
-    ~/.local/bin/labby setup host-service install -y
+    LAB_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+    case "$LAB_TARGET_DIR" in
+      /*) LABBY_BIN="$LAB_TARGET_DIR/$profile/labby" ;;
+      *)  LABBY_BIN="$(pwd)/$LAB_TARGET_DIR/$profile/labby" ;;
+    esac
+    sudo install -D -m 755 "$LABBY_BIN" /usr/local/bin/labby
+    sudo /usr/local/bin/labby setup host-service install -y
 
 host-service-restart:
-    ~/.local/bin/labby setup host-service restart -y
-    ~/.local/bin/labby setup host-service status --json
+    sudo /usr/local/bin/labby setup host-service restart -y
+    sudo /usr/local/bin/labby setup host-service status --json
 
 host-service-status:
-    ~/.local/bin/labby setup host-service status --json
+    sudo /usr/local/bin/labby setup host-service status --json
 
 # Explicit container compatibility path. Prefer host-sync for normal gateway
 # development; this remains useful for prod-like image smoke and Docker-specific

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ Open `http://127.0.0.1:8765/setup` or `http://127.0.0.1:8765/`.
 Build static Labby assets with `just web-build` first when running from a source
 checkout.
 
+### Self-Host The Gateway
+
+The supported self-hosted gateway substrate is an amd64 Debian 13 Incus system
+container. Docker is retained for explicit development/image smoke, but it is
+not the primary production boundary for Labby because stdio MCP servers and
+agent CLIs are installed and launched at runtime.
+
+```bash
+scripts/incus-bootstrap.sh --version vX.Y.Z
+incus exec labby -- systemctl status labby --no-pager
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready
+```
+
+See [docs/runtime/HOST_GATEWAY.md](./docs/runtime/HOST_GATEWAY.md) for the
+Incus runbook, `/dev/net/tun` Tailscale passthrough, manual `claude`/`codex`/
+`gemini` login checklist, and rollback commands.
+
 ## Core Workflows
 
 ### Start Labby

--- a/crates/labby-gateway/src/gateway/manager/tests/views.rs
+++ b/crates/labby-gateway/src/gateway/manager/tests/views.rs
@@ -224,6 +224,29 @@ async fn runtime_view_includes_last_upstream_error() {
         runtime.last_error.as_deref(),
         Some("stdio handshake failed")
     );
+    assert!(runtime.dependency_hint.is_none());
+}
+
+#[tokio::test]
+async fn runtime_view_includes_dependency_hint_for_missing_leaf_dependency() {
+    let pool = UpstreamPool::new();
+    let now = std::time::Instant::now();
+    let mut entry = fixture_upstream_entry("broken-upstream", HashMap::new());
+    entry.tool_health = UpstreamHealth::Unhealthy {
+        consecutive_failures: 1,
+    };
+    entry.tool_unhealthy_since = Some(now);
+    entry.tool_last_error = Some("ffmpeg: command not found".to_string());
+
+    pool.insert_entry_for_tests("broken-upstream", entry).await;
+
+    let runtime = runtime_view(Some(&pool), "broken-upstream", None).await;
+    let hint = runtime.dependency_hint.expect("dependency hint");
+    assert_eq!(hint.package_hint.as_deref(), Some("ffmpeg"));
+    assert_eq!(
+        hint.install_command.as_deref(),
+        Some("sudo apt install ffmpeg")
+    );
 }
 
 #[tokio::test]
@@ -352,5 +375,29 @@ async fn errored_upstream_reports_disconnected_even_when_circuit_closed() {
     assert_eq!(
         view.warnings.first().map(|warning| warning.code.as_str()),
         Some("auth_failed")
+    );
+}
+
+#[tokio::test]
+async fn errored_upstream_reports_disconnected_even_with_stale_exposed_counts() {
+    let pool = UpstreamPool::new();
+    let mut entry = healthy_entry_with_tool("broken-upstream", "transcode");
+    entry.tool_health = UpstreamHealth::Unhealthy {
+        consecutive_failures: 1,
+    };
+    entry.tool_last_error = Some("ffmpeg: command not found".to_string());
+    pool.insert_entry_for_tests("broken-upstream", entry).await;
+
+    let upstream = fixture_http_upstream("broken-upstream");
+    let view = server_view_from_upstream(Some(&pool), &upstream).await;
+    assert!(
+        !view.connected,
+        "stale exposed counts must not hide current upstream errors"
+    );
+    assert!(!view.surfaces.mcp.connected);
+    assert_eq!(view.exposed_tool_count, 1);
+    assert_eq!(
+        view.warnings.first().map(|warning| warning.code.as_str()),
+        Some("missing_leaf_dependency")
     );
 }

--- a/crates/labby-gateway/src/gateway/projection.rs
+++ b/crates/labby-gateway/src/gateway/projection.rs
@@ -5,7 +5,8 @@ use regex::Regex;
 
 use crate::gateway::service_registry::GatewayServiceRegistry;
 use crate::gateway::types::{
-    GatewayConfigView, GatewayRuntimeView, ServiceConfigFieldView, ServiceConfigView,
+    DependencyHintView, GatewayConfigView, GatewayRuntimeView, ServiceConfigFieldView,
+    ServiceConfigView,
 };
 use crate::gateway::view_models::{
     ServerConfigSummaryView, ServerView, SurfaceStateView, SurfaceStatesView,
@@ -24,6 +25,8 @@ pub(crate) struct ServiceHealth {
 }
 
 const WARNING_UNKNOWN_SERVICE: &str = "unknown_service";
+const DIAGNOSTIC_TAIL_MAX_LINES: usize = 12;
+const DIAGNOSTIC_TAIL_MAX_BYTES: usize = 2048;
 
 pub(super) fn config_view(
     upstream: &UpstreamConfig,
@@ -202,6 +205,9 @@ pub(super) fn operator_visible_upstream_error(message: Option<String>) -> Option
 }
 
 pub(super) fn upstream_warning_code(message: &str) -> &'static str {
+    if dependency_hint_from_error(message).is_some() {
+        return "dependency_missing";
+    }
     let lower = message.to_ascii_lowercase();
     if lower.contains("auth required")
         || lower.contains("unauthorized")
@@ -227,6 +233,95 @@ pub(super) fn upstream_warning_code(message: &str) -> &'static str {
     }
 }
 
+pub(super) fn dependency_hint_from_error(message: &str) -> Option<DependencyHintView> {
+    let lower = message.to_ascii_lowercase();
+    let (code, package_hint, install_command) = if lower.contains("ffmpeg: command not found")
+        || lower.contains("ffmpeg.exe: command not found")
+        || (lower.contains("no such file or directory") && lower.contains("ffmpeg"))
+        || (lower.contains("enoent") && lower.contains("ffmpeg"))
+    {
+        (
+            "missing_leaf_dependency",
+            Some("ffmpeg"),
+            Some("sudo apt install ffmpeg"),
+        )
+    } else if lower.contains("failed to run `uvx`")
+        || lower.contains("failed to spawn `uvx`")
+        || (lower.contains("enoent") && lower.contains("uvx"))
+    {
+        (
+            "missing_runtime_floor",
+            Some("uv"),
+            Some("labby setup --provision --yes"),
+        )
+    } else if lower.contains("failed to run `npx`")
+        || lower.contains("failed to spawn `npx`")
+        || (lower.contains("enoent") && lower.contains("npx"))
+    {
+        (
+            "missing_runtime_floor",
+            Some("nodejs"),
+            Some("labby setup --provision --yes"),
+        )
+    } else if lower.contains("failed to run `python`")
+        || lower.contains("failed to spawn `python`")
+        || (lower.contains("enoent") && lower.contains("python"))
+    {
+        (
+            "missing_runtime_floor",
+            Some("python"),
+            Some("labby setup --provision --yes"),
+        )
+    } else {
+        return None;
+    };
+
+    let (redacted_tail, truncated) = redacted_diagnostic_tail(message);
+    Some(DependencyHintView {
+        code: code.to_string(),
+        package_hint: package_hint.map(str::to_string),
+        install_command: install_command.map(str::to_string),
+        redacted_tail,
+        truncated,
+    })
+}
+
+fn redacted_diagnostic_tail(message: &str) -> (String, bool) {
+    let mut truncated = false;
+    let lines = message.lines().collect::<Vec<_>>();
+    let selected = if lines.len() > DIAGNOSTIC_TAIL_MAX_LINES {
+        truncated = true;
+        &lines[lines.len() - DIAGNOSTIC_TAIL_MAX_LINES..]
+    } else {
+        &lines[..]
+    };
+    let joined = selected.join("\n");
+    let capped = if joined.len() > DIAGNOSTIC_TAIL_MAX_BYTES {
+        truncated = true;
+        let mut start = joined.len() - DIAGNOSTIC_TAIL_MAX_BYTES;
+        while start < joined.len() && !joined.is_char_boundary(start) {
+            start += 1;
+        }
+        format!("…[truncated]\n{}", &joined[start..])
+    } else {
+        joined
+    };
+    let redacted = redact_secret_like_segments(&redact_stdio_value(&capped))
+        .lines()
+        .map(|line| {
+            if let Some((prefix, _)) = line.split_once("Authorization: Bearer ") {
+                format!("{prefix}Authorization: Bearer [redacted]")
+            } else if line.contains("TS_AUTHKEY=") {
+                "TS_AUTHKEY=[redacted]".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (redacted, truncated)
+}
+
 pub(super) async fn upstream_summary(
     pool: Option<&UpstreamPool>,
     upstream_name: &str,
@@ -249,22 +344,22 @@ pub(super) async fn server_view_from_upstream(
         Some(pool) => pool.upstream_last_error(&upstream.name).await,
         None => None,
     });
+    let dependency_hint = last_error.as_deref().and_then(dependency_hint_from_error);
     let health = match pool {
         Some(pool) => pool.upstream_tool_health(&upstream.name).await,
         None => None,
     };
     // Health-aware connectivity (mirrors `server_view_from_virtual_server`): an
-    // upstream counts as connected when it is actively exposing capabilities OR
-    // it is healthy with no recorded error. The health term keeps lazily
+    // upstream counts as connected when it has no recorded error and is either
+    // actively exposing capabilities or healthy. The health term keeps lazily
     // discovered upstreams — whose catalog stays empty until their first use —
-    // from rendering as "Disconnected" at rest, while upstreams with a recorded
-    // error or an open circuit breaker still surface as down.
+    // from rendering as "Disconnected" at rest, while upstreams with stale
+    // exposed counts plus a current error still surface as down.
     let exposing_capabilities = summary.exposed_tool_count > 0
         || summary.exposed_resource_count > 0
         || summary.exposed_prompt_count > 0;
-    let health_ok =
-        last_error.is_none() && health.map(|health| health.is_routable()).unwrap_or(false);
-    let connected = exposing_capabilities || health_ok;
+    let health_ok = health.map(|health| health.is_routable()).unwrap_or(false);
+    let connected = last_error.is_none() && (exposing_capabilities || health_ok);
     let enabled = upstream.enabled;
     let pid = match pool {
         Some(pool) => pool
@@ -295,15 +390,25 @@ pub(super) async fn server_view_from_upstream(
             },
             ..SurfaceStatesView::default()
         },
-        warnings: last_error
-            .as_ref()
-            .map(|message| {
+        warnings: match (&last_error, &dependency_hint) {
+            (Some(message), Some(hint)) => {
+                vec![super::view_models::ServerWarningView {
+                    code: hint.code.clone(),
+                    message: hint
+                        .install_command
+                        .as_ref()
+                        .map(|cmd| format!("missing dependency; suggested fix: {cmd}"))
+                        .unwrap_or_else(|| message.clone()),
+                }]
+            }
+            (Some(message), None) => {
                 vec![super::view_models::ServerWarningView {
                     code: upstream_warning_code(message).to_string(),
                     message: message.clone(),
                 }]
-            })
-            .unwrap_or_default(),
+            }
+            _ => Vec::new(),
+        },
         config_summary: ServerConfigSummaryView {
             transport: Some(if upstream.command.is_some() {
                 "stdio".to_string()
@@ -485,6 +590,9 @@ pub(super) async fn runtime_view(
         None => summary.exposed_prompt_count,
     };
 
+    let last_error = operator_visible_upstream_error(pool.upstream_last_error(name).await);
+    let dependency_hint = last_error.as_deref().and_then(dependency_hint_from_error);
+
     GatewayRuntimeView {
         name: name.to_string(),
         tool_count: summary.discovered_tool_count,
@@ -493,7 +601,8 @@ pub(super) async fn runtime_view(
         exposed_tool_count: summary.exposed_tool_count,
         exposed_resource_count: summary.exposed_resource_count,
         exposed_prompt_count: summary.exposed_prompt_count,
-        last_error: operator_visible_upstream_error(pool.upstream_last_error(name).await),
+        last_error,
+        dependency_hint,
     }
 }
 
@@ -563,6 +672,57 @@ mod tests {
             rendered.contains("[REDACTED]") && !rendered.contains("ghp_"),
             "bare positional token must be redacted, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn dependency_hint_classifies_ffmpeg_without_raw_secret_leak() {
+        let token = ["sk", "abcdefghijklmnopqrstuvwxyz"].join("-");
+        let hint = dependency_hint_from_error(&format!(
+            "server failed\nAuthorization: Bearer {token}\nffmpeg: command not found"
+        ))
+        .expect("dependency hint");
+
+        assert_eq!(hint.code, "missing_leaf_dependency");
+        assert_eq!(hint.package_hint.as_deref(), Some("ffmpeg"));
+        assert_eq!(
+            hint.install_command.as_deref(),
+            Some("sudo apt install ffmpeg")
+        );
+        assert!(!hint.redacted_tail.contains(&token));
+    }
+
+    #[test]
+    fn dependency_hint_classifies_runtime_enoent() {
+        let hint = dependency_hint_from_error("failed to run `uvx`: No such file or directory")
+            .expect("dependency hint");
+
+        assert_eq!(hint.code, "missing_runtime_floor");
+        assert_eq!(hint.package_hint.as_deref(), Some("uv"));
+        assert_eq!(
+            hint.install_command.as_deref(),
+            Some("labby setup --provision --yes")
+        );
+    }
+
+    #[test]
+    fn dependency_hint_ignores_auth_failures() {
+        assert!(dependency_hint_from_error("server exited because API_KEY is missing").is_none());
+        assert!(dependency_hint_from_error("401 unauthorized invalid_token").is_none());
+    }
+
+    #[test]
+    fn diagnostic_tail_is_bounded() {
+        let long = (0..20)
+            .map(|line| format!("line-{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let hint = dependency_hint_from_error(&format!("{long}\nffmpeg: command not found"))
+            .expect("dependency hint");
+
+        assert!(hint.truncated);
+        assert!(!hint.redacted_tail.contains("line-0"));
+        assert!(hint.redacted_tail.contains("ffmpeg: command not found"));
     }
 
     #[test]

--- a/crates/labby-gateway/src/gateway/types.rs
+++ b/crates/labby-gateway/src/gateway/types.rs
@@ -176,6 +176,19 @@ pub struct GatewayRuntimeView {
     pub exposed_prompt_count: usize,
     #[serde(default)]
     pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_hint: Option<DependencyHintView>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyHintView {
+    pub code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_command: Option<String>,
+    pub redacted_tail: String,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/labby/src/cli/setup.rs
+++ b/crates/labby/src/cli/setup.rs
@@ -14,6 +14,7 @@
 //! incrementally without breaking the CLI surface contract.
 
 use std::future::Future;
+use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 
 use anyhow::Result;
@@ -26,6 +27,22 @@ use crate::output::{OutputFormat, print};
 
 #[derive(Debug, Args)]
 pub struct SetupArgs {
+    /// Provision this Debian 13/Incus box for the Labby gateway.
+    #[arg(long)]
+    pub provision: bool,
+
+    /// Print the provisioning plan and do not mutate anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Confirm provisioning without prompting.
+    #[arg(short = 'y', long, alias = "no-confirm")]
+    pub yes: bool,
+
+    /// Skip runtime dependency installation and only converge user/service state.
+    #[arg(long)]
+    pub skip_deps: bool,
+
     /// Setup UI mode. Standalone setup defaults to full; /setup-core passes plugin.
     #[arg(long, value_enum, default_value_t = SetupModeArg::Full)]
     pub mode: SetupModeArg,
@@ -67,7 +84,7 @@ impl SetupModeArg {
 pub enum SetupCommand {
     /// Manage the local setup draft.
     Draft(DraftArgs),
-    /// Manage the host user systemd Labby gateway service.
+    /// Manage the systemd Labby gateway service.
     HostService(HostServiceArgs),
     /// List installed Claude Code lab plugins.
     InstalledPlugins {
@@ -119,11 +136,11 @@ pub struct HostServiceArgs {
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]
 pub enum HostServiceCommand {
-    /// Print the user systemd unit that Labby would install.
+    /// Print the system unit that Labby would install.
     Unit,
-    /// Install and start labby.service under systemd --user.
+    /// Install and start labby.service as a system unit.
     Install {
-        /// Copy this labby binary into ~/.local/bin/labby before installing the service.
+        /// Copy this labby binary into /usr/local/bin/labby before installing the service.
         #[arg(long)]
         install_self: bool,
         /// Confirm installation and service start.
@@ -134,7 +151,7 @@ pub enum HostServiceCommand {
     Status,
     /// Restart labby.service.
     Restart {
-        /// Copy this labby binary into ~/.local/bin/labby before restarting the service.
+        /// Copy this labby binary into /usr/local/bin/labby before restarting the service.
         #[arg(long)]
         install_self: bool,
         /// Confirm service restart.
@@ -222,7 +239,32 @@ fn install_self() -> Result<std::path::PathBuf> {
     Ok(dest)
 }
 
+fn install_self_system() -> Result<std::path::PathBuf> {
+    let exe = std::env::current_exe()?;
+    let bin_dir = std::path::PathBuf::from("/usr/local/bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let dest = bin_dir.join("labby");
+    if dest == exe {
+        return Ok(dest);
+    }
+    let tmp = bin_dir.join(".labby.tmp");
+    std::fs::copy(&exe, &tmp)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))?;
+    }
+    std::fs::rename(&tmp, &dest)?;
+    Ok(dest)
+}
+
 pub async fn run(args: SetupArgs, format: OutputFormat) -> Result<ExitCode> {
+    if args.provision {
+        return run_provision(args, format).await;
+    }
+    if args.dry_run || args.yes || args.skip_deps {
+        anyhow::bail!("--dry-run, --yes, and --skip-deps are only valid with --provision");
+    }
     if let Some(command) = args.command {
         return run_command(command, format).await;
     }
@@ -278,6 +320,50 @@ pub async fn run(args: SetupArgs, format: OutputFormat) -> Result<ExitCode> {
         "{}",
         theme.muted("Tip: set LAB_SKIP_SETUP=1 to suppress this message in CI.")
     );
+    Ok(ExitCode::SUCCESS)
+}
+
+async fn run_provision(args: SetupArgs, format: OutputFormat) -> Result<ExitCode> {
+    if args.command.is_some() {
+        anyhow::bail!("--provision cannot be combined with a setup subcommand");
+    }
+    let mut yes = args.yes;
+    let plan = crate::dispatch::setup::provision::provision_plan_text(args.skip_deps);
+    if !format.is_json() {
+        println!("{plan}");
+    }
+    if !args.dry_run && !yes {
+        if !io::stdin().is_terminal() {
+            anyhow::bail!("setup --provision requires --yes when stdin is not a TTY");
+        }
+        eprint!("Proceed? [y/N] ");
+        io::stderr().flush()?;
+        let mut answer = String::new();
+        io::stdin().read_line(&mut answer)?;
+        yes = matches!(answer.trim(), "y" | "Y" | "yes" | "YES");
+        if !yes {
+            anyhow::bail!("setup --provision cancelled");
+        }
+    }
+    let outcome = crate::dispatch::setup::provision::provision(
+        crate::dispatch::setup::provision::ProvisionOptions {
+            dry_run: args.dry_run,
+            yes,
+            skip_deps: args.skip_deps,
+        },
+    )
+    .await?;
+    if format.is_json() {
+        print(&serde_json::to_value(outcome)?, format)?;
+    } else if outcome.dry_run {
+        println!("dry-run complete; no changes made");
+    } else {
+        println!(
+            "provision complete: executed={}, skipped={}",
+            outcome.executed.len(),
+            outcome.skipped.len()
+        );
+    }
     Ok(ExitCode::SUCCESS)
 }
 
@@ -382,7 +468,7 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
         } => {
             require_host_service_confirmation("install", yes)?;
             if install_self_flag {
-                install_self()?;
+                install_self_system()?;
             }
             run_host_service_logged(
                 "host_service.install",
@@ -405,7 +491,7 @@ async fn run_host_service_command(args: HostServiceArgs, format: OutputFormat) -
         } => {
             require_host_service_confirmation("restart", yes)?;
             if install_self_flag {
-                install_self()?;
+                install_self_system()?;
             }
             run_host_service_logged(
                 "host_service.restart",
@@ -523,6 +609,10 @@ mod tests {
     async fn no_setup_flag_exits_cleanly() {
         let code = run(
             SetupArgs {
+                provision: false,
+                dry_run: false,
+                yes: false,
+                skip_deps: false,
                 mode: SetupModeArg::Full,
                 no_setup: true,
                 no_browser: true,
@@ -600,6 +690,26 @@ mod tests {
                 _ => panic!("unexpected setup subcommand for {command}"),
             }
         }
+    }
+
+    #[test]
+    fn parses_setup_provision_flags() {
+        let cli = crate::cli::Cli::try_parse_from([
+            "labby",
+            "setup",
+            "--provision",
+            "--dry-run",
+            "--skip-deps",
+        ])
+        .unwrap();
+        let crate::cli::Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+
+        assert!(args.provision);
+        assert!(args.dry_run);
+        assert!(args.skip_deps);
+        assert!(args.command.is_none());
     }
 
     #[test]

--- a/crates/labby/src/dispatch/doctor/gateway.rs
+++ b/crates/labby/src/dispatch/doctor/gateway.rs
@@ -26,6 +26,35 @@ fn is_nonessential_capability_error(message: &str) -> bool {
         || message.starts_with("does not implement MCP resources discovery")
 }
 
+#[cfg(feature = "gateway")]
+fn dependency_fix_hint(message: &str) -> Option<&'static str> {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("ffmpeg: command not found")
+        || lower.contains("ffmpeg.exe: command not found")
+        || (lower.contains("no such file or directory") && lower.contains("ffmpeg"))
+        || (lower.contains("enoent") && lower.contains("ffmpeg"))
+    {
+        Some("missing leaf dependency `ffmpeg`; suggested fix: sudo apt install ffmpeg")
+    } else if lower.contains("failed to run `uvx`")
+        || lower.contains("failed to spawn `uvx`")
+        || (lower.contains("enoent") && lower.contains("uvx"))
+    {
+        Some("missing runtime floor `uv`; suggested fix: labby setup --provision --yes")
+    } else if lower.contains("failed to run `npx`")
+        || lower.contains("failed to spawn `npx`")
+        || (lower.contains("enoent") && lower.contains("npx"))
+    {
+        Some("missing runtime floor `nodejs`; suggested fix: labby setup --provision --yes")
+    } else if lower.contains("failed to run `python`")
+        || lower.contains("failed to spawn `python`")
+        || (lower.contains("enoent") && lower.contains("python"))
+    {
+        Some("missing runtime floor `python`; suggested fix: labby setup --provision --yes")
+    } else {
+        None
+    }
+}
+
 /// Run the gateway upstream pool health check and return a `Report`.
 ///
 /// Returns a single informational `Finding` when the gateway manager is not
@@ -92,7 +121,9 @@ pub async fn check_gateway_upstreams() -> Report {
                 .await
                 .filter(|msg| !is_nonessential_capability_error(msg));
 
-            let (severity, message) = upstream_finding(name, *health, last_error.as_deref());
+            let dependency_hint = last_error.as_deref().and_then(dependency_fix_hint);
+            let (severity, message) =
+                upstream_finding(name, *health, last_error.as_deref(), dependency_hint);
             findings.push(Finding {
                 service: "gateway".to_string(),
                 check: format!("upstream:{name}"),
@@ -112,10 +143,16 @@ fn upstream_finding(
     name: &str,
     health: UpstreamHealth,
     last_error: Option<&str>,
+    dependency_hint: Option<&str>,
 ) -> (Severity, String) {
     match health {
         UpstreamHealth::Healthy => {
-            if let Some(err) = last_error {
+            if let Some(hint) = dependency_hint {
+                (
+                    Severity::Warn,
+                    format!("`{name}` is routable but has a dependency warning: {hint}"),
+                )
+            } else if let Some(err) = last_error {
                 // Healthy but has a stale warning (e.g. partial capability failure).
                 (
                     Severity::Warn,
@@ -136,6 +173,9 @@ fn upstream_finding(
                 "degraded"
             };
             let error_detail = last_error.map(|e| format!(": {e}")).unwrap_or_default();
+            let error_detail = dependency_hint
+                .map(|hint| format!(": {hint}"))
+                .unwrap_or(error_detail);
             (
                 Severity::Fail,
                 format!(
@@ -154,7 +194,7 @@ mod tests {
 
     #[test]
     fn healthy_upstream_no_error_is_ok() {
-        let (sev, msg) = upstream_finding("my-server", UpstreamHealth::Healthy, None);
+        let (sev, msg) = upstream_finding("my-server", UpstreamHealth::Healthy, None, None);
         assert!(matches!(sev, Severity::Ok));
         assert!(msg.contains("my-server"));
     }
@@ -165,6 +205,7 @@ mod tests {
             "my-server",
             UpstreamHealth::Healthy,
             Some("prompts not supported"),
+            None,
         );
         assert!(matches!(sev, Severity::Warn));
     }
@@ -177,6 +218,7 @@ mod tests {
                 consecutive_failures: CIRCUIT_BREAKER_THRESHOLD,
             },
             Some("connection refused"),
+            None,
         );
         assert!(matches!(sev, Severity::Fail));
         assert!(msg.contains("circuit breaker OPEN"));
@@ -191,9 +233,31 @@ mod tests {
                 consecutive_failures: CIRCUIT_BREAKER_THRESHOLD - 1,
             },
             None,
+            None,
         );
         assert!(matches!(sev, Severity::Fail));
         assert!(msg.contains("degraded"));
         assert!(!msg.contains("circuit breaker OPEN"));
+    }
+
+    #[test]
+    fn dependency_hint_rewrites_doctor_error_detail() {
+        let hint = dependency_fix_hint("ffmpeg: command not found").expect("hint");
+        let (sev, msg) = upstream_finding(
+            "media-upstream",
+            UpstreamHealth::Unhealthy {
+                consecutive_failures: 1,
+            },
+            Some("ffmpeg: command not found"),
+            Some(hint),
+        );
+
+        assert!(matches!(sev, Severity::Fail));
+        assert!(msg.contains("sudo apt install ffmpeg"));
+    }
+
+    #[test]
+    fn dependency_hint_does_not_match_auth_errors() {
+        assert!(dependency_fix_hint("server exited because API_KEY is missing").is_none());
     }
 }

--- a/crates/labby/src/dispatch/setup.rs
+++ b/crates/labby/src/dispatch/setup.rs
@@ -15,6 +15,7 @@ mod draft;
 pub(crate) mod host_service;
 mod params;
 mod plugin_hook;
+pub(crate) mod provision;
 mod secret_mask;
 mod settings;
 mod state;

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -1,4 +1,4 @@
-//! CLI-only management helpers for the host `systemd --user` Labby service.
+//! CLI-only management helpers for the system `labby.service`.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -11,6 +11,8 @@ use tokio::process::Command;
 use crate::dispatch::error::ToolError;
 
 const SERVICE_NAME: &str = "labby.service";
+const LAB_HOME: &str = "/home/lab";
+const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const READY_TIMEOUT: Duration = Duration::from_secs(15);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(300);
@@ -49,16 +51,15 @@ struct CommandCapture {
 }
 
 pub(crate) async fn unit() -> Result<String, ToolError> {
-    Ok(unit_text())
+    Ok(unit_text().to_string())
 }
 
 pub(crate) async fn install() -> Result<HostServiceOutcome, ToolError> {
     preflight_port_available("install").await?;
-    let home = current_home()?;
-    let path = unit_path(&home);
+    let path = unit_path();
     let text = unit_text();
-    std::fs::create_dir_all(unit_dir(&home)).map_err(io_error)?;
-    let changed = std::fs::read_to_string(&path).ok().as_deref() != Some(text.as_str());
+    std::fs::create_dir_all(unit_dir()).map_err(io_error)?;
+    let changed = std::fs::read_to_string(&path).ok().as_deref() != Some(text);
     if changed {
         atomic_write(&path, text.as_bytes())?;
     }
@@ -95,8 +96,7 @@ pub(crate) async fn install() -> Result<HostServiceOutcome, ToolError> {
 }
 
 pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
-    let home = current_home()?;
-    let path = unit_path(&home);
+    let path = unit_path();
     let installed = path.is_file();
     let (docker_labby_master_running, docker_labby_master_error) =
         match docker_labby_master_running().await {
@@ -142,7 +142,17 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
         Some(false) => Some(false),
         None => None,
     };
-    let local_ready = ready_response.map(|ready| ready && ready_owned_by_service == Some(true));
+    let local_ready = match (ready_response, ready_owned_by_service) {
+        (Some(true), Some(true)) => Some(true),
+        (Some(true), Some(false)) => {
+            local_ready_error.get_or_insert_with(|| {
+                "ready endpoint responded, but the listener is not labby.service".to_string()
+            });
+            Some(false)
+        }
+        (Some(false), _) => Some(false),
+        (None, _) | (Some(true), None) => None,
+    };
 
     Ok(HostServiceStatus {
         installed,
@@ -161,10 +171,43 @@ pub(crate) async fn status() -> Result<HostServiceStatus, ToolError> {
     })
 }
 
+pub(crate) async fn installed_and_ready() -> Result<bool, ToolError> {
+    let path = unit_path();
+    if !unit_file_is_current(&path) || !Path::new("/usr/local/bin/labby").is_file() {
+        return Ok(false);
+    }
+
+    let output = match run_systemctl(&[
+        "show",
+        SERVICE_NAME,
+        "--property=LoadState,ActiveState,MainPID",
+        "--no-pager",
+    ])
+    .await
+    {
+        Ok(output) => output,
+        Err(err) if command_not_found(&err) => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    let props = parse_systemctl_show(&output.stdout);
+    if non_empty_prop(&props, "LoadState").as_deref() != Some("loaded")
+        || non_empty_prop(&props, "ActiveState").as_deref() != Some("active")
+    {
+        return Ok(false);
+    }
+    let Some(main_pid) = parse_main_pid(&props) else {
+        return Ok(false);
+    };
+    if check_ready().await.unwrap_or(false) {
+        readiness_owner_matches(Some(main_pid)).await
+    } else {
+        Ok(false)
+    }
+}
+
 pub(crate) async fn restart() -> Result<HostServiceOutcome, ToolError> {
     preflight_port_available("restart").await?;
-    let home = current_home()?;
-    let path = unit_path(&home);
+    let path = unit_path();
     let restart = run_systemctl(&["restart", SERVICE_NAME]).await?;
     let mut stderr = restart.stderr;
     if let Err(err) = poll_ready().await {
@@ -188,8 +231,7 @@ pub(crate) async fn restart() -> Result<HostServiceOutcome, ToolError> {
 }
 
 pub(crate) async fn uninstall() -> Result<HostServiceOutcome, ToolError> {
-    let home = current_home()?;
-    let path = unit_path(&home);
+    let path = unit_path();
     let mut stdout = String::new();
     let mut stderr = String::new();
     if path.exists() {
@@ -220,7 +262,7 @@ pub(crate) async fn uninstall() -> Result<HostServiceOutcome, ToolError> {
     }
 }
 
-fn unit_text() -> String {
+fn unit_text() -> &'static str {
     r"[Unit]
 Description=Labby host gateway
 After=network-online.target
@@ -228,10 +270,31 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/labby serve
-WorkingDirectory=%h
-Environment=PATH=%h/.local/bin:%h/.cargo/bin:%h/.local/share/mise/shims:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
-EnvironmentFile=-%h/.lab/.env
+User=lab
+Group=lab
+ExecStart=/usr/local/bin/labby serve
+WorkingDirectory=/home/lab
+Environment=HOME=/home/lab
+Environment=XDG_CACHE_HOME=/home/lab/.cache
+Environment=XDG_CONFIG_HOME=/home/lab/.config
+Environment=XDG_DATA_HOME=/home/lab/.local/share
+Environment=PATH=/home/lab/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-/home/lab/.lab/.env
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/lab/.lab /home/lab/.local /home/lab/.cache /home/lab/.config /home/lab/.npm /home/lab/.codex /home/lab/.claude /home/lab/.gemini /home/lab/downloads
+ProtectHome=read-only
+PrivateTmp=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictSUIDSGID=true
+LockPersonality=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+TasksMax=1000
+MemoryMax=4G
 Restart=on-failure
 RestartSec=3
 StartLimitIntervalSec=60
@@ -239,26 +302,20 @@ StartLimitBurst=5
 KillSignal=SIGINT
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target
 "
-    .to_string()
 }
 
-fn unit_dir(home: &Path) -> PathBuf {
-    home.join(".config/systemd/user")
+fn unit_file_is_current(path: &Path) -> bool {
+    std::fs::read_to_string(path).ok().as_deref() == Some(unit_text())
 }
 
-fn unit_path(home: &Path) -> PathBuf {
-    unit_dir(home).join(SERVICE_NAME)
+fn unit_dir() -> PathBuf {
+    PathBuf::from(SYSTEM_UNIT_DIR)
 }
 
-fn current_home() -> Result<PathBuf, ToolError> {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| ToolError::Sdk {
-            sdk_kind: "internal_error".to_string(),
-            message: "HOME is not set; cannot manage user systemd service".to_string(),
-        })
+fn unit_path() -> PathBuf {
+    unit_dir().join(SERVICE_NAME)
 }
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), ToolError> {
@@ -281,7 +338,7 @@ async fn append_optional_verify(
     stdout: &mut String,
     stderr: &mut String,
 ) -> Result<(), ToolError> {
-    match run_command("systemd-analyze", &["--user", "verify", path_to_str(path)?]).await {
+    match run_command("systemd-analyze", &["verify", path_to_str(path)?]).await {
         Ok(output) => {
             stdout.push_str(&output.stdout);
             stderr.push_str(&output.stderr);
@@ -370,7 +427,7 @@ fn configured_local_port_from(
 }
 
 fn env_file_value(key: &str) -> Option<String> {
-    let path = current_home().ok()?.join(".lab/.env");
+    let path = Path::new(LAB_HOME).join(".lab/.env");
     let text = std::fs::read_to_string(path).ok()?;
     for line in text.lines() {
         let line = line.trim();
@@ -548,9 +605,7 @@ fn parse_main_pid(props: &BTreeMap<String, String>) -> Option<u32> {
 }
 
 async fn run_systemctl(args: &[&str]) -> Result<CommandCapture, ToolError> {
-    let mut command_args = vec!["--user"];
-    command_args.extend_from_slice(args);
-    run_command("systemctl", &command_args).await
+    run_command("systemctl", args).await
 }
 
 async fn run_command(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
@@ -622,14 +677,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unit_uses_durable_host_binary_and_lab_env() {
+    fn unit_uses_hardened_system_binary_and_lab_env() {
         let unit = unit_text();
 
         assert!(unit.contains("Description=Labby host gateway"));
-        assert!(unit.contains("ExecStart=%h/.local/bin/labby serve"));
-        assert!(unit.contains("WorkingDirectory=%h"));
-        assert!(unit.contains("Environment=PATH=%h/.local/bin:%h/.cargo/bin:%h/.local/share/mise/shims:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin"));
-        assert!(unit.contains("EnvironmentFile=-%h/.lab/.env"));
+        assert!(unit.contains("User=lab"));
+        assert!(unit.contains("Group=lab"));
+        assert!(unit.contains("ExecStart=/usr/local/bin/labby serve"));
+        assert!(unit.contains("WorkingDirectory=/home/lab"));
+        assert!(unit.contains("Environment=HOME=/home/lab"));
+        assert!(
+            unit.contains("Environment=PATH=/home/lab/.local/bin:/usr/local/bin:/usr/bin:/bin")
+        );
+        assert!(unit.contains("EnvironmentFile=-/home/lab/.lab/.env"));
+        assert!(unit.contains("WantedBy=multi-user.target"));
+        assert!(!unit.contains("%h"));
     }
 
     #[test]
@@ -652,12 +714,34 @@ mod tests {
     }
 
     #[test]
-    fn unit_path_lives_under_user_systemd_dir() {
-        let home = Path::new("/home/example");
+    fn unit_contains_hardening_baseline() {
+        let unit = unit_text();
 
+        for directive in [
+            "NoNewPrivileges=true",
+            "ProtectSystem=strict",
+            "ProtectHome=read-only",
+            "PrivateTmp=true",
+            "RestrictNamespaces=true",
+            "RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX",
+            "RestrictSUIDSGID=true",
+            "LockPersonality=true",
+            "ProtectKernelTunables=true",
+            "ProtectKernelModules=true",
+            "CapabilityBoundingSet=",
+            "SystemCallFilter=@system-service",
+            "TasksMax=1000",
+            "MemoryMax=4G",
+        ] {
+            assert!(unit.contains(directive), "missing {directive}");
+        }
+    }
+
+    #[test]
+    fn unit_path_lives_under_systemd_system_dir() {
         assert_eq!(
-            unit_path(home),
-            PathBuf::from("/home/example/.config/systemd/user/labby.service")
+            unit_path(),
+            PathBuf::from("/etc/systemd/system/labby.service")
         );
     }
 

--- a/crates/labby/src/dispatch/setup/host_service.rs
+++ b/crates/labby/src/dispatch/setup/host_service.rs
@@ -1,6 +1,6 @@
 //! CLI-only management helpers for the system `labby.service`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::time::Duration;
@@ -11,6 +11,7 @@ use tokio::process::Command;
 use crate::dispatch::error::ToolError;
 
 const SERVICE_NAME: &str = "labby.service";
+const LAB_USER: &str = "lab";
 const LAB_HOME: &str = "/home/lab";
 const SYSTEM_UNIT_DIR: &str = "/etc/systemd/system";
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
@@ -267,6 +268,8 @@ fn unit_text() -> &'static str {
 Description=Labby host gateway
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -297,8 +300,6 @@ TasksMax=1000
 MemoryMax=4G
 Restart=on-failure
 RestartSec=3
-StartLimitIntervalSec=60
-StartLimitBurst=5
 KillSignal=SIGINT
 
 [Install]
@@ -361,6 +362,14 @@ async fn preflight_port_available(operation: &str) -> Result<(), ToolError> {
     } else {
         (None, None)
     };
+    if docker_running != Some(true)
+        && holder.is_some()
+        && active_state.as_deref() == Some("active")
+        && (main_pid.is_some_and(|pid| process_listens_on_port(pid, port))
+            || lab_user_listens_on_port(port))
+    {
+        return Ok(());
+    }
     preflight_decision(
         operation,
         port,
@@ -475,7 +484,10 @@ async fn readiness_owner_matches(main_pid: Option<u32>) -> Result<bool, ToolErro
     let Some(holder) = port_holder(configured_local_port()).await? else {
         return Ok(false);
     };
-    Ok(holder_contains_pid(&holder, pid))
+    let port = configured_local_port();
+    Ok(holder_contains_pid(&holder, pid)
+        || process_listens_on_port(pid, port)
+        || lab_user_listens_on_port(port))
 }
 
 fn holder_can_be_host_service_from(
@@ -504,6 +516,90 @@ fn holder_contains_pid(holder: &str, pid: u32) -> bool {
     })
 }
 
+fn process_listens_on_port(pid: u32, port: u16) -> bool {
+    let inodes = listener_socket_inodes(port);
+    !inodes.is_empty() && process_has_socket_inode(pid, &inodes)
+}
+
+fn listener_socket_inodes(port: u16) -> BTreeSet<String> {
+    let mut inodes = BTreeSet::new();
+    for (_, inode) in listener_socket_entries(port) {
+        inodes.insert(inode);
+    }
+    inodes
+}
+
+fn lab_user_listens_on_port(port: u16) -> bool {
+    let Some(uid) = lab_uid() else {
+        return false;
+    };
+    listener_socket_entries(port)
+        .into_iter()
+        .any(|(listener_uid, _)| listener_uid == uid)
+}
+
+fn lab_uid() -> Option<u32> {
+    std::fs::read_to_string("/etc/passwd")
+        .ok()?
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split(':');
+            let name = fields.next()?;
+            let uid = fields.nth(1)?;
+            (name == LAB_USER).then(|| uid.parse().ok()).flatten()
+        })
+}
+
+fn listener_socket_entries(port: u16) -> Vec<(u32, String)> {
+    let mut entries = Vec::new();
+    collect_listener_socket_entries("/proc/net/tcp", port, &mut entries);
+    collect_listener_socket_entries("/proc/net/tcp6", port, &mut entries);
+    entries
+}
+
+fn collect_listener_socket_entries(path: &str, port: u16, entries: &mut Vec<(u32, String)>) {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return;
+    };
+    for line in text.lines().skip(1) {
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() <= 9 || fields[3] != "0A" {
+            continue;
+        }
+        let Some((_, port_hex)) = fields[1].rsplit_once(':') else {
+            continue;
+        };
+        if u16::from_str_radix(port_hex, 16).ok() == Some(port) {
+            let Ok(uid) = fields[7].parse::<u32>() else {
+                continue;
+            };
+            entries.push((uid, fields[9].to_string()));
+        }
+    }
+}
+
+fn process_has_socket_inode(pid: u32, inodes: &BTreeSet<String>) -> bool {
+    let fd_dir = format!("/proc/{pid}/fd");
+    let Ok(entries) = std::fs::read_dir(fd_dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let Ok(target) = std::fs::read_link(entry.path()) else {
+            return false;
+        };
+        let Some(target) = target.to_str() else {
+            return false;
+        };
+        let Some(inode) = target
+            .strip_prefix("socket:[")
+            .and_then(|rest| rest.strip_suffix(']'))
+        else {
+            return false;
+        };
+        inodes.contains(inode)
+    })
+}
+
 async fn docker_labby_master_running() -> Result<Option<bool>, ToolError> {
     match run_command(
         "docker",
@@ -523,16 +619,24 @@ async fn poll_ready() -> Result<(), String> {
     let mut last_err = String::new();
     while tokio::time::Instant::now() < deadline {
         match check_ready().await {
-            Ok(true) => match systemctl_main_pid().await {
-                Ok(main_pid) => match readiness_owner_matches(main_pid).await {
-                    Ok(true) => return Ok(()),
-                    Ok(false) => {
-                        last_err =
-                            "ready endpoint responded, but the listener is not labby.service"
-                                .to_string();
+            Ok(true) => match systemctl_service_identity().await {
+                Ok((active_state, main_pid)) if active_state.as_deref() == Some("active") => {
+                    match readiness_owner_matches(main_pid).await {
+                        Ok(true) => return Ok(()),
+                        Ok(false) => {
+                            last_err =
+                                "ready endpoint responded, but the listener is not labby.service"
+                                    .to_string();
+                        }
+                        Err(err) => last_err = err.to_string(),
                     }
-                    Err(err) => last_err = err.to_string(),
-                },
+                }
+                Ok((active_state, _)) => {
+                    last_err = format!(
+                        "ready endpoint responded, but {SERVICE_NAME} is not active ({})",
+                        active_state.unwrap_or_else(|| "unknown".to_string())
+                    );
+                }
                 Err(err) => last_err = err.to_string(),
             },
             Ok(false) => last_err = "ready endpoint returned non-success".to_string(),
@@ -541,10 +645,6 @@ async fn poll_ready() -> Result<(), String> {
         tokio::time::sleep(READY_POLL_INTERVAL).await;
     }
     Err(last_err)
-}
-
-async fn systemctl_main_pid() -> Result<Option<u32>, ToolError> {
-    Ok(systemctl_service_identity().await?.1)
 }
 
 async fn systemctl_service_identity() -> Result<(Option<String>, Option<u32>), ToolError> {

--- a/crates/labby/src/dispatch/setup/provision.rs
+++ b/crates/labby/src/dispatch/setup/provision.rs
@@ -3,6 +3,7 @@
 //! This module is intentionally not routed through the setup action catalog:
 //! callers reach it only through `labby setup --provision`.
 
+use std::borrow::Cow;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -15,7 +16,7 @@ use tokio::process::Command;
 
 use crate::dispatch::error::ToolError;
 
-const COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
 const CAPTURE_BYTES: usize = 16 * 1024;
 const STALE_LOCK_AFTER: Duration = Duration::from_secs(60 * 60);
 const LOCK_PATH: &str = "/var/lock/labby-provision.lock";
@@ -39,6 +40,7 @@ const APT_FLOOR: &[&str] = &[
     "gh",
     "ca-certificates",
     "curl",
+    "xz-utils",
     "zsh",
 ];
 
@@ -68,7 +70,7 @@ enum Privilege {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ProvisionAction {
     privilege: Privilege,
-    label: &'static str,
+    label: Cow<'static, str>,
     kind: ActionKind,
 }
 
@@ -171,37 +173,39 @@ fn build_plan(skip_deps: bool) -> Vec<ProvisionAction> {
     if !skip_deps {
         actions.push(ProvisionAction {
             privilege: Privilege::Root,
-            label: "apt install: git openssh-client gh ca-certificates curl zsh",
+            label: Cow::Owned(format!("apt install: {}", APT_FLOOR.join(" "))),
             kind: ActionKind::AptFloor,
         });
     }
     actions.push(ProvisionAction {
         privilege: Privilege::Root,
-        label: "useradd lab (if absent)",
+        label: Cow::Borrowed("useradd lab (if absent)"),
         kind: ActionKind::LabUser,
     });
     if !skip_deps {
         actions.extend([
             ProvisionAction {
                 privilege: Privilege::Lab,
-                label: "install node v24.x (official static tarball, on PATH)",
+                label: Cow::Borrowed("install node v24.x (official static tarball, on PATH)"),
                 kind: ActionKind::Node,
             },
             ProvisionAction {
                 privilege: Privilege::Lab,
-                label: "install uv + python (user-space)",
+                label: Cow::Borrowed("install uv + python (user-space)"),
                 kind: ActionKind::UvPython,
             },
             ProvisionAction {
                 privilege: Privilege::Lab,
-                label: "install claude + codex (npm, user-space)",
+                label: Cow::Borrowed("install claude + codex + gemini (npm, user-space)"),
                 kind: ActionKind::AgentClis,
             },
         ]);
     }
     actions.push(ProvisionAction {
         privilege: Privilege::Root,
-        label: "write /etc/systemd/system/labby.service and systemctl enable --now labby",
+        label: Cow::Borrowed(
+            "write /etc/systemd/system/labby.service and systemctl enable --now labby",
+        ),
         kind: ActionKind::HostService,
     });
     actions
@@ -215,7 +219,7 @@ fn render_plan(actions: &[ProvisionAction]) -> String {
             Privilege::Root => "[root] ",
             Privilege::Lab => "[lab ] ",
         });
-        out.push_str(action.label);
+        out.push_str(&action.label);
         out.push('\n');
     }
     out.push_str(
@@ -415,12 +419,13 @@ async fn lab_user_ready() -> Result<bool, ToolError> {
 }
 
 async fn apt_floor_installed() -> Result<bool, ToolError> {
-    let query = APT_FLOOR.join(" ");
-    command_success(
-        "sh",
-        &["-c", &format!("dpkg-query -W {query} >/dev/null 2>&1")],
-    )
-    .await
+    for package in APT_FLOOR {
+        let output = run_command("dpkg-query", &["-W", "-f=${db:Status-Abbrev}", package]).await?;
+        if !output.status.success() || !output.stdout.starts_with("ii ") {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 async fn lab_command_success(script: &str) -> Result<bool, ToolError> {
@@ -450,7 +455,9 @@ async fn run_as_lab(script: &str) -> Result<CommandCapture, ToolError> {
 }
 
 fn lab_shell_script(script: &str) -> String {
-    format!("export HOME={LAB_HOME}; export PATH={LAB_PATH}; {script}")
+    format!(
+        "export HOME={LAB_HOME}; export PATH={LAB_PATH}; export XDG_CONFIG_HOME={LAB_HOME}/.config; export XDG_CACHE_HOME={LAB_HOME}/.cache; cd {LAB_HOME}; {script}"
+    )
 }
 
 async fn run_checked(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
@@ -653,10 +660,11 @@ mod tests {
     fn dry_run_plan_renders_privilege_and_non_actions() {
         let text = provision_plan_text(false);
 
-        assert!(
-            text.contains("[root] apt install: git openssh-client gh ca-certificates curl zsh")
-        );
+        assert!(text.contains(
+            "[root] apt install: git openssh-client gh ca-certificates curl xz-utils zsh"
+        ));
         assert!(text.contains("[lab ] install node v24.x"));
+        assert!(text.contains("[lab ] install claude + codex + gemini"));
         assert!(text.contains("[root] write /etc/systemd/system/labby.service"));
         assert!(text.contains("It will NOT:"));
         assert!(text.contains("install or modify Incus"));

--- a/crates/labby/src/dispatch/setup/provision.rs
+++ b/crates/labby/src/dispatch/setup/provision.rs
@@ -1,0 +1,742 @@
+//! Local-only in-box provisioning for the Incus/bare-metal Labby gateway.
+//!
+//! This module is intentionally not routed through the setup action catalog:
+//! callers reach it only through `labby setup --provision`.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+use std::time::{Duration, SystemTime};
+
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+use crate::dispatch::error::ToolError;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+const CAPTURE_BYTES: usize = 16 * 1024;
+const STALE_LOCK_AFTER: Duration = Duration::from_secs(60 * 60);
+const LOCK_PATH: &str = "/var/lock/labby-provision.lock";
+const LAB_USER: &str = "lab";
+const LAB_HOME: &str = "/home/lab";
+const LAB_PATH: &str = "/home/lab/.local/bin:/usr/local/bin:/usr/bin:/bin";
+const LAB_USER_DIRS: &[&str] = &[
+    "/home/lab/.lab",
+    "/home/lab/.local/bin",
+    "/home/lab/.cache",
+    "/home/lab/.config",
+    "/home/lab/.npm",
+    "/home/lab/.codex",
+    "/home/lab/.claude",
+    "/home/lab/.gemini",
+    "/home/lab/downloads",
+];
+const APT_FLOOR: &[&str] = &[
+    "git",
+    "openssh-client",
+    "gh",
+    "ca-certificates",
+    "curl",
+    "zsh",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProvisionOptions {
+    pub dry_run: bool,
+    pub yes: bool,
+    pub skip_deps: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct ProvisionOutcome {
+    pub ok: bool,
+    pub dry_run: bool,
+    pub changed: bool,
+    pub plan: String,
+    pub executed: Vec<String>,
+    pub skipped: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Privilege {
+    Root,
+    Lab,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProvisionAction {
+    privilege: Privilege,
+    label: &'static str,
+    kind: ActionKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionKind {
+    AptFloor,
+    LabUser,
+    Node,
+    UvPython,
+    AgentClis,
+    HostService,
+}
+
+struct ProvisionLock {
+    path: PathBuf,
+    released: bool,
+}
+
+impl Drop for ProvisionLock {
+    fn drop(&mut self) {
+        if !self.released {
+            drop(std::fs::remove_file(&self.path));
+        }
+    }
+}
+
+impl ProvisionLock {
+    fn release(mut self) -> Result<(), ToolError> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {
+                self.released = true;
+                Ok(())
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                self.released = true;
+                Ok(())
+            }
+            Err(err) => Err(io_error(err)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CommandCapture {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+pub(crate) async fn provision(options: ProvisionOptions) -> Result<ProvisionOutcome, ToolError> {
+    let plan = build_plan(options.skip_deps);
+    let rendered = render_plan(&plan);
+    if options.dry_run {
+        return Ok(ProvisionOutcome {
+            ok: true,
+            dry_run: true,
+            changed: false,
+            plan: rendered,
+            executed: Vec::new(),
+            skipped: Vec::new(),
+        });
+    }
+    if !options.yes {
+        return Err(ToolError::ConfirmationRequired {
+            message: "setup --provision mutates packages, users, and systemd; pass --yes or confirm interactively".into(),
+        });
+    }
+
+    let lock = acquire_lock()?;
+    let mut executed = Vec::new();
+    let mut skipped = Vec::new();
+    for action in &plan {
+        if action.is_done().await? {
+            skipped.push(action.label.to_string());
+            continue;
+        }
+        action.execute().await?;
+        action.verify().await?;
+        executed.push(action.label.to_string());
+    }
+
+    let outcome = ProvisionOutcome {
+        ok: true,
+        dry_run: false,
+        changed: !executed.is_empty(),
+        plan: rendered,
+        executed,
+        skipped,
+    };
+    lock.release()?;
+    Ok(outcome)
+}
+
+pub(crate) fn provision_plan_text(skip_deps: bool) -> String {
+    render_plan(&build_plan(skip_deps))
+}
+
+fn build_plan(skip_deps: bool) -> Vec<ProvisionAction> {
+    let mut actions = Vec::new();
+    if !skip_deps {
+        actions.push(ProvisionAction {
+            privilege: Privilege::Root,
+            label: "apt install: git openssh-client gh ca-certificates curl zsh",
+            kind: ActionKind::AptFloor,
+        });
+    }
+    actions.push(ProvisionAction {
+        privilege: Privilege::Root,
+        label: "useradd lab (if absent)",
+        kind: ActionKind::LabUser,
+    });
+    if !skip_deps {
+        actions.extend([
+            ProvisionAction {
+                privilege: Privilege::Lab,
+                label: "install node v24.x (official static tarball, on PATH)",
+                kind: ActionKind::Node,
+            },
+            ProvisionAction {
+                privilege: Privilege::Lab,
+                label: "install uv + python (user-space)",
+                kind: ActionKind::UvPython,
+            },
+            ProvisionAction {
+                privilege: Privilege::Lab,
+                label: "install claude + codex (npm, user-space)",
+                kind: ActionKind::AgentClis,
+            },
+        ]);
+    }
+    actions.push(ProvisionAction {
+        privilege: Privilege::Root,
+        label: "write /etc/systemd/system/labby.service and systemctl enable --now labby",
+        kind: ActionKind::HostService,
+    });
+    actions
+}
+
+fn render_plan(actions: &[ProvisionAction]) -> String {
+    let mut out = String::from("labby setup --provision will:\n");
+    for action in actions {
+        out.push_str("  ");
+        out.push_str(match action.privilege {
+            Privilege::Root => "[root] ",
+            Privilege::Lab => "[lab ] ",
+        });
+        out.push_str(action.label);
+        out.push('\n');
+    }
+    out.push_str(
+        "\nIt will NOT:\n  - install or modify Incus\n  - touch any package outside the list above\n  - modify anything on the host outside this container\n  - transmit anything off-box except explicit package/runtime downloads\n",
+    );
+    out
+}
+
+impl ProvisionAction {
+    async fn is_done(&self) -> Result<bool, ToolError> {
+        match self.kind {
+            ActionKind::AptFloor => apt_floor_installed().await,
+            ActionKind::LabUser => lab_user_ready().await,
+            ActionKind::Node => {
+                lab_command_success("command -v node >/dev/null && command -v npm >/dev/null && command -v npx >/dev/null && node --version | grep -Eq '^v24\\.'").await
+            }
+            ActionKind::UvPython => {
+                lab_command_success("command -v uv >/dev/null && uv python find >/dev/null").await
+            }
+            ActionKind::AgentClis => {
+                lab_command_success(
+                    "command -v claude >/dev/null && command -v codex >/dev/null && command -v gemini >/dev/null",
+                )
+                .await
+            }
+            ActionKind::HostService => super::host_service::installed_and_ready().await,
+        }
+    }
+
+    async fn execute(&self) -> Result<(), ToolError> {
+        match self.kind {
+            ActionKind::AptFloor => {
+                run_checked("apt-get", &["update"]).await?;
+                let mut args = vec!["install", "-y"];
+                args.extend(APT_FLOOR.iter().copied());
+                run_checked("apt-get", &args).await?;
+            }
+            ActionKind::LabUser => {
+                if !command_success("id", &["-u", LAB_USER]).await? {
+                    run_checked(
+                        "useradd",
+                        &["--create-home", "--shell", "/usr/bin/zsh", LAB_USER],
+                    )
+                    .await?;
+                }
+                let mut args = vec!["-p"];
+                args.extend_from_slice(LAB_USER_DIRS);
+                run_checked("mkdir", &args).await?;
+                run_checked("chown", &["-R", "lab:lab", "/home/lab"]).await?;
+            }
+            ActionKind::Node => {
+                run_as_lab(
+                    r#"set -eu
+case "$(uname -m)" in
+    x86_64|amd64) ;;
+    *) echo "unsupported Node static tarball architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+mkdir -p "$HOME/.local/bin" "$HOME/.local/opt"
+base="https://nodejs.org/dist/latest-v24.x"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+asset="$(curl -fsSL "$base/SHASUMS256.txt" | awk '/linux-x64.tar.xz$/ {print $2; exit}')"
+test -n "$asset"
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/SHASUMS256.txt" "$base/SHASUMS256.txt"
+(cd "$tmp" && grep "  $asset$" SHASUMS256.txt | sha256sum -c -)
+tar -xJf "$tmp/$asset" -C "$HOME/.local/opt"
+dir="$HOME/.local/opt/${asset%.tar.xz}"
+ln -sfn "$dir" "$HOME/.local/opt/node"
+ln -sfn "$dir/bin/node" "$HOME/.local/bin/node"
+ln -sfn "$dir/bin/npm" "$HOME/.local/bin/npm"
+ln -sfn "$dir/bin/npx" "$HOME/.local/bin/npx""#,
+                )
+                .await?;
+            }
+            ActionKind::UvPython => {
+                run_as_lab(
+                    r#"set -eu
+mkdir -p "$HOME/.local/bin"
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$HOME/.local/bin" sh
+"$HOME/.local/bin/uv" python install"#,
+                )
+                .await?;
+            }
+            ActionKind::AgentClis => {
+                run_as_lab(
+                    r#"set -eu
+npm config set prefix "$HOME/.local"
+npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli"#,
+                )
+                .await?;
+            }
+            ActionKind::HostService => {
+                drop(run_checked("systemctl", &["reset-failed", "labby.service"]).await);
+                super::host_service::install().await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn verify(&self) -> Result<(), ToolError> {
+        if self.is_done().await? {
+            Ok(())
+        } else {
+            Err(ToolError::Sdk {
+                sdk_kind: "internal_error".into(),
+                message: format!("provision step did not verify: {}", self.label),
+            })
+        }
+    }
+}
+
+fn acquire_lock() -> Result<ProvisionLock, ToolError> {
+    let path = PathBuf::from(LOCK_PATH);
+    match try_create_lock(&path) {
+        Ok(lock) => Ok(lock),
+        Err(err)
+            if err.kind() == std::io::ErrorKind::AlreadyExists && cleanup_stale_lock(&path)? =>
+        {
+            try_create_lock(&path).map_err(io_error)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Err(ToolError::Conflict {
+            message: lock_conflict_message(&path),
+            existing_id: LOCK_PATH.to_string(),
+        }),
+        Err(err) => Err(io_error(err)),
+    }
+}
+
+fn try_create_lock(path: &Path) -> std::io::Result<ProvisionLock> {
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            writeln!(file, "pid={}", std::process::id())?;
+            Ok(ProvisionLock {
+                path: path.to_path_buf(),
+                released: false,
+            })
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn cleanup_stale_lock(path: &Path) -> Result<bool, ToolError> {
+    let Some(pid) = lock_owner_pid(path) else {
+        return Ok(false);
+    };
+    if Path::new(&format!("/proc/{pid}")).exists() {
+        return Ok(false);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(io_error(err)),
+    }
+}
+
+fn lock_owner_pid(path: &Path) -> Option<u32> {
+    let text = std::fs::read_to_string(path).ok()?;
+    text.lines()
+        .find_map(|line| line.strip_prefix("pid=")?.parse().ok())
+}
+
+fn lock_conflict_message(path: &Path) -> String {
+    let stale_note = std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .filter(|age| *age > STALE_LOCK_AFTER)
+        .map(|age| {
+            format!(
+                "; lock is older than {} minutes, verify no provision run is active before removing it",
+                age.as_secs() / 60
+            )
+        })
+        .unwrap_or_default();
+    format!("another labby setup --provision is running ({LOCK_PATH} exists{stale_note})")
+}
+
+async fn lab_user_ready() -> Result<bool, ToolError> {
+    if !command_success("id", &["-u", LAB_USER]).await? {
+        return Ok(false);
+    }
+    let home_ok = std::fs::metadata(LAB_HOME)
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false);
+    if !home_ok {
+        return Ok(false);
+    }
+    if LAB_USER_DIRS.iter().any(|path| {
+        !std::fs::metadata(path)
+            .map(|meta| meta.is_dir())
+            .unwrap_or(false)
+    }) {
+        return Ok(false);
+    }
+    lab_command_success("test -w \"$HOME/.lab\" && test -w \"$HOME/.local/bin\"").await
+}
+
+async fn apt_floor_installed() -> Result<bool, ToolError> {
+    let query = APT_FLOOR.join(" ");
+    command_success(
+        "sh",
+        &["-c", &format!("dpkg-query -W {query} >/dev/null 2>&1")],
+    )
+    .await
+}
+
+async fn lab_command_success(script: &str) -> Result<bool, ToolError> {
+    let script = lab_shell_script(script);
+    command_success(
+        "runuser",
+        &["-u", LAB_USER, "--", "sh", "-lc", script.as_str()],
+    )
+    .await
+}
+
+async fn command_success(program: &str, args: &[&str]) -> Result<bool, ToolError> {
+    match run_command(program, args).await {
+        Ok(output) => Ok(output.status.success()),
+        Err(err) if command_not_found(&err) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+async fn run_as_lab(script: &str) -> Result<CommandCapture, ToolError> {
+    let script = lab_shell_script(script);
+    run_checked(
+        "runuser",
+        &["-u", LAB_USER, "--", "sh", "-lc", script.as_str()],
+    )
+    .await
+}
+
+fn lab_shell_script(script: &str) -> String {
+    format!("export HOME={LAB_HOME}; export PATH={LAB_PATH}; {script}")
+}
+
+async fn run_checked(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
+    let output = run_command(program, args).await?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(ToolError::Sdk {
+            sdk_kind: "internal_error".into(),
+            message: format!(
+                "command failed: {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+                command_display(program, args),
+                output.status,
+                redact_command_output(&output.stdout),
+                redact_command_output(&output.stderr)
+            ),
+        })
+    }
+}
+
+async fn run_command(program: &str, args: &[&str]) -> Result<CommandCapture, ToolError> {
+    let display = command_display(program, args);
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    {
+        command.process_group(0);
+    }
+    let mut child = command.spawn().map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".into(),
+        message: format!("failed to run `{display}`: {err}"),
+    })?;
+    let child_id = child.id();
+    let stdout = tokio::spawn(read_capped(child.stdout.take()));
+    let stderr = tokio::spawn(read_capped(child.stderr.take()));
+    let status = tokio::time::timeout(COMMAND_TIMEOUT, child.wait())
+        .await
+        .map_err(|_| {
+            kill_process_tree(child_id);
+            ToolError::Sdk {
+                sdk_kind: "internal_error".into(),
+                message: format!("command timed out after {COMMAND_TIMEOUT:?}: {display}"),
+            }
+        })?
+        .map_err(io_error)?;
+    let stdout = stdout
+        .await
+        .unwrap_or_else(|err| format!("failed to join command output reader: {err}"));
+    let stderr = stderr
+        .await
+        .unwrap_or_else(|err| format!("failed to join command output reader: {err}"));
+    Ok(CommandCapture {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+async fn read_capped<R>(reader: Option<R>) -> String
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(mut reader) = reader else {
+        return String::new();
+    };
+    let mut captured = Vec::new();
+    let mut truncated = false;
+    let mut chunk = [0; 1024];
+    loop {
+        match reader.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                captured.extend_from_slice(&chunk[..n]);
+                if captured.len() > CAPTURE_BYTES {
+                    let excess = captured.len() - CAPTURE_BYTES;
+                    captured.drain(..excess);
+                    truncated = true;
+                }
+            }
+            Err(err) => return format!("failed to read command output: {err}"),
+        }
+    }
+    let mut text = String::from_utf8_lossy(&captured).to_string();
+    if truncated {
+        text.insert_str(0, "…[truncated]\n");
+    }
+    text
+}
+
+#[cfg(unix)]
+fn kill_process_tree(child_id: Option<u32>) {
+    let Some(pid) = child_id else {
+        return;
+    };
+    let group = format!("-{pid}");
+    drop(
+        std::process::Command::new("kill")
+            .args(["-TERM", &group])
+            .status(),
+    );
+    std::thread::sleep(Duration::from_millis(500));
+    drop(
+        std::process::Command::new("kill")
+            .args(["-KILL", &group])
+            .status(),
+    );
+}
+
+#[cfg(not(unix))]
+fn kill_process_tree(_child_id: Option<u32>) {}
+
+fn command_display(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .map(str::to_string)
+        .chain(args.iter().map(|arg| redact_command_output(arg)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn redact_command_output(output: &str) -> String {
+    const MAX_LINES: usize = 40;
+    const MAX_BYTES: usize = 4096;
+    let joined = output
+        .lines()
+        .rev()
+        .take(MAX_LINES)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n");
+    let capped = if joined.len() > MAX_BYTES {
+        let mut cut = MAX_BYTES;
+        while cut > 0 && !joined.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        format!("{}…[truncated]", &joined[..cut])
+    } else {
+        joined
+    };
+    labby_runtime::redact::redact_stdio_value(&capped)
+        .lines()
+        .map(|line| {
+            if let Some((prefix, _)) = line.split_once("Authorization: Bearer ") {
+                format!("{prefix}Authorization: Bearer [redacted]")
+            } else if line.contains("TS_AUTHKEY=") {
+                "TS_AUTHKEY=[redacted]".to_string()
+            } else {
+                redact_secret_like_segments(line)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn redact_secret_like_segments(input: &str) -> String {
+    input
+        .split_whitespace()
+        .map(|segment| {
+            let looks_secret = segment.starts_with("sk-")
+                || segment.starts_with("ghp_")
+                || segment.starts_with("github_pat_")
+                || segment.starts_with("glpat-")
+                || segment.starts_with("xoxb-")
+                || segment.starts_with("xoxp-")
+                || segment.starts_with("tskey-")
+                || segment.starts_with("eyJ");
+            if looks_secret {
+                "[redacted]".to_string()
+            } else {
+                segment.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn command_not_found(err: &ToolError) -> bool {
+    let message = err.to_string();
+    message.contains("failed to run `")
+        && (message.contains("No such file or directory") || message.contains("os error 2"))
+}
+
+fn io_error(err: std::io::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dry_run_plan_renders_privilege_and_non_actions() {
+        let text = provision_plan_text(false);
+
+        assert!(
+            text.contains("[root] apt install: git openssh-client gh ca-certificates curl zsh")
+        );
+        assert!(text.contains("[lab ] install node v24.x"));
+        assert!(text.contains("[root] write /etc/systemd/system/labby.service"));
+        assert!(text.contains("It will NOT:"));
+        assert!(text.contains("install or modify Incus"));
+    }
+
+    #[test]
+    fn skip_deps_plan_is_service_only() {
+        let text = provision_plan_text(true);
+
+        assert!(!text.contains("apt install"));
+        assert!(!text.contains("install node"));
+        assert!(text.contains("useradd lab"));
+        assert!(text.contains("systemctl enable --now labby"));
+    }
+
+    #[tokio::test]
+    async fn dry_run_does_not_require_confirmation_or_lock() {
+        let outcome = provision(ProvisionOptions {
+            dry_run: true,
+            yes: false,
+            skip_deps: false,
+        })
+        .await
+        .unwrap();
+
+        assert!(outcome.ok);
+        assert!(outcome.dry_run);
+        assert!(!outcome.changed);
+        assert!(outcome.executed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mutation_without_yes_is_refused() {
+        let err = provision(ProvisionOptions {
+            dry_run: false,
+            yes: false,
+            skip_deps: true,
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.kind(), "confirmation_required");
+    }
+
+    #[test]
+    fn redacts_sensitive_command_output() {
+        let bearer = ["sk", "abcdefghijklmnopqrstuvwxyz"].join("-");
+        let ts_key = ["tskey", "secret"].join("-");
+        let redacted = redact_command_output(&format!(
+            "Authorization: Bearer {bearer}\nTS_AUTHKEY={ts_key}\n"
+        ));
+
+        assert!(!redacted.contains(&bearer));
+        assert!(!redacted.contains(&ts_key));
+    }
+
+    #[tokio::test]
+    async fn failed_command_redacts_stdout_and_stderr() {
+        let stdout_token = ["sk", "stdout-secret"].join("-");
+        let stderr_token = ["tskey", "stderr-secret"].join("-");
+        let script = format!(
+            "printf 'Authorization: Bearer {stdout_token}'; printf 'TS_AUTHKEY={stderr_token}' >&2; exit 9"
+        );
+        let err = run_checked("sh", &["-c", script.as_str()])
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(!err.contains(&stdout_token));
+        assert!(!err.contains(&stderr_token));
+        assert!(err.contains("Authorization: Bearer [redacted]"));
+        assert!(err.contains("TS_AUTHKEY=[redacted]"));
+    }
+
+    #[test]
+    fn provision_is_not_in_setup_action_catalog() {
+        assert!(
+            !super::super::catalog::ACTIONS
+                .iter()
+                .any(|action| action.name.contains("provision"))
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The docs are split by topic so contributors do not have to recover architecture,
 - Use [SERVICES.md](./dev/SERVICES.md), [CLI.md](./surfaces/CLI.md), and [MCP.md](./surfaces/MCP.md) for current surface-specific behavior. [TUI.md](./surfaces/TUI.md) records deferred TUI status.
 - Use [design/CLI_DESIGN_SYSTEM.md](./design/CLI_DESIGN_SYSTEM.md) for the human-readable CLI output language and shared color policy.
 - Use [design/component-development.md](./design/component-development.md) and [design/design-system-contract.md](./design/design-system-contract.md) when building or revising Labby web UI components.
-- Use [CONFIG.md](./runtime/CONFIG.md) and [OPERATIONS.md](./OPERATIONS.md) for setup and operator workflows.
+- Use [CONFIG.md](./runtime/CONFIG.md), [HOST_GATEWAY.md](./runtime/HOST_GATEWAY.md), and [OPERATIONS.md](./OPERATIONS.md) for setup, Incus gateway deployment, and operator workflows.
 - Refer to [OAUTH.md](./runtime/OAUTH.md) for bearer vs OAuth mode selection, Google-backed authorization flow, lab-issued JWT behavior, and callback-forwarding constraints.
 - Use [GATEWAY.md](./services/GATEWAY.md) when managing upstream MCP gateways over CLI, MCP, `/v1/gateway`, or Gateway-managed OAuth protected MCP routes.
 - Use [acp/README.md](./acp/README.md) for ACP service architecture, the `acp` vs `chat` boundary, and gateway integration direction.
@@ -70,15 +70,16 @@ The docs are split by topic so contributors do not have to recover architecture,
 ### If You Are Operating the Project
 
 1. [CONFIG.md](./runtime/CONFIG.md)
-2. [TRANSPORT.md](./surfaces/TRANSPORT.md)
-3. [OAUTH.md](./runtime/OAUTH.md) (if deploying with OAuth)
-4. [GATEWAY.md](./services/GATEWAY.md) (if managing upstream MCP gateways)
-5. [UPSTREAM.md](./services/UPSTREAM.md) (if proxying upstream MCP servers)
-6. [DEVICE_RUNTIME.md](./runtime/DEVICE_RUNTIME.md)
-7. [NODE_RUNTIME_CONTRACT.md](./runtime/NODE_RUNTIME_CONTRACT.md)
-8. [DEPLOY.md](./runtime/DEPLOY.md)
-9. [OPERATIONS.md](./OPERATIONS.md)
-10. [CLI.md](./surfaces/CLI.md)
+2. [HOST_GATEWAY.md](./runtime/HOST_GATEWAY.md)
+3. [TRANSPORT.md](./surfaces/TRANSPORT.md)
+4. [OAUTH.md](./runtime/OAUTH.md) (if deploying with OAuth)
+5. [GATEWAY.md](./services/GATEWAY.md) (if managing upstream MCP gateways)
+6. [UPSTREAM.md](./services/UPSTREAM.md) (if proxying upstream MCP servers)
+7. [DEVICE_RUNTIME.md](./runtime/DEVICE_RUNTIME.md)
+8. [NODE_RUNTIME_CONTRACT.md](./runtime/NODE_RUNTIME_CONTRACT.md)
+9. [DEPLOY.md](./runtime/DEPLOY.md)
+10. [OPERATIONS.md](./OPERATIONS.md)
+11. [CLI.md](./surfaces/CLI.md)
 
 ## Topic Map
 
@@ -160,6 +161,8 @@ The docs are split by topic so contributors do not have to recover architecture,
   Deferred TUI status.
 - [CONFIG.md](./runtime/CONFIG.md)
   Env and TOML config ownership, load order, secrets handling, and instance naming.
+- [HOST_GATEWAY.md](./runtime/HOST_GATEWAY.md)
+  Primary amd64 Debian 13 Incus gateway runtime, in-box provisioning, hardened system service, Tailscale TUN passthrough, Docker smoke path, and rollback.
 - [ENV.md](./runtime/ENV.md)
   Deployment-ready env examples and auth-mode variables.
 - [OBSERVABILITY.md](./dev/OBSERVABILITY.md)

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -651,7 +651,7 @@ Usage: setup [OPTIONS] [COMMAND]
 
 Commands:
   draft                Manage the local setup draft
-  host-service         Manage the host user systemd Labby gateway service
+  host-service         Manage the systemd Labby gateway service
   installed-plugins    List installed Claude Code lab plugins
   services-status      Join service configuration, draft, and Claude plugin state
   plugin-hook          Run binary-owned local setup checks for Claude plugin hooks
@@ -669,17 +669,29 @@ Options:
       --json
           Emit JSON instead of human-readable tables
 
-      --mode <MODE>
-          Setup UI mode. Standalone setup defaults to full; /setup-core passes plugin
-
-          [default: full]
-          [possible values: plugin, full]
+      --provision
+          Provision this Debian 13/Incus box for the Labby gateway
 
       --color <COLOR>
           Control human-readable CLI styling
 
           [default: auto]
           [possible values: auto, plain, color]
+
+      --dry-run
+          Print the provisioning plan and do not mutate anything
+
+  -y, --yes
+          Confirm provisioning without prompting
+
+      --skip-deps
+          Skip runtime dependency installation and only converge user/service state
+
+      --mode <MODE>
+          Setup UI mode. Standalone setup defaults to full; /setup-core passes plugin
+
+          [default: full]
+          [possible values: plugin, full]
 
       --no-setup
           Skip the wizard and exit cleanly. Equivalent to LAB_SKIP_SETUP=1
@@ -761,13 +773,13 @@ Arguments:
 ## `labby setup host-service`
 
 ```text
-Manage the host user systemd Labby gateway service
+Manage the systemd Labby gateway service
 
 Usage: host-service [OPTIONS] <COMMAND>
 
 Commands:
-  unit       Print the user systemd unit that Labby would install
-  install    Install and start labby.service under systemd --user
+  unit       Print the system unit that Labby would install
+  install    Install and start labby.service as a system unit
   status     Read labby.service status
   restart    Restart labby.service
   uninstall  Stop, disable, and remove labby.service
@@ -790,7 +802,7 @@ Options:
 ## `labby setup host-service unit`
 
 ```text
-Print the user systemd unit that Labby would install
+Print the system unit that Labby would install
 
 Usage: unit [OPTIONS]
 
@@ -811,13 +823,13 @@ Options:
 ## `labby setup host-service install`
 
 ```text
-Install and start labby.service under systemd --user
+Install and start labby.service as a system unit
 
 Usage: install [OPTIONS]
 
 Options:
       --install-self
-          Copy this labby binary into ~/.local/bin/labby before installing the service
+          Copy this labby binary into /usr/local/bin/labby before installing the service
 
       --json
           Emit JSON instead of human-readable tables
@@ -865,7 +877,7 @@ Usage: restart [OPTIONS]
 
 Options:
       --install-self
-          Copy this labby binary into ~/.local/bin/labby before restarting the service
+          Copy this labby binary into /usr/local/bin/labby before restarting the service
 
       --json
           Emit JSON instead of human-readable tables

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -1,6 +1,6 @@
 # Labby Gateway Runtime
 
-The primary supported self-hosted Labby gateway runtime is an **amd64 Debian 13
+The primary supported self-hosted Labby gateway runtime is an **amd64 Ubuntu 24.04
 Incus system container**. Labby launches stdio MCP servers and agent CLIs at
 runtime, so the deployment needs a persistent system environment with normal
 package installation, systemd, SSH, and user caches. Docker remains useful for
@@ -29,9 +29,9 @@ scripts/incus-bootstrap.sh --version vX.Y.Z
 ```
 
 The bootstrap is idempotent. It creates or reuses the `labby` container, launches
-`images:debian/13`, enforces isolated idmap and non-nesting settings, passes
-exactly one host device (`/dev/net/tun`), installs `/usr/local/bin/labby`, and
-runs:
+`images:ubuntu/24.04`, configures a privileged non-nesting system container,
+passes exactly one host device (`/dev/net/tun`), installs
+`/usr/local/bin/labby`, and runs:
 
 ```bash
 incus exec labby -- labby setup --provision --yes
@@ -49,6 +49,23 @@ Add `--tailscale-ssh` only when you intentionally want Tailscale SSH enabled for
 the container. Tailscale SSH is governed by tailnet ACLs; enabling it changes who
 can reach the container over SSH.
 
+The container is privileged because this host's unprivileged Incus containers
+deny signal delivery even for same-UID processes. `systemctl restart
+labby.service` needs normal signal semantics; without them, a stale Labby
+process can keep answering `/ready` while systemd reports the unit as failed.
+The service itself still runs as the unprivileged `lab` user inside the
+container.
+
+For local PR validation before a release exists, push a built checkout binary
+instead of downloading a GitHub release:
+
+```bash
+cargo build --workspace --all-features --bin labby
+scripts/incus-bootstrap.sh --local-binary target/debug/labby
+```
+
+The release path should still use `--version vX.Y.Z`.
+
 ## In-Box Provisioning
 
 Inside the container, `labby setup --provision` owns the bounded environment
@@ -61,10 +78,12 @@ labby setup --provision --yes
 labby setup --provision --yes --skip-deps
 ```
 
-The plan is explicit about privilege. Root actions are limited to the Debian
-package floor, `lab` user creation, writing `/etc/systemd/system/labby.service`,
-and enabling/restarting the service. User-space actions run as `lab` and install
-Node v24.x, `uv` plus Python, `claude`, and `codex`.
+The plan is explicit about privilege. Root actions are limited to the apt
+package floor (`git`, `openssh-client`, `gh`, `ca-certificates`, `curl`,
+`xz-utils`, `zsh`), `lab` user creation, writing
+`/etc/systemd/system/labby.service`, and enabling/restarting the service.
+User-space actions run as `lab` and install Node v24.x, `uv` plus Python,
+`claude`, `codex`, and `gemini`.
 
 Provisioning does not install or initialize Incus, silently install leaf
 packages such as `ffmpeg`, or expose root package/user/systemd mutation through
@@ -102,6 +121,10 @@ It also applies the hardening baseline from the implementation plan, including
 `ProtectSystem=strict`, `NoNewPrivileges=true`, `PrivateTmp=true`, restricted
 address families, and explicit `ReadWritePaths` for the `lab` user's runtime
 state.
+
+Readiness verification requires both an active `labby.service` unit and a
+successful loopback `/ready` response. This prevents stale processes from
+masking failed service restarts.
 
 ## Post-Provision Checklist
 

--- a/docs/runtime/HOST_GATEWAY.md
+++ b/docs/runtime/HOST_GATEWAY.md
@@ -1,136 +1,185 @@
-# Host Labby Gateway
+# Labby Gateway Runtime
 
-The preferred Labby gateway runtime is a host user service:
+The primary supported self-hosted Labby gateway runtime is an **amd64 Debian 13
+Incus system container**. Labby launches stdio MCP servers and agent CLIs at
+runtime, so the deployment needs a persistent system environment with normal
+package installation, systemd, SSH, and user caches. Docker remains useful for
+explicit development and image-smoke work, but it is no longer the default
+self-hosting boundary.
+
+The supported substrate is currently amd64 because the release binary includes
+Code Mode's QuickJS engine (`rquickjs-sys`), which does not cross-compile
+cleanly in the current release path. ARM hosts can still build from source, but
+they should not expect the same prebuilt cold-start path.
+
+## Primary: Incus System Container
+
+Install and initialize Incus explicitly on the host first. The bootstrap script
+does not install or initialize Incus for you:
 
 ```bash
-~/.local/bin/labby serve
+sudo apt install incus
+sudo incus admin init
 ```
 
-It runs as `labby.service` under `systemd --user`. Bind host, port, auth, and
-upstream gateway configuration continue to come from `~/.lab/.env` and Labby
-config. Do not bake public bind settings into the systemd unit.
-
-## Install
+Then launch and provision the gateway container with a pinned Labby release:
 
 ```bash
+scripts/incus-bootstrap.sh --version vX.Y.Z
+```
+
+The bootstrap is idempotent. It creates or reuses the `labby` container, launches
+`images:debian/13`, enforces isolated idmap and non-nesting settings, passes
+exactly one host device (`/dev/net/tun`), installs `/usr/local/bin/labby`, and
+runs:
+
+```bash
+incus exec labby -- labby setup --provision --yes
+```
+
+`/dev/net/tun` is required when Tailscale runs inside the container. To join the
+tailnet during bootstrap, provide an ephemeral, preauthorized, tag-scoped auth
+key:
+
+```bash
+TS_AUTHKEY=tskey-... scripts/incus-bootstrap.sh --version vX.Y.Z
+```
+
+Add `--tailscale-ssh` only when you intentionally want Tailscale SSH enabled for
+the container. Tailscale SSH is governed by tailnet ACLs; enabling it changes who
+can reach the container over SSH.
+
+## In-Box Provisioning
+
+Inside the container, `labby setup --provision` owns the bounded environment
+floor:
+
+```bash
+labby setup --provision --dry-run
+labby setup --provision
+labby setup --provision --yes
+labby setup --provision --yes --skip-deps
+```
+
+The plan is explicit about privilege. Root actions are limited to the Debian
+package floor, `lab` user creation, writing `/etc/systemd/system/labby.service`,
+and enabling/restarting the service. User-space actions run as `lab` and install
+Node v24.x, `uv` plus Python, `claude`, and `codex`.
+
+Provisioning does not install or initialize Incus, silently install leaf
+packages such as `ffmpeg`, or expose root package/user/systemd mutation through
+MCP, HTTP, Code Mode, or remote admin actions.
+
+Supply-chain trust is intentionally explicit: the Labby release install path
+requires the GitHub release checksum, and Node downloads are verified against
+the upstream SHA256 manifest. `uv`, Tailscale, and the agent CLIs still trust
+their upstream installer/package channels (`astral.sh`, `tailscale.com`, and
+npm) during provisioning. Use this path only when those upstreams are acceptable
+for the container boundary; otherwise pre-bake those runtimes into a controlled
+image and run `labby setup --provision --yes --skip-deps`.
+
+## System Service
+
+The default service is a hardened system unit:
+
+```bash
+labby setup host-service unit
 labby setup host-service install --install-self -y
-systemctl --user --no-pager --full status labby.service
+systemctl status labby --no-pager
 ```
 
-From a source checkout, `just host-service-install` is a convenience wrapper
-that builds `labby`, installs it to `~/.local/bin/labby`, then runs the same
-CLI host-service install path.
+The unit runs:
 
-## Migrate From The Docker Dev Container
+```text
+User=lab
+Group=lab
+ExecStart=/usr/local/bin/labby serve
+WorkingDirectory=/home/lab
+WantedBy=multi-user.target
+```
 
-Stop the container before starting the host service because both runtimes bind
-the configured local MCP HTTP port:
+It also applies the hardening baseline from the implementation plan, including
+`ProtectSystem=strict`, `NoNewPrivileges=true`, `PrivateTmp=true`, restricted
+address families, and explicit `ReadWritePaths` for the `lab` user's runtime
+state.
+
+## Post-Provision Checklist
+
+After bootstrap or provisioning:
+
+```bash
+incus exec labby -- systemctl status labby --no-pager
+incus exec labby -- curl -fsS http://127.0.0.1:8765/ready
+incus exec labby -- su - lab
+```
+
+Then run the interactive agent logins inside that `lab` shell:
+
+```bash
+claude login
+codex login
+gemini
+```
+
+When Tailscale is enabled:
+
+```bash
+incus exec labby -- tailscale ip -4
+```
+
+## Local Development Shortcut
+
+For source checkouts, a local host service can still be useful while iterating,
+but it now uses the same system-unit semantics as the Incus runtime. Build and
+install the binary into `/usr/local/bin`, then restart the service:
+
+```bash
+cargo build --workspace --all-features --bin labby
+sudo install -D -m 755 target/debug/labby /usr/local/bin/labby
+sudo labby setup host-service restart -y
+```
+
+Do not rely on `systemd --user`, linger, or `XDG_RUNTIME_DIR` for the supported
+self-hosted runtime.
+
+## Explicit Docker Smoke Path
+
+Docker remains an explicit compatibility and development-image smoke path:
+
+```bash
+just dev-container
+just dev-container-debug
+```
+
+Stop Docker before starting the system service because both runtimes bind the
+configured Labby HTTP port:
 
 ```bash
 docker compose -f docker-compose.yml stop labby-master
 labby setup host-service install --install-self -y
-labby setup host-service status --json
-labby gateway list
 ```
 
-## Update The Running Host Gateway
+## Rollback
+
+Rollback from the Incus path by stopping or deleting the container:
 
 ```bash
-labby setup host-service restart --install-self -y
-labby setup host-service status --json
-labby gateway code exec --json --code 'async () => 1'
+incus stop labby
+incus delete labby
 ```
 
-From a source checkout, `just host-sync` remains the rebuild-and-restart
-shortcut for ordinary Rust changes.
-
-## Verify The Public MCP Route
+Rollback to Docker for a compatibility smoke only:
 
 ```bash
-set -a
-. ~/.lab/.env
-set +a
-TOKEN="$LAB_MCP_HTTP_TOKEN"
-mcporter list https://lab.tootie.tv/mcp \
-  --header Authorization="Bearer $TOKEN" \
-  --status \
-  --exit-code
-```
-
-Then call Code Mode through the same public MCP route:
-
-```bash
-mcporter call \
-  --http-url https://lab.tootie.tv/mcp \
-  --header Authorization="Bearer $TOKEN" \
-  --tool codemode \
-  --args '{"code":"async () => 1"}' \
-  --output json
-```
-
-Expected result includes:
-
-```json
-{"result":1}
-```
-
-Also prove the public route is backed by the host service:
-
-```bash
-host_pid=$(systemctl --user show labby.service --property=MainPID --value)
-public_pid=$(curl -fsS https://lab.tootie.tv/health | jq -r .pid)
-test "$public_pid" = "$host_pid"
-readlink "/proc/$host_pid/exe"
-docker inspect -f '{{.State.Running}}' labby-master
-```
-
-Expected: the public health PID matches `labby.service` `MainPID`,
-`/proc/$host_pid/exe` points at `/home/jmagar/.local/bin/labby`, and the Docker
-container reports `false`.
-
-## Roll Back To Docker
-
-```bash
-systemctl --user disable --now labby.service
+systemctl disable --now labby.service
 docker compose -f docker-compose.yml up -d labby-master --no-deps
 curl -fsS http://127.0.0.1:8765/ready
 ```
 
-## Known Failure Mode: Deleted Executable
+## Dependency Diagnostics
 
-If Code Mode reports `failed to spawn Code Mode runner` after replacing a
-running binary, check:
-
-```bash
-labby setup host-service status --json | jq -r .process_exe
-```
-
-If the path ends in `(deleted)`, restart the service:
-
-```bash
-systemctl --user restart labby.service
-```
-
-Advanced operators can point Code Mode at an alternate validated Labby binary
-before restarting the service. The path must be absolute, executable, owned by
-the current user or root, and not group/world-writable:
-
-```bash
-install -D -m 755 target/release-fast/labby ~/.local/bin/labby.next
-env_file="$HOME/.lab/.env"
-tmp="$(mktemp)"
-grep -v '^LAB_CODE_MODE_RUNNER_EXE=' "$env_file" > "$tmp"
-printf 'LAB_CODE_MODE_RUNNER_EXE=%s\n' "$HOME/.local/bin/labby.next" >> "$tmp"
-install -m 600 "$tmp" "$env_file"
-rm -f "$tmp"
-systemctl --user restart labby.service
-labby gateway code exec --json --code 'async () => 1'
-```
-
-Remove `LAB_CODE_MODE_RUNNER_EXE` from `~/.lab/.env` after the normal
-`~/.local/bin/labby` path is healthy again:
-
-```bash
-sed -i '/^LAB_CODE_MODE_RUNNER_EXE=/d' ~/.lab/.env
-systemctl --user restart labby.service
-```
+The gateway runtime floor covers `npx`, `uvx`, `python`, and `ssh`. Missing leaf
+dependencies are diagnosed from the existing bounded upstream stderr/health path
+and reported as redacted hints. For example, an upstream that fails with
+`ffmpeg: command not found` reports an explicit `sudo apt install ffmpeg` hint,
+but Labby does not run that command automatically.

--- a/docs/sessions/2026-06-25-incus-gateway-provisioning-work-it.md
+++ b/docs/sessions/2026-06-25-incus-gateway-provisioning-work-it.md
@@ -1,0 +1,169 @@
+---
+date: 2026-06-25 17:42:48 EDT
+repo: git@github.com:jmagar/lab.git
+branch: issue-156-incus-primary-deployment
+head: aafff383
+plan: docs/superpowers/plans/2026-06-25-issue-156-incus-primary-deployment.md
+working directory: /home/jmagar/.codex/worktrees/c0993e06-da09-4fe0-bbc7-964d65b628df/lab/.worktrees/issue-156-incus-primary-deployment
+worktree: /home/jmagar/.codex/worktrees/c0993e06-da09-4fe0-bbc7-964d65b628df/lab/.worktrees/issue-156-incus-primary-deployment
+pr: "#158 Add Incus gateway provisioning https://github.com/jmagar/labby/pull/158"
+beads: lab-fh1wv, lab-fh1wv.1, lab-fh1wv.2, lab-fh1wv.3, lab-fh1wv.4, lab-fh1wv.5, lab-fh1wv.6
+---
+
+# Incus gateway provisioning work-it session
+
+## User Request
+
+Run the full `vibin:work-it` flow for GitHub issue #156, after making the issue self-contained with all bead context.
+
+## Session Overview
+
+Implemented PR #158 for the Incus-primary Labby gateway deployment path. The PR adds a hardened system `labby.service`, a local-only `labby setup --provision` flow, an Incus bootstrap script, Tailscale key cleanup, dependency diagnostics, updated deployment docs, and review fixes from multiple passes.
+
+## Sequence of Events
+
+1. Updated GitHub issue #156 so it contained the full epic context from beads and could stand alone.
+2. Planned and researched the work with Lavra skills, then exported the implementation plan under `docs/superpowers/plans/`.
+3. Executed implementation in the isolated worktree and opened PR #158.
+4. Ran review waves, including Lavra engineering review, simplification passes, PR review tooling, GitHub review comments, GitGuardian, and CodeRabbit comments.
+5. Addressed review findings, reran validation, pushed the PR branch, resolved GitHub review threads, and recorded the bead close-out comment.
+
+## Key Findings
+
+- `systemd --user` is not the right default for a headless Incus gateway; the supported runtime now uses a system unit with `User=lab`.
+- Provisioning must be explicit and local-only; the long-running gateway path should not run package or runtime installation.
+- Node must be systemd-safe and amd64-bounded for the current substrate, so provisioning uses a static Node 24 tarball with an architecture guard.
+- Missing upstream leaf dependencies should be surfaced as diagnostics instead of silently running apt.
+- Review comments exposed important hardening gaps: stale locks, partial idempotency checks, JSON stdout pollution, Tailscale key cleanup, fake scanner secrets, and bootstrap supply-chain examples.
+
+## Technical Decisions
+
+- Kept provisioning under `crates/labby/src/dispatch/setup/provision.rs` and exposed it only through `labby setup --provision`, not the MCP/API catalog.
+- Kept privileged work in bootstrap/provision and kept `labby serve` unprivileged under the `lab` user.
+- Implemented dry-run and bounded plan rendering so operators see `[root]` and `[lab ]` actions before mutation.
+- Used explicit skip signaling for the retired Dozzle checkout check: missing `plugins/dozzle` now fails unless `LAB_ALLOW_MISSING_DOZZLE=1` is set by the lint recipe.
+- Left the optional Incus distrobuilder image as follow-up because the working path is install script plus `setup --provision`.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `CLAUDE.md` | - | Update runtime instructions for the Incus/system-service path. | `git show --name-status aafff383` |
+| modified | `Justfile` | - | Align host-sync and make missing Dozzle skip explicit. | `git show --name-status aafff383` |
+| modified | `README.md` | - | Point public docs at the Incus deployment path. | `git show --name-status aafff383` |
+| modified | `crates/labby-gateway/src/gateway/manager/tests/views.rs` | - | Cover gateway dependency diagnostic projection. | `git show --name-status aafff383` |
+| modified | `crates/labby-gateway/src/gateway/projection.rs` | - | Add dependency hints, connected-state fix, and redacted tail handling. | `git show --name-status aafff383` |
+| modified | `crates/labby-gateway/src/gateway/types.rs` | - | Add dependency diagnostic fields. | `git show --name-status aafff383` |
+| modified | `crates/labby/src/cli/setup.rs` | - | Add `setup --provision` CLI and stderr confirmation prompt. | `git show --name-status aafff383` |
+| modified | `crates/labby/src/dispatch/doctor/gateway.rs` | - | Mirror gateway dependency hints in doctor output. | `git show --name-status aafff383` |
+| modified | `crates/labby/src/dispatch/setup.rs` | - | Register provision dispatch module. | `git show --name-status aafff383` |
+| modified | `crates/labby/src/dispatch/setup/host_service.rs` | - | Convert host service defaults to hardened system unit behavior. | `git show --name-status aafff383` |
+| created | `crates/labby/src/dispatch/setup/provision.rs` | - | Implement provisioning plan, execution, lock, idempotency, redaction, and tests. | `git show --name-status aafff383` |
+| modified | `docs/README.md` | - | Include runtime doc references. | `git show --name-status aafff383` |
+| modified | `docs/generated/cli-help.md` | - | Refresh generated CLI help for setup provision. | `git show --name-status aafff383` |
+| modified | `docs/runtime/HOST_GATEWAY.md` | - | Rewrite operator runbook around Incus, TUN, login, rollback, and supply-chain notes. | `git show --name-status aafff383` |
+| created | `docs/superpowers/plans/2026-06-25-issue-156-incus-primary-deployment.md` | - | Save the implementation plan. | `git show --name-status aafff383` |
+| modified | `plugins/scripts/check-dozzle-skill` | - | Make missing Dozzle skip explicit and auditable. | `git show --name-status aafff383` |
+| created | `scripts/incus-bootstrap.sh` | - | Add Incus launch/provision/Tailscale bootstrap flow. | `git show --name-status aafff383` |
+| modified | `scripts/install.sh` | - | Improve fail-closed source fallback messaging. | `git show --name-status aafff383` |
+
+## Beads Activity
+
+| bead | title | action | final status | why |
+|---|---|---|---|---|
+| `lab-fh1wv` | Make Incus the primary supported Labby gateway deployment path | Read, planned, commented | open | Epic tracks issue #156 and remains open until PR merge and optional image follow-up are decided. |
+| `lab-fh1wv.1` | Convert Labby host service to hardened system unit | Implemented in PR | open | System unit work is in PR #158 but not merged. |
+| `lab-fh1wv.2` | Add labby setup --provision | Implemented in PR | open | Provision command is in PR #158 but not merged. |
+| `lab-fh1wv.3` | Add Incus bootstrap script and Tailscale join | Implemented in PR | open | Bootstrap script is in PR #158 but not merged. |
+| `lab-fh1wv.4` | Surface just-in-time upstream dependency diagnostics | Implemented first slice | open | Diagnostics are in PR #158; manifest expansion can continue later. |
+| `lab-fh1wv.5` | Rewrite deployment docs | Implemented in PR | open | Docs are in PR #158 but not merged. |
+| `lab-fh1wv.6` | Add optional Incus distrobuilder release image | Not implemented | open | Explicit follow-up after the provisioning path stabilizes. |
+
+## Repository Maintenance
+
+- Plans: checked `docs/plans`; `docs/plans/fleet-ws-plan-lab-n07n.md` was not related to this session, and `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` was already complete. No plan files were moved.
+- Beads: read `lab-fh1wv` and recent bead state, then added an implementation comment with PR, validation, review status, and why the epic was not closed.
+- Worktrees and branches: inspected `git worktree list --porcelain`, local branches, and remote branches. Active/sibling worktrees were left untouched because ownership or merge state was not safe to clean.
+- Stale docs: updated the runtime, README, generated CLI help, and plan docs that the implementation contradicted.
+- GitHub review: review threads are resolved according to GitHub GraphQL; CodeRabbit status remains pending/rate-limited after the latest push.
+
+## Tools and Skills Used
+
+- Skills: `vibin:work-it`, `vibin:save-to-md`, `lavra-plan`, `lavra-research`, `lavra-eng-review`, review/simplification tooling.
+- Shell and Git: worktree management, commits, force-with-lease pushes after amend, status, logs, validation commands, and GitHub CLI API reads.
+- Beads: `bd show`, `bd list`, and `bd comment` for issue-tracker evidence and close-out notes.
+- GitHub: issue update, PR creation, review-comment refresh, status checks, and review thread inspection.
+- Subagents: implementation and review agents were used earlier in the `work-it` flow.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git diff --check` | Passed. |
+| `target/debug/labby setup --provision --dry-run` | Passed; printed bounded root/lab plan and no-actions section. |
+| `scripts/incus-bootstrap.sh --version v0.0.0 --dry-run` | Passed; reported Incus missing locally and printed non-mutating command plan. |
+| `just check` | Passed. |
+| `just docs-check` | Passed; 15 docs artifacts fresh. |
+| `just lint` | Passed after the explicit Dozzle skip adjustment. |
+| `just test` | Passed; 2180 tests run, 2180 passed, 13 skipped. |
+| `gh api repos/jmagar/labby/pulls/158` | PR open, mergeable, head `aafff383`. |
+| `gh api graphql ... reviewThreads` | All fetched review threads reported resolved. |
+
+## Errors Encountered
+
+- GitGuardian initially flagged scanner-looking fake tokens in tests. The fixtures now assemble token-shaped values from fragments, and GitGuardian later reported no secrets remaining.
+- CodeRabbit flagged several real issues. Fixes included stderr prompting, stale-lock cleanup, stronger idempotency checks, Node architecture rejection, Gemini install alignment, Tailscale auth-key cleanup, safer bootstrap examples, and explicit Dozzle skip gating.
+- CodeRabbit later became rate-limited/pending after the final push, so no fresh automated review summary was available at close-out.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Gateway service | User service under `systemd --user` guidance. | Hardened system `labby.service` running as `lab`. |
+| Provisioning | Manual scattered setup. | `labby setup --provision` with dry-run, confirmation, idempotency, and redacted output. |
+| Incus deployment | Not the primary documented path. | `scripts/incus-bootstrap.sh` plus Incus-first runtime docs. |
+| Dependency failures | Generic upstream unhealthy messages. | Gateway and doctor surfaces can show redacted dependency hints. |
+| Dozzle check | Missing checkout skipped silently. | Missing checkout fails unless explicitly opted out. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `git diff --check` | No whitespace errors. | No output. | pass |
+| `target/debug/labby setup --provision --dry-run` | Non-mutating plan. | Printed root/lab plan and "dry-run complete". | pass |
+| `scripts/incus-bootstrap.sh --version v0.0.0 --dry-run` | Non-mutating Incus command plan. | Printed missing-Incus notice and dry-run commands. | pass |
+| `just check` | Workspace all-features check passes. | Finished successfully. | pass |
+| `just docs-check` | Generated docs fresh. | Checked 15 docs artifacts: fresh. | pass |
+| `just lint` | Skill drift, wrapper test, clippy, fmt pass. | Finished successfully. | pass |
+| `just test` | Full nextest suite passes. | 2180 passed, 13 skipped. | pass |
+
+## Risks and Rollback
+
+- Risk: full live Incus mutation was not executed in this environment because Incus is not installed here. Rollback for an attempted container is documented as `incus stop labby` and `incus delete labby`.
+- Risk: CodeRabbit final status is pending/rate-limited after the last push. Review threads visible through GitHub were resolved, but a later bot run may produce new comments.
+- Rollback: revert PR #158 or remove the Incus container and restore the prior host-service runtime path from `main`.
+
+## Decisions Not Taken
+
+- Did not implement the optional distrobuilder image in this slice; the universal install/provision path is the foundation.
+- Did not close the beads because PR #158 is still open and the optional image child remains future work.
+- Did not delete sibling worktrees or branches because they are active, dirty state was not audited deeply, or they are known long-lived variants.
+
+## References
+
+- GitHub issue: https://github.com/jmagar/labby/issues/156
+- Pull request: https://github.com/jmagar/labby/pull/158
+- Plan: `docs/superpowers/plans/2026-06-25-issue-156-incus-primary-deployment.md`
+- Bead epic: `lab-fh1wv`
+
+## Open Questions
+
+- Whether to trigger CodeRabbit again after the rate-limit window clears.
+- Whether to close bead children after PR merge or keep the optional distrobuilder child as the remaining epic item.
+
+## Next Steps
+
+- Wait for PR #158 checks and bot review to finish.
+- Merge PR #158 when external checks are acceptable.
+- After merge, decide whether to close `lab-fh1wv.1` through `lab-fh1wv.5` and leave `lab-fh1wv.6` as follow-up.
+- Run a live Incus bootstrap on a host with Incus installed before announcing the path as operational beyond dry-run/local verification.

--- a/docs/sessions/2026-06-25-incus-gateway-provisioning-work-it.md
+++ b/docs/sessions/2026-06-25-incus-gateway-provisioning-work-it.md
@@ -114,6 +114,13 @@ Implemented PR #158 for the Incus-primary Labby gateway deployment path. The PR 
 - GitGuardian initially flagged scanner-looking fake tokens in tests. The fixtures now assemble token-shaped values from fragments, and GitGuardian later reported no secrets remaining.
 - CodeRabbit flagged several real issues. Fixes included stderr prompting, stale-lock cleanup, stronger idempotency checks, Node architecture rejection, Gemini install alignment, Tailscale auth-key cleanup, safer bootstrap examples, and explicit Dozzle skip gating.
 - CodeRabbit later became rate-limited/pending after the final push, so no fresh automated review summary was available at close-out.
+- Live Incus validation found additional setup bugs that dry-runs missed:
+  - Fresh Ubuntu 24.04 containers needed `xz-utils` for the Node `.tar.xz` install.
+  - `dpkg-query -W` was too weak for idempotency because known-but-not-installed packages still returned success; the check now requires installed `ii` status.
+  - `runuser` inherited `/root` as cwd, causing `uv` to look for `/root/uv.toml`; lab user commands now `cd /home/lab` and set lab-owned XDG paths.
+  - First-run downloads can exceed two minutes, so provisioning command timeout increased to 10 minutes.
+  - Unprivileged Incus containers on this host denied signal delivery even for same-UID child processes; the bootstrap now uses a privileged system container while the service still runs as `lab`.
+  - `ss -ltnp` in Incus may omit process ownership; service readiness verification now has `/proc` socket fallback and also requires `labby.service` to be active.
 
 ## Behavior Changes (Before/After)
 
@@ -132,6 +139,12 @@ Implemented PR #158 for the Incus-primary Labby gateway deployment path. The PR 
 | `git diff --check` | No whitespace errors. | No output. | pass |
 | `target/debug/labby setup --provision --dry-run` | Non-mutating plan. | Printed root/lab plan and "dry-run complete". | pass |
 | `scripts/incus-bootstrap.sh --version v0.0.0 --dry-run` | Non-mutating Incus command plan. | Printed missing-Incus notice and dry-run commands. | pass |
+| `scripts/incus-bootstrap.sh --local-binary target/debug/labby` | Clean Incus bootstrap from no container to ready service. | `provision complete: executed=6, skipped=0` in privileged `images:ubuntu/24.04` container. | pass |
+| `incus exec labby-e2e -- systemctl is-active labby.service` | Service active after bootstrap. | `active`. | pass |
+| `incus exec labby-e2e -- curl -fsS http://127.0.0.1:8765/ready` | Readiness endpoint reports ready. | `{"status":"ready"}`. | pass |
+| `incus exec labby-e2e -- runuser -u lab -- sh -lc 'node --version && npm --version && uv --version && python3 --version && claude --version && codex --version && gemini --version'` | Provisioned runtime and agent CLIs available as `lab`. | Node v24.18.0, npm 11.16.0, uv 0.11.24, Python 3.12.3, Claude Code 2.1.193, codex-cli 0.142.2, Gemini 0.49.0. | pass |
+| `incus exec labby-e2e -- systemctl restart labby.service` plus ready check | Restart keeps service active and ready. | `active`, `{"status":"ready"}`, `ExecMainStatus=0`. | pass |
+| Re-run `scripts/incus-bootstrap.sh --local-binary target/debug/labby` | Idempotent rerun skips completed provision steps. | `provision complete: executed=0, skipped=6`. | pass |
 | `just check` | Workspace all-features check passes. | Finished successfully. | pass |
 | `just docs-check` | Generated docs fresh. | Checked 15 docs artifacts: fresh. | pass |
 | `just lint` | Skill drift, wrapper test, clippy, fmt pass. | Finished successfully. | pass |
@@ -139,7 +152,7 @@ Implemented PR #158 for the Incus-primary Labby gateway deployment path. The PR 
 
 ## Risks and Rollback
 
-- Risk: full live Incus mutation was not executed in this environment because Incus is not installed here. Rollback for an attempted container is documented as `incus stop labby` and `incus delete labby`.
+- Risk: the tested Incus path uses `images:ubuntu/24.04` and a privileged system container. Earlier Debian 13 attempts on this host did not receive working container networking, and unprivileged containers denied signal delivery needed for service restarts.
 - Risk: CodeRabbit final status is pending/rate-limited after the last push. Review threads visible through GitHub were resolved, but a later bot run may produce new comments.
 - Rollback: revert PR #158 or remove the Incus container and restore the prior host-service runtime path from `main`.
 
@@ -166,4 +179,4 @@ Implemented PR #158 for the Incus-primary Labby gateway deployment path. The PR 
 - Wait for PR #158 checks and bot review to finish.
 - Merge PR #158 when external checks are acceptable.
 - After merge, decide whether to close `lab-fh1wv.1` through `lab-fh1wv.5` and leave `lab-fh1wv.6` as follow-up.
-- Run a live Incus bootstrap on a host with Incus installed before announcing the path as operational beyond dry-run/local verification.
+- Decide whether the privileged Incus container requirement is acceptable for the primary runtime or whether a future VM/distrobuilder path should replace it.

--- a/docs/superpowers/plans/2026-06-25-issue-156-incus-primary-deployment.md
+++ b/docs/superpowers/plans/2026-06-25-issue-156-incus-primary-deployment.md
@@ -1,0 +1,743 @@
+## Summary
+
+Replace Docker with an **Incus system container** as the primary, supported way to self-host the Labby gateway. Docker is the wrong shape for this workload: the gateway spawns arbitrary stdio MCP servers and runs the agent CLIs (`claude`, `codex`, `gemini`), so its dependency closure is user-defined at runtime, not knowable at image-build time. The current Docker deployment papers over that with many bind mounts, credential-lockstep file mounts, hostname hacks, and per-binary mounts. Almost all of that exists to defeat the host/container boundary, which means Docker is the wrong boundary.
+
+An Incus system container behaves like a lightweight VM sharing the host kernel: full systemd, normal package installation, SSH access, and a persistent rootfs. The migration is mostly deletion of compose-specific workaround config, not a one-to-one translation.
+
+This issue is now self-contained. It also has a local Beads plan for execution tracking:
+
+- Epic: `lab-fh1wv` — Make Incus the primary supported Labby gateway deployment path
+- Children: `lab-fh1wv.1` through `lab-fh1wv.6`
+- `bd swarm validate lab-fh1wv` passes.
+- Ready waves: `.1` -> `.2` -> `.3/.4/.6` -> `.5`; max parallelism 3.
+
+## What Already Exists
+
+Build on this; do not rebuild it.
+
+- `scripts/install.sh` is already the bootstrap we want. Its job is getting `labby` on PATH; everything after is owned by the binary via `labby setup`. It fetches the prebuilt release and SHA-verifies where possible, with a cargo fallback. It supports `LAB_INSTALL_DIR`, which is required for installing inside the Incus container to `/usr/local/bin`.
+- `labby setup host-service install|status|restart|uninstall` in `crates/labby/src/dispatch/setup/host_service.rs` is already a complete service manager: atomic unit write, `systemd-analyze verify`, `/ready` readiness poll, PID ownership validation, Docker `labby-master` conflict preflight, and `systemctl show` status parsing. It is currently built around `systemd --user`; this issue changes that default.
+- `.github/workflows/release.yml` already builds the Linux release artifact and bundles the gateway-admin frontend.
+- Prior host-service plan and implementation notes live in `docs/superpowers/plans/2026-06-22-host-labby-gateway.md` and `docs/sessions/2026-06-22-host-labby-gateway-work-it.md`.
+
+## Hard Constraint: amd64 Debian 13 Incus
+
+Both install/release constraints currently make amd64 the supported substrate. `rquickjs-sys`, used by Code Mode's QuickJS engine, does not cross-compile cleanly in the current release path. The supported self-hosted deployment substrate for this issue is therefore:
+
+- **amd64**
+- **Debian 13**
+- **Incus system container**
+
+Document this explicitly. ARM users do not have the same prebuilt path today and may fall back to a slower cargo build. The optional distrobuilder image is amd64-only as well.
+
+## Runtime Floor
+
+Labby is a gateway for running stdio MCP servers and agent CLIs, so the runtime environment is the floor by definition.
+
+Bake/install:
+
+- `node`
+- `python`
+- `uv`
+- `git`
+- `gh`
+- `openssh-client`
+- `claude`
+- `codex`
+
+Do not bake:
+
+- `ffmpeg` and other per-upstream leaf libraries. They are handled by just-in-time dependency diagnostics and explicit operator action.
+
+Privilege split:
+
+- `[root]` apt: `git`, `openssh-client`, `gh`, `ca-certificates`, `curl`, `zsh`
+- `[lab]` user-space: `node`, Python via `uv python install`, `claude`, `codex`
+
+Node decision:
+
+- Do **not** use `fnm`. It depends on shell hooks and silently falls off PATH in systemd/non-login contexts.
+- Use NodeSource apt or the official static tarball into `/usr/local`; either path must put `node`, `npm`, and `npx` on PATH for the `lab` user and systemd service.
+- `mise` is acceptable only if a manager is genuinely wanted, but it is unnecessary for one pinned Node version.
+
+## Architecture
+
+There are two honest layers:
+
+1. `scripts/incus-bootstrap.sh` runs on the host. It creates/configures the Incus container, passes `/dev/net/tun`, installs `labby` inside the box, then runs the in-box provisioning flow.
+2. `labby setup --provision` runs inside the box, or on bare metal when desired. It owns the environment: install the floor, create the `lab` user, write the system unit, and enable/start the service.
+
+The long-running `labby serve` process stays small, unprivileged, and responsible only for its own runtime. Privileged one-time setup stays out of `serve`.
+
+## Locked Decisions
+
+- Incus system container is the primary supported self-hosted deployment path.
+- Supported substrate is amd64 Debian 13.
+- Docker remains only an explicit compatibility/dev-container/prod-like smoke path until deprecation docs and checks are updated.
+- Long-running `labby serve` stays unprivileged.
+- Privileged setup is explicit, bounded, and consent-gated.
+- The system service runs as `User=lab` / `Group=lab`, not `systemd --user`.
+- Tailscale runs inside the container and requires `/dev/net/tun` passthrough.
+- Adding upstreams must not silently run apt. Missing leaf dependencies are diagnosed or declared and require explicit operator consent.
+- Mutating `setup --provision` execution is local CLI-only. Do not expose root apt/useradd/systemctl execution through MCP, HTTP, Code Mode, or remote admin actions.
+- Distrobuilder is optional and downstream of the universal install/provision path.
+
+## Security Model
+
+Threat model: supply-chain-compromised upstream dependency or opportunistic automated abuse, not a targeted kernel 0-day attacker.
+
+Required controls:
+
+- Unprivileged Incus container.
+- `security.idmap.isolated=true`.
+- `security.nesting=false`.
+- Keep Incus default AppArmor profile.
+- Exactly one host passthrough device: `/dev/net/tun`.
+- Hardened systemd unit constrains `labby` and all spawned child processes.
+- Downloads/scratch dir should be `noexec,nosuid,nodev` where practical.
+- Optional LAN egress hardening can block RFC1918 LAN ranges while allowing internet and tailnet dependencies.
+- Future per-child sandboxing can shrink blast radius from whole container to one upstream, but that is not v1.
+
+## Engineering Review Guardrails
+
+Architecture review:
+
+- The substrate split is sound: host bootstrap, in-box provision, unprivileged `labby serve`.
+- Reuse `host_service.rs` primitives instead of replacing them.
+- `--install-self` currently means copy to `~/.local/bin`; the system unit wants `/usr/local/bin/labby`. Do not overload semantics accidentally.
+- Tailscale ownership must be clear: bootstrap passes TUN/auth context; provision may install/join, but one path owns it.
+- Known-upstream dependency hints are advisory diagnostics, not install authority.
+
+Simplicity review:
+
+- Convert `host_service.rs` in place. Do not build `SystemdBackend`, `PackageManager`, `ProvisionProvider`, boxed executor traits, or a multi-distro abstraction.
+- Target one supported substrate: amd64 Debian 13.
+- Keep `incus-bootstrap.sh` as shell, not Rust.
+- Keep Docker as explicit smoke/dev path, not a second first-class deployment model.
+- Do not start distrobuilder before the plain install-script plus provision path works.
+
+Security review:
+
+- Provisioning must stay local CLI-only.
+- Dependency diagnostics can leak secrets; add a final operator-visible sanitizer.
+- Incus production bootstrap install path must fail closed: require checksum, pin release/version, ignore unsafe inherited `LAB_INSTALL_REPO`, and make source-build fallback explicit.
+- Avoid writable PATH persistence risk under `User=lab`: no writable directories before trusted binaries.
+- `TS_AUTHKEY` must never be printed, persisted to systemd env files, captured in traces, or left in process args longer than necessary.
+- Incus isolation requirements are acceptance criteria, not docs-only.
+
+Performance/reliability review:
+
+- `/ready` alone is insufficient; system unit can be ready while stdio upstreams fail.
+- Smoke at least one `npx` and one `uvx` upstream under the hardened service.
+- Provisioning must be resumable and idempotent after partial failure.
+- Status ownership checks may need `owner=unknown` when non-root callers cannot see `ss -ltnp` process ownership.
+- Dependency diagnostics must reuse existing bounded upstream stderr capture and circuit-breaker paths; do not add serial bulk probes.
+- Avoid any path that can turn import/provision into `N * 15s` serial probes across many upstreams.
+
+## Research Findings
+
+- systemd docs support the system-unit direction: `WantedBy=multi-user.target` ties the service to normal headless/server boot. Hardening directives such as `ProtectSystem=strict`, `ProtectHome`, `NoNewPrivileges`, `ReadWritePaths`, and `RestrictSUIDSGID` affect child MCP and agent processes and must be smoke-tested.
+- Incus docs distinguish `incus init` from `incus launch`; `incus launch` creates and starts the instance. Incus `unix-char` devices expose host character devices like `/dev/net/tun` inside the instance.
+- Tailscale supports unattended joins with `tailscale up --auth-key=...`; auth keys can also be supplied through a `file:` path. Tailscale SSH is a tailnet SSH authorization layer, so `--ssh` needs explicit operator awareness and ACL implications in docs.
+- MCP tool discovery does not expose system package requirements. Launcher token inspection can validate only runtime floor classes such as `uvx`, `npx`, `python`, and `ssh`; leaf deps need curated hints or stderr diagnosis.
+- `.lavra/memory/recall.sh` was absent in this worktree, so Lavra local memory recall was not available. Research used repo evidence plus current primary docs.
+
+External docs referenced:
+
+- Incus instance creation: https://linuxcontainers.org/incus/docs/main/howto/instances_create/
+- Incus `unix-char` devices: https://linuxcontainers.org/incus/docs/main/reference/devices_unix_char/
+- systemd exec/unit docs: https://www.freedesktop.org/software/systemd/man/systemd.exec.html and https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+- Tailscale CLI up: https://tailscale.com/docs/reference/tailscale-cli/up
+- Tailscale SSH: https://tailscale.com/docs/features/tailscale-ssh
+
+## Work Item 1 / `lab-fh1wv.1` — Convert Host Service to Hardened System Unit
+
+### What
+
+Convert the existing `labby setup host-service` implementation from a `systemd --user` service to a hardened system unit suitable for a headless Incus container, while preserving a non-default workstation/user-service escape hatch only if needed.
+
+### Context
+
+`host_service.rs` currently owns unit rendering, install/status/restart/uninstall, preflight port checks, Docker `labby-master` conflict detection, readiness polling, `systemctl show` parsing, PID ownership validation, and atomic unit writes. Reuse those pieces. The core issue is that `systemd --user` is wrong for a headless container because it relies on user D-Bus/session state or linger.
+
+### Required Changes
+
+- `unit_dir` / `unit_path` -> `/etc/systemd/system/labby.service`.
+- `run_systemctl` drops the `--user` flag for default system mode.
+- Unit gains `User=lab`, `Group=lab`, and `WantedBy=multi-user.target`.
+- Drop `%h` user-manager path tricks; use absolute paths.
+- `ExecStart=/usr/local/bin/labby serve`.
+- Install binary to `/usr/local/bin/labby`, root-owned and executable by `lab`.
+- Optionally keep previous `systemd --user` mode behind an explicit non-default flag/subcommand, or drop it entirely if no real need remains.
+
+### Hardening Baseline
+
+Start from this, then relax only if required by smoke tests:
+
+```ini
+[Service]
+User=lab
+Group=lab
+ExecStart=/usr/local/bin/labby serve
+WorkingDirectory=/home/lab
+Environment=HOME=/home/lab
+Environment=XDG_CACHE_HOME=/home/lab/.cache
+Environment=XDG_CONFIG_HOME=/home/lab/.config
+Environment=XDG_DATA_HOME=/home/lab/.local/share
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/lab/.lab /home/lab/.local /home/lab/.cache /home/lab/.config /home/lab/.npm /home/lab/.codex /home/lab/.claude /home/lab/.gemini /home/lab/downloads
+ProtectHome=read-only
+PrivateTmp=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictSUIDSGID=true
+LockPersonality=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+TasksMax=1000
+MemoryMax=4G
+Restart=on-failure
+RestartSec=3
+```
+
+### Locked Decisions
+
+- Default target is `/etc/systemd/system/labby.service` using normal `systemctl`, not `systemctl --user`.
+- Unit runs `ExecStart=/usr/local/bin/labby serve` with `User=lab` and `Group=lab`.
+- Unit is wanted by `multi-user.target`.
+- Keep the gateway runtime unprivileged; root is only for unit write/install and package provisioning.
+- Add hardening directives from this issue, but test against real stdio upstream behavior before shipping.
+- Keep existing readiness and port/PID ownership checks.
+
+### Discretion
+
+- Whether previous user-service mode remains behind an explicit flag/subcommand or is split into a separate helper.
+- Exact hardening directive set if a directive breaks required stdio/agent CLI behavior; document any deliberate relaxation.
+
+### Testing
+
+- [ ] Unit-rendering tests assert `User=lab`, `Group=lab`, `/usr/local/bin/labby serve`, `WantedBy=multi-user.target`, and no `%h` user-manager paths in default system mode.
+- [ ] Command-construction tests prove default calls omit `--user`.
+- [ ] Existing preflight/readiness/status parsing tests still pass.
+- [ ] Hardened unit is verified with `systemd-analyze verify` where available.
+- [ ] Smoke proves a restarted service owns the `/ready` listener.
+- [ ] Smoke at least one `npx` and one `uvx` stdio upstream under the hardened service.
+
+### Validation
+
+- [ ] `labby setup host-service unit` renders the system unit by default.
+- [ ] `labby setup host-service install --install-self -y` installs to the system path or routes through the provision flow clearly.
+- [ ] Service survives a headless reboot/restart path without `loginctl enable-linger` or `XDG_RUNTIME_DIR`.
+- [ ] `/ready` owner check passes when run as root during install/provision.
+- [ ] `status` distinguishes `ready=true, owner=unknown` from `ready=false` when non-root callers cannot see PID ownership.
+
+### Files
+
+- `crates/labby/src/dispatch/setup/host_service.rs`
+- `crates/labby/src/cli/setup.rs`
+- `crates/labby/src/output/*` if CLI status rendering needs updates
+
+### Dependencies
+
+- None. This is first in the critical path.
+
+### Notes from Research and Review
+
+- Add a rendered-unit test that asserts every writable runtime/cache/home path needed by spawned stdio upstreams is either inside allowed lab-user paths or explicitly listed in `ReadWritePaths`; over-hardening should fail in smoke, not production.
+- Acceptance must include `npx` and `uvx` stdio upstream smoke under the unit, explicit `HOME`/`XDG_*`/`PATH`/`WorkingDirectory` for `/home/lab`, and writable cache/config paths needed by spawned agent and MCP processes.
+- Avoid writable directories ahead of trusted binaries in PATH.
+
+## Work Item 2 / `lab-fh1wv.2` — Add `labby setup --provision`
+
+### What
+
+Add `labby setup --provision` as the one in-box provisioning command that installs the runtime floor, creates the `lab` user if needed, writes/enables the system service, and supports plan/consent/dry-run behavior.
+
+### Context
+
+Provisioning belongs in the binary and runs inside the Incus container or on bare metal. It must not run from the long-lived `serve` path. Existing `setup` CLI and setup dispatch are the right ownership area; keep CLI thin and put behavior in `crates/labby/src/dispatch/setup/`.
+
+### Command Contract
+
+- `labby setup --provision --dry-run`: print the full plan; mutate nothing.
+- `labby setup --provision`: print the plan and prompt `y/N`.
+- `labby setup --provision --yes`: non-interactive execution for bootstrap/CI.
+- `labby setup --provision --skip-deps`: service-only path for baked image/prepared box.
+
+### Plan Output Contract
+
+Plan output must be bounded and explicit about privilege:
+
+```text
+labby setup --provision will:
+  [root] apt install: git openssh-client gh ca-certificates curl zsh
+  [lab ] install node v24.x  (NodeSource / static, on PATH)
+  [lab ] install uv + python (user-space)
+  [lab ] install claude + codex (npm, user-space)
+  [root] write /etc/systemd/system/labby.service
+  [root] useradd lab (if absent)
+  [root] systemctl enable --now labby
+
+It will NOT:
+  - install or modify Incus
+  - touch any package outside the list above
+  - modify anything on the host outside this container
+  - transmit anything off-box
+
+Proceed? [y/N]
+```
+
+### Locked Decisions
+
+- Root actions: apt install only the bounded floor (`git`, `openssh-client`, `gh`, `ca-certificates`, `curl`, `zsh`), create `lab` user, write `/etc/systemd/system/labby.service`, enable/start service.
+- Lab-user actions: install node, uv + Python, `claude`, `codex`.
+- Do not use `fnm` for Node; use NodeSource apt or official static tarball.
+- Support `--dry-run`, default prompt, `--yes`, and `--skip-deps`.
+- Output plan is bounded and tagged `[root]` / `[lab ]`, including an `It will NOT` section.
+- Check-first/idempotent: commands no-op when required versions/tools are already present.
+- Mutating provision execution is local CLI-only. Do not expose it through MCP/API/Code Mode.
+
+### Discretion
+
+- Exact module split under `crates/labby/src/dispatch/setup/`.
+- Whether implementation shells out to package managers directly or uses small typed command builders, as long as tests cover plan construction and idempotency decisions.
+
+### Implementation Pattern
+
+Use a typed plan/executor, not an opaque shell script:
+
+- `ProvisionPlan { actions, non_actions }`
+- Each action should have `check`, `plan`, `execute`, `verify`, and `rollback_hint` semantics.
+- Dry-run calls checks and renders the plan only.
+- `--yes` verifies after every step and is safely resumable.
+- Add a global provisioning lock.
+- Use bounded command timeouts.
+- Redact stderr.
+- Keep apt package list closed.
+- Use fake executor tests for dry-run/idempotency.
+
+### Testing
+
+- [ ] Dry-run test proves no mutating command executor is called.
+- [ ] Plan rendering snapshot includes root/lab actions and explicit non-actions.
+- [ ] Idempotency tests cover already-present node/python/uv/claude/codex and package floor checks.
+- [ ] Confirmation behavior refuses by default and proceeds with `--yes`.
+- [ ] Failure surfaces command stderr without leaking secrets.
+- [ ] Tests prove mutating `setup --provision` is not in MCP/API catalogs.
+
+### Validation
+
+- [ ] `labby setup --provision --dry-run` exits successfully and mutates nothing.
+- [ ] `labby setup --provision --yes --skip-deps` can write/enable only the service on a prepared box.
+- [ ] Re-running `--provision --yes` on a provisioned box is a no-op except service status verification.
+- [ ] Node/npm/npx are verified from the `lab` user before enabling service.
+- [ ] `systemctl reset-failed labby.service` is used when fixing dependencies after restart-loop failures.
+
+### Files
+
+- `crates/labby/src/cli/setup.rs`
+- `crates/labby/src/dispatch/setup.rs`
+- `crates/labby/src/dispatch/setup/provision.rs`
+- `crates/labby/src/dispatch/setup/host_service.rs`
+- `docs/generated/*` after help regeneration
+
+### Dependencies
+
+- Depends on Work Item 1.
+
+### Notes from Research and Review
+
+- Provisioning should keep Node off shell-hook managers because systemd/non-login environments do not run interactive shell hooks.
+- Incus production bootstrap should fail closed on install integrity: require release checksum, pin release/version, ignore unsafe inherited `LAB_INSTALL_REPO`, and make source-build fallback explicit.
+- Partial failure is expected: apt lock, network outage, npm registry outage, expired Tailscale auth key, interrupted install. Rerun must be safe.
+
+## Work Item 3 / `lab-fh1wv.3` — Add Incus Bootstrap and Tailscale Join
+
+### What
+
+Create `scripts/incus-bootstrap.sh` to launch the Debian 13 Incus system container, pass `/dev/net/tun`, install `labby` inside the container, run `labby setup --provision --yes`, and print the remaining manual login steps.
+
+### Context
+
+The bootstrap is the only host-side piece. It may create/configure the container and TUN device, but it must not silently install or initialize Incus itself. Tailscale runs inside the container and gets its own tailnet IP; the TUN device is mandatory and must be visible in output and docs.
+
+### Bootstrap Shape
+
+```sh
+#!/bin/sh
+set -eu
+if ! command -v incus >/dev/null; then
+  echo "Incus is not installed. Options:"
+  echo "  [I] install it (apt, needs root) + run 'incus admin init'"
+  echo "  [P] print the commands and exit"
+  # read choice; never force host mutation
+fi
+incus launch images:debian/13 labby
+incus config device add labby tun unix-char path=/dev/net/tun
+incus file push scripts/install.sh labby/tmp/labby-install.sh
+incus exec labby -- env \
+  LAB_INSTALL_DIR=/usr/local/bin \
+  LAB_INSTALL_VERSION=vX.Y.Z \
+  LAB_REQUIRE_CHECKSUM=1 \
+  LAB_ALLOW_SOURCE_FALLBACK=0 \
+  sh /tmp/labby-install.sh
+incus exec labby -- rm -f /tmp/labby-install.sh
+incus exec labby -- labby setup --provision --yes
+cat <<'DONE'
+Done. Manual steps remain:
+  1. incus exec labby -- su - lab
+  2. claude login && codex login && gemini
+  3. verify: incus exec labby -- systemctl status labby
+DONE
+```
+
+The final implementation should avoid `sh -c` for user-controlled values. Use typed command construction wherever values can vary.
+
+### Locked Decisions
+
+- Detect missing Incus and offer install/print options; do not force privileged host setup silently.
+- Launch `images:debian/13` amd64 container named `labby` unless overridden.
+- Add TUN passthrough with `incus config device add labby tun unix-char path=/dev/net/tun`.
+- Run `scripts/install.sh` inside the box with `LAB_INSTALL_DIR=/usr/local/bin`.
+- Run `labby setup --provision --yes` inside the box.
+- Accept `TS_AUTHKEY`; when present, provision/join Tailscale with `tailscale up --auth-key=... --ssh` only when explicitly enabled.
+- Print manual `claude login`, `codex login`, and `gemini`/Gemini login guidance after service setup.
+
+### Discretion
+
+- CLI flags for container name, image alias, and dry-run output.
+- Whether Tailscale install belongs in provision or bootstrap, provided the public contract is one bootstrap path and one provision path.
+
+### Idempotency Requirements
+
+Bootstrap must detect and handle:
+
+- existing container
+- correct image architecture
+- TUN device already present or missing
+- installed `/usr/local/bin/labby`
+- provision state
+- service status
+- Tailscale state
+
+A partial first run must not make reruns useless. For example, if first run creates the container but fails before adding TUN, rerun must add TUN and continue.
+
+### Tailscale Requirements
+
+- Tailscale runs inside the container and gets its own tailnet IP.
+- `/dev/net/tun` passthrough is mandatory.
+- `TS_AUTHKEY` must never be printed, persisted in systemd env files, captured in shell traces, or left in process args longer than necessary.
+- Prefer ephemeral, preauthorized, tag-scoped auth keys with short expiry.
+- `--ssh` exposes Tailscale SSH behavior; docs and plan output must state ACL/security implications.
+
+### Incus Isolation Requirements
+
+Bootstrap should verify or enforce:
+
+- isolated idmap
+- non-nested container
+- non-privileged profile
+- default AppArmor
+- exactly one host passthrough device: `/dev/net/tun`
+
+### Testing
+
+- [ ] Shellcheck or equivalent syntax validation for `scripts/incus-bootstrap.sh`.
+- [ ] Dry-run/print-only path can be tested without Incus mutation.
+- [ ] Script refuses or prompts clearly when Incus is missing.
+- [ ] Generated command sequence includes TUN device and in-box install/provision commands.
+- [ ] Idempotency tests or dry-run fixtures cover existing container and existing TUN device.
+
+### Validation
+
+- [ ] Fresh Incus container reaches running `labby.service` with zero Docker bind mounts.
+- [ ] Container survives `incus restart labby` and gateway comes back.
+- [ ] Tailscale reports a 100.x tailnet IP when auth key is supplied.
+- [ ] `incus restart labby` followed by `/ready` and service owner check passes.
+
+### Files
+
+- `scripts/incus-bootstrap.sh`
+- `scripts/install.sh`
+- `crates/labby/src/dispatch/setup/provision.rs` if Tailscale join is in provision
+- `docs/runtime/*` for operator runbook references
+
+### Dependencies
+
+- Depends on Work Item 2.
+
+### Notes from Research and Review
+
+- Incus `unix-char` is the right mechanism for `/dev/net/tun`.
+- Tailscale auth-key join is viable but must be handled as sensitive input.
+- The bootstrap must not auto-install or auto-initialize Incus without explicit operator choice.
+
+## Work Item 4 / `lab-fh1wv.4` — Just-in-Time Upstream Dependency Diagnostics
+
+### What
+
+Add the v1 mechanism for missing per-upstream leaf dependency handling: validate launcher runtimes from gateway config, diagnose failed first spawns from stderr, optionally consult a small known-upstreams manifest, and surface suggested fixes without silently running apt.
+
+### Context
+
+MCP servers do not declare system package requirements. A server announces tools, not system dependencies. Launcher commands can reveal only runtime class (`npx`, `uvx`, `python`, `ssh`), which should already be covered by the runtime floor. Leaf libraries like `ffmpeg` must be declared in curated metadata or diagnosed from process stderr.
+
+### Design
+
+- Runtime detection: first command token maps to runtime floor (`uvx`/`uv` -> uv, `npx`/`node` -> node, `python` -> python, `ssh` -> openssh). This validates the floor; it does not discover leaf libraries.
+- Leaf diagnosis: when an upstream fails on first spawn, classify existing bounded stderr/circuit-breaker health state and produce a structured hint.
+- Optional curated hints: a small `known-upstreams` mapping can exist for popular upstreams, but it must be advisory and test-backed.
+- No silent apt. Any package installation is a separate explicit consent action.
+
+### Locked Decisions
+
+- Adding/importing an upstream must not silently mutate system packages.
+- General mechanism is diagnose-first: failed spawn stderr is surfaced with a suggested fix when patterns match.
+- A thin curated manifest for common upstreams is allowed but not required to block v1.
+- Hook near `gateway.add` / import approval and `doctor` so failures are visible immediately and during audits.
+- Redact secrets and cap stderr tail output.
+
+### Discretion
+
+- Manifest filename/location and exact schema.
+- Initial known upstream set; keep it small and test-backed.
+- Whether `apt install` execution is a follow-up action or consent-gated option in the add response.
+
+### Required Diagnostic Shape
+
+Expose structured redacted values only, never raw stderr:
+
+```text
+RedactedDiagnostic {
+  code,
+  package_hint,
+  redacted_tail,
+  truncated,
+}
+```
+
+or equivalent:
+
+```text
+DependencyHint {
+  package,
+  reason,
+  install_command,
+  stderr_tail,
+}
+```
+
+### Redaction Requirements
+
+Operator-visible diagnostics need a final sanitizer for:
+
+- loaded secret values
+- token-like strings
+- `Authorization` headers
+- `TS_AUTHKEY`
+- OAuth codes
+- sensitive paths
+
+Cap visible diagnostic tails by bytes and lines.
+
+### Performance Requirements
+
+- Reuse existing bounded upstream stderr capture and circuit-breaker paths.
+- Do not add another raw process-output capture path.
+- Do not add serial bulk probes outside existing single-flight/discovery-timeout/circuit-breaker behavior.
+- Bulk import of many bad upstreams must not become `N * 15s` serial latency.
+
+### Testing
+
+- [ ] Unit tests map launcher commands to runtime-floor validation.
+- [ ] Stderr pattern tests cover `ffmpeg: command not found`, `ENOENT`, and unknown failures.
+- [ ] Add/import response tests include capped stderr and suggested fix without mutating packages.
+- [ ] Doctor tests report missing leaf deps as actionable warnings.
+- [ ] Redaction tests prove env values/tokens are not printed.
+- [ ] Tests cover false-positive prevention: app-level auth/PATH errors should not become wrong apt advice.
+
+### Validation
+
+- [ ] Adding a `uvx` upstream with a missing leaf dependency surfaces the stderr tail and package suggestion.
+- [ ] Unknown stderr remains a normal unhealthy upstream report without false apt advice.
+- [ ] Existing healthy upstream add/import flows are unchanged.
+
+### Files
+
+- `crates/labby-gateway/src/*` or `crates/labby/src/dispatch/gateway/*` depending on current gateway ownership
+- `crates/labby/src/dispatch/doctor/*`
+- `crates/labby-runtime/src/*` if shared DTOs are needed
+- `docs/dev/ERRORS.md` if new error/warning kinds are introduced
+
+### Dependencies
+
+- Depends on Work Item 2.
+
+### Notes from Research and Review
+
+- Existing gateway validation and doctor health/error reporting are likely the right hooks.
+- The current stderr path is already bounded; classify from that path rather than capturing stderr separately.
+- Keep package installation as separate explicit consent so `gateway.add` remains unsurprising.
+
+## Work Item 5 / `lab-fh1wv.5` — Rewrite Deployment Docs Around Incus Primary Path
+
+### What
+
+Update public/operator docs, README references, generated help, and agent instructions so Incus is the primary deployment path, Docker is explicit/non-primary, and manual post-provision login/TUN requirements are visible.
+
+### Context
+
+The repo currently documents host service as the normal local/dookie runtime and Docker as a supported prod-like smoke path. This issue changes the supported self-hosted substrate to an Incus system container, while retaining host-service development shortcuts and explicit Docker smoke where needed.
+
+### Locked Decisions
+
+- Lead with amd64 Debian 13 Incus system container.
+- Document `/dev/net/tun` as required device passthrough for in-container Tailscale.
+- Document manual agent CLI login steps in bootstrap output and docs, not just a wiki page.
+- State that Docker is no longer the primary gateway deployment shape; keep explicit dev-container/prod-like smoke instructions only where still supported.
+- Update docs against the actual CLI surface after implementation.
+
+### Discretion
+
+- Exact doc layout under `docs/runtime/`, `docs/deploy/`, or README anchors.
+- Whether Docker compose files are marked deprecated in comments or moved to clearly named smoke paths.
+
+### Required Doc Split
+
+Docs must clearly distinguish three surfaces:
+
+1. Local development host-service shortcut.
+2. Primary self-hosted Incus system-container path.
+3. Explicit Docker smoke/dev-container compatibility path.
+
+Do not mix these into one deployment story.
+
+### Required Post-Provision Checklist
+
+Bootstrap output and docs should share the same checklist:
+
+1. Verify service.
+2. Verify tailnet IP when Tailscale is enabled.
+3. Run `claude login`, `codex login`, and `gemini` login/setup.
+4. Verify gateway readiness.
+
+### Testing
+
+- [ ] Generated CLI help refreshed if setup commands changed.
+- [ ] Markdown links checked for changed docs.
+- [ ] README no longer implies Docker is the default production/self-host path.
+- [ ] `CLAUDE.md` updates preserve source-of-truth symlink rules if memory files are edited.
+
+### Validation
+
+- [ ] A new operator can follow docs from Incus install/prep through running gateway.
+- [ ] Docs include rollback and verification commands.
+- [ ] Docs explicitly call out amd64-only and Code Mode/QuickJS reason.
+- [ ] Docs should not declare Docker obsolete before Incus smoke is repeatable and rollback is documented.
+
+### Files
+
+- `README.md`
+- `CLAUDE.md`
+- `docs/README.md`
+- `docs/runtime/HOST_GATEWAY.md` or new Incus deployment doc
+- `docs/generated/*`
+- `docker-compose.yml`
+- `docker-compose.prod.yml`
+
+### Dependencies
+
+- Depends on Work Item 3.
+
+### Notes from Research and Review
+
+- Keep Docker preflight/migration guard until Docker docs are actually retired.
+- Avoid stale generated help by refreshing only after CLI flags stabilize.
+
+## Work Item 6 / `lab-fh1wv.6` — Optional Incus Distrobuilder Release Image
+
+### What
+
+Add the optional distrobuilder image flow after the provisioning path is stable. This is a convenience accelerator, not the foundation.
+
+### Context
+
+The universal path is install script plus `labby setup --provision` inside a Debian 13 container or bare-metal host. The image should call the same provisioning dependency routine so a baked image and freshly provisioned box converge.
+
+### Locked Decisions
+
+- amd64-only image.
+- Build on self-hosted Tootie runner because distrobuilder needs privileged/overlayfs behavior that hosted runners fight.
+- Upload unified Incus image tarball as a GitHub Release asset.
+- Image cadence can be weekly or dependency-bump driven; do not require every Labby release to rebuild the base image.
+- No second source of truth for packages; reuse provision dependency logic.
+
+### Discretion
+
+- Exact `labby-base.yaml` layout and release asset naming.
+- Whether first pass is manual workflow dispatch before scheduled builds.
+
+### Testing
+
+- [ ] Distrobuilder config validates locally/on runner.
+- [ ] Imported release asset boots and converges with `labby setup --provision` behavior.
+- [ ] Release workflow does not block normal binary release if image build is skipped or manually gated.
+
+### Validation
+
+- [ ] `incus image import` of the release asset yields a usable base image.
+- [ ] First boot or first provision installs/runs current `labby` consistently.
+
+### Files
+
+- `.github/workflows/release.yml`
+- `packaging/incus/labby-base.yaml` or equivalent
+- `scripts/incus-bootstrap.sh` if it supports imported image path
+- `docs/runtime/*`
+
+### Dependencies
+
+- Depends on Work Item 2. Defer until the system unit, provision command, and bootstrap path are proven.
+
+### Notes from Research and Review
+
+- Distrobuilder must remain downstream of provisioning.
+- Do not let image package lists diverge from `setup --provision`.
+- It is acceptable for this to be weekly or manually dispatched rather than tied to every binary release.
+
+## Build Order
+
+1. Harden `unit_text()` and convert host service to default system unit with `User=lab` in `host_service.rs`.
+2. Add `labby setup --provision` with bounded floor install, consent, dry-run, `--yes`, and `--skip-deps`.
+3. Add `scripts/incus-bootstrap.sh` with Incus launch, TUN passthrough, in-box install/provision, and post-provision login output.
+4. Update docs around amd64 Debian 13 Incus primary substrate, TUN, and manual agent CLI login steps.
+5. Add just-in-time dependency diagnostics.
+6. Add optional distrobuilder image only once cold-start time actually matters.
+
+## Acceptance Criteria
+
+- [ ] `incus launch images:debian/13 labby` -> `scripts/incus-bootstrap.sh` -> running gateway with zero Docker bind mounts.
+- [ ] Service survives `incus restart labby` with no linger and no user D-Bus requirement.
+- [ ] `labby setup --provision --dry-run` prints a complete bounded plan and mutates nothing.
+- [ ] Re-running `labby setup --provision --yes` is a no-op on an already provisioned box except status verification.
+- [ ] Tailscale comes up inside the container with its own tailnet IP when `TS_AUTHKEY` is supplied and `/dev/net/tun` is present.
+- [ ] systemd hardening directives are applied and all existing stdio upstreams still spawn.
+- [ ] At least one `npx` and one `uvx` upstream smoke successfully under the hardened service.
+- [ ] Adding an upstream whose leaf dependency is missing surfaces a redacted stderr/fix hint in the add/import or doctor response.
+- [ ] Operator-visible diagnostics are redacted for secrets, tokens, auth headers, Tailscale auth keys, OAuth codes, and sensitive paths.
+- [ ] Bootstrap install path fails closed on missing checksum/unpinned release unless source-build fallback is explicitly requested.
+- [ ] Bootstrap is idempotent across partial failures.
+- [ ] Docs clearly state amd64 Debian 13 Incus as the supported substrate, Docker's reduced role, TUN requirements, rollback path, and manual login steps.
+- [ ] All changes validate with the all-features build/test/lint path appropriate to touched code.
+- [ ] Optional distrobuilder image, if implemented, converges with fresh `setup --provision` behavior.
+
+## Open Questions
+
+- Keep `systemd --user` path as a non-default workstation escape hatch, or drop entirely?
+- Prune Docker `labby-master` detection once Docker is unsupported, or keep as a migration courtesy?
+- Start v1 dependency hints with a tiny manifest plus stderr diagnosis, or diagnosis-only first?
+- Choose NodeSource apt vs official static tarball for Node.
+- Decide whether Tailscale installation/join lives in `setup --provision` or the bootstrap script; keep one owner.

--- a/plugins/scripts/check-dozzle-skill
+++ b/plugins/scripts/check-dozzle-skill
@@ -8,6 +8,16 @@ target="plugins/dozzle"
 
 failures=0
 
+if [[ ! -d "$target" ]]; then
+  if [[ "${LAB_ALLOW_MISSING_DOZZLE:-0}" != "1" ]]; then
+    printf 'dozzle skill check failed: %s is not present in this checkout\n' "$target" >&2
+    printf 'set LAB_ALLOW_MISSING_DOZZLE=1 only when the retired Dozzle plugin checkout is intentionally absent\n' >&2
+    exit 1
+  fi
+  printf 'dozzle skill check skipped: %s is not present in this checkout\n' "$target"
+  exit 0
+fi
+
 check_absent() {
   local description="$1"
   local pattern="$2"

--- a/scripts/incus-bootstrap.sh
+++ b/scripts/incus-bootstrap.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# Bootstrap Labby into an Incus Debian 13 system container.
+# Bootstrap Labby into an Incus Ubuntu 24.04 system container.
 
 set -eu
 
 NAME="labby"
-IMAGE="images:debian/13"
+IMAGE="images:ubuntu/24.04"
 VERSION="${LAB_INSTALL_VERSION:-}"
+LOCAL_BINARY=""
 DRY_RUN=0
 TAILSCALE_SSH=0
 ALLOW_SOURCE_FALLBACK=0
@@ -20,8 +21,9 @@ Usage: scripts/incus-bootstrap.sh --version vX.Y.Z [options]
 
 Options:
   --name NAME                 Container name (default: labby)
-  --image IMAGE               Incus image alias (default: images:debian/13)
+  --image IMAGE               Incus image alias (default: images:ubuntu/24.04)
   --version TAG               Labby release tag to install, e.g. v0.22.2
+  --local-binary PATH          Push a locally built labby binary instead of downloading a release
   --dry-run                   Print commands only
   --tailscale-ssh             Run tailscale up with --ssh when TS_AUTHKEY is set
   --allow-source-fallback     Allow install.sh cargo fallback if release asset is unavailable
@@ -53,6 +55,7 @@ while [ "$#" -gt 0 ]; do
         --name) NAME="${2:?missing --name value}"; shift 2 ;;
         --image) IMAGE="${2:?missing --image value}"; shift 2 ;;
         --version) VERSION="${2:?missing --version value}"; shift 2 ;;
+        --local-binary) LOCAL_BINARY="${2:?missing --local-binary value}"; shift 2 ;;
         --dry-run|--print-only) DRY_RUN=1; shift ;;
         --tailscale-ssh) TAILSCALE_SSH=1; shift ;;
         --allow-source-fallback) ALLOW_SOURCE_FALLBACK=1; shift ;;
@@ -61,7 +64,12 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-[ -n "$VERSION" ] || fail "--version is required so bootstrap installs a pinned release"
+if [ -z "$VERSION" ] && [ -z "$LOCAL_BINARY" ]; then
+    fail "--version is required unless --local-binary is provided"
+fi
+if [ -n "$LOCAL_BINARY" ] && [ "$DRY_RUN" -eq 0 ] && [ ! -f "$LOCAL_BINARY" ]; then
+    fail "--local-binary path does not exist: $LOCAL_BINARY"
+fi
 
 INCUS_AVAILABLE=1
 if ! command -v incus >/dev/null 2>&1; then
@@ -79,21 +87,31 @@ MISSING
 fi
 
 if [ "$INCUS_AVAILABLE" -eq 1 ] && ! incus info >/dev/null 2>&1; then
-    fail "incus is present but not initialized or reachable; run 'incus admin init' explicitly"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        err "Incus is present but not initialized or reachable; dry-run will still print the command plan."
+        INCUS_AVAILABLE=0
+    else
+        fail "incus is present but not initialized or reachable; run 'incus admin init' explicitly"
+    fi
 fi
 
 if [ "$INCUS_AVAILABLE" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
-    run incus launch "$IMAGE" "$NAME" -c security.idmap.isolated=true -c security.nesting=false
+    run incus launch "$IMAGE" "$NAME" -c security.privileged=true -c security.nesting=false
 elif ! incus list "$NAME" -c n --format csv 2>/dev/null | grep -qx "$NAME"; then
-    run incus launch "$IMAGE" "$NAME" -c security.idmap.isolated=true -c security.nesting=false
+    run incus launch "$IMAGE" "$NAME" -c security.privileged=true -c security.nesting=false
 else
     say "container exists: $NAME"
-    run incus config set "$NAME" security.idmap.isolated true
+    run incus config set "$NAME" security.privileged true
     run incus config set "$NAME" security.nesting false
+    if ! incus list "$NAME" -c s --format csv 2>/dev/null | grep -qx RUNNING; then
+        run incus start "$NAME"
+    fi
 fi
 
 if [ "$INCUS_AVAILABLE" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
     run incus config device add "$NAME" tun unix-char path=/dev/net/tun
+elif [ "$DRY_RUN" -eq 0 ] && incus exec "$NAME" -- test -c /dev/net/tun 2>/dev/null; then
+    say "TUN device already present in container"
 elif ! incus config device show "$NAME" | grep -q '^tun:'; then
     run incus config device add "$NAME" tun unix-char path=/dev/net/tun
 else
@@ -104,16 +122,24 @@ if [ "$DRY_RUN" -eq 0 ]; then
     incus exec "$NAME" -- test -c /dev/net/tun || fail "$NAME is missing /dev/net/tun"
 fi
 
-fallback="$ALLOW_SOURCE_FALLBACK"
-run incus file push scripts/install.sh "$NAME/tmp/labby-install.sh"
-run incus exec "$NAME" -- env \
-    LAB_INSTALL_DIR=/usr/local/bin \
-    LAB_INSTALL_REPO=jmagar/lab \
-    LAB_INSTALL_VERSION="$VERSION" \
-    LAB_REQUIRE_CHECKSUM=1 \
-    LAB_ALLOW_SOURCE_FALLBACK="$fallback" \
-    sh /tmp/labby-install.sh
-run incus exec "$NAME" -- rm -f /tmp/labby-install.sh
+if [ -n "$LOCAL_BINARY" ]; then
+    remote_tmp="/usr/local/bin/.labby-upload-$$"
+    run incus exec "$NAME" -- mkdir -p /usr/local/bin
+    run incus file push "$LOCAL_BINARY" "$NAME$remote_tmp"
+    run incus exec "$NAME" -- chmod 0755 "$remote_tmp"
+    run incus exec "$NAME" -- mv -f "$remote_tmp" /usr/local/bin/labby
+else
+    fallback="$ALLOW_SOURCE_FALLBACK"
+    run incus file push scripts/install.sh "$NAME/tmp/labby-install.sh"
+    run incus exec "$NAME" -- env \
+        LAB_INSTALL_DIR=/usr/local/bin \
+        LAB_INSTALL_REPO=jmagar/lab \
+        LAB_INSTALL_VERSION="$VERSION" \
+        LAB_REQUIRE_CHECKSUM=1 \
+        LAB_ALLOW_SOURCE_FALLBACK="$fallback" \
+        sh /tmp/labby-install.sh
+    run incus exec "$NAME" -- rm -f /tmp/labby-install.sh
+fi
 
 run incus exec "$NAME" -- labby setup --provision --yes
 

--- a/scripts/incus-bootstrap.sh
+++ b/scripts/incus-bootstrap.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# Bootstrap Labby into an Incus Debian 13 system container.
+
+set -eu
+
+NAME="labby"
+IMAGE="images:debian/13"
+VERSION="${LAB_INSTALL_VERSION:-}"
+DRY_RUN=0
+TAILSCALE_SSH=0
+ALLOW_SOURCE_FALLBACK=0
+
+say() { printf '%s\n' "$*"; }
+err() { printf '%s\n' "$*" >&2; }
+fail() { err "incus-bootstrap.sh: $*"; exit 1; }
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/incus-bootstrap.sh --version vX.Y.Z [options]
+
+Options:
+  --name NAME                 Container name (default: labby)
+  --image IMAGE               Incus image alias (default: images:debian/13)
+  --version TAG               Labby release tag to install, e.g. v0.22.2
+  --dry-run                   Print commands only
+  --tailscale-ssh             Run tailscale up with --ssh when TS_AUTHKEY is set
+  --allow-source-fallback     Allow install.sh cargo fallback if release asset is unavailable
+  -h, --help                  Show this help
+
+Environment:
+  TS_AUTHKEY                  Optional Tailscale auth key for in-container join
+USAGE
+}
+
+quote() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '+'
+        for arg in "$@"; do
+            printf ' %s' "$(quote "$arg")"
+        done
+        printf '\n'
+    else
+        "$@"
+    fi
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --name) NAME="${2:?missing --name value}"; shift 2 ;;
+        --image) IMAGE="${2:?missing --image value}"; shift 2 ;;
+        --version) VERSION="${2:?missing --version value}"; shift 2 ;;
+        --dry-run|--print-only) DRY_RUN=1; shift ;;
+        --tailscale-ssh) TAILSCALE_SSH=1; shift ;;
+        --allow-source-fallback) ALLOW_SOURCE_FALLBACK=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1" ;;
+    esac
+done
+
+[ -n "$VERSION" ] || fail "--version is required so bootstrap installs a pinned release"
+
+INCUS_AVAILABLE=1
+if ! command -v incus >/dev/null 2>&1; then
+    INCUS_AVAILABLE=0
+    cat >&2 <<'MISSING'
+Incus is not installed or not on PATH.
+
+Install and initialize it explicitly, then rerun this script. For Debian/Ubuntu:
+  sudo apt install incus
+  sudo incus admin init
+
+This bootstrap does not install or initialize Incus automatically.
+MISSING
+    [ "$DRY_RUN" -eq 1 ] || exit 1
+fi
+
+if [ "$INCUS_AVAILABLE" -eq 1 ] && ! incus info >/dev/null 2>&1; then
+    fail "incus is present but not initialized or reachable; run 'incus admin init' explicitly"
+fi
+
+if [ "$INCUS_AVAILABLE" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
+    run incus launch "$IMAGE" "$NAME" -c security.idmap.isolated=true -c security.nesting=false
+elif ! incus list "$NAME" -c n --format csv 2>/dev/null | grep -qx "$NAME"; then
+    run incus launch "$IMAGE" "$NAME" -c security.idmap.isolated=true -c security.nesting=false
+else
+    say "container exists: $NAME"
+    run incus config set "$NAME" security.idmap.isolated true
+    run incus config set "$NAME" security.nesting false
+fi
+
+if [ "$INCUS_AVAILABLE" -eq 0 ] && [ "$DRY_RUN" -eq 1 ]; then
+    run incus config device add "$NAME" tun unix-char path=/dev/net/tun
+elif ! incus config device show "$NAME" | grep -q '^tun:'; then
+    run incus config device add "$NAME" tun unix-char path=/dev/net/tun
+else
+    say "TUN passthrough already configured"
+fi
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    incus exec "$NAME" -- test -c /dev/net/tun || fail "$NAME is missing /dev/net/tun"
+fi
+
+fallback="$ALLOW_SOURCE_FALLBACK"
+run incus file push scripts/install.sh "$NAME/tmp/labby-install.sh"
+run incus exec "$NAME" -- env \
+    LAB_INSTALL_DIR=/usr/local/bin \
+    LAB_INSTALL_REPO=jmagar/lab \
+    LAB_INSTALL_VERSION="$VERSION" \
+    LAB_REQUIRE_CHECKSUM=1 \
+    LAB_ALLOW_SOURCE_FALLBACK="$fallback" \
+    sh /tmp/labby-install.sh
+run incus exec "$NAME" -- rm -f /tmp/labby-install.sh
+
+run incus exec "$NAME" -- labby setup --provision --yes
+
+if [ -n "${TS_AUTHKEY:-}" ]; then
+	run incus exec "$NAME" -- sh -c "curl -fsSL https://tailscale.com/install.sh | sh"
+	ts_args="--auth-key=file:/run/labby-ts-authkey"
+	if [ "$TAILSCALE_SSH" -eq 1 ]; then
+		ts_args="$ts_args --ssh"
+	fi
+	if [ "$DRY_RUN" -eq 1 ]; then
+		say "+ incus exec $(quote "$NAME") -- tailscale up $ts_args"
+	else
+		incus exec "$NAME" -- sh -c "umask 077; cat > /run/labby-ts-authkey" <<EOF
+$TS_AUTHKEY
+EOF
+		trap 'incus exec "$NAME" -- rm -f /run/labby-ts-authkey >/dev/null 2>&1 || true' EXIT INT TERM
+		set +e
+		# shellcheck disable=SC2086
+		incus exec "$NAME" -- tailscale up $ts_args
+		ts_status=$?
+		set -e
+		incus exec "$NAME" -- rm -f /run/labby-ts-authkey
+		trap - EXIT INT TERM
+		if [ "$ts_status" -ne 0 ]; then
+			exit "$ts_status"
+		fi
+	fi
+fi
+
+cat <<DONE
+Done. Manual steps remain:
+  1. incus exec $NAME -- su - lab
+  2. claude login && codex login && gemini
+  3. verify service: incus exec $NAME -- systemctl status labby --no-pager
+  4. verify readiness: incus exec $NAME -- curl -fsS http://127.0.0.1:8765/ready
+  5. if Tailscale is enabled, verify: incus exec $NAME -- tailscale ip -4
+
+Rollback:
+  incus stop $NAME
+  incus delete $NAME
+DONE

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,12 +16,16 @@
 #   LAB_INSTALL_DIR     install directory       (default: ~/.local/bin)
 #   LAB_INSTALL_REPO    owner/repo to fetch     (default: jmagar/lab)
 #   LAB_INSTALL_VERSION release tag, e.g. v0.22.2 (default: latest)
+#   LAB_REQUIRE_CHECKSUM fail if the .sha256 asset is absent (default: 0)
+#   LAB_ALLOW_SOURCE_FALLBACK allow cargo fallback after release failure (default: 1)
 
 set -eu
 
 REPO="${LAB_INSTALL_REPO:-jmagar/lab}"
 INSTALL_DIR="${LAB_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${LAB_INSTALL_VERSION:-latest}"
+REQUIRE_CHECKSUM="${LAB_REQUIRE_CHECKSUM:-0}"
+ALLOW_SOURCE_FALLBACK="${LAB_ALLOW_SOURCE_FALLBACK:-1}"
 
 say() { printf '%s\n' "$*" >&2; }
 fail() { say "install.sh: $*"; exit 1; }
@@ -91,6 +95,7 @@ install_from_release() {
             || fail "checksum verification FAILED for $asset — aborting"
         say "sha256 verified"
     else
+        [ "$REQUIRE_CHECKSUM" = "1" ] && fail "no .sha256 asset published for $asset and LAB_REQUIRE_CHECKSUM=1"
         say "warning: no .sha256 asset published — skipping checksum verification"
     fi
 
@@ -113,6 +118,9 @@ install_from_source() {
 main() {
     if install_from_release; then
         :
+    elif [ "$ALLOW_SOURCE_FALLBACK" != "1" ]; then
+        fail "could not install: release install failed and LAB_ALLOW_SOURCE_FALLBACK=$ALLOW_SOURCE_FALLBACK disables source fallback.
+Choose a supported prebuilt release or re-run with LAB_ALLOW_SOURCE_FALLBACK=1 to build from source."
     elif install_from_source; then
         :
     else


### PR DESCRIPTION
## Summary
- add local-only `labby setup --provision` for Debian/Incus guests with dry-run/yes/skip-deps controls, locking, timeouts, and redacted command output
- default host-service generation to the hardened lab user system unit and document rollback/operations
- add an explicit Incus bootstrap script and surface upstream dependency failures in gateway runtime/doctor views

## Validation
- `just check`
- `just lint`
- `just docs-check`
- `just test`
- `target/debug/labby setup --provision --dry-run`
- `scripts/incus-bootstrap.sh --version v0.0.0 --dry-run`

Closes #156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Incus the primary self-hosted runtime and adds guided provisioning for an amd64 Ubuntu 24.04 Incus gateway. Fulfills #156 with `labby setup --provision`, a hardened system `labby.service`, actionable dependency hints, and updated docs.

- **New Features**
  - `labby setup --provision` for Ubuntu 24.04/Incus with `--dry-run`, `--yes`, `--skip-deps`, locking, timeouts, and redacted/truncated command tails.
  - `scripts/incus-bootstrap.sh` to create an Incus Ubuntu 24.04 container and install a tagged release; supports `--dry-run`, `--tailscale-ssh`, `--allow-source-fallback`, and `--local-binary`.
  - Gateway runtime and doctor surface missing dependency hints (e.g., `ffmpeg`, `uv`, `npx`) with package names and suggested install commands; runtime JSON adds `dependency_hint` with a redacted tail and truncation flag.
  - System `labby.service` under `/etc/systemd/system` using a hardened `lab` user; `setup host-service` subcommands manage the unit.
  - `scripts/install.sh` adds `LAB_REQUIRE_CHECKSUM` and `LAB_ALLOW_SOURCE_FALLBACK`; docs updated for the Incus runbook/CLI/README; tests cover dependency-hint projection.

- **Migration**
  - Bootstrap: `scripts/incus-bootstrap.sh --version vX.Y.Z`, then `incus exec labby -- systemctl status labby` and readiness probe.
  - Converge inside the container: `labby setup --provision --dry-run` to review, then `--yes` to apply.
  - Move any user services to the system `labby.service`; follow the updated runbook in `docs/runtime/HOST_GATEWAY.md`.

<sup>Written for commit b61cf4eee8b34586be9771feea1258afb36622b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new guided self-hosted gateway provisioning flow with dry-run, confirmation, and skip-dependency options.
  * Added support for running the gateway as a hardened system service in an Incus-based deployment.
  * Improved runtime diagnostics with actionable hints for missing dependencies.

* **Bug Fixes**
  * Gateway errors now surface clearer guidance for common missing tools and services.
  * Diagnostic output is now redacted and truncated to avoid exposing sensitive data.

* **Documentation**
  * Updated setup and operator docs for the new primary deployment path and rollback steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->