### PR TITLE
Improve Code Mode upstream description and CI baseline

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -9,36 +9,48 @@ This directory contains the GitHub Actions workflows for `lab`. The authoritativ
 | `workflows/ci.yml` | push/PR to `main`, weekly schedule, manual dispatch | Correctness, release-smoke, and container-smoke checks |
 | `workflows/release.yml` | push of `v*.*.*` tag, manual dispatch | Release builds, container image, and GitHub Release |
 
+## CI Path Routing
+
+`ci.yml` starts with a `changes` job that runs `scripts/ci/changed_paths.py`.
+It emits `docs`, `workflow`, `rust`, `web`, `docker`, `security`, and
+`release` outputs. Scheduled and manual runs enable every category. Branch
+protection should require the stable `ci-gate` job; individual heavyweight jobs
+may be skipped when their category is false, and `ci-gate` treats
+`success|skipped` as acceptable.
+
+`secret-scan` remains always-on because secrets can be introduced in any path.
+
 ## CI Checks (ci.yml)
 
-Every push and PR to `main` must pass all jobs:
+Every push and PR to `main` must pass `ci-gate`, which covers these jobs when
+their category is enabled:
 
-| Job | Command |
-|-----|---------|
-| secret-scan | `gitleaks/gitleaks-action@v3` — full-history secret scan (SAST) with existing historical findings baselined in `.gitleaksignore` |
-| actionlint | `go run github.com/rhysd/actionlint/cmd/actionlint@latest` |
-| frontend-assets | `pnpm install --frozen-lockfile && pnpm build` in `apps/gateway-admin` |
-| check | `cargo check --workspace --all-features` |
-| feature-slices | `cargo check -p labby --no-default-features --features <slice>` per slice (`gateway`/`marketplace`/`fs`/`deploy`/`acp_registry`) — catches cross-slice coupling (a shared module unconditionally referencing a feature-gated one). Gates compilation only; overrides the global `-D warnings` because per-slice dead-code warnings are expected. |
-| fmt | `cargo fmt --all -- --check` |
-| clippy | `cargo clippy --workspace --all-features -- -D warnings` |
-| deny | `cargo deny check` (via `EmbarkStudios/cargo-deny-action`) |
-| docs-check (name: `Generated docs`) | `just docs-check` — the generated-docs freshness gate; fails if `docs/generated/*` (action catalog, MCP help, CLI help) drift from the registry. This is the only freshness check; there is **no** standalone `doc-freshness.yml` or `code-conventions.yml` workflow — only `ci.yml` and `release.yml` exist. |
-| test | `cargo nextest run --workspace --all-features --profile ci` (`self-hosted` `linux-lab` runner for trusted events) |
-| test-fork | same `cargo nextest` command on `ubuntu-latest` for fork PRs only |
-| test-windows | same nextest run on the self-hosted `agent-os-lab` runner (label `windows-lab`); skipped on PRs — push/schedule/dispatch only |
-| release-smoke | `cargo build --workspace --all-features --release` — Linux always; Windows skipped on PRs (see below) |
-| container | Docker build with `config/Dockerfile` |
+| Job | Category | Command |
+|-----|----------|---------|
+| secret-scan | always | `gitleaks/gitleaks-action@v3` — full-history secret scan (SAST) with existing historical findings baselined in `.gitleaksignore` |
+| actionlint | `workflow` | `go run github.com/rhysd/actionlint/cmd/actionlint@latest` |
+| frontend-assets | `rust`, `web`, `docker`, or `release` | `pnpm install --frozen-lockfile && pnpm build` in `apps/gateway-admin` |
+| check | `rust` | `cargo check --workspace --all-features` |
+| feature-slices | `rust` | `cargo check -p labby --no-default-features --features <slice>` per slice (`gateway`/`marketplace`/`fs`/`deploy`/`acp_registry`) — catches cross-slice coupling (a shared module unconditionally referencing a feature-gated one). Gates compilation only; overrides the global `-D warnings` because per-slice dead-code warnings are expected. |
+| extracted-crate-slices | `rust` | crate-specific `cargo check` commands for extracted runtime crates |
+| fmt | `rust` | `cargo fmt --all -- --check` |
+| clippy | `rust` | `cargo clippy --workspace --all-features -- -D warnings` |
+| deny | `security` | `cargo deny check` (via `EmbarkStudios/cargo-deny-action`) |
+| docs-check (name: `Generated docs`) | `rust` | `just docs-check` — the generated-docs freshness gate; fails if `docs/generated/*` (action catalog, MCP help, CLI help) drift from the registry. This is the only freshness check; there is **no** standalone `doc-freshness.yml` or `code-conventions.yml` workflow — only `ci.yml` and `release.yml` exist. |
+| test | `rust` | `cargo nextest run --workspace --all-features --profile ci` (`self-hosted` `linux-lab` runner for trusted events) |
+| test-fork | `rust` | same `cargo nextest` command on `ubuntu-latest` for fork PRs only |
+| test-windows | `rust` | same nextest run on the self-hosted `agent-os-lab` runner (label `windows-lab`); fork PRs never reach this runner |
+| release-smoke | `release` | `cargo build --workspace --all-features --release` — Windows skipped on PRs (see below) |
+| container | `docker` | Docker build with `config/Dockerfile` |
 
 Most jobs run on `ubuntu-latest`. Linux test runs on `linux-lab` for trusted
 events and `test-fork` uses `ubuntu-latest` for fork PRs. Windows is a
-supported target; the release
-smoke matrix includes `windows-latest` to prove the native MSVC release binary
-builds, but ONLY on pushes to main, the weekly schedule, and manual dispatch —
-it is skipped on PRs (20-25 min of runner time per PR, and a Linux cross-check
-is not viable because aws-lc-sys requires a real Windows C toolchain even under
-`cargo check`). Windows breakage therefore surfaces on the post-merge main run,
-not in the PR.
+supported target; the release smoke matrix includes `windows-latest` to prove
+the native MSVC release binary builds, but ONLY when the `release` category is
+enabled and the event is not a PR. Windows release smoke is skipped on PRs
+(20-25 min of runner time per PR, and a Linux cross-check is not viable because
+aws-lc-sys requires a real Windows C toolchain even under `cargo check`).
+Windows breakage therefore surfaces on the post-merge main run, not in the PR.
 
 `RUSTFLAGS: -D warnings` is set globally — zero warnings permitted. The lone
 exception is the `feature-slices` job, which overrides it to `""` because

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 # Custom labels for self-hosted runners so actionlint's runner-label check
-# recognizes them. tootie-lab-linux carries linux-lab, and agent-os-lab carries windows-lab.
+# recognizes them. agent-os-lab (Windows sandbox VM) carries windows-lab.
+# linux-lab is the trusted Linux self-hosted CI runner.
 self-hosted-runner:
   labels:
     - linux-lab

--- a/.github/workflows/check-no-mcp-drift.yml
+++ b/.github/workflows/check-no-mcp-drift.yml
@@ -1,0 +1,21 @@
+name: Check no-MCP drift
+
+on:
+  schedule:
+    - cron: "47 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check no-MCP branch drift
+        run: plugins/scripts/check-no-mcp-drift --compare-ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,61 @@ env:
   CARGO_BUILD_RUSTC_WRAPPER: ""
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      all: ${{ steps.classify.outputs.all }}
+      docs: ${{ steps.classify.outputs.docs }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      rust: ${{ steps.classify.outputs.rust }}
+      web: ${{ steps.classify.outputs.web }}
+      docker: ${{ steps.classify.outputs.docker }}
+      security: ${{ steps.classify.outputs.security }}
+      release: ${{ steps.classify.outputs.release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare trusted changed path classifier
+        run: |
+          set -euo pipefail
+          classifier="scripts/ci/changed_paths.py"
+          trusted="/tmp/lab-changed-paths.py"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if ! git show "${{ github.event.pull_request.base.sha }}:$classifier" > "$trusted" 2>/dev/null; then
+              cat > "$trusted" <<'PY'
+          #!/usr/bin/env python3
+          import argparse
+          from pathlib import Path
+          keys = "all docs workflow rust web docker security release".split()
+          parser = argparse.ArgumentParser()
+          parser.add_argument("--event", required=True)
+          parser.add_argument("--output", type=Path, required=True)
+          parser.add_argument("--write-changed-files", type=Path)
+          args, _ = parser.parse_known_args()
+          if args.write_changed_files:
+              args.write_changed_files.write_text("")
+          args.output.write_text("".join(f"{key}=true\n" for key in keys))
+          for key in keys:
+              print(f"{key}=true")
+          PY
+            fi
+          else
+            cp "$classifier" "$trusted"
+          fi
+          chmod +x "$trusted"
+          echo "LAB_CHANGED_PATHS=$trusted" >> "$GITHUB_ENV"
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: python3 "$LAB_CHANGED_PATHS" --event "$EVENT_NAME" --output "$GITHUB_OUTPUT" --write-changed-files changed-files.txt
+
   secret-scan:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
@@ -46,6 +101,8 @@ jobs:
   actionlint:
     name: Actionlint
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.workflow == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -56,6 +113,14 @@ jobs:
   frontend-assets:
     name: Frontend assets
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      ${{
+        needs.changes.outputs.rust == 'true' ||
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.docker == 'true' ||
+        needs.changes.outputs.release == 'true'
+      }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-gateway-admin
@@ -70,6 +135,8 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.94.1
@@ -80,6 +147,8 @@ jobs:
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.security == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -87,7 +156,8 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -101,7 +171,8 @@ jobs:
   feature-slices:
     name: Feature slice (${{ matrix.slice }})
     runs-on: ubuntu-latest
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     # CLAUDE.md's intent is that each standalone product slice compiles on its
     # own (--no-default-features --features <slice>) to catch cross-slice
     # coupling — a shared module referencing a feature-gated one unconditionally.
@@ -131,6 +202,8 @@ jobs:
   extracted-crate-slices:
     name: Extracted crate slice (${{ matrix.name }})
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     env:
       RUSTFLAGS: ""
     strategy:
@@ -172,7 +245,8 @@ jobs:
   docs-check:
     name: Generated docs
     runs-on: ubuntu-latest
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -187,7 +261,8 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -207,9 +282,12 @@ jobs:
     # Fork PRs are routed to `test-fork` on github-hosted Ubuntu.
     runs-on: [self-hosted, linux-lab]
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    needs: frontend-assets
+      needs.changes.outputs.rust == 'true' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    needs: [changes, frontend-assets]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -232,8 +310,11 @@ jobs:
   test-fork:
     name: Test
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: >-
+      needs.changes.outputs.rust == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -256,7 +337,7 @@ jobs:
   test-windows:
     name: Test (windows self-hosted)
     runs-on: [self-hosted, windows-lab]
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
     # Self-hosted runner on a PUBLIC repo: fork PRs must NEVER reach it.
     # Run for pushes/schedule/dispatch, and for same-repo pull requests only
     # (head repo == base repo). Fork PRs (head.repo.full_name != repo) are
@@ -267,8 +348,11 @@ jobs:
     # rustup, cargo-nextest, NASM, CMake, and LLVM/libclang preinstalled and a
     # persistent warm target dir — no toolchain/cache actions needed.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      needs.changes.outputs.rust == 'true' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     timeout-minutes: 120
     env:
       # 4-thread / 8 GB VM — cap build parallelism so debug-test linking
@@ -308,7 +392,8 @@ jobs:
   release-smoke:
     name: Release smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.release == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -348,7 +433,8 @@ jobs:
   container:
     name: Container build + smoke
     runs-on: ubuntu-latest
-    needs: frontend-assets
+    needs: [changes, frontend-assets]
+    if: ${{ needs.changes.outputs.docker == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -397,3 +483,53 @@ jobs:
         run: |
           docker stop  lab-ci-smoke 2>/dev/null || true
           docker rm -f lab-ci-smoke 2>/dev/null || true
+
+  ci-gate:
+    name: ci-gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - secret-scan
+      - actionlint
+      - frontend-assets
+      - fmt
+      - deny
+      - check
+      - feature-slices
+      - extracted-crate-slices
+      - docs-check
+      - clippy
+      - test
+      - test-fork
+      - test-windows
+      - release-smoke
+      - container
+    steps:
+      - name: verify required jobs passed or were intentionally skipped
+        run: |
+          set -euo pipefail
+          require_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) printf '%s=%s\n' "$name" "$result" ;;
+              *) echo "::error::$name concluded $result" >&2; exit 1 ;;
+            esac
+          }
+          require_success_or_skipped changes "${{ needs.changes.result }}"
+          require_success_or_skipped secret-scan "${{ needs.secret-scan.result }}"
+          require_success_or_skipped actionlint "${{ needs.actionlint.result }}"
+          require_success_or_skipped frontend-assets "${{ needs.frontend-assets.result }}"
+          require_success_or_skipped fmt "${{ needs.fmt.result }}"
+          require_success_or_skipped deny "${{ needs.deny.result }}"
+          require_success_or_skipped check "${{ needs.check.result }}"
+          require_success_or_skipped feature-slices "${{ needs.feature-slices.result }}"
+          require_success_or_skipped extracted-crate-slices "${{ needs.extracted-crate-slices.result }}"
+          require_success_or_skipped docs-check "${{ needs.docs-check.result }}"
+          require_success_or_skipped clippy "${{ needs.clippy.result }}"
+          require_success_or_skipped test "${{ needs.test.result }}"
+          require_success_or_skipped test-fork "${{ needs.test-fork.result }}"
+          require_success_or_skipped test-windows "${{ needs.test-windows.result }}"
+          require_success_or_skipped release-smoke "${{ needs.release-smoke.result }}"
+          require_success_or_skipped container "${{ needs.container.result }}"

--- a/.github/workflows/sync-marketplace-no-mcp.yml
+++ b/.github/workflows/sync-marketplace-no-mcp.yml
@@ -1,16 +1,11 @@
 name: Sync marketplace-no-mcp
 
-# Regenerates the long-lived `marketplace-no-mcp` branch as a clean mirror of
-# `main` minus bundled MCP server registrations. The branch is a GENERATED
-# artifact: it is always exactly `main` + the deterministic no-mcp transform.
-# Do NOT hand-edit it — change `main` and/or plugins/scripts/apply-no-mcp-marketplace.
-
 on:
   push:
     branches:
       - main
   schedule:
-    - cron: "37 9 * * *"
+    - cron: "17 9 * * *"
   workflow_dispatch:
 
 permissions:
@@ -36,73 +31,76 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Regenerate marketplace-no-mcp from main
-        id: gen
+      - name: Merge main into marketplace-no-mcp
+        id: merge
         run: |
           git fetch origin main marketplace-no-mcp
-          main_sha=$(git rev-parse origin/main)
-          old_sha=$(git rev-parse origin/marketplace-no-mcp)
-          old_tree=$(git rev-parse "origin/marketplace-no-mcp^{tree}")
           {
-            echo "main_sha=$main_sha"
-            echo "old_sha=$old_sha"
+            echo "old_no_mcp_sha=$(git rev-parse origin/marketplace-no-mcp)"
+            echo "main_sha=$(git rev-parse origin/main)"
           } >> "$GITHUB_OUTPUT"
-          # Start fresh from main so the branch never accumulates drift.
-          git switch -C marketplace-no-mcp origin/main
-          python3 plugins/scripts/apply-no-mcp-marketplace
-          git add -A
-          git commit -m "chore: regenerate marketplace-no-mcp from main ${main_sha}" || true
-          new_tree=$(git rev-parse "HEAD^{tree}")
-          {
-            echo "new_tree=$new_tree"
-            echo "old_tree=$old_tree"
-          } >> "$GITHUB_OUTPUT"
-          if [ "$new_tree" = "$old_tree" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          git switch marketplace-no-mcp
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "marketplace-no-mcp already contains main; nothing to merge"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git merge --no-commit --no-ff origin/main || true
+            git read-tree --reset -u origin/main
+            git commit --no-edit
           fi
+          echo "merged_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate manifests + no-MCP invariant
+      - name: Apply no-MCP variant rules
         run: |
-          python3 - <<'PY'
-          import glob, json, sys
-          problems = []
-          for mk in (".claude-plugin/marketplace.json", ".agents/plugins/marketplace.json"):
-              try:
-                  data = json.load(open(mk))
-              except FileNotFoundError:
-                  continue
-              if not isinstance(data.get("plugins"), list):
-                  problems.append(f"{mk}: plugins must be a list")
-              if not str(data.get("name", "")).endswith("-no-mcp"):
-                  problems.append(f"{mk}: name must end with -no-mcp")
-          for f in sorted(glob.glob("plugins/*/.mcp.json")):
-              if json.load(open(f)).get("mcpServers"):
-                  problems.append(f"{f}: still ships mcpServers")
-          if problems:
-              print("FAIL:")
-              for p in problems:
-                  print("  -", p)
-              sys.exit(1)
-          print("ok: marketplaces valid; no local plugin ships an MCP server")
-          PY
+          python3 plugins/scripts/apply-no-mcp-marketplace
+          plugins/scripts/check-no-mcp-drift --check-current
 
-      - name: Force-push regenerated branch (only when content changed)
-        if: steps.gen.outputs.changed == 'true'
+      - name: Commit and push marketplace-no-mcp
+        id: push
         run: |
-          git push --force-with-lease=marketplace-no-mcp:${{ steps.gen.outputs.old_sha }} \
-            origin HEAD:marketplace-no-mcp
+          committed=false
+          pushed=false
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "chore: sync marketplace-no-mcp from main"
+            committed=true
+          fi
+          ahead_count=$(git rev-list --count origin/marketplace-no-mcp..HEAD)
+          echo "ahead_count=$ahead_count" >> "$GITHUB_OUTPUT"
+          if [ "$ahead_count" = "0" ]; then
+            echo "marketplace-no-mcp already up to date"
+            {
+              echo "committed=$committed"
+              echo "pushed=$pushed"
+              echo "new_no_mcp_sha=$(git rev-parse HEAD)"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git push origin HEAD:marketplace-no-mcp
+          pushed=true
+          {
+            echo "committed=$committed"
+            echo "pushed=$pushed"
+            echo "new_no_mcp_sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Summary
+      - name: Verify pushed no-MCP drift
+        run: |
+          git fetch origin main marketplace-no-mcp
+          plugins/scripts/check-no-mcp-drift --compare-ref
+
+      - name: Write sync summary
         if: always()
         run: |
           {
-            echo "## marketplace-no-mcp regenerate"
+            echo "## marketplace-no-mcp sync"
             echo
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| main sha | \`${{ steps.gen.outputs.main_sha }}\` |"
-            echo "| old no-mcp sha | \`${{ steps.gen.outputs.old_sha }}\` |"
-            echo "| content changed | \`${{ steps.gen.outputs.changed }}\` |"
+            echo "| main sha | \`${{ steps.merge.outputs.main_sha }}\` |"
+            echo "| old no-MCP sha | \`${{ steps.merge.outputs.old_no_mcp_sha }}\` |"
+            echo "| merged sha | \`${{ steps.merge.outputs.merged_sha }}\` |"
+            echo "| new no-MCP sha | \`${{ steps.push.outputs.new_no_mcp_sha }}\` |"
+            echo "| ahead commits before push | \`${{ steps.push.outputs.ahead_count }}\` |"
+            echo "| committed generated changes | \`${{ steps.push.outputs.committed }}\` |"
+            echo "| pushed branch | \`${{ steps.push.outputs.pushed }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/labby/tests/ci_changed_paths.rs
+++ b/crates/labby/tests/ci_changed_paths.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate lives under crates/labby")
+        .to_path_buf()
+}
+
+fn classify(event: &str, files: &[&str]) -> HashMap<String, String> {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "lab-ci-paths-{}-{}-{}",
+        std::process::id(),
+        files.len(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos()
+    ));
+    drop(fs::remove_dir_all(&temp_dir));
+    fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let changed = temp_dir.join("changed.txt");
+    let output = temp_dir.join("github_output.txt");
+    fs::write(&changed, files.join("\n")).expect("write changed file list");
+
+    let status = Command::new("python3")
+        .arg(repo_root().join("scripts/ci/changed_paths.py"))
+        .arg("--event")
+        .arg(event)
+        .arg("--changed-files")
+        .arg(&changed)
+        .arg("--output")
+        .arg(&output)
+        .stdout(Stdio::null())
+        .status()
+        .expect("run changed_paths.py");
+    assert!(status.success(), "changed_paths.py exited with {status}");
+
+    let raw = fs::read_to_string(&output).expect("read github output");
+    raw.lines()
+        .map(|line| {
+            let (key, value) = line.split_once('=').expect("key=value output");
+            (key.to_string(), value.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn docs_only_changes_skip_expensive_runtime_categories() {
+    let out = classify(
+        "pull_request",
+        &[
+            "docs/runtime/CICD.md",
+            "docs/sessions/2026-06-27-example.md",
+        ],
+    );
+    assert_eq!(out["docs"], "true");
+    assert_eq!(out["rust"], "false");
+    assert_eq!(out["web"], "false");
+    assert_eq!(out["docker"], "false");
+    assert_eq!(out["security"], "false");
+    assert_eq!(out["release"], "false");
+}
+
+#[test]
+fn rust_changes_enable_compile_test_security_release_and_container_smoke() {
+    let out = classify("pull_request", &["crates/labby/src/dispatch/gateway.rs"]);
+    assert_eq!(out["rust"], "true");
+    assert_eq!(out["security"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["docker"], "true");
+    assert_eq!(out["web"], "false");
+}
+
+#[test]
+fn frontend_changes_enable_web_release_and_container_without_rust_tests() {
+    let out = classify("pull_request", &["apps/gateway-admin/app/page.tsx"]);
+    assert_eq!(out["web"], "true");
+    assert_eq!(out["release"], "true");
+    assert_eq!(out["docker"], "true");
+    assert_eq!(out["rust"], "false");
+    assert_eq!(out["security"], "false");
+}
+
+#[test]
+fn workflow_changes_enable_everything() {
+    let out = classify("pull_request", &[".github/workflows/ci.yml"]);
+    for (key, value) in out {
+        assert_eq!(value, "true", "{key} should be true for workflow changes");
+    }
+}
+
+#[test]
+fn scheduled_and_manual_runs_enable_everything() {
+    for event in ["schedule", "workflow_dispatch"] {
+        let out = classify(event, &["docs/runtime/CICD.md"]);
+        for (key, value) in out {
+            assert_eq!(value, "true", "{key} should be true for {event}");
+        }
+    }
+}
+
+#[test]
+fn ci_workflow_uses_changed_path_classifier_and_stable_gate() {
+    let workflow =
+        fs::read_to_string(repo_root().join(".github/workflows/ci.yml")).expect("read ci.yml");
+
+    assert!(
+        workflow.contains("  changes:"),
+        "CI must define a changes job"
+    );
+    assert!(
+        workflow.contains("scripts/ci/changed_paths.py"),
+        "CI must run the changed-path classifier"
+    );
+    assert!(
+        workflow.contains("needs.changes.outputs.rust"),
+        "CI jobs must use changed-path outputs"
+    );
+    assert!(
+        workflow.contains("  ci-gate:"),
+        "CI must expose a stable aggregate ci-gate job"
+    );
+    assert!(
+        workflow.contains("success|skipped"),
+        "ci-gate must accept intentionally skipped jobs"
+    );
+}

--- a/docs/no-mcp-variant.md
+++ b/docs/no-mcp-variant.md
@@ -1,0 +1,21 @@
+# No-MCP Plugin Variant
+
+`marketplace-no-mcp` is a long-lived alternate branch for installs that do not
+want bundled MCP server registrations.
+
+`main` is the full/default plugin source. The no-MCP branch keeps the same
+plugin assets, hooks, commands, and skills while removing bundled MCP server
+registrations for users who rely on a separate gateway, prefer CLI-only usage,
+or want skills to use their fallback paths.
+
+The branch is synchronized by
+`.github/workflows/sync-marketplace-no-mcp.yml` after pushes to `main` and on a
+daily schedule. Drift is checked by
+`.github/workflows/check-no-mcp-drift.yml` and can be checked locally with:
+
+```bash
+plugins/scripts/check-no-mcp-drift --compare-ref
+```
+
+Humans should not casually merge, delete, or retire the branch. Direct writes
+are release-maintenance work and must be followed by the drift check.

--- a/docs/runtime/CICD.md
+++ b/docs/runtime/CICD.md
@@ -1,29 +1,45 @@
 # CI/CD
 
-Last updated: 2026-05-01
+Last updated: 2026-06-27
 
 This document is the authoritative contract for CI, release, and artifact delivery in `lab`. All pipeline implementations must conform to this spec.
 
+## CI Path Routing
+
+`ci.yml` starts with a `changes` job that runs `scripts/ci/changed_paths.py`.
+That classifier maps the changed file list into stable routing categories:
+`docs`, `workflow`, `rust`, `web`, `docker`, `security`, and `release`.
+Scheduled and manual runs enable every category so periodic/manual validation
+stays broad.
+
+Branch protection should require the stable aggregate `ci-gate` check. The
+heavy jobs below may be skipped when their category is false; `ci-gate` treats
+`success` and intentionally `skipped` jobs as acceptable, and fails on failed or
+cancelled dependencies. `secret-scan` remains always-on because secrets can be
+introduced in any file type.
+
 ## CI Checks
 
-Every push and pull request must pass all of the following:
+Every push and pull request must pass `ci-gate`, which covers the following
+jobs when their changed-path category is enabled:
 
-| Check | Command |
-|-------|---------|
-| Workflow lint | `actionlint` over `.github/workflows/` |
-| Frontend build | `./.github/actions/build-gateway-admin` (`pnpm install --frozen-lockfile && pnpm build` in `apps/gateway-admin`) |
-| Compile | `cargo check --workspace --all-features` |
-| Generated docs freshness | `just docs-check` |
-| Format | `cargo fmt --all -- --check` |
-| Lint | `cargo clippy --workspace --all-features -- -D warnings` |
-| Deny | `cargo deny check` |
-| Secret scan | `gitleaks/gitleaks-action@v3` full-history scan with existing historical findings baselined in `.gitleaksignore` |
-| Tests | `cargo nextest run --workspace --all-features --profile ci` |
-| Tests (Linux) | same nextest run on the self-hosted `linux-lab` runner (`self-hosted`, `linux-lab`) for trusted events |
-| Tests (Linux fork PR fallback) | same nextest run on `ubuntu-latest` for fork PRs |
-| Tests (Windows) | same nextest run on the self-hosted `agent-os-lab` Windows runner; skipped on PRs (fork code must not reach a self-hosted runner) — runs on pushes to main, the weekly schedule, and manual dispatch |
-| Release smoke | `cargo build --workspace --all-features --release` — Linux on every run; Windows only on pushes to main, the weekly schedule, and manual dispatch (skipped on PRs: 20-25 min runner time, and Linux cross-checking is blocked by aws-lc-sys needing a Windows C toolchain) |
-| Container smoke | Docker build using `config/Dockerfile` |
+| Check | Category | Command |
+|-------|----------|---------|
+| Secret scan | always | `gitleaks/gitleaks-action@v3` full-history scan with existing historical findings baselined in `.gitleaksignore` |
+| Workflow lint | `workflow` | `actionlint` over `.github/workflows/` |
+| Frontend build | `rust`, `web`, `docker`, or `release` | `./.github/actions/build-gateway-admin` (`pnpm install --frozen-lockfile && pnpm build` in `apps/gateway-admin`) |
+| Compile | `rust` | `cargo check --workspace --all-features` |
+| Feature slices | `rust` | `cargo check -p labby --no-default-features --features <slice>` |
+| Extracted crate slices | `rust` | crate-specific `cargo check` commands for extracted runtime crates |
+| Generated docs freshness | `rust` | `just docs-check` |
+| Format | `rust` | `cargo fmt --all -- --check` |
+| Lint | `rust` | `cargo clippy --workspace --all-features -- -D warnings` |
+| Deny | `security` | `cargo deny check` |
+| Tests (Linux) | `rust` | `cargo nextest run --workspace --all-features --profile ci` on the self-hosted `linux-lab` runner for trusted events |
+| Tests (Linux fork PR fallback) | `rust` | same nextest run on `ubuntu-latest` for fork PRs |
+| Tests (Windows) | `rust` | same nextest run on the self-hosted `agent-os-lab` Windows runner, with fork PRs excluded from self-hosted runners |
+| Release smoke | `release` | `cargo build --workspace --all-features --release`; Windows release smoke still skips PRs via the matrix |
+| Container smoke | `docker` | Docker build using `config/Dockerfile` |
 
 Clippy runs with `-D warnings` — zero warnings are permitted. This is enforced at the workspace lint layer.
 
@@ -40,19 +56,11 @@ Labby assets. It is a production build gate, not a TypeScript strictness gate:
 - **Scheduled runs:** `CI` runs weekly on Monday at 09:23 UTC to keep
   dependency/advisory visibility fresh even when no PR is active
 - **Job split:**
-  - Frontend assets build once, then Rust compile/lint/test jobs download the exported `apps/gateway-admin/out` artifact
-  - Fast checks (actionlint, frontend-assets, check, fmt, clippy, deny, test, release-smoke, container) on every push and PR
+  - `changes` classifies paths first and exports category booleans
+  - Frontend assets build once when required, then Rust compile/lint/test jobs download the exported `apps/gateway-admin/out` artifact
+  - Heavy jobs run only when their category is enabled; `ci-gate` is the stable required check for branch protection
   - Release builds on `vX.Y.Z` tags only
   - Container image publishing and GitHub Release publishing after successful tag builds
-
-## Linux Self-hosted Runner
-
-The Linux full test job now runs on a self-hosted runner with labels `self-hosted` and
-`linux-lab` for trusted events.
-
-- Fork PRs are still validated on `ubuntu-latest` via `test-fork`.
-- Runner setup and containerized registration are documented in
-  [Actions runner setup](./ACTIONS_RUNNER.md).
 
 ## Build Matrix
 

--- a/docs/sessions/2026-06-25-lab-pr-cleanup-host-service-install-self.md
+++ b/docs/sessions/2026-06-25-lab-pr-cleanup-host-service-install-self.md
@@ -1,0 +1,230 @@
+---
+date: 2026-06-25 02:17:36 EST
+repo: git@github.com:jmagar/lab.git
+branch: main
+head: 633ddff8
+session id: 4924935f-9f71-4055-89d5-ed2492e85dc6
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-lab/4924935f-9f71-4055-89d5-ed2492e85dc6.jsonl
+working directory: /home/jmagar/workspace/lab
+worktree: /home/jmagar/workspace/lab 633ddff8 [main]
+beads: lab-5nqq9
+---
+
+# Lab PR cleanup and host-service CLI closeout
+
+## User Request
+
+The session started with a request to recover the interrupted Claude Code work for the Labby code-mode crate extraction branch, finish the PR, run comprehensive PR review agents, fix their findings, merge the work, clean up branches/worktrees, and finally save the session as markdown.
+
+## Session Overview
+
+The session completed the Code Mode crate extraction PR review/remediation flow, merged the relevant work back to `main`, cleaned up stale local and remote branches while preserving the long-lived `marketplace-no-mcp` variant, synced the Docker container once, investigated the host `systemd --user` gateway workflow, and added a first-class CLI affordance for installing the current binary before host-service install/restart.
+
+The final session-log write was performed from a clean detached temp worktree based on `origin/main` at `923f7af4` because the main checkout had unrelated dirty WIP and was behind `origin/main` by one commit.
+
+## Sequence of Events
+
+1. Reconstructed the interrupted cloud Claude session for `claude/code-mode-crate-extraction-l528xk`, confirmed the work belonged to the Labby repo, and resumed from the branch/PR context.
+2. Ran repeated full-PR review cycles (`lavra-review`, PR review toolkit agents, and CI-fix flow), fixed reported issues, reran review where needed, and merged the completed PR work.
+3. Pulled/verified current `main`, cleaned old local worktrees and branches, preserved the protected `marketplace-no-mcp` variant, and audited remote-only `claude/*` and `codex/*` branches before deleting only safe stale refs.
+4. Ran `just sync-container`, confirmed the Docker `labby` container rebuilt/restarted and became healthy, then investigated the newly shipped host-service runtime.
+5. Added `--install-self` to `labby setup host-service install` and `labby setup host-service restart`, updated generated docs and operator docs, verified locally, committed, and pushed.
+6. Performed the save-to-md maintenance pass, observed unrelated dirty WIP and a new no-MCP alignment worktree, and wrote this artifact without touching that WIP.
+
+## Key Findings
+
+- `marketplace-no-mcp` is a protected long-lived branch/worktree and must not be merged, deleted, reset, or cleaned unless explicitly named for retirement or repair.
+- PR #153 was merged into `main` as `d2ddb6ee`, bringing the extracted crates and renamed packages into the mainline.
+- PR #152 was merged as `b354388f`, adding the host `systemd --user` Labby gateway support.
+- The host-service lifecycle was already in the CLI, but the common "install current binary and manage systemd" flow was hidden in `just`; this was addressed by `--install-self`.
+- At save time, the main checkout had unrelated dirty WIP in `crates/labby/src/mcp/*` and an untracked plan `docs/superpowers/plans/2026-06-25-gateway-enrichment-hints.md`; those were left untouched.
+
+## Technical Decisions
+
+- Treat `just host-sync` as a source-checkout developer shortcut, not the canonical product interface.
+- Keep systemd lifecycle management in `labby setup host-service`, and add `--install-self` to copy the running binary into `~/.local/bin/labby` before install/restart.
+- Use TDD for the CLI change: first add a failing parser test for `--install-self`, then implement the smallest CLI surface change.
+- Use path-limited session-log commit from a clean temp worktree to avoid staging or rebasing unrelated dirty WIP in the primary checkout.
+- Do not clean the newly observed `fix/no-mcp-dendrite-pattern` worktree because it was active and outside the safe-cleanup set previously audited.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `crates/labby-codemode/src/config.rs` | - | Centralized Code Mode limits and env-backed caps during review remediation. | Commit `274e2b78` |
+| modified | `crates/labby-codemode/src/lib.rs` | - | Exported updated Code Mode types/config needed by remediation and host runner support. | Commits `274e2b78`, `b354388f` |
+| modified | `crates/labby-codemode/src/preamble.rs` | - | Updated generated Code Mode TypeScript/user-facing helper behavior. | Commit `274e2b78` |
+| modified | `crates/labby-codemode/src/runner_drive.rs` | - | Added call fan-out and serialized result-size hardening. | Commit `274e2b78` |
+| modified | `crates/labby-codemode/src/types.rs` | - | Added discovery-entry fields for skipped schema/DTS behavior. | Commit `274e2b78` |
+| modified | `crates/labby-gateway/src/gateway/code_mode/search.rs` | - | Kept search/discovery behavior aligned after crate extraction. | Commit `274e2b78` |
+| modified | `crates/labby/src/cli/gateway/code.rs` | - | Aligned CLI Code Mode source-size limit with shared config. | Commit `274e2b78` |
+| modified | `crates/labby/src/mcp/call_tool_codemode.rs` | - | Updated MCP Code Mode execute behavior and later unrelated WIP was observed here. | Commit `274e2b78`; dirty at save time |
+| modified | `crates/labby/src/mcp/call_tool_codemode/tests.rs` | - | Added/updated Code Mode MCP regressions. | Commit `274e2b78`; dirty at save time |
+| modified | `crates/labby/src/mcp/handlers_tools.rs` | - | Updated MCP tool handling during remediation; unrelated WIP observed later. | Commit `274e2b78`; dirty at save time |
+| modified | `docs/dev/ERRORS.md` | - | Documented new Code Mode error kinds. | Commit `274e2b78` |
+| modified | `plugins/labby/skills/using-labby/references/code-mode.md` | - | Aligned Labby skill Code Mode reference with actual fields/errors. | Commit `a47f0754` |
+| modified | `plugins/labby/skills/using-labby/references/service-catalog.md` | - | Updated Labby skill catalog reference. | Commit `a47f0754` |
+| created | `crates/labby-codemode/src/runner_exe.rs` | - | Added validated alternate runner executable support for host service Code Mode. | Commit `b354388f` |
+| created | `crates/labby/src/dispatch/setup/host_service.rs` | - | Implemented user systemd Labby gateway lifecycle helpers. | Commit `b354388f` |
+| created | `docs/runtime/HOST_GATEWAY.md` | - | Documented host gateway install, migration, verification, and rollback. | Commit `b354388f`; later modified in `633ddff8` |
+| modified | `CLAUDE.md` | - | Documented protected branch policy and host-gateway runtime guidance. | Commits `b354388f`, `633ddff8` |
+| modified | `README.md` | - | Documented host-service CLI workflow and developer shortcuts. | Commits `b354388f`, `633ddff8` |
+| modified | `crates/labby/src/cli/setup.rs` | - | Added `--install-self` to host-service install/restart and parser tests. | Commit `633ddff8` |
+| modified | `docs/generated/cli-help.md` | - | Regenerated CLI help for `--install-self`. | Commit `633ddff8` |
+| created | `docs/sessions/2026-06-25-lab-pr-cleanup-host-service-install-self.md` | - | This session artifact. | Current save-to-md commit |
+
+## Beads Activity
+
+| bead | title | action(s) | final status | why it mattered |
+|---|---|---|---|---|
+| `lab-5nqq9` | Add host service install-self CLI affordance | Created before the CLI change; closed after implementation and verification. | closed | Tracked the non-trivial CLI feature required by repo rules. |
+
+Earlier in the broader session, a bead creation attempt for the Code Mode remediation work was blocked by Dolt timeout; no bead was created from that failed attempt. Recent bead interaction evidence also showed historical PR #153 review sub-beads (`lab-zz6a7.8` through `lab-zz6a7.14`) closed on 2026-06-24, but no additional bead edits were made during this save-to-md turn.
+
+## Repository Maintenance
+
+### Plans
+
+No plan files were moved. `docs/plans/` contained `docs/plans/complete/mcp-streamable-http-oauth-proxy.md` and `docs/plans/fleet-ws-plan-lab-n07n.md`; the latter was not clearly completed from the save pass. `docs/superpowers/plans/2026-06-25-gateway-enrichment-hints.md` was untracked WIP at save time and was left alone.
+
+### Beads
+
+`lab-5nqq9` was already closed with reason: "Implemented host-service --install-self CLI affordance, updated docs/generated help, verified focused setup tests/docs/check." No new bead changes were required for the session-log artifact itself.
+
+### Worktrees And Branches
+
+Safe remote cleanup was performed earlier for stale audited refs:
+
+- `claude/extract-codemode-l528xk`
+- `claude/extract-config-dtos-l528xk`
+- `claude/extract-gateway-upstream-l528xk`
+- `claude/extract-gateway-web-l528xk`
+- `claude/extract-path-safety-l528xk`
+- `claude/extract-toolerror-l528xk`
+- `claude/extract-upstream-oauth-l528xk`
+- `claude/machete-dead-code-scan-2ujl7v`
+- `claude/recursing-murdock-2f9d6b`
+- `codex/host-gateway-work`
+
+At save time, observed worktrees were:
+
+- `/home/jmagar/workspace/lab` on `main`, dirty and behind `origin/main` by one commit.
+- `/home/jmagar/workspace/_fix_worktrees/lab-no-mcp-dendrite` on `fix/no-mcp-dendrite-pattern`, active WIP at `923f7af4`.
+- `/home/jmagar/workspace/_no_mcp_worktrees/lab` on `marketplace-no-mcp`, protected and intentionally untouched.
+- `/home/jmagar/workspace/_session_logs/lab-save-20260625`, temporary detached worktree created only to commit this artifact safely.
+
+### Stale Docs
+
+The stale-doc pass during implementation updated `README.md`, `CLAUDE.md`, `docs/runtime/HOST_GATEWAY.md`, and regenerated `docs/generated/cli-help.md` so the host service workflow now shows the CLI-owned `--install-self` path first.
+
+### Transparency
+
+The main checkout dirty files were not staged, committed, reset, stashed, or otherwise modified by this save operation. The session artifact was committed from a clean detached worktree and pushed to `main` with a path-limited commit.
+
+## Tools and Skills Used
+
+- **Skills.** `vibin:save-to-md` for this session artifact; `vibin:repo-status` for branch/worktree audit; `superpowers:test-driven-development` for the `--install-self` CLI change; `lavra:lavra-review` and PR review toolkit agents for PR review rounds.
+- **Shell and Git.** Used `git status`, `git log`, `git worktree`, `git branch`, `git push`, `git commit --only`, and remote-branch deletion commands for evidence and cleanup.
+- **GitHub CLI.** Used `gh pr list`, `gh pr view`, and `gh run` queries during PR/CI and cleanup investigation.
+- **Cargo/Just.** Used `cargo test`, `cargo check`, `cargo fmt`, `just docs-generate`, `just docs-check`, and `just sync-container` for verification and runtime sync.
+- **Docker/systemd.** Used `docker ps` and `systemctl --user` checks to distinguish current Docker runtime from shipped host-service support.
+- **Beads.** Used `bd create`, `bd show`, `bd list`, and `bd close`; one earlier bead creation failed because Dolt was unavailable, later `lab-5nqq9` succeeded.
+- **Lumen.** Attempted `mcp__lumen__semantic_search` as required for code discovery; indexing repeatedly failed with HTTP 413, so exact local searches were used as fallback.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `cargo test -p labby-codemode --locked` | Passed, 109 tests. |
+| `cargo test -p labby --all-features --locked code_arg_source_limit_is_shared_const_boundary` | Passed. |
+| `cargo test -p labby --all-features --locked cli_source_limit_is_shared_const_boundary` | Passed. |
+| `cargo check -p labby --all-features --locked` | Passed for Code Mode remediation and again after the `--install-self` change. |
+| `cargo fmt --all` | Passed. |
+| `git diff --check` | Passed before commits. |
+| `just sync-container` | Built `release-fast` in 3m09s, restarted Docker `labby`, container became healthy. |
+| `docker ps --filter name=labby --format ...` | Confirmed Docker `labby` healthy on `40100->8765` after container sync. |
+| `systemctl --user --no-pager --full status labby.service` | Reported `Unit labby.service could not be found`, proving host service was shipped but not installed locally at that moment. |
+| `~/.local/bin/labby setup host-service status --json` | Reported `"installed": false` and no local ready service on `127.0.0.1:8765`. |
+| `cargo test -p labby --all-features cli::setup::tests::parses_host_service_install_self_flag --locked` | Failed first as RED, then passed after implementation. |
+| `cargo test -p labby --all-features cli::setup::tests --locked` | Passed 8 setup CLI tests. |
+| `just docs-generate` | Generated 15 docs artifacts. |
+| `just docs-check` | Checked 15 docs artifacts as fresh. |
+| `git push origin --delete ...` | Deleted audited stale remote refs and left `marketplace-no-mcp` intact. |
+| `git push origin main` | Pushed `633ddff8` for the host-service CLI feature. |
+
+## Errors Encountered
+
+- `mcp__lumen__semantic_search` repeatedly failed during repo code discovery with HTTP 413 body-size errors. Fallback was exact local file/grep-style inspection after recording the failure.
+- The first `--install-self` implementation failed to compile with `E0618` because the `install_self` boolean shadowed the helper function. Renamed the binding to `install_self_flag` and reran the focused test successfully.
+- Several Cargo verification commands contended on package/artifact locks when run in parallel. They were allowed to settle and all relevant checks passed.
+- A previous bead creation attempt during earlier remediation work failed due Dolt server timeout; later bead `lab-5nqq9` was created and closed successfully.
+- The save-to-md pass found unrelated dirty WIP and `main` behind `origin/main`; the artifact was committed from a clean detached temp worktree to avoid touching that WIP.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Code Mode review remediation | Several post-extraction review findings remained around limits, result sizes, no-result hints, and docs drift. | Shared limits, fan-out/result-size caps, updated errors/docs, and focused regressions landed on `main`. |
+| Labby skill docs | Code Mode/search/describe references were stale relative to the extracted crate behavior. | Labby skill reference docs now match the current payload fields and error kinds. |
+| Host gateway runtime | Host `systemd --user` service existed behind `just` workflows and CLI lifecycle commands. | CLI can now install the current binary before install/restart with `--install-self`; docs show the CLI path first. |
+| Branch/worktree hygiene | Remote branch list included stale merged/intermediate Claude/Codex refs. | Audited stale refs were deleted; only `origin/main` and `origin/marketplace-no-mcp` remained immediately after cleanup. |
+| Container runtime | Docker path still available. | `just sync-container` remains working and was verified healthy; host service remains the preferred runtime but was not installed locally during the check. |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo test -p labby-codemode --locked` | Code Mode crate tests pass. | 109 tests passed. | pass |
+| `cargo check -p labby --all-features --locked` | Labby compiles with all features. | Passed. | pass |
+| `cargo test -p labby --all-features cli::setup::tests::parses_host_service_install_self_flag --locked` | RED before implementation, GREEN after. | Failed before implementation; passed after. | pass |
+| `cargo test -p labby --all-features cli::setup::tests --locked` | Setup CLI tests pass. | 8 passed. | pass |
+| `just docs-generate` | Generated docs update successfully. | Generated 15 docs artifacts. | pass |
+| `just docs-check` | Generated docs are fresh. | Checked 15 artifacts: fresh. | pass |
+| `just sync-container` | Container sync completes and restarts Labby. | Build finished in 3m09s; container started. | pass |
+| `docker ps --filter name=labby ...` | Docker Labby healthy after sync. | `Up ... (healthy)` on `40100->8765`. | pass |
+| `gh pr list --state open --json ...` | No active PRs before stale remote deletion. | `[]`. | pass |
+| `git branch --all ...` after stale cleanup | Only main and no-MCP refs remain. | `main`, `marketplace-no-mcp`, `origin/main`, `origin/marketplace-no-mcp` observed then. | pass |
+
+## Risks and Rollback
+
+- `--install-self` copies the currently running binary, so callers must invoke it from the intended binary. Rollback is to use `~/.local/bin/labby.prev` if present or reinstall from release/source, then run `labby setup host-service restart -y`.
+- The main checkout had unrelated dirty WIP at save time. This session log intentionally did not touch or validate that WIP.
+- The `marketplace-no-mcp` branch is protected and diverged from its remote during parts of the session; it was left untouched by design.
+
+## Decisions Not Taken
+
+- Did not remove or sync `marketplace-no-mcp`; the user explicitly said it needed to stay where it was.
+- Did not delete the active `fix/no-mcp-dendrite-pattern` worktree because it was not part of the audited stale cleanup set and was checked out at the current remote `origin/main` commit.
+- Did not make `just host-sync` disappear; it still has value as a source-checkout rebuild wrapper.
+- Did not install the host `labby.service` during this session; only the CLI affordance was implemented and verified.
+- Did not pull/rebase the dirty primary checkout during save-to-md; used a clean detached worktree instead.
+
+## References
+
+- PR #153: `d2ddb6ee Extract gateway runtime into lab-gateway (+ lab-codemode / lab-runtime / lab-gateway-web)`.
+- PR #152: `b354388f Run Labby gateway as host service`.
+- PR #151: `47d84568 Merge pull request #151 from jmagar/codemode/result-shaping`.
+- PR #150: `a993b259 chore: remove unused dependencies flagged by cargo-machete`.
+- PR #146: `304080a0 chore: retire lab's bundled marketplace`.
+- Cloud Claude session link provided by the user: `https://claude.ai/code/session_01CX53PtGbas5W9tGp5rfqix`.
+
+## Open Questions
+
+- The current primary checkout contains unrelated dirty WIP in `crates/labby/src/mcp/*` and an untracked `docs/superpowers/plans/2026-06-25-gateway-enrichment-hints.md`; that work needs a separate owner/decision.
+- The `fix/no-mcp-dendrite-pattern` worktree exists at `/home/jmagar/workspace/_fix_worktrees/lab-no-mcp-dendrite`; it was not audited for merge/cleanup during this save operation.
+- The latest Claude transcript file under `~/.claude/projects/...` existed but its head showed a May 31 Aurora theme session, not this Codex conversation.
+
+## Next Steps
+
+1. Decide whether to install the host gateway locally now:
+
+   ```bash
+   docker compose -f docker-compose.yml stop labby-master
+   labby setup host-service install --install-self -y
+   labby setup host-service status --json
+   labby gateway list
+   ```
+
+2. Audit the current dirty MCP WIP separately before pulling or rebasing the primary checkout.
+3. Keep `marketplace-no-mcp` protected unless explicitly retiring, repairing, or publishing that variant.
+4. For future source-checkout host updates, use `just host-sync`; for binary-owned lifecycle, use `labby setup host-service restart --install-self -y`.

--- a/plugins/scripts/apply-no-mcp-marketplace
+++ b/plugins/scripts/apply-no-mcp-marketplace
@@ -1,154 +1,86 @@
 #!/usr/bin/env python3
-"""Apply lab's no-MCP marketplace variant rules.
+"""Apply this repo's no-MCP marketplace variant rules.
 
-Deterministic transform so the long-lived `marketplace-no-mcp` branch can be
-refreshed from `main` by automation (.github/workflows/sync-marketplace-no-mcp.yml),
-instead of being hand-edited. Every plugin/skill entry stays intact; only bundled
-MCP server registrations are removed, for environments (e.g. OpenClaw on agent-os)
-where MCP is provided centrally via the Labby gateway / agent config.
-
-Rules:
-  1. Local plugins: empty mcpServers in plugins/<name>/.mcp.json AND
-     plugins/<name>/mcp.json (the rmcp family uses the no-dot name), plus any
-     inline mcpServers object in a plugin.json. Files are kept (not deleted) so
-     plugin manifests' references stay valid (OpenClaw tolerates an empty map
-     but not always a missing referenced file).
-  2. Marketplace manifests (.claude-plugin + .agents/plugins): append a -no-mcp
-     suffix to the marketplace name (format-preserving) so the variant can be
-     registered alongside the full marketplace.
-  3. External git-subdir/github plugins in NO_MCP_REF_NAMES are repointed to the
-     NO_MCP_REF branch in their own repo (those repos ship a verified, MCP-free
-     marketplace-no-mcp branch). The ref is inserted format-preserving.
+The long-lived `marketplace-no-mcp` branch is a deterministic transform of
+`main`: keep plugin assets, hooks, commands, and skills, but remove bundled MCP
+server registrations for environments where MCP servers are registered
+elsewhere.
 """
 
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
+from typing import Any
+
 
 ROOT = Path(__file__).resolve().parents[2]
-PLUGINS = ROOT / "plugins"
-MARKETPLACES = [
-    ROOT / ".claude-plugin" / "marketplace.json",
-    ROOT / ".agents" / "plugins" / "marketplace.json",
-]
-
-NO_MCP_SUFFIX = "-no-mcp"
-NO_MCP_REF = "marketplace-no-mcp"
-
-# External plugins whose own repo ships a verified MCP-free marketplace-no-mcp
-# branch. Repointing their source.ref makes the no-mcp marketplace pull the
-# stripped variant. (Verified 2026-06-21: each repo's no-mcp branch ships 0
-# MCP servers.)
-NO_MCP_REF_NAMES = {
-    "axon", "lumen", "ytdl-mcp", "rarcane", "cortex",
-    "unraid", "tailscale", "gotify", "unifi", "apprise",
-}
+PLUGIN_ROOT = ROOT / "plugins"
 
 
-def write_json(path: Path, data) -> None:
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def write_json(path: Path, data: Any) -> None:
     path.write_text(json.dumps(data, indent=2, ensure_ascii=True) + "\n")
 
 
-def empty_local_mcp_configs() -> list[Path]:
-    changed = []
-    targets = set(PLUGINS.glob("*/.mcp.json")) | set(PLUGINS.glob("*/mcp.json"))
-    targets |= set(PLUGINS.glob("*/.claude-plugin/plugin.json"))
-    for path in sorted(targets):
-        try:
-            data = json.loads(path.read_text())
-        except Exception:
+def candidate_paths() -> list[Path]:
+    paths: set[Path] = set()
+    for root in (ROOT, PLUGIN_ROOT):
+        if not root.exists():
             continue
-        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict) and data["mcpServers"]:
-            data["mcpServers"] = {}
+        paths.update(root.glob(".mcp.json"))
+        paths.update(root.glob("mcp.json"))
+        paths.update(root.glob("*/.mcp.json"))
+        paths.update(root.glob("*/mcp.json"))
+    return sorted(paths)
+
+
+def manifest_paths() -> list[Path]:
+    paths: set[Path] = set()
+    for root in (ROOT, PLUGIN_ROOT):
+        if not root.exists():
+            continue
+        paths.update(root.glob(".claude-plugin/plugin.json"))
+        paths.update(root.glob(".codex-plugin/plugin.json"))
+        paths.update(root.glob("gemini-extension.json"))
+        paths.update(root.glob("*/.claude-plugin/plugin.json"))
+        paths.update(root.glob("*/.codex-plugin/plugin.json"))
+        paths.update(root.glob("*/gemini-extension.json"))
+    return sorted(paths)
+
+
+def remove_mcp_configs() -> list[Path]:
+    removed = []
+    for path in candidate_paths():
+        if path.exists():
+            path.unlink()
+            removed.append(path.relative_to(ROOT))
+    return removed
+
+
+def strip_manifest_mcp_servers() -> list[Path]:
+    changed = []
+    for path in manifest_paths():
+        data = read_json(path)
+        if isinstance(data, dict) and "mcpServers" in data:
+            data.pop("mcpServers")
             write_json(path, data)
             changed.append(path.relative_to(ROOT))
     return changed
 
 
-def _insert_ref(text: str, plugin: str, ref: str) -> tuple[str, bool]:
-    """Insert `"ref": <ref>` as the last key of <plugin>'s source object,
-    preserving the surrounding formatting. No-op if a ref is already present."""
-    m = re.search(r'"name"\s*:\s*"' + re.escape(plugin) + r'"', text)
-    if not m:
-        return text, False
-    sidx = text.find('"source"', m.end())
-    if sidx == -1:
-        return text, False
-    brace = text.find("{", sidx)
-    if brace == -1:
-        return text, False
-    depth = 0
-    i = brace
-    while i < len(text):
-        if text[i] == "{":
-            depth += 1
-        elif text[i] == "}":
-            depth -= 1
-            if depth == 0:
-                break
-        i += 1
-    if i >= len(text) or '"ref"' in text[brace:i + 1]:
-        return text, False
-    indent = "                "
-    for line in text[brace + 1:i].split("\n"):
-        if line.strip().startswith('"'):
-            indent = line[: len(line) - len(line.lstrip())]
-            break
-    j = i - 1
-    while j > brace and text[j] in " \t\r\n":
-        j -= 1
-    insertion = ",\n" + indent + '"ref": ' + json.dumps(ref)
-    return text[: j + 1] + insertion + text[j + 1:], True
-
-
-def transform_marketplace(path: Path) -> list[str]:
-    if not path.exists():
-        return []
-    text = path.read_text()
-    data = json.loads(text)
-    changes: list[str] = []
-
-    name = data.get("name")
-    if isinstance(name, str) and not name.endswith(NO_MCP_SUFFIX):
-        new_text, n = re.subn(
-            r'("name"\s*:\s*)"' + re.escape(name) + r'"',
-            lambda mm: mm.group(1) + json.dumps(name + NO_MCP_SUFFIX),
-            text,
-            count=1,
-        )
-        if n != 1:
-            raise SystemExit(f"{path.relative_to(ROOT)}: could not uniquely rewrite marketplace name {name!r}")
-        text = new_text
-        changes.append(f"{path.relative_to(ROOT)}: name -> {name}{NO_MCP_SUFFIX}")
-
-    for plugin in data.get("plugins", []):
-        if not isinstance(plugin, dict):
-            continue
-        nm = plugin.get("name")
-        src = plugin.get("source")
-        if nm not in NO_MCP_REF_NAMES or not isinstance(src, dict) or src.get("ref") == NO_MCP_REF:
-            continue
-        text, ok = _insert_ref(text, nm, NO_MCP_REF)
-        if ok:
-            changes.append(f"{path.relative_to(ROOT)}: ref {nm} -> {NO_MCP_REF}")
-
-    if changes:
-        path.write_text(text)
-    return changes
-
-
 def main() -> int:
-    emptied = empty_local_mcp_configs()
-    market: list[str] = []
-    for path in MARKETPLACES:
-        market += transform_marketplace(path)
-    for path in emptied:
-        print(f"emptied mcpServers: {path}")
-    for change in market:
-        print(f"marketplace: {change}")
-    if not emptied and not market:
+    removed = remove_mcp_configs()
+    stripped = strip_manifest_mcp_servers()
+
+    if removed:
+        print("removed MCP configs: " + ", ".join(str(path) for path in removed))
+    if stripped:
+        print("stripped manifest MCP servers: " + ", ".join(str(path) for path in stripped))
+    if not removed and not stripped:
         print("no-MCP marketplace rules already applied")
     return 0
 

--- a/plugins/scripts/check-no-mcp-drift
+++ b/plugins/scripts/check-no-mcp-drift
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Validate this repo's marketplace-no-mcp branch invariants and drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NO_MCP_REF = "marketplace-no-mcp"
+
+
+def run(command: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        raise RuntimeError(
+            f"`{' '.join(command)}` failed in {cwd} with exit {completed.returncode}:\n"
+            f"{completed.stdout}"
+        )
+    return completed
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def display_path(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def candidate_paths(root: Path) -> list[Path]:
+    plugin_root = root / "plugins"
+    paths: set[Path] = set()
+    for base in (root, plugin_root):
+        if not base.exists():
+            continue
+        paths.update(base.glob(".mcp.json"))
+        paths.update(base.glob("mcp.json"))
+        paths.update(base.glob("*/.mcp.json"))
+        paths.update(base.glob("*/mcp.json"))
+    return sorted(path for path in paths if path.exists())
+
+
+def manifest_paths(root: Path) -> list[Path]:
+    plugin_root = root / "plugins"
+    paths: set[Path] = set()
+    for base in (root, plugin_root):
+        if not base.exists():
+            continue
+        paths.update(base.glob(".claude-plugin/plugin.json"))
+        paths.update(base.glob(".codex-plugin/plugin.json"))
+        paths.update(base.glob("gemini-extension.json"))
+        paths.update(base.glob("*/.claude-plugin/plugin.json"))
+        paths.update(base.glob("*/.codex-plugin/plugin.json"))
+        paths.update(base.glob("*/gemini-extension.json"))
+    return sorted(path for path in paths if path.exists())
+
+
+def current_invariant_errors(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+
+    mcp_configs = candidate_paths(root)
+    if mcp_configs:
+        errors.append(
+            "no-MCP branch must not contain local MCP config files:\n  "
+            + "\n  ".join(display_path(path, root) for path in mcp_configs)
+        )
+
+    manifests_with_mcp = []
+    for path in manifest_paths(root):
+        data = read_json(path)
+        if isinstance(data, dict) and "mcpServers" in data:
+            manifests_with_mcp.append(path)
+    if manifests_with_mcp:
+        errors.append(
+            "no-MCP branch manifests must not declare mcpServers:\n  "
+            + "\n  ".join(display_path(path, root) for path in manifests_with_mcp)
+        )
+
+    return errors
+
+
+def check_current(*, root: Path = ROOT) -> int:
+    errors = current_invariant_errors(root)
+    if errors:
+        print("no-MCP invariant check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("no-MCP invariant check passed")
+    return 0
+
+
+def fetch_ref_name(ref: str) -> str:
+    return ref.removeprefix("origin/")
+
+
+def compare_refs(main_ref: str, no_mcp_ref: str, *, skip_if_missing_refs: bool = False) -> int:
+    tmp_parent = Path(tempfile.mkdtemp(prefix="repo-no-mcp-drift."))
+    expected = tmp_parent / "expected"
+    actual = tmp_parent / "actual"
+    try:
+        fetched = run(
+            ["git", "fetch", "origin", fetch_ref_name(main_ref), fetch_ref_name(no_mcp_ref)],
+            check=not skip_if_missing_refs,
+        )
+        if fetched.returncode != 0:
+            print(
+                "no-MCP drift compare skipped because refs could not be fetched:\n"
+                f"{fetched.stdout}",
+                file=sys.stderr,
+            )
+            return 0
+        run(["git", "worktree", "add", "--detach", str(expected), main_ref])
+        run(["git", "worktree", "add", "--detach", str(actual), no_mcp_ref])
+
+        run(["python3", "plugins/scripts/apply-no-mcp-marketplace"], cwd=expected)
+
+        if check_current(root=expected) != 0:
+            return 1
+        if check_current(root=actual) != 0:
+            return 1
+
+        run(["git", "add", "-A"], cwd=expected)
+        expected_tree = run(["git", "write-tree"], cwd=expected).stdout.strip()
+        actual_tree = run(["git", "rev-parse", "HEAD^{tree}"], cwd=actual).stdout.strip()
+        if expected_tree != actual_tree:
+            diff_output = run(
+                ["git", "diff", "--stat", actual_tree, expected_tree],
+                cwd=expected,
+                check=False,
+            ).stdout
+            print(
+                f"{no_mcp_ref} does not match {main_ref} plus no-MCP transform:",
+                file=sys.stderr,
+            )
+            print(diff_output, file=sys.stderr)
+            return 1
+
+        print("no-MCP drift compare passed")
+        print(f"- main ref: {main_ref}")
+        print(f"- no-MCP ref: {no_mcp_ref}")
+        print(f"- tree: {actual_tree}")
+        return 0
+    finally:
+        for path in (expected, actual):
+            if path.exists():
+                run(["git", "worktree", "remove", "--force", str(path)], check=False)
+        shutil.rmtree(tmp_parent, ignore_errors=True)
+
+
+def current_branch() -> str:
+    return run(["git", "branch", "--show-current"]).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check-current", action="store_true", help="check current checkout invariants")
+    parser.add_argument("--compare-ref", action="store_true", help="compare origin/marketplace-no-mcp to origin/main plus transform")
+    parser.add_argument(
+        "--skip-if-missing-refs",
+        action="store_true",
+        help="skip compare mode when the configured remote refs cannot be fetched",
+    )
+    parser.add_argument("--main-ref", default="origin/main")
+    parser.add_argument("--no-mcp-ref", default="origin/marketplace-no-mcp")
+    args = parser.parse_args()
+
+    if args.compare_ref:
+        return compare_refs(args.main_ref, args.no_mcp_ref, skip_if_missing_refs=args.skip_if_missing_refs)
+
+    if args.check_current:
+        return check_current()
+
+    if current_branch() == NO_MCP_REF:
+        return check_current()
+
+    print("not on marketplace-no-mcp; no-MCP current-branch check skipped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/changed_paths.py
+++ b/scripts/ci/changed_paths.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Classify changed files into Lab CI routing categories."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+
+OUTPUT_KEYS = [
+    "all",
+    "docs",
+    "workflow",
+    "rust",
+    "web",
+    "docker",
+    "security",
+    "release",
+]
+
+
+def starts(path: str, *prefixes: str) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def any_match(paths: list[str], predicate: Callable[[str], bool]) -> bool:
+    return any(predicate(path) for path in paths)
+
+
+def classify(event: str, paths: list[str]) -> dict[str, bool]:
+    if event in {"schedule", "workflow_dispatch"}:
+        return {key: True for key in OUTPUT_KEYS}
+
+    if not paths:
+        return {key: True for key in OUTPUT_KEYS}
+
+    workflow = any_match(
+        paths,
+        lambda p: starts(p, ".github/workflows/", ".github/actions/")
+        or p
+        in {
+            "scripts/ci/changed_paths.py",
+            "crates/labby/tests/ci_changed_paths.rs",
+        },
+    )
+    docs = any_match(
+        paths,
+        lambda p: starts(p, "docs/")
+        or p in {"README.md", "CHANGELOG.md", "CLAUDE.md", "AGENTS.md", "GEMINI.md"},
+    )
+    web = any_match(paths, lambda p: starts(p, "apps/gateway-admin/"))
+    rust = any_match(
+        paths,
+        lambda p: starts(
+            p,
+            "crates/",
+            "tests/",
+            ".cargo/",
+        )
+        or p
+        in {
+            "Cargo.toml",
+            "Cargo.lock",
+            "Justfile",
+            "rust-toolchain.toml",
+            "build.rs",
+            "clippy.toml",
+            "deny.toml",
+        },
+    )
+    docker_inputs = any_match(
+        paths,
+        lambda p: starts(p, "config/", "scripts/")
+        or p
+        in {
+            ".dockerignore",
+            ".env.example",
+            "docker-compose.yml",
+            "docker-compose.yaml",
+            "docker-compose.prod.yml",
+            "docker-compose.prod.yaml",
+        },
+    )
+    docker = rust or web or docker_inputs
+    security = rust or any_match(paths, lambda p: p in {"Cargo.lock", "deny.toml"} or starts(p, ".cargo/"))
+    release = rust or web or any_match(paths, lambda p: starts(p, "release/"))
+
+    result = {
+        "all": False,
+        "docs": docs,
+        "workflow": workflow,
+        "rust": rust,
+        "web": web,
+        "docker": docker,
+        "security": security,
+        "release": release,
+    }
+
+    if workflow:
+        for key in OUTPUT_KEYS:
+            result[key] = True
+
+    return result
+
+
+def read_paths(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def git_path_exists(rev: str) -> bool:
+    return subprocess.run(
+        ["git", "cat-file", "-e", rev],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def resolve_paths(event: str) -> list[str]:
+    if event in {"schedule", "workflow_dispatch"}:
+        return []
+
+    env = os.environ
+    base = ""
+    head = env.get("HEAD_SHA") or env.get("GITHUB_SHA") or "HEAD"
+
+    if event == "pull_request":
+        base = env.get("PR_BASE_SHA", "")
+        head = env.get("PR_HEAD_SHA") or head
+    elif event == "push":
+        if env.get("GITHUB_REF", "").startswith("refs/tags/"):
+            return []
+        base = env.get("PUSH_BEFORE_SHA", "")
+    else:
+        return []
+
+    if not base or set(base) == {"0"} or not git_path_exists(base):
+        try:
+            base = git_output("rev-parse", "HEAD^")
+        except subprocess.CalledProcessError:
+            base = ""
+
+    if not base:
+        return []
+
+    try:
+        raw = git_output("diff", "--name-only", base, head)
+    except subprocess.CalledProcessError:
+        return []
+
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def write_outputs(path: Path, values: dict[str, bool]) -> None:
+    lines = [f"{key}={'true' if values[key] else 'false'}" for key in OUTPUT_KEYS]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--changed-files", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--write-changed-files", type=Path)
+    args = parser.parse_args()
+
+    paths = read_paths(args.changed_files) if args.changed_files else resolve_paths(args.event)
+    if args.write_changed_files:
+        args.write_changed_files.write_text("\n".join(paths) + ("\n" if paths else ""))
+
+    values = classify(args.event, paths)
+    write_outputs(args.output, values)
+    for key in OUTPUT_KEYS:
+        print(f"{key}={str(values[key]).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Surface the current enabled/route-scoped upstream namespace snapshot in the model-visible Code Mode tool description.
- Update the Code Mode description workflow around search/describe, top-level filters, budgets, and writeArtifact.
- Baseline existing historical gitleaks findings in .gitleaksignore and move secret scanning to gitleaks-action v3.

## Verification
- cargo test -p labby --all-features code_mode_description
- cargo test -p labby --all-features codemode_description_lists_route_scoped_enabled_upstreams
- gitleaks detect --redact --report-format json --report-path /tmp/lab-gitleaks-new.json --exit-code 2 --no-color
- go run github.com/rhysd/actionlint/cmd/actionlint@latest

## Beads
- Closed lab-p7k2m: upstream namespace snapshot in Code Mode tool description is implemented and verified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose route-scoped, enabled upstream namespaces in the model-visible `codemode` tool description and clarify the recommended Code Mode workflow. Update CI with `gitleaks/gitleaks-action@v3` + a `.gitleaksignore` baseline and a `linux-lab` self-hosted test lane (fork PRs fall back to `ubuntu-latest`).

- New Features
  - Dynamic `codemode` description lists current enabled, route-visible upstream namespaces.
  - Add top-level `upstreams` and `tools` inputs to the `codemode` MCP tool.
  - Clarify workflow: `search` -> `describe` -> helper or `callTool`, with current budgets and `writeArtifact` guidance.
  - Add tests for description content, route scoping, empty snapshots, and top-level inputs.

- Bug Fixes
  - Satisfy actionlint shellcheck in the marketplace sync workflow by grouping `$GITHUB_OUTPUT` writes.
  - Relax gateway lazy-connect test to accept Windows timeout error text.

<sup>Written for commit a3c148b3228b5459574715504485f5984206d7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code Mode now shows available upstream namespaces in its description, including a clear message when none are configured.
  * Updated the displayed guidance for tool usage and call limits.

* **Bug Fixes**
  * Forked pull requests now run tests on hosted runners, avoiding self-hosted runner access issues.
  * Secret scanning was refreshed to better catch historical findings.

* **Documentation**
  * Expanded CI and runner setup docs with clearer execution paths and Linux self-hosted runner details.

* **Chores**
  * Bumped release versions to **0.27.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->