### PR TITLE
Add Code Mode state and git V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Code Mode local state and git providers** — added V1 `state.*` workspace
+  APIs and local-only `git.*` commands inside the Code Mode sandbox, backed by a
+  jailed `$LAB_HOME/code-mode-workspaces/` workspace with path, quota, output,
+  and git process guards.
+
 ---
 
 ## [0.28.0] - 2026-06-27

--- a/crates/labby-codemode/Cargo.toml
+++ b/crates/labby-codemode/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 labby-runtime = { path = "../labby-runtime" }
 
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["process", "sync"] }
 futures.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/labby-codemode/src/execute.rs
+++ b/crates/labby-codemode/src/execute.rs
@@ -137,7 +137,7 @@ impl<H: CodeModeHost> CodeModeBroker<'_, H> {
         scope: &ToolScope,
     ) -> Result<String, ToolError> {
         let Some(host) = self.host else {
-            return Ok(String::new());
+            return Ok(super::preamble::generate_local_provider_js());
         };
         let include_snippets = caller.can_use_snippets() && !scope.is_scoped();
         // CLI with no explicit namespace scope can be served from the host's
@@ -184,7 +184,10 @@ impl<H: CodeModeHost> CodeModeBroker<'_, H> {
                     message,
                 },
             )?;
-        Ok(format!("{discovery_js}\n{namespace_js}"))
+        let local_provider_js = super::preamble::generate_local_provider_js();
+        Ok(format!(
+            "{local_provider_js}\n{discovery_js}\n{namespace_js}"
+        ))
     }
 
     async fn execute_sandboxed(

--- a/crates/labby-codemode/src/git.rs
+++ b/crates/labby-codemode/src/git.rs
@@ -1,0 +1,2 @@
+pub(crate) mod command;
+pub(crate) mod provider;

--- a/crates/labby-codemode/src/git/command.rs
+++ b/crates/labby-codemode/src/git/command.rs
@@ -1,0 +1,154 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::error::ToolError;
+use crate::state::path::VirtualPath;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitCommandSpec {
+    pub(crate) args: Vec<String>,
+}
+
+impl GitCommandSpec {
+    pub(crate) fn status() -> Self {
+        Self {
+            args: base_args(["status", "--short"]),
+        }
+    }
+
+    pub(crate) fn for_method(method: &str, params: Value) -> Result<Self, ToolError> {
+        match method {
+            "init" => Ok(Self {
+                args: base_args(["init"]),
+            }),
+            "status" => Ok(Self::status()),
+            "add" => {
+                let params: PathParams = parse_params(params)?;
+                let path = VirtualPath::parse(&params.path)?;
+                let mut args = base_args(["add", "--"]);
+                args.push(path.as_str().to_string());
+                Ok(Self { args })
+            }
+            "commit" => {
+                let params: CommitParams = parse_params(params)?;
+                if params.message.trim().is_empty() {
+                    return Err(ToolError::InvalidParam {
+                        message: "git commit message must not be empty".to_string(),
+                        param: "message".to_string(),
+                    });
+                }
+                let author = format!("{} <{}>", params.author_name, params.author_email);
+                let mut args = base_args([
+                    "-c",
+                    "user.name=Lab",
+                    "-c",
+                    "user.email=lab@example.invalid",
+                    "commit",
+                    "--no-gpg-sign",
+                    "--author",
+                ]);
+                args.push(author);
+                args.push("-m".to_string());
+                args.push(params.message);
+                Ok(Self { args })
+            }
+            "log" => {
+                let params: LimitParams = parse_params(params)?;
+                let limit = params.limit.unwrap_or(20).clamp(1, 50).to_string();
+                let mut args = base_args(["log", "--oneline", "-n"]);
+                args.push(limit);
+                Ok(Self { args })
+            }
+            "diff" => {
+                let params: OptionalPathParams = parse_params(params)?;
+                let mut args = base_args(["diff", "--"]);
+                if let Some(path) = params.path {
+                    args.push(VirtualPath::parse(&path)?.as_str().to_string());
+                }
+                Ok(Self { args })
+            }
+            other => Err(ToolError::Sdk {
+                sdk_kind: "unknown_tool".to_string(),
+                message: format!("unknown git method `{other}`"),
+            }),
+        }
+    }
+}
+
+fn base_args<const N: usize>(tail: [&str; N]) -> Vec<String> {
+    let mut args = vec![
+        "-c".to_string(),
+        "core.hooksPath=/dev/null".to_string(),
+        "-c".to_string(),
+        "protocol.file.allow=never".to_string(),
+        "-c".to_string(),
+        "protocol.ext.allow=never".to_string(),
+    ];
+    args.extend(tail.into_iter().map(str::to_string));
+    args
+}
+
+fn parse_params<T: for<'de> Deserialize<'de>>(params: Value) -> Result<T, ToolError> {
+    serde_json::from_value(params).map_err(|err| ToolError::InvalidParam {
+        message: format!("invalid git params: {err}"),
+        param: "params".to_string(),
+    })
+}
+
+#[derive(Deserialize)]
+struct PathParams {
+    path: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CommitParams {
+    message: String,
+    author_name: String,
+    author_email: String,
+}
+
+#[derive(Deserialize)]
+struct LimitParams {
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct OptionalPathParams {
+    path: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_status_builds_fixed_argv() {
+        let cmd = GitCommandSpec::status();
+        assert_eq!(
+            cmd.args,
+            vec![
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "protocol.file.allow=never",
+                "-c",
+                "protocol.ext.allow=never",
+                "status",
+                "--short"
+            ]
+        );
+    }
+
+    #[test]
+    fn git_rejects_unsupported_method() {
+        assert!(GitCommandSpec::for_method("push", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn git_add_validates_virtual_path() {
+        let err = GitCommandSpec::for_method("add", serde_json::json!({"path": "../outside"}))
+            .unwrap_err();
+        assert_eq!(err.kind(), "path_traversal");
+    }
+}

--- a/crates/labby-codemode/src/git/provider.rs
+++ b/crates/labby-codemode/src/git/provider.rs
@@ -2,12 +2,16 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 use crate::error::ToolError;
 use crate::state::workspace::StateWorkspace;
 
 use super::command::GitCommandSpec;
+
+const MAX_GIT_STDOUT_BYTES: usize = 64 * 1024;
+const MAX_GIT_STDERR_BYTES: usize = 16 * 1024;
 
 pub(crate) async fn dispatch_git_method(
     workspace: &StateWorkspace,
@@ -26,7 +30,7 @@ pub(crate) async fn run_git(workspace_root: &Path, args: &[String]) -> Result<St
         .args(args)
         .current_dir(workspace_root)
         .env_clear()
-        .env("PATH", "/usr/bin:/bin")
+        .env("PATH", git_search_path())
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", null_device())
@@ -34,25 +38,16 @@ pub(crate) async fn run_git(workspace_root: &Path, args: &[String]) -> Result<St
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    let output = tokio::time::timeout(Duration::from_secs(10), command.output())
+    let result = tokio::time::timeout(Duration::from_secs(10), run_capped_command(command))
         .await
         .map_err(|_| ToolError::Sdk {
             sdk_kind: "timeout".to_string(),
             message: "git command timed out".to_string(),
-        })?
-        .map_err(|err| ToolError::Sdk {
-            sdk_kind: "internal_error".to_string(),
-            message: format!("failed to run git: {err}"),
         })?;
+    let output = result?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout)
-        .chars()
-        .take(64 * 1024)
-        .collect::<String>();
-    let stderr = String::from_utf8_lossy(&output.stderr)
-        .chars()
-        .take(16 * 1024)
-        .collect::<String>();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     if !output.status.success() {
         return Err(ToolError::Sdk {
             sdk_kind: "git_failed".to_string(),
@@ -60,6 +55,94 @@ pub(crate) async fn run_git(workspace_root: &Path, args: &[String]) -> Result<St
         });
     }
     Ok(redact_git_output(&stdout))
+}
+
+struct CappedGitOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+struct CappedPipe {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+async fn run_capped_command(mut command: Command) -> Result<CappedGitOutput, ToolError> {
+    let mut child = command.spawn().map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to run git: {err}"),
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: "failed to capture git stdout".to_string(),
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: "failed to capture git stderr".to_string(),
+    })?;
+
+    let mut stdout_task = tokio::spawn(read_capped_pipe(stdout, MAX_GIT_STDOUT_BYTES));
+    let mut stderr_task = tokio::spawn(read_capped_pipe(stderr, MAX_GIT_STDERR_BYTES));
+    let mut stdout_result = None;
+    let mut stderr_result = None;
+
+    while stdout_result.is_none() || stderr_result.is_none() {
+        tokio::select! {
+            result = &mut stdout_task, if stdout_result.is_none() => {
+                let pipe = join_capped_pipe(result)?;
+                if pipe.truncated {
+                    drop(child.start_kill());
+                }
+                stdout_result = Some(pipe);
+            }
+            result = &mut stderr_task, if stderr_result.is_none() => {
+                let pipe = join_capped_pipe(result)?;
+                if pipe.truncated {
+                    drop(child.start_kill());
+                }
+                stderr_result = Some(pipe);
+            }
+        }
+    }
+
+    let status = child.wait().await.map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to wait for git: {err}"),
+    })?;
+    Ok(CappedGitOutput {
+        status,
+        stdout: stdout_result.expect("stdout result set").bytes,
+        stderr: stderr_result.expect("stderr result set").bytes,
+    })
+}
+
+async fn read_capped_pipe<R>(reader: R, max_bytes: usize) -> Result<CappedPipe, std::io::Error>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(max_bytes.min(8192));
+    reader
+        .take(max_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+        .await?;
+    let truncated = bytes.len() > max_bytes;
+    bytes.truncate(max_bytes);
+    Ok(CappedPipe { bytes, truncated })
+}
+
+fn join_capped_pipe(
+    result: Result<Result<CappedPipe, std::io::Error>, tokio::task::JoinError>,
+) -> Result<CappedPipe, ToolError> {
+    result
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to join git output reader: {err}"),
+        })?
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to read git output: {err}"),
+        })
 }
 
 fn git_binary() -> PathBuf {
@@ -70,6 +153,17 @@ fn git_binary() -> PathBuf {
     #[cfg(not(windows))]
     {
         PathBuf::from("/usr/bin/git")
+    }
+}
+
+fn git_search_path() -> &'static str {
+    #[cfg(windows)]
+    {
+        r"C:\Program Files\Git\cmd;C:\Program Files\Git\bin;C:\Windows\System32;C:\Windows"
+    }
+    #[cfg(not(windows))]
+    {
+        "/usr/local/bin:/usr/bin:/bin"
     }
 }
 
@@ -85,7 +179,11 @@ fn null_device() -> &'static str {
 }
 
 fn redact_git_output(value: &str) -> String {
-    let value = value.replace("https://", "https://[REDACTED]@");
+    let https_userinfo =
+        regex::Regex::new(r"https://[^/\s@]+@").expect("static https userinfo redaction regex");
+    let value = https_userinfo
+        .replace_all(value, "https://[REDACTED]@")
+        .to_string();
     let tokenish = regex::Regex::new(r"(ghp_|github_pat_|glpat-)[A-Za-z0-9_]+")
         .expect("static git token redaction regex");
     tokenish.replace_all(&value, "[REDACTED]").to_string()
@@ -131,5 +229,16 @@ mod tests {
             .await
             .unwrap();
         assert!(log["stdout"].as_str().unwrap().contains("initial state"));
+    }
+
+    #[test]
+    fn redacts_only_https_userinfo_and_tokens() {
+        let redacted = redact_git_output(
+            "https://example.com/a https://user:pass@example.com/b ghp_abcdefghijklmnopqrstuvwxyz",
+        );
+        assert!(redacted.contains("https://example.com/a"));
+        assert!(redacted.contains("https://[REDACTED]@example.com/b"));
+        assert!(!redacted.contains("user:pass"));
+        assert!(!redacted.contains("ghp_abcdefghijklmnopqrstuvwxyz"));
     }
 }

--- a/crates/labby-codemode/src/git/provider.rs
+++ b/crates/labby-codemode/src/git/provider.rs
@@ -1,0 +1,135 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+use crate::error::ToolError;
+use crate::state::workspace::StateWorkspace;
+
+use super::command::GitCommandSpec;
+
+pub(crate) async fn dispatch_git_method(
+    workspace: &StateWorkspace,
+    method: &str,
+    params: Value,
+) -> Result<Value, ToolError> {
+    let spec = GitCommandSpec::for_method(method, params)?;
+    let stdout = run_git(workspace.root_path(), &spec.args).await?;
+    Ok(json!({ "ok": true, "stdout": stdout }))
+}
+
+pub(crate) async fn run_git(workspace_root: &Path, args: &[String]) -> Result<String, ToolError> {
+    let git = git_binary();
+    let mut command = Command::new(git);
+    command
+        .args(args)
+        .current_dir(workspace_root)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", null_device())
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let output = tokio::time::timeout(Duration::from_secs(10), command.output())
+        .await
+        .map_err(|_| ToolError::Sdk {
+            sdk_kind: "timeout".to_string(),
+            message: "git command timed out".to_string(),
+        })?
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to run git: {err}"),
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .chars()
+        .take(64 * 1024)
+        .collect::<String>();
+    let stderr = String::from_utf8_lossy(&output.stderr)
+        .chars()
+        .take(16 * 1024)
+        .collect::<String>();
+    if !output.status.success() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "git_failed".to_string(),
+            message: format!("git failed: {}", redact_git_output(&stderr)),
+        });
+    }
+    Ok(redact_git_output(&stdout))
+}
+
+fn git_binary() -> PathBuf {
+    #[cfg(windows)]
+    {
+        PathBuf::from("git.exe")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/usr/bin/git")
+    }
+}
+
+fn null_device() -> &'static str {
+    #[cfg(windows)]
+    {
+        "NUL"
+    }
+    #[cfg(not(windows))]
+    {
+        "/dev/null"
+    }
+}
+
+fn redact_git_output(value: &str) -> String {
+    let value = value.replace("https://", "https://[REDACTED]@");
+    let tokenish = regex::Regex::new(r"(ghp_|github_pat_|glpat-)[A-Za-z0-9_]+")
+        .expect("static git token redaction regex");
+    tokenish.replace_all(&value, "[REDACTED]").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::quota::StateWorkspaceLimits;
+
+    #[tokio::test]
+    async fn git_provider_initializes_and_commits_workspace_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace =
+            StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+                .unwrap();
+        workspace
+            .write_file(
+                &crate::state::path::VirtualPath::parse("src/app.rs").unwrap(),
+                "fn main() {}\n",
+            )
+            .await
+            .unwrap();
+
+        dispatch_git_method(&workspace, "init", json!({}))
+            .await
+            .unwrap();
+        dispatch_git_method(&workspace, "add", json!({"path": "src/app.rs"}))
+            .await
+            .unwrap();
+        dispatch_git_method(
+            &workspace,
+            "commit",
+            json!({
+                "message": "initial state",
+                "authorName": "Lab",
+                "authorEmail": "lab@example.invalid"
+            }),
+        )
+        .await
+        .unwrap();
+        let log = dispatch_git_method(&workspace, "log", json!({"limit": 1}))
+            .await
+            .unwrap();
+        assert!(log["stdout"].as_str().unwrap().contains("initial state"));
+    }
+}

--- a/crates/labby-codemode/src/lib.rs
+++ b/crates/labby-codemode/src/lib.rs
@@ -37,6 +37,8 @@ mod runner_io;
 mod schema;
 mod shape;
 pub mod snippet;
+#[allow(dead_code)]
+mod state;
 mod trace;
 mod truncate;
 /// Live TypeScript signature / `.d.ts` generator for Code Mode tool descriptors.

--- a/crates/labby-codemode/src/lib.rs
+++ b/crates/labby-codemode/src/lib.rs
@@ -25,6 +25,7 @@ mod broker;
 mod config;
 mod execute;
 pub mod host;
+mod local_provider;
 mod normalize;
 mod pool;
 mod preamble;

--- a/crates/labby-codemode/src/lib.rs
+++ b/crates/labby-codemode/src/lib.rs
@@ -24,6 +24,7 @@ mod artifacts;
 mod broker;
 mod config;
 mod execute;
+mod git;
 pub mod host;
 mod local_provider;
 mod normalize;

--- a/crates/labby-codemode/src/lib.rs
+++ b/crates/labby-codemode/src/lib.rs
@@ -37,7 +37,6 @@ mod runner_io;
 mod schema;
 mod shape;
 pub mod snippet;
-#[allow(dead_code)]
 mod state;
 mod trace;
 mod truncate;

--- a/crates/labby-codemode/src/local_provider.rs
+++ b/crates/labby-codemode/src/local_provider.rs
@@ -1,0 +1,73 @@
+//! Local Code Mode providers reserved by the Lab runtime.
+//!
+//! These providers are not upstream MCP tools. The runner still emits them
+//! through the existing `ToolCall` protocol so promise settlement and tracing
+//! stay uniform, but the parent intercepts the reserved namespaces before
+//! `CodeModeHost::call_tool` can route to an upstream named `state` or `git`.
+
+use serde_json::Value;
+
+use crate::error::ToolError;
+use crate::types::split_namespaced_id;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalProviderName {
+    State,
+    Git,
+}
+
+impl LocalProviderName {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::State => "state",
+            Self::Git => "git",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LocalProviderCall {
+    pub(crate) provider: LocalProviderName,
+    pub(crate) method: String,
+    pub(crate) params: Value,
+}
+
+pub(crate) fn is_reserved_provider_namespace(namespace: &str) -> bool {
+    matches!(namespace, "state" | "git")
+}
+
+pub(crate) fn try_parse_local_provider_call(
+    id: &str,
+) -> Result<Option<LocalProviderCall>, ToolError> {
+    let trimmed = id.trim();
+    let Some((namespace, method)) = split_namespaced_id(trimmed) else {
+        if let Some((namespace, _)) = trimmed.split_once("::")
+            && is_reserved_provider_namespace(namespace.trim())
+        {
+            return Err(ToolError::InvalidParam {
+                message: "local provider method must not be empty".to_string(),
+                param: "id".to_string(),
+            });
+        }
+        return Ok(None);
+    };
+
+    let provider = match namespace {
+        "state" => LocalProviderName::State,
+        "git" => LocalProviderName::Git,
+        _ => return Ok(None),
+    };
+
+    if method.trim().is_empty() {
+        return Err(ToolError::InvalidParam {
+            message: "local provider method must not be empty".to_string(),
+            param: "id".to_string(),
+        });
+    }
+
+    Ok(Some(LocalProviderCall {
+        provider,
+        method: method.to_string(),
+        params: Value::Null,
+    }))
+}

--- a/crates/labby-codemode/src/preamble.rs
+++ b/crates/labby-codemode/src/preamble.rs
@@ -332,6 +332,36 @@ codemode.step = function(name, fn) {{
     ))
 }
 
+pub(crate) fn generate_local_provider_js() -> String {
+    r#"
+function __labLocalProviderCall(id, params) {
+  return callTool(id, params == null ? {} : params);
+}
+globalThis.state = Object.freeze({
+  readFile: function(params) { return __labLocalProviderCall("state::readFile", params); },
+  writeFile: function(params) { return __labLocalProviderCall("state::writeFile", params); },
+  list: function(params) { return __labLocalProviderCall("state::list", params); },
+  readdir: function(params) { return __labLocalProviderCall("state::readdir", params); },
+  glob: function(params) { return __labLocalProviderCall("state::glob", params); },
+  searchFiles: function(params) { return __labLocalProviderCall("state::searchFiles", params); },
+  replaceInFiles: function(params) { return __labLocalProviderCall("state::replaceInFiles", params); },
+  planEdits: function(params) { return __labLocalProviderCall("state::planEdits", params); },
+  applyEditPlan: function(params) { return __labLocalProviderCall("state::applyEditPlan", params); }
+});
+var state = globalThis.state;
+globalThis.git = Object.freeze({
+  init: function(params) { return __labLocalProviderCall("git::init", params); },
+  status: function(params) { return __labLocalProviderCall("git::status", params); },
+  add: function(params) { return __labLocalProviderCall("git::add", params); },
+  commit: function(params) { return __labLocalProviderCall("git::commit", params); },
+  log: function(params) { return __labLocalProviderCall("git::log", params); },
+  diff: function(params) { return __labLocalProviderCall("git::diff", params); }
+});
+var git = globalThis.git;
+"#
+    .to_string()
+}
+
 /// Generate a JavaScript preamble string that defines the `codemode` proxy
 /// namespace, plus `codemode.__meta__.namespaces()` and a `__namespaces__`
 /// script-global, for use inside the sandbox.

--- a/crates/labby-codemode/src/runner_drive.rs
+++ b/crates/labby-codemode/src/runner_drive.rs
@@ -17,6 +17,7 @@ use ulid::Ulid;
 
 use crate::error::ToolError;
 use crate::host::CodeModeHost;
+use crate::local_provider::LocalProviderCall;
 
 use super::CodeModeBroker;
 use super::artifacts::{
@@ -334,15 +335,39 @@ impl<H: CodeModeHost> CodeModeBroker<'_, H> {
                                     return DriveOutcome::RunnerUnhealthy(err);
                                 }
                             } else {
-                                enqueue_tool_call(
-                                    self,
-                                    seq,
-                                    id,
-                                    params,
-                                    deadline,
-                                    cfg,
-                                    &mut pending_tool_calls,
-                                );
+                                match crate::local_provider::try_parse_local_provider_call(&id) {
+                                    Ok(Some(local)) => {
+                                        enqueue_local_provider_call(
+                                            seq,
+                                            id,
+                                            local,
+                                            params,
+                                            cfg,
+                                            &mut pending_tool_calls,
+                                        );
+                                    }
+                                    Ok(None) => {
+                                        enqueue_tool_call(
+                                            self,
+                                            seq,
+                                            id,
+                                            params,
+                                            deadline,
+                                            cfg,
+                                            &mut pending_tool_calls,
+                                        );
+                                    }
+                                    Err(err) => {
+                                        enqueue_rejected_tool_call(
+                                            seq,
+                                            id,
+                                            params,
+                                            err,
+                                            cfg,
+                                            &mut pending_tool_calls,
+                                        );
+                                    }
+                                }
                             }
                         }
                         CodeModeRunnerOutput::ArtifactWrite {
@@ -542,6 +567,53 @@ fn enqueue_tool_call<'a, H: CodeModeHost>(
         let elapsed_ms = call_start.elapsed().as_millis();
         (seq, call_id, redacted_params, result, elapsed_ms)
     }));
+}
+
+fn enqueue_local_provider_call<'a>(
+    seq: u64,
+    id: String,
+    local: LocalProviderCall,
+    params: Value,
+    cfg: &RunnerConfig,
+    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'a>>,
+) {
+    let redacted_params = super::trace::redact_trace_params(&params, cfg.trace_params);
+    pending_tool_calls.push(Box::pin(async move {
+        let call_start = std::time::Instant::now();
+        let result = dispatch_local_provider_stub(local, params).await;
+        let elapsed_ms = call_start.elapsed().as_millis();
+        (seq, id, redacted_params, result, elapsed_ms)
+    }));
+}
+
+fn enqueue_rejected_tool_call<'a>(
+    seq: u64,
+    id: String,
+    params: Value,
+    err: ToolError,
+    cfg: &RunnerConfig,
+    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'a>>,
+) {
+    let redacted_params = super::trace::redact_trace_params(&params, cfg.trace_params);
+    pending_tool_calls.push(Box::pin(
+        async move { (seq, id, redacted_params, Err(err), 0) },
+    ));
+}
+
+async fn dispatch_local_provider_stub(
+    local: LocalProviderCall,
+    params: Value,
+) -> Result<Value, ToolError> {
+    let provider = local.provider.as_str();
+    drop(params);
+    drop(local.params);
+    Err(ToolError::Sdk {
+        sdk_kind: "unknown_tool".to_string(),
+        message: format!(
+            "Code Mode local provider `{provider}` method `{}` is not implemented yet",
+            local.method
+        ),
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/labby-codemode/src/runner_drive.rs
+++ b/crates/labby-codemode/src/runner_drive.rs
@@ -8,11 +8,13 @@
 //! select loop readable.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use futures::{StreamExt, stream::FuturesUnordered};
 use serde_json::{Value, json};
 use tokio::process::ChildStdin;
+use tokio::sync::Mutex;
 use ulid::Ulid;
 
 use crate::error::ToolError;
@@ -41,6 +43,8 @@ use super::types::{
     CodeModeCaller, CodeModeExecutedCall, CodeModeExecutionError, CodeModeExecutionResponse,
     CodeModeSurface, ToolScope,
 };
+
+static LOCAL_PROVIDER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 const ARTIFACT_WRITE_CALL_ID: &str = "code_mode::write_artifact";
 
@@ -573,30 +577,34 @@ fn enqueue_tool_call<'a, H: CodeModeHost>(
     }));
 }
 
-fn enqueue_local_provider_call<'a>(
+fn enqueue_local_provider_call(
     seq: u64,
     id: String,
     local: LocalProviderCall,
     params: Value,
     cfg: &RunnerConfig,
-    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'a>>,
+    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'_>>,
 ) {
     let redacted_params = super::trace::redact_trace_params(&params, cfg.trace_params);
     pending_tool_calls.push(Box::pin(async move {
         let call_start = std::time::Instant::now();
+        let _guard = LOCAL_PROVIDER_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .await;
         let result = dispatch_local_provider_stub(local, params).await;
         let elapsed_ms = call_start.elapsed().as_millis();
         (seq, id, redacted_params, result, elapsed_ms)
     }));
 }
 
-fn enqueue_rejected_tool_call<'a>(
+fn enqueue_rejected_tool_call(
     seq: u64,
     id: String,
     params: Value,
     err: ToolError,
     cfg: &RunnerConfig,
-    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'a>>,
+    pending_tool_calls: &mut FuturesUnordered<ToolCallFut<'_>>,
 ) {
     let redacted_params = super::trace::redact_trace_params(&params, cfg.trace_params);
     pending_tool_calls.push(Box::pin(

--- a/crates/labby-codemode/src/runner_drive.rs
+++ b/crates/labby-codemode/src/runner_drive.rs
@@ -17,7 +17,10 @@ use ulid::Ulid;
 
 use crate::error::ToolError;
 use crate::host::CodeModeHost;
-use crate::local_provider::LocalProviderCall;
+use crate::local_provider::{LocalProviderCall, LocalProviderName};
+use crate::state::provider::dispatch_state_method;
+use crate::state::quota::StateWorkspaceLimits;
+use crate::state::workspace::StateWorkspace;
 
 use super::CodeModeBroker;
 use super::artifacts::{
@@ -604,16 +607,24 @@ async fn dispatch_local_provider_stub(
     local: LocalProviderCall,
     params: Value,
 ) -> Result<Value, ToolError> {
-    let provider = local.provider.as_str();
-    drop(params);
     drop(local.params);
-    Err(ToolError::Sdk {
-        sdk_kind: "unknown_tool".to_string(),
-        message: format!(
-            "Code Mode local provider `{provider}` method `{}` is not implemented yet",
-            local.method
-        ),
-    })
+    let provider_name = local.provider.as_str();
+    match local.provider {
+        LocalProviderName::State => {
+            let workspace_root = labby_runtime::lab_home()
+                .join("code-mode-workspaces")
+                .join("default");
+            let workspace = StateWorkspace::new(workspace_root, StateWorkspaceLimits::default())?;
+            dispatch_state_method(&workspace, &local.method, params).await
+        }
+        LocalProviderName::Git => Err(ToolError::Sdk {
+            sdk_kind: "unknown_tool".to_string(),
+            message: format!(
+                "Code Mode local provider `{provider_name}` method `{}` is not implemented yet",
+                local.method
+            ),
+        }),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/labby-codemode/src/runner_drive.rs
+++ b/crates/labby-codemode/src/runner_drive.rs
@@ -16,6 +16,7 @@ use tokio::process::ChildStdin;
 use ulid::Ulid;
 
 use crate::error::ToolError;
+use crate::git::provider::dispatch_git_method;
 use crate::host::CodeModeHost;
 use crate::local_provider::{LocalProviderCall, LocalProviderName};
 use crate::state::provider::dispatch_state_method;
@@ -617,13 +618,14 @@ async fn dispatch_local_provider_stub(
             let workspace = StateWorkspace::new(workspace_root, StateWorkspaceLimits::default())?;
             dispatch_state_method(&workspace, &local.method, params).await
         }
-        LocalProviderName::Git => Err(ToolError::Sdk {
-            sdk_kind: "unknown_tool".to_string(),
-            message: format!(
-                "Code Mode local provider `{provider_name}` method `{}` is not implemented yet",
-                local.method
-            ),
-        }),
+        LocalProviderName::Git => {
+            let workspace_root = labby_runtime::lab_home()
+                .join("code-mode-workspaces")
+                .join("default");
+            let workspace = StateWorkspace::new(workspace_root, StateWorkspaceLimits::default())?;
+            let _ = provider_name;
+            dispatch_git_method(&workspace, &local.method, params).await
+        }
     }
 }
 

--- a/crates/labby-codemode/src/state.rs
+++ b/crates/labby-codemode/src/state.rs
@@ -1,0 +1,3 @@
+pub(crate) mod path;
+pub(crate) mod quota;
+pub(crate) mod workspace;

--- a/crates/labby-codemode/src/state.rs
+++ b/crates/labby-codemode/src/state.rs
@@ -1,3 +1,4 @@
 pub(crate) mod path;
+pub(crate) mod provider;
 pub(crate) mod quota;
 pub(crate) mod workspace;

--- a/crates/labby-codemode/src/state/path.rs
+++ b/crates/labby-codemode/src/state/path.rs
@@ -1,0 +1,134 @@
+use std::path::{Component, Path};
+
+use crate::error::ToolError;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct VirtualPath(String);
+
+impl VirtualPath {
+    pub(crate) fn parse(raw: &str) -> Result<Self, ToolError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "/" {
+            return Err(ToolError::InvalidParam {
+                message: "state path must name a file or directory inside the workspace"
+                    .to_string(),
+                param: "path".to_string(),
+            });
+        }
+
+        let normalized = trimmed.replace('\\', "/");
+        if has_windows_drive_prefix(&normalized) {
+            return Err(path_traversal(raw));
+        }
+
+        let stripped = normalized.trim_start_matches('/');
+        let mut parts = Vec::new();
+        for component in Path::new(stripped).components() {
+            match component {
+                Component::Normal(value) => {
+                    let part = value.to_string_lossy();
+                    if !part.is_empty() {
+                        parts.push(part.to_string());
+                    }
+                }
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    return Err(path_traversal(raw));
+                }
+            }
+        }
+
+        if parts.is_empty() {
+            return Err(ToolError::InvalidParam {
+                message: "state path must name a file or directory inside the workspace"
+                    .to_string(),
+                param: "path".to_string(),
+            });
+        }
+
+        let value = parts.join("/");
+        reject_credential_like_path(&value)?;
+        Ok(Self(value))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn path_traversal(raw: &str) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "path_traversal".to_string(),
+        message: format!("state path `{raw}` escapes the workspace"),
+    }
+}
+
+fn reject_credential_like_path(path: &str) -> Result<(), ToolError> {
+    let lower = path.to_ascii_lowercase();
+    let denied = [
+        ".env",
+        ".ssh/",
+        ".git/config",
+        ".git/credentials",
+        ".aws/",
+        ".config/gcloud/",
+        ".netrc",
+        "id_rsa",
+        "id_ed25519",
+    ];
+    if denied
+        .iter()
+        .any(|needle| lower == *needle || lower.contains(needle))
+    {
+        return Err(ToolError::Sdk {
+            sdk_kind: "permission_denied".to_string(),
+            message: "state path is denied because it looks credential-related".to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_path_accepts_rooted_and_relative_paths() {
+        assert_eq!(
+            VirtualPath::parse("/src/app.rs").unwrap().as_str(),
+            "src/app.rs"
+        );
+        assert_eq!(
+            VirtualPath::parse("src/app.rs").unwrap().as_str(),
+            "src/app.rs"
+        );
+    }
+
+    #[test]
+    fn virtual_path_rejects_escape_and_host_paths() {
+        for raw in ["../secret", "/../secret", "C:/Users/x", "C:relative", "/"] {
+            assert!(VirtualPath::parse(raw).is_err(), "{raw} should fail");
+        }
+    }
+
+    #[test]
+    fn virtual_path_normalizes_windows_separators() {
+        assert_eq!(
+            VirtualPath::parse("src\\\\app.rs").unwrap().as_str(),
+            "src/app.rs"
+        );
+    }
+
+    #[test]
+    fn virtual_path_rejects_credential_like_paths() {
+        for raw in [".env", "src/.env", ".ssh/id_ed25519", ".git/config"] {
+            let err = VirtualPath::parse(raw).expect_err("credential path should fail");
+            assert_eq!(err.kind(), "permission_denied");
+        }
+    }
+}

--- a/crates/labby-codemode/src/state/path.rs
+++ b/crates/labby-codemode/src/state/path.rs
@@ -70,11 +70,19 @@ fn path_traversal(raw: &str) -> ToolError {
 
 fn reject_credential_like_path(path: &str) -> Result<(), ToolError> {
     let lower = path.to_ascii_lowercase();
+    if lower
+        .split('/')
+        .any(|segment| segment == ".git" || segment == ".labby-state")
+    {
+        return Err(ToolError::Sdk {
+            sdk_kind: "permission_denied".to_string(),
+            message: "state path is denied because it targets provider metadata".to_string(),
+        });
+    }
+
     let denied = [
         ".env",
         ".ssh/",
-        ".git/config",
-        ".git/credentials",
         ".aws/",
         ".config/gcloud/",
         ".netrc",
@@ -126,9 +134,25 @@ mod tests {
 
     #[test]
     fn virtual_path_rejects_credential_like_paths() {
-        for raw in [".env", "src/.env", ".ssh/id_ed25519", ".git/config"] {
+        for raw in [
+            ".env",
+            "src/.env",
+            ".ssh/id_ed25519",
+            ".git/config",
+            ".git/HEAD",
+            "src/.git/config",
+            ".labby-state/plans/abc.json",
+        ] {
             let err = VirtualPath::parse(raw).expect_err("credential path should fail");
             assert_eq!(err.kind(), "permission_denied");
         }
+    }
+
+    #[test]
+    fn virtual_path_allows_git_substrings_outside_reserved_segments() {
+        assert_eq!(
+            VirtualPath::parse("docs/foo.gitkeep").unwrap().as_str(),
+            "docs/foo.gitkeep"
+        );
     }
 }

--- a/crates/labby-codemode/src/state/provider.rs
+++ b/crates/labby-codemode/src/state/provider.rs
@@ -1,0 +1,232 @@
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::error::ToolError;
+
+use super::path::VirtualPath;
+use super::workspace::{FileEdit, StateWorkspace, default_search_limit, default_true};
+
+#[derive(Deserialize)]
+struct PathParams {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct WriteFileParams {
+    path: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct GlobParams {
+    pattern: String,
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct SearchFilesParams {
+    pattern: String,
+    query: String,
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct ReplaceInFilesParams {
+    pattern: String,
+    search: String,
+    replace: String,
+    #[serde(default = "default_true", rename = "dryRun")]
+    dry_run: bool,
+}
+
+#[derive(Deserialize)]
+struct PlanEditsParams {
+    edits: Vec<FileEdit>,
+}
+
+#[derive(Deserialize)]
+struct ApplyEditPlanParams {
+    plan_id: String,
+}
+
+pub(crate) async fn dispatch_state_method(
+    workspace: &StateWorkspace,
+    method: &str,
+    params: Value,
+) -> Result<Value, ToolError> {
+    match method {
+        "readFile" => {
+            let params: PathParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace
+                .read_file(&VirtualPath::parse(&params.path)?)
+                .await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "writeFile" => {
+            let params: WriteFileParams = serde_json::from_value(params).map_err(invalid_params)?;
+            workspace
+                .write_file(&VirtualPath::parse(&params.path)?, &params.content)
+                .await?;
+            Ok(json!({ "ok": true, "path": params.path }))
+        }
+        "list" | "readdir" => {
+            let params: PathParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace.list(&VirtualPath::parse(&params.path)?).await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "glob" => {
+            let params: GlobParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace
+                .glob(
+                    &params.pattern,
+                    params.limit.unwrap_or(default_search_limit()),
+                )
+                .await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "searchFiles" => {
+            let params: SearchFilesParams =
+                serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace
+                .search_files(
+                    &params.pattern,
+                    &params.query,
+                    params.limit.unwrap_or(default_search_limit()),
+                )
+                .await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "replaceInFiles" => {
+            let params: ReplaceInFilesParams =
+                serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace
+                .replace_in_files(
+                    &params.pattern,
+                    &params.search,
+                    &params.replace,
+                    params.dry_run,
+                )
+                .await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "planEdits" => {
+            let params: PlanEditsParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace.plan_edits(params.edits).await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "applyEditPlan" => {
+            let params: ApplyEditPlanParams =
+                serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace.apply_edit_plan(&params.plan_id).await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        other => Err(ToolError::Sdk {
+            sdk_kind: "unknown_tool".to_string(),
+            message: format!("unknown state method `{other}`"),
+        }),
+    }
+}
+
+fn invalid_params(err: serde_json::Error) -> ToolError {
+    ToolError::InvalidParam {
+        message: format!("invalid state params: {err}"),
+        param: "params".to_string(),
+    }
+}
+
+fn serialize_error(err: serde_json::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to serialize state result: {err}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::state::quota::StateWorkspaceLimits;
+
+    #[tokio::test]
+    async fn write_and_read_file_dispatch_round_trip() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace =
+            StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+                .unwrap();
+        dispatch_state_method(
+            &workspace,
+            "writeFile",
+            json!({
+                "path": "/src/app.rs",
+                "content": "fn main() {}\n"
+            }),
+        )
+        .await
+        .unwrap();
+        let result = dispatch_state_method(
+            &workspace,
+            "readFile",
+            json!({
+                "path": "src/app.rs"
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result["content"], "fn main() {}\n");
+    }
+
+    #[tokio::test]
+    async fn search_replace_plan_and_apply_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace =
+            StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+                .unwrap();
+        dispatch_state_method(
+            &workspace,
+            "writeFile",
+            json!({"path": "src/app.rs", "content": "println!(\"hi\");\n"}),
+        )
+        .await
+        .unwrap();
+
+        let matches = dispatch_state_method(
+            &workspace,
+            "searchFiles",
+            json!({"pattern": "src/**/*.rs", "query": "println"}),
+        )
+        .await
+        .unwrap();
+        assert_eq!(matches["matches"].as_array().unwrap().len(), 1);
+
+        let dry_run = dispatch_state_method(
+            &workspace,
+            "replaceInFiles",
+            json!({
+                "pattern": "src/**/*.rs",
+                "search": "println",
+                "replace": "eprintln",
+                "dryRun": true
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dry_run["dry_run"], true);
+
+        let plan = dispatch_state_method(
+            &workspace,
+            "planEdits",
+            json!({"edits": [{"path": "src/app.rs", "search": "println", "replace": "eprintln"}]}),
+        )
+        .await
+        .unwrap();
+        let plan_id = plan["plan_id"].as_str().unwrap();
+        dispatch_state_method(&workspace, "applyEditPlan", json!({"plan_id": plan_id}))
+            .await
+            .unwrap();
+        let result = dispatch_state_method(&workspace, "readFile", json!({"path": "src/app.rs"}))
+            .await
+            .unwrap();
+        assert!(result["content"].as_str().unwrap().contains("eprintln"));
+    }
+}

--- a/crates/labby-codemode/src/state/provider.rs
+++ b/crates/labby-codemode/src/state/provider.rs
@@ -46,6 +46,7 @@ struct PlanEditsParams {
 
 #[derive(Deserialize)]
 struct ApplyEditPlanParams {
+    #[serde(rename = "planId", alias = "plan_id")]
     plan_id: String,
 }
 
@@ -221,7 +222,7 @@ mod tests {
         .await
         .unwrap();
         let plan_id = plan["plan_id"].as_str().unwrap();
-        dispatch_state_method(&workspace, "applyEditPlan", json!({"plan_id": plan_id}))
+        dispatch_state_method(&workspace, "applyEditPlan", json!({"planId": plan_id}))
             .await
             .unwrap();
         let result = dispatch_state_method(&workspace, "readFile", json!({"path": "src/app.rs"}))

--- a/crates/labby-codemode/src/state/quota.rs
+++ b/crates/labby-codemode/src/state/quota.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Clone)]
+pub(crate) struct StateWorkspaceLimits {
+    pub(crate) max_file_bytes: usize,
+    pub(crate) max_total_bytes: u64,
+    pub(crate) max_entries: u64,
+    pub(crate) max_result_bytes: usize,
+}
+
+impl Default for StateWorkspaceLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: 1024 * 1024,
+            max_total_bytes: 64 * 1024 * 1024,
+            max_entries: 10_000,
+            max_result_bytes: 1024 * 1024,
+        }
+    }
+}

--- a/crates/labby-codemode/src/state/workspace.rs
+++ b/crates/labby-codemode/src/state/workspace.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,18 @@ impl StateWorkspace {
         self.root.join(path.as_str())
     }
 
+    async fn reject_existing_symlink_path(&self, path: &Path) -> Result<(), ToolError> {
+        match tokio::fs::symlink_metadata(path).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => Err(ToolError::Sdk {
+                sdk_kind: "permission_denied".to_string(),
+                message: "state path is denied because it is a symlink".to_string(),
+            }),
+            Ok(_) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(internal_io("read state path metadata")(err)),
+        }
+    }
+
     pub(crate) async fn write_file(
         &self,
         path: &VirtualPath,
@@ -117,17 +129,18 @@ impl StateWorkspace {
 
         let destination = self.resolve(path);
         labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        self.reject_existing_symlink_path(&destination).await?;
         if let Some(parent) = destination.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
                 .map_err(internal_io("create state directory"))?;
         }
         labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        self.reject_existing_symlink_path(&destination).await?;
 
-        let tmp = destination.with_extension("tmp-labby-state");
+        let tmp = self.create_temp_path().await?;
         let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
+            .create_new(true)
             .write(true)
             .open(&tmp)
             .await
@@ -139,10 +152,40 @@ impl StateWorkspace {
             .await
             .map_err(internal_io("flush state temp file"))?;
         drop(file);
+        let tmp_metadata = tokio::fs::symlink_metadata(&tmp)
+            .await
+            .map_err(internal_io("inspect state temp file"))?;
+        if !tmp_metadata.is_file() || tmp_metadata.file_type().is_symlink() {
+            drop(tokio::fs::remove_file(&tmp).await);
+            return Err(ToolError::Sdk {
+                sdk_kind: "permission_denied".to_string(),
+                message: "state temp path is not a regular file".to_string(),
+            });
+        }
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        self.reject_existing_symlink_path(&destination).await?;
         tokio::fs::rename(&tmp, &destination)
             .await
             .map_err(internal_io("move state temp file"))?;
         Ok(())
+    }
+
+    async fn create_temp_path(&self) -> Result<PathBuf, ToolError> {
+        let dir = self.root.join(".labby-state").join("tmp");
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .map_err(internal_io("create state temp directory"))?;
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &dir)?;
+        let metadata = tokio::fs::symlink_metadata(&dir)
+            .await
+            .map_err(internal_io("inspect state temp directory"))?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err(ToolError::Sdk {
+                sdk_kind: "permission_denied".to_string(),
+                message: "state temp directory is not a directory".to_string(),
+            });
+        }
+        Ok(dir.join(format!("{}.tmp", ulid::Ulid::new())))
     }
 
     async fn check_total_bytes_after_write(
@@ -174,6 +217,7 @@ impl StateWorkspace {
     pub(crate) async fn read_file(&self, path: &VirtualPath) -> Result<ReadFileResult, ToolError> {
         let destination = self.resolve(path);
         labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        self.reject_existing_symlink_path(&destination).await?;
         let file = tokio::fs::File::open(&destination)
             .await
             .map_err(not_found_or_internal("open state file"))?;
@@ -198,6 +242,7 @@ impl StateWorkspace {
     pub(crate) async fn list(&self, path: &VirtualPath) -> Result<ListResult, ToolError> {
         let dir = self.resolve(path);
         labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &dir)?;
+        self.reject_existing_symlink_path(&dir).await?;
         let mut read_dir = tokio::fs::read_dir(&dir)
             .await
             .map_err(not_found_or_internal("read state directory"))?;
@@ -222,7 +267,7 @@ impl StateWorkspace {
     pub(crate) async fn glob(&self, pattern: &str, limit: usize) -> Result<GlobResult, ToolError> {
         let limit = normalize_limit(limit);
         let matcher = glob_pattern_regex(pattern)?;
-        let mut files = self.walk_files(limit.saturating_add(1)).await?;
+        let mut files = self.walk_files(self.limits.max_entries as usize).await?;
         files.sort();
         let mut matches = Vec::new();
         for file in files {
@@ -380,7 +425,7 @@ impl StateWorkspace {
 
     async fn restore_rollbacks(
         &self,
-        rollback_root: &PathBuf,
+        rollback_root: &Path,
         changed: &[String],
     ) -> Result<(), ToolError> {
         for path in changed.iter().rev() {
@@ -421,13 +466,15 @@ impl StateWorkspace {
                     Err(_) => continue,
                 };
                 let virtual_path = labby_runtime::path_safety::rel_to_unix_string(relative);
-                if virtual_path.starts_with(".labby-state/") {
+                if is_reserved_metadata_path(&virtual_path) {
                     continue;
                 }
-                let metadata = entry
-                    .metadata()
+                let metadata = tokio::fs::symlink_metadata(&path)
                     .await
                     .map_err(internal_io("read state workspace metadata"))?;
+                if metadata.file_type().is_symlink() {
+                    continue;
+                }
                 if metadata.is_dir() {
                     stack.push(path);
                 } else if metadata.is_file() {
@@ -461,9 +508,9 @@ fn not_found_or_internal(action: &'static str) -> impl FnOnce(std::io::Error) ->
     }
 }
 
-async fn workspace_total_bytes(root: &PathBuf) -> Result<u64, ToolError> {
+async fn workspace_total_bytes(root: &Path) -> Result<u64, ToolError> {
     let mut total = 0_u64;
-    let mut stack = vec![root.clone()];
+    let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let mut read_dir = match tokio::fs::read_dir(&dir).await {
             Ok(read_dir) => read_dir,
@@ -475,18 +522,36 @@ async fn workspace_total_bytes(root: &PathBuf) -> Result<u64, ToolError> {
             .await
             .map_err(internal_io("scan state workspace entry"))?
         {
-            let metadata = entry
-                .metadata()
+            let path = entry.path();
+            let relative = match path.strip_prefix(root) {
+                Ok(relative) => relative,
+                Err(_) => continue,
+            };
+            let virtual_path = labby_runtime::path_safety::rel_to_unix_string(relative);
+            if is_reserved_metadata_path(&virtual_path) {
+                continue;
+            }
+            let metadata = tokio::fs::symlink_metadata(&path)
                 .await
                 .map_err(internal_io("read state workspace metadata"))?;
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
             if metadata.is_dir() {
-                stack.push(entry.path());
+                stack.push(path);
             } else if metadata.is_file() {
                 total = total.saturating_add(metadata.len());
             }
         }
     }
     Ok(total)
+}
+
+fn is_reserved_metadata_path(path: &str) -> bool {
+    path == ".git"
+        || path.starts_with(".git/")
+        || path == ".labby-state"
+        || path.starts_with(".labby-state/")
 }
 
 fn normalize_limit(limit: usize) -> usize {
@@ -689,6 +754,45 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.kind(), "symlink_rejected");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_walkers_skip_symlinked_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(outside.path().join("src")).unwrap();
+        std::fs::write(outside.path().join("src/outside.rs"), "fn outside() {}\n").unwrap();
+        std::os::unix::fs::symlink(outside.path(), temp.path().join("linked")).unwrap();
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+
+        let glob = ws.glob("**/*.rs", 10).await.unwrap();
+
+        assert!(glob.matches.is_empty(), "{:?}", glob.matches);
+    }
+
+    #[tokio::test]
+    async fn workspace_glob_scans_past_nonmatching_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+        for index in 0..5 {
+            ws.write_file(
+                &VirtualPath::parse(&format!("docs/{index}.txt")).unwrap(),
+                "not rust\n",
+            )
+            .await
+            .unwrap();
+        }
+        ws.write_file(&VirtualPath::parse("src/app.rs").unwrap(), "fn main() {}\n")
+            .await
+            .unwrap();
+
+        let glob = ws.glob("src/**/*.rs", 1).await.unwrap();
+
+        assert_eq!(glob.matches, vec!["src/app.rs"]);
+        assert!(glob.truncated);
     }
 
     #[tokio::test]

--- a/crates/labby-codemode/src/state/workspace.rs
+++ b/crates/labby-codemode/src/state/workspace.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::error::ToolError;
@@ -23,6 +26,58 @@ pub(crate) struct ReadFileResult {
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct ListResult {
     pub(crate) entries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GlobResult {
+    pub(crate) matches: Vec<String>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SearchMatch {
+    pub(crate) path: String,
+    pub(crate) line: usize,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SearchFilesResult {
+    pub(crate) matches: Vec<SearchMatch>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReplaceInFilesResult {
+    pub(crate) changed: Vec<String>,
+    pub(crate) dry_run: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct FileEdit {
+    pub(crate) path: String,
+    pub(crate) search: String,
+    pub(crate) replace: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EditPlanResult {
+    pub(crate) plan_id: String,
+    pub(crate) edits: Vec<FileEdit>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ApplyEditPlanResult {
+    pub(crate) ok: bool,
+    pub(crate) changed: Vec<String>,
+}
+
+pub(crate) fn default_search_limit() -> usize {
+    200
+}
+
+pub(crate) fn default_true() -> bool {
+    true
 }
 
 impl StateWorkspace {
@@ -159,6 +214,228 @@ impl StateWorkspace {
         entries.sort();
         Ok(ListResult { entries })
     }
+
+    pub(crate) async fn glob(&self, pattern: &str, limit: usize) -> Result<GlobResult, ToolError> {
+        let limit = normalize_limit(limit);
+        let matcher = glob_pattern_regex(pattern)?;
+        let mut files = self.walk_files(limit.saturating_add(1)).await?;
+        files.sort();
+        let mut matches = Vec::new();
+        for file in files {
+            if matcher.is_match(&file) {
+                matches.push(file);
+                if matches.len() >= limit {
+                    return Ok(GlobResult {
+                        matches,
+                        truncated: true,
+                    });
+                }
+            }
+        }
+        Ok(GlobResult {
+            matches,
+            truncated: false,
+        })
+    }
+
+    pub(crate) async fn search_files(
+        &self,
+        pattern: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<SearchFilesResult, ToolError> {
+        if query.is_empty() {
+            return Err(ToolError::InvalidParam {
+                message: "state search query must not be empty".to_string(),
+                param: "query".to_string(),
+            });
+        }
+        let limit = normalize_limit(limit);
+        let glob = self.glob(pattern, self.limits.max_entries as usize).await?;
+        let mut matches = Vec::new();
+        for path in glob.matches {
+            let virtual_path = VirtualPath::parse(&path)?;
+            let file = self.read_file(&virtual_path).await?;
+            for (index, line) in file.content.lines().enumerate() {
+                if line.contains(query) {
+                    matches.push(SearchMatch {
+                        path: path.clone(),
+                        line: index + 1,
+                        text: cap_line_preview(line),
+                    });
+                    if matches.len() >= limit {
+                        return Ok(SearchFilesResult {
+                            matches,
+                            truncated: true,
+                        });
+                    }
+                    ensure_serialized_result_fits(&matches, self.limits.max_result_bytes)?;
+                }
+            }
+        }
+        Ok(SearchFilesResult {
+            matches,
+            truncated: glob.truncated,
+        })
+    }
+
+    pub(crate) async fn replace_in_files(
+        &self,
+        pattern: &str,
+        search: &str,
+        replace: &str,
+        dry_run: bool,
+    ) -> Result<ReplaceInFilesResult, ToolError> {
+        if search.is_empty() {
+            return Err(ToolError::InvalidParam {
+                message: "state replace search must not be empty".to_string(),
+                param: "search".to_string(),
+            });
+        }
+        let glob = self.glob(pattern, self.limits.max_entries as usize).await?;
+        let mut changed = Vec::new();
+        for path in glob.matches {
+            let virtual_path = VirtualPath::parse(&path)?;
+            let file = self.read_file(&virtual_path).await?;
+            if !file.content.contains(search) {
+                continue;
+            }
+            changed.push(path.clone());
+            if !dry_run {
+                let next = file.content.replace(search, replace);
+                self.write_file(&virtual_path, &next).await?;
+            }
+        }
+        Ok(ReplaceInFilesResult { changed, dry_run })
+    }
+
+    pub(crate) async fn plan_edits(
+        &self,
+        edits: Vec<FileEdit>,
+    ) -> Result<EditPlanResult, ToolError> {
+        let edits = normalize_edits(edits)?;
+        let canonical = serde_json::to_vec(&edits).map_err(serialize_error)?;
+        let plan_id = hex::encode(Sha256::digest(&canonical));
+        let plan_path = self.plan_path(&plan_id);
+        if let Some(parent) = plan_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(internal_io("create state edit plan directory"))?;
+        }
+        tokio::fs::write(&plan_path, canonical)
+            .await
+            .map_err(internal_io("write state edit plan"))?;
+        Ok(EditPlanResult { plan_id, edits })
+    }
+
+    pub(crate) async fn apply_edit_plan(
+        &self,
+        plan_id: &str,
+    ) -> Result<ApplyEditPlanResult, ToolError> {
+        validate_plan_id(plan_id)?;
+        let plan_path = self.plan_path(plan_id);
+        let plan = tokio::fs::read(&plan_path)
+            .await
+            .map_err(not_found_or_internal("read state edit plan"))?;
+        let edits: Vec<FileEdit> = serde_json::from_slice(&plan).map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to parse state edit plan: {err}"),
+        })?;
+
+        let mut changed = Vec::new();
+        let rollback_root = self
+            .root
+            .join(".labby-state")
+            .join("rollback")
+            .join(plan_id);
+        for edit in edits {
+            let path = VirtualPath::parse(&edit.path)?;
+            let original = self.read_file(&path).await?;
+            if !original.content.contains(&edit.search) {
+                continue;
+            }
+            let rollback_path = rollback_root.join(path.as_str());
+            if let Some(parent) = rollback_path.parent() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(internal_io("create state rollback directory"))?;
+            }
+            tokio::fs::write(&rollback_path, original.content.as_bytes())
+                .await
+                .map_err(internal_io("write state rollback file"))?;
+            let next = original.content.replace(&edit.search, &edit.replace);
+            if let Err(err) = self.write_file(&path, &next).await {
+                self.restore_rollbacks(&rollback_root, &changed).await?;
+                return Err(err);
+            }
+            changed.push(path.as_str().to_string());
+        }
+
+        Ok(ApplyEditPlanResult { ok: true, changed })
+    }
+
+    async fn restore_rollbacks(
+        &self,
+        rollback_root: &PathBuf,
+        changed: &[String],
+    ) -> Result<(), ToolError> {
+        for path in changed.iter().rev() {
+            let rollback_path = rollback_root.join(path);
+            let content = tokio::fs::read_to_string(&rollback_path)
+                .await
+                .map_err(internal_io("read state rollback file"))?;
+            self.write_file(&VirtualPath::parse(path)?, &content)
+                .await?;
+        }
+        Ok(())
+    }
+
+    fn plan_path(&self, plan_id: &str) -> PathBuf {
+        self.root
+            .join(".labby-state")
+            .join("plans")
+            .join(format!("{plan_id}.json"))
+    }
+
+    async fn walk_files(&self, limit: usize) -> Result<Vec<String>, ToolError> {
+        let mut files = Vec::new();
+        let mut stack = vec![self.root.clone()];
+        while let Some(dir) = stack.pop() {
+            let mut read_dir = match tokio::fs::read_dir(&dir).await {
+                Ok(read_dir) => read_dir,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(internal_io("walk state workspace")(error)),
+            };
+            while let Some(entry) = read_dir
+                .next_entry()
+                .await
+                .map_err(internal_io("walk state workspace entry"))?
+            {
+                let path = entry.path();
+                let relative = match path.strip_prefix(&self.root) {
+                    Ok(relative) => relative,
+                    Err(_) => continue,
+                };
+                let virtual_path = labby_runtime::path_safety::rel_to_unix_string(relative);
+                if virtual_path.starts_with(".labby-state/") {
+                    continue;
+                }
+                let metadata = entry
+                    .metadata()
+                    .await
+                    .map_err(internal_io("read state workspace metadata"))?;
+                if metadata.is_dir() {
+                    stack.push(path);
+                } else if metadata.is_file() {
+                    files.push(virtual_path);
+                    if files.len() > limit {
+                        return Ok(files);
+                    }
+                }
+            }
+        }
+        Ok(files)
+    }
 }
 
 fn internal_io(action: &'static str) -> impl FnOnce(std::io::Error) -> ToolError {
@@ -206,6 +483,116 @@ async fn workspace_total_bytes(root: &PathBuf) -> Result<u64, ToolError> {
         }
     }
     Ok(total)
+}
+
+fn normalize_limit(limit: usize) -> usize {
+    limit.clamp(1, 10_000)
+}
+
+fn glob_pattern_regex(pattern: &str) -> Result<Regex, ToolError> {
+    if pattern.trim().is_empty() {
+        return Err(ToolError::InvalidParam {
+            message: "state glob pattern must not be empty".to_string(),
+            param: "pattern".to_string(),
+        });
+    }
+    if pattern.contains("..") || pattern.starts_with('/') || pattern.contains(':') {
+        return Err(ToolError::Sdk {
+            sdk_kind: "path_traversal".to_string(),
+            message: "state glob pattern must stay inside the workspace".to_string(),
+        });
+    }
+    let mut regex = String::from("^");
+    let chars = pattern.chars().collect::<Vec<_>>();
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '*' if chars.get(i + 1) == Some(&'*') && chars.get(i + 2) == Some(&'/') => {
+                regex.push_str("(?:.*/)?");
+                i += 3;
+            }
+            '*' if chars.get(i + 1) == Some(&'*') => {
+                regex.push_str(".*");
+                i += 2;
+            }
+            '*' => {
+                regex.push_str("[^/]*");
+                i += 1;
+            }
+            '?' => {
+                regex.push_str("[^/]");
+                i += 1;
+            }
+            ch => {
+                regex.push_str(&regex::escape(&ch.to_string()));
+                i += 1;
+            }
+        }
+    }
+    regex.push('$');
+    Regex::new(&regex).map_err(|err| ToolError::InvalidParam {
+        message: format!("invalid state glob pattern: {err}"),
+        param: "pattern".to_string(),
+    })
+}
+
+fn cap_line_preview(line: &str) -> String {
+    line.chars().take(512).collect()
+}
+
+fn ensure_serialized_result_fits<T: Serialize>(value: &T, max: usize) -> Result<(), ToolError> {
+    let len = serde_json::to_vec(value).map_err(serialize_error)?.len();
+    if len > max {
+        return Err(ToolError::Sdk {
+            sdk_kind: "response_too_large".to_string(),
+            message: "state search result exceeded max result bytes".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn normalize_edits(edits: Vec<FileEdit>) -> Result<Vec<FileEdit>, ToolError> {
+    if edits.is_empty() {
+        return Err(ToolError::InvalidParam {
+            message: "state edit plan must include at least one edit".to_string(),
+            param: "edits".to_string(),
+        });
+    }
+    edits
+        .into_iter()
+        .map(|edit| {
+            if edit.search.is_empty() {
+                return Err(ToolError::InvalidParam {
+                    message: "state edit search must not be empty".to_string(),
+                    param: "search".to_string(),
+                });
+            }
+            let path = VirtualPath::parse(&edit.path)?.as_str().to_string();
+            Ok(FileEdit {
+                path,
+                search: edit.search,
+                replace: edit.replace,
+            })
+        })
+        .collect()
+}
+
+fn validate_plan_id(plan_id: &str) -> Result<(), ToolError> {
+    let valid = plan_id.len() == 64 && plan_id.chars().all(|ch| ch.is_ascii_hexdigit());
+    if !valid {
+        return Err(ToolError::InvalidParam {
+            message: "state edit plan id must be a sha256 hex string".to_string(),
+            param: "planId".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn serialize_error(err: serde_json::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to serialize state value: {err}"),
+    }
 }
 
 #[cfg(test)]
@@ -298,5 +685,48 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.kind(), "symlink_rejected");
+    }
+
+    #[tokio::test]
+    async fn workspace_glob_search_replace_and_edit_plan() {
+        let temp = tempfile::tempdir().unwrap();
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+        ws.write_file(
+            &VirtualPath::parse("src/app.rs").unwrap(),
+            "fn main() { println!(\"hi\"); }\n",
+        )
+        .await
+        .unwrap();
+
+        let glob = ws.glob("src/**/*.rs", 10).await.unwrap();
+        assert_eq!(glob.matches, vec!["src/app.rs"]);
+
+        let matches = ws.search_files("src/**/*.rs", "println", 10).await.unwrap();
+        assert_eq!(matches.matches.len(), 1);
+        assert_eq!(matches.matches[0].line, 1);
+
+        let dry = ws
+            .replace_in_files("src/**/*.rs", "println", "eprintln", true)
+            .await
+            .unwrap();
+        assert_eq!(dry.changed, vec!["src/app.rs"]);
+        assert!(dry.dry_run);
+
+        let plan = ws
+            .plan_edits(vec![FileEdit {
+                path: "src/app.rs".to_string(),
+                search: "println".to_string(),
+                replace: "eprintln".to_string(),
+            }])
+            .await
+            .unwrap();
+        let applied = ws.apply_edit_plan(&plan.plan_id).await.unwrap();
+        assert_eq!(applied.changed, vec!["src/app.rs"]);
+        let updated = ws
+            .read_file(&VirtualPath::parse("src/app.rs").unwrap())
+            .await
+            .unwrap();
+        assert!(updated.content.contains("eprintln"));
     }
 }

--- a/crates/labby-codemode/src/state/workspace.rs
+++ b/crates/labby-codemode/src/state/workspace.rs
@@ -89,6 +89,10 @@ impl StateWorkspace {
         Ok(Self { root, limits })
     }
 
+    pub(crate) fn root_path(&self) -> &PathBuf {
+        &self.root
+    }
+
     fn resolve(&self, path: &VirtualPath) -> PathBuf {
         self.root.join(path.as_str())
     }

--- a/crates/labby-codemode/src/state/workspace.rs
+++ b/crates/labby-codemode/src/state/workspace.rs
@@ -1,0 +1,302 @@
+use std::path::PathBuf;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::ToolError;
+
+use super::path::VirtualPath;
+use super::quota::StateWorkspaceLimits;
+
+#[derive(Debug, Clone)]
+pub(crate) struct StateWorkspace {
+    root: PathBuf,
+    limits: StateWorkspaceLimits,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ReadFileResult {
+    pub(crate) path: String,
+    pub(crate) content: String,
+    pub(crate) bytes: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ListResult {
+    pub(crate) entries: Vec<String>,
+}
+
+impl StateWorkspace {
+    pub(crate) fn new(root: PathBuf, limits: StateWorkspaceLimits) -> Result<Self, ToolError> {
+        std::fs::create_dir_all(&root).map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to create code mode workspace root: {err}"),
+        })?;
+        Ok(Self { root, limits })
+    }
+
+    fn resolve(&self, path: &VirtualPath) -> PathBuf {
+        self.root.join(path.as_str())
+    }
+
+    pub(crate) async fn write_file(
+        &self,
+        path: &VirtualPath,
+        content: &str,
+    ) -> Result<(), ToolError> {
+        if content.len() > self.limits.max_file_bytes {
+            return Err(ToolError::InvalidParam {
+                message: format!(
+                    "state file content is {} bytes; maximum is {}",
+                    content.len(),
+                    self.limits.max_file_bytes
+                ),
+                param: "content".to_string(),
+            });
+        }
+        self.check_total_bytes_after_write(path, content.len() as u64)
+            .await?;
+
+        let destination = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(internal_io("create state directory"))?;
+        }
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+
+        let tmp = destination.with_extension("tmp-labby-state");
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)
+            .await
+            .map_err(internal_io("create state temp file"))?;
+        file.write_all(content.as_bytes())
+            .await
+            .map_err(internal_io("write state temp file"))?;
+        file.flush()
+            .await
+            .map_err(internal_io("flush state temp file"))?;
+        drop(file);
+        tokio::fs::rename(&tmp, &destination)
+            .await
+            .map_err(internal_io("move state temp file"))?;
+        Ok(())
+    }
+
+    async fn check_total_bytes_after_write(
+        &self,
+        path: &VirtualPath,
+        next_file_bytes: u64,
+    ) -> Result<(), ToolError> {
+        let destination = self.resolve(path);
+        let current_file_bytes = match tokio::fs::metadata(&destination).await {
+            Ok(metadata) if metadata.is_file() => metadata.len(),
+            Ok(_) | Err(_) => 0,
+        };
+        let total = workspace_total_bytes(&self.root).await?;
+        let projected = total
+            .saturating_sub(current_file_bytes)
+            .saturating_add(next_file_bytes);
+        if projected > self.limits.max_total_bytes {
+            return Err(ToolError::Sdk {
+                sdk_kind: "quota_exceeded".to_string(),
+                message: format!(
+                    "state workspace would be {projected} bytes; maximum is {}",
+                    self.limits.max_total_bytes
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn read_file(&self, path: &VirtualPath) -> Result<ReadFileResult, ToolError> {
+        let destination = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        let file = tokio::fs::File::open(&destination)
+            .await
+            .map_err(not_found_or_internal("open state file"))?;
+        let mut content = String::new();
+        file.take(self.limits.max_result_bytes as u64 + 1)
+            .read_to_string(&mut content)
+            .await
+            .map_err(internal_io("read state file"))?;
+        if content.len() > self.limits.max_result_bytes {
+            return Err(ToolError::Sdk {
+                sdk_kind: "response_too_large".to_string(),
+                message: "state read result exceeded max result bytes".to_string(),
+            });
+        }
+        Ok(ReadFileResult {
+            path: path.as_str().to_string(),
+            bytes: content.len(),
+            content,
+        })
+    }
+
+    pub(crate) async fn list(&self, path: &VirtualPath) -> Result<ListResult, ToolError> {
+        let dir = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &dir)?;
+        let mut read_dir = tokio::fs::read_dir(&dir)
+            .await
+            .map_err(not_found_or_internal("read state directory"))?;
+        let mut entries = Vec::new();
+        while let Some(entry) = read_dir
+            .next_entry()
+            .await
+            .map_err(internal_io("read state directory entry"))?
+        {
+            entries.push(entry.file_name().to_string_lossy().to_string());
+            if entries.len() as u64 > self.limits.max_entries {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "response_too_large".to_string(),
+                    message: "state list exceeded max entries".to_string(),
+                });
+            }
+        }
+        entries.sort();
+        Ok(ListResult { entries })
+    }
+}
+
+fn internal_io(action: &'static str) -> impl FnOnce(std::io::Error) -> ToolError {
+    move |err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to {action}: {err}"),
+    }
+}
+
+fn not_found_or_internal(action: &'static str) -> impl FnOnce(std::io::Error) -> ToolError {
+    move |err| ToolError::Sdk {
+        sdk_kind: if err.kind() == std::io::ErrorKind::NotFound {
+            "not_found"
+        } else {
+            "internal_error"
+        }
+        .to_string(),
+        message: format!("failed to {action}: {err}"),
+    }
+}
+
+async fn workspace_total_bytes(root: &PathBuf) -> Result<u64, ToolError> {
+    let mut total = 0_u64;
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let mut read_dir = match tokio::fs::read_dir(&dir).await {
+            Ok(read_dir) => read_dir,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(internal_io("scan state workspace")(error)),
+        };
+        while let Some(entry) = read_dir
+            .next_entry()
+            .await
+            .map_err(internal_io("scan state workspace entry"))?
+        {
+            let metadata = entry
+                .metadata()
+                .await
+                .map_err(internal_io("read state workspace metadata"))?;
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::quota::StateWorkspaceLimits;
+
+    #[tokio::test]
+    async fn workspace_writes_reads_and_reopens() {
+        let temp = tempfile::tempdir().unwrap();
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+        ws.write_file(
+            &VirtualPath::parse("/src/app.rs").unwrap(),
+            "fn main() {}\n",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            ws.read_file(&VirtualPath::parse("src/app.rs").unwrap())
+                .await
+                .unwrap()
+                .content,
+            "fn main() {}\n"
+        );
+        let ws2 = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+        assert_eq!(
+            ws2.list(&VirtualPath::parse("src").unwrap())
+                .await
+                .unwrap()
+                .entries
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_rejects_large_writes_and_reads() {
+        let temp = tempfile::tempdir().unwrap();
+        let limits = StateWorkspaceLimits {
+            max_file_bytes: 4,
+            max_result_bytes: 4,
+            ..StateWorkspaceLimits::default()
+        };
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), limits).unwrap();
+        let err = ws
+            .write_file(&VirtualPath::parse("too-big.txt").unwrap(), "12345")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+
+        std::fs::write(temp.path().join("existing.txt"), "12345").unwrap();
+        let err = ws
+            .read_file(&VirtualPath::parse("existing.txt").unwrap())
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "response_too_large");
+    }
+
+    #[tokio::test]
+    async fn workspace_enforces_total_byte_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let limits = StateWorkspaceLimits {
+            max_file_bytes: 10,
+            max_total_bytes: 6,
+            ..StateWorkspaceLimits::default()
+        };
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), limits).unwrap();
+        ws.write_file(&VirtualPath::parse("a.txt").unwrap(), "1234")
+            .await
+            .unwrap();
+        let err = ws
+            .write_file(&VirtualPath::parse("b.txt").unwrap(), "1234")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "quota_exceeded");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_rejects_symlink_ancestors() {
+        let temp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default())
+            .unwrap();
+        std::os::unix::fs::symlink(outside.path(), temp.path().join("link")).unwrap();
+        let err = ws
+            .write_file(&VirtualPath::parse("link/file.txt").unwrap(), "x")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "symlink_rejected");
+    }
+}

--- a/crates/labby-codemode/src/tests_ids_schema.rs
+++ b/crates/labby-codemode/src/tests_ids_schema.rs
@@ -14,6 +14,34 @@ use super::protocol::CodeModeRunnerOutput;
 use super::schema::validate_code_mode_params_against_schema;
 
 #[test]
+fn local_provider_ids_are_detected_before_upstream_ids() {
+    let state = crate::local_provider::try_parse_local_provider_call("state::readFile")
+        .expect("parse succeeds")
+        .expect("state provider detected");
+    assert_eq!(state.provider.as_str(), "state");
+    assert_eq!(state.method, "readFile");
+
+    let git = crate::local_provider::try_parse_local_provider_call("git::status")
+        .expect("parse succeeds")
+        .expect("git provider detected");
+    assert_eq!(git.provider.as_str(), "git");
+    assert_eq!(git.method, "status");
+
+    assert!(
+        crate::local_provider::try_parse_local_provider_call("movie::search")
+            .expect("ordinary upstream id is valid")
+            .is_none()
+    );
+}
+
+#[test]
+fn local_provider_ids_reject_bad_methods() {
+    let err = crate::local_provider::try_parse_local_provider_call("state::")
+        .expect_err("empty local method is rejected");
+    assert_eq!(err.kind(), "invalid_param");
+}
+
+#[test]
 fn artifact_write_protocol_round_trips() {
     let output = CodeModeRunnerOutput::ArtifactWrite {
         seq: 7,

--- a/crates/labby-codemode/src/tests_normalize.rs
+++ b/crates/labby-codemode/src/tests_normalize.rs
@@ -4,10 +4,29 @@
 #[test]
 fn state_and_git_globals_are_present_in_preamble() {
     let js = crate::preamble::generate_local_provider_js();
+    assert!(js.contains("function __labLocalProviderCall"));
+    assert!(js.contains("return callTool(id, params == null ? {} : params);"));
     assert!(js.contains("globalThis.state"));
     assert!(js.contains("globalThis.git"));
-    assert!(js.contains("state::readFile"));
-    assert!(js.contains("git::status"));
+    for method in [
+        "state::readFile",
+        "state::writeFile",
+        "state::list",
+        "state::readdir",
+        "state::glob",
+        "state::searchFiles",
+        "state::replaceInFiles",
+        "state::planEdits",
+        "state::applyEditPlan",
+        "git::init",
+        "git::status",
+        "git::add",
+        "git::commit",
+        "git::log",
+        "git::diff",
+    ] {
+        assert!(js.contains(method), "{method} missing from preamble");
+    }
 }
 
 #[test]

--- a/crates/labby-codemode/src/tests_normalize.rs
+++ b/crates/labby-codemode/src/tests_normalize.rs
@@ -2,6 +2,15 @@
 #![cfg(test)]
 
 #[test]
+fn state_and_git_globals_are_present_in_preamble() {
+    let js = crate::preamble::generate_local_provider_js();
+    assert!(js.contains("globalThis.state"));
+    assert!(js.contains("globalThis.git"));
+    assert!(js.contains("state::readFile"));
+    assert!(js.contains("git::status"));
+}
+
+#[test]
 fn normalize_user_code_strips_javascript_markdown_fences() {
     let fenced = "```javascript\nconsole.log('hi');\n```";
     let result = super::normalize_user_code(fenced);

--- a/docs/dev/CODE_MODE.md
+++ b/docs/dev/CODE_MODE.md
@@ -26,6 +26,35 @@ Inside the sandbox:
 - `await codemode.github.list_pull_requests(params)` calls the generated helper.
 - `await callTool("github::list_pull_requests", params)` calls the raw bridge.
 
+### Local State And Git Providers
+
+Code Mode also exposes two local sandbox globals: `state` and `git`. They are
+not upstream MCP tools and they do not grant host filesystem or shell access.
+All paths are virtual workspace paths rooted inside `$LAB_HOME/code-mode-workspaces/`.
+
+V1 state methods:
+
+- `state.readFile({ path })`
+- `state.writeFile({ path, content })`
+- `state.list({ path })` / `state.readdir({ path })`
+- `state.glob({ pattern, limit })`
+- `state.searchFiles({ pattern, query, limit })`
+- `state.replaceInFiles({ pattern, search, replace, dryRun })`
+- `state.planEdits({ edits })`
+- `state.applyEditPlan({ planId })`
+
+V1 git methods:
+
+- `git.init({})`
+- `git.status({})`
+- `git.add({ path })`
+- `git.commit({ message, authorName, authorEmail })`
+- `git.log({ limit })`
+- `git.diff({ path })`
+
+Remote git operations, hidden git auth, checkout/branch/remotes, archive/hash/detect,
+advanced JSON helpers, and broad file-management APIs are not V1.
+
 Example:
 
 ```ts

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -821,7 +821,7 @@ git commit -m "feat: add code mode state provider"
 - Produces: `dispatch_git_method(workspace: &StateWorkspace, method: &str, params: Value) -> Result<Value, ToolError>`.
 - Produces V1 methods: `init`, `status`, `add`, `commit`, `log`, `diff`.
 
-- [ ] **Step 1: Write failing argv tests**
+- [x] **Step 1: Write failing argv tests**
 
 Create `git/command.rs` tests:
 
@@ -838,7 +838,7 @@ fn git_rejects_unsupported_method() {
 }
 ```
 
-- [ ] **Step 2: Implement git command specs**
+- [x] **Step 2: Implement git command specs**
 
 Create `git.rs`:
 
@@ -898,7 +898,7 @@ fn base_args<const N: usize>(tail: [&str; N]) -> Vec<String> {
 }
 ```
 
-- [ ] **Step 3: Implement guarded git execution**
+- [x] **Step 3: Implement guarded git execution**
 
 Create `git/provider.rs` with an async runner using `tokio::process::Command`:
 
@@ -954,7 +954,7 @@ fn redact_git_output(value: &str) -> String {
 
 If `/usr/bin/git` is not portable enough for this repo, implement a resolver that finds `git` once outside the workspace and stores the absolute path. Do not run a relative `git` from inside the workspace.
 
-- [ ] **Step 4: Implement git provider dispatch**
+- [x] **Step 4: Implement git provider dispatch**
 
 `dispatch_git_method` should parse object params:
 
@@ -988,11 +988,11 @@ Build method-specific argv in `GitCommandSpec::for_method`:
 - `log`: parse optional `{ limit }`, clamp to `1..=50`, and append `["log", "--oneline", "-n", limit]`.
 - `diff`: parse optional `{ path }`; without a path use `["diff", "--"]`, with a path validate via `VirtualPath::parse` and append the virtual path after `--`.
 
-- [ ] **Step 5: Wire git provider to runner drive**
+- [x] **Step 5: Wire git provider to runner drive**
 
 In the local provider routing branch from Task 1, dispatch `LocalProviderName::Git` with the same workspace root as state.
 
-- [ ] **Step 6: Run tests**
+- [x] **Step 6: Run tests**
 
 Run: `cargo test -p labby-codemode git:: --all-features`
 
@@ -1002,7 +1002,7 @@ Run: `cargo test -p labby-codemode --all-features`
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add crates/labby-codemode/src/git.rs crates/labby-codemode/src/git crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/lib.rs

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -1,0 +1,1140 @@
+# Code Mode State Git V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a narrow V1 Code Mode `state.*` and local-only `git.*` runtime backed by a durable jailed workspace.
+
+**Architecture:** Keep `labby-codemode` host-neutral. Add local provider routing before upstream `CodeModeHost::call_tool`, store workspace state under `$LAB_HOME/code-mode-workspaces/`, enforce method caps before `ToolResult`, and run local git commands through a dedicated guarded runner.
+
+**Tech Stack:** Rust 2024, Tokio, Javy/QuickJS runner subprocess, serde/serde_json, existing `ToolError`, existing Code Mode `ToolCall` protocol, tempdir-based tests.
+
+## Global Constraints
+
+- V1 only: no remote git operations, no hidden remote auth, no branch/checkout/remotes, no full Cloudflare StateBackend parity.
+- Public MCP `codemode` input schema remains `code`, `upstreams`, and `tools`.
+- `state` and `git` are sandbox globals only; they are not normal upstream MCP tools.
+- Paths are virtual workspace paths. Reject host absolute paths, Windows drive roots, traversal, symlink escape, and credential-like paths.
+- Enforce caps before `ToolResult`; final response truncation is not a state safety boundary.
+- Local git uses no shell, no inherited git config/env, controlled hooks path, timeout, output caps, and redaction.
+- Verify with all-features paths before completion: `cargo nextest run --workspace --all-features` and `cargo build --workspace --all-features`.
+
+---
+
+## File Structure
+
+- Create `crates/labby-codemode/src/local_provider.rs`: local provider IDs, routing enum, descriptors, local-provider budget counters.
+- Modify `crates/labby-codemode/src/types.rs`: add local provider references or helper parsing while preserving upstream IDs.
+- Modify `crates/labby-codemode/src/runner_drive.rs`: dispatch local provider calls before upstream host calls and enforce independent local budgets.
+- Modify `crates/labby-codemode/src/preamble.rs`: generate top-level `state` and `git` proxy globals and reserve names against upstream collisions.
+- Modify `crates/labby-codemode/src/lib.rs`: expose new modules internally.
+- Create `crates/labby-codemode/src/state.rs` and `crates/labby-codemode/src/state/*`: workspace backend, virtual path policy, quotas, caps, state method dispatch.
+- Create `crates/labby-codemode/src/git.rs` and `crates/labby-codemode/src/git/*`: local-only git command runner and provider dispatch.
+- Modify `crates/labby-codemode/src/config.rs`: add state/git local-provider budget and cap env parsing.
+- Modify `crates/labby-codemode/src/host.rs`: add workspace root/config access only if the local provider implementation cannot derive it from `CodeModeConfig`.
+- Modify `crates/labby-codemode/Cargo.toml`: add minimal dependencies only if needed, such as `tempfile` dev-dependency.
+- Modify `docs/dev/CODE_MODE.md`: document narrowed V1 only.
+- Create `tests/smoke-code-mode-state-git.sh`: isolated `LAB_HOME` smoke test.
+
+---
+
+### Task 1: Local Provider Routing And Proxy Globals
+
+**Files:**
+- Create: `crates/labby-codemode/src/local_provider.rs`
+- Modify: `crates/labby-codemode/src/types.rs`
+- Modify: `crates/labby-codemode/src/preamble.rs`
+- Modify: `crates/labby-codemode/src/runner_drive.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Test: `crates/labby-codemode/src/tests_ids_schema.rs`
+- Test: `crates/labby-codemode/src/tests_normalize.rs`
+
+**Interfaces:**
+- Consumes: existing `CodeModeRunnerOutput::ToolCall { seq, id, params }`.
+- Produces: `LocalProviderCall { provider: LocalProviderName, method: String, params: Value }`.
+- Produces: `try_parse_local_provider_call(id: &str) -> Result<Option<LocalProviderCall>, ToolError>`.
+- Produces: top-level JS globals `state` and `git` that call reserved IDs such as `state::readFile`.
+
+- [ ] **Step 1: Add failing ID parsing tests**
+
+Add tests in `crates/labby-codemode/src/tests_ids_schema.rs`:
+
+```rust
+#[test]
+fn local_provider_ids_are_detected_before_upstream_ids() {
+    let state = crate::local_provider::try_parse_local_provider_call("state::readFile")
+        .expect("parse succeeds")
+        .expect("state provider detected");
+    assert_eq!(state.provider.as_str(), "state");
+    assert_eq!(state.method, "readFile");
+
+    let git = crate::local_provider::try_parse_local_provider_call("git::status")
+        .expect("parse succeeds")
+        .expect("git provider detected");
+    assert_eq!(git.provider.as_str(), "git");
+    assert_eq!(git.method, "status");
+
+    assert!(
+        crate::local_provider::try_parse_local_provider_call("movie::search")
+            .expect("ordinary upstream id is valid")
+            .is_none()
+    );
+}
+
+#[test]
+fn local_provider_ids_reject_bad_methods() {
+    let err = crate::local_provider::try_parse_local_provider_call("state::")
+        .expect_err("empty local method is rejected");
+    assert_eq!(err.kind(), "invalid_param");
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cargo test -p labby-codemode local_provider_ids --all-features`
+
+Expected: FAIL with unresolved module or function `local_provider`.
+
+- [ ] **Step 3: Implement local provider parser**
+
+Create `crates/labby-codemode/src/local_provider.rs`:
+
+```rust
+use serde_json::Value;
+
+use crate::error::ToolError;
+use crate::types::split_namespaced_id;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalProviderName {
+    State,
+    Git,
+}
+
+impl LocalProviderName {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::State => "state",
+            Self::Git => "git",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LocalProviderCall {
+    pub(crate) provider: LocalProviderName,
+    pub(crate) method: String,
+    pub(crate) params: Value,
+}
+
+pub(crate) fn is_reserved_provider_namespace(namespace: &str) -> bool {
+    matches!(namespace, "state" | "git")
+}
+
+pub(crate) fn try_parse_local_provider_call(
+    id: &str,
+) -> Result<Option<LocalProviderCall>, ToolError> {
+    let Some((namespace, method)) = split_namespaced_id(id) else {
+        return Ok(None);
+    };
+    let provider = match namespace {
+        "state" => LocalProviderName::State,
+        "git" => LocalProviderName::Git,
+        _ => return Ok(None),
+    };
+    if method.trim().is_empty() {
+        return Err(ToolError::InvalidParam {
+            message: "local provider method must not be empty".to_string(),
+            param: "id".to_string(),
+        });
+    }
+    Ok(Some(LocalProviderCall {
+        provider,
+        method: method.to_string(),
+        params: Value::Null,
+    }))
+}
+```
+
+Modify `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod local_provider;
+```
+
+- [ ] **Step 4: Add state/git proxy generation tests**
+
+Add tests in `crates/labby-codemode/src/tests_normalize.rs` or existing preamble tests:
+
+```rust
+#[test]
+fn state_and_git_globals_are_present_in_preamble() {
+    let js = crate::preamble::generate_local_provider_js();
+    assert!(js.contains("globalThis.state"));
+    assert!(js.contains("globalThis.git"));
+    assert!(js.contains("state::readFile"));
+    assert!(js.contains("git::status"));
+}
+```
+
+- [ ] **Step 5: Implement local provider proxy JS**
+
+Modify `crates/labby-codemode/src/preamble.rs`:
+
+```rust
+pub(crate) fn generate_local_provider_js() -> String {
+    r#"
+function __labLocalProviderCall(id, params) {
+  return callTool(id, params || {});
+}
+globalThis.state = Object.freeze({
+  readFile: function(params) { return __labLocalProviderCall("state::readFile", params); },
+  writeFile: function(params) { return __labLocalProviderCall("state::writeFile", params); },
+  list: function(params) { return __labLocalProviderCall("state::list", params); },
+  readdir: function(params) { return __labLocalProviderCall("state::readdir", params); },
+  glob: function(params) { return __labLocalProviderCall("state::glob", params); },
+  searchFiles: function(params) { return __labLocalProviderCall("state::searchFiles", params); },
+  replaceInFiles: function(params) { return __labLocalProviderCall("state::replaceInFiles", params); },
+  planEdits: function(params) { return __labLocalProviderCall("state::planEdits", params); },
+  applyEditPlan: function(params) { return __labLocalProviderCall("state::applyEditPlan", params); }
+});
+var state = globalThis.state;
+globalThis.git = Object.freeze({
+  init: function(params) { return __labLocalProviderCall("git::init", params); },
+  status: function(params) { return __labLocalProviderCall("git::status", params); },
+  add: function(params) { return __labLocalProviderCall("git::add", params); },
+  commit: function(params) { return __labLocalProviderCall("git::commit", params); },
+  log: function(params) { return __labLocalProviderCall("git::log", params); },
+  diff: function(params) { return __labLocalProviderCall("git::diff", params); }
+});
+var git = globalThis.git;
+"#.to_string()
+}
+```
+
+Inject this JS beside the existing proxy in `runner.rs` where `Start { code, proxy }` is handled. Use:
+
+```rust
+let local_provider_proxy = crate::preamble::generate_local_provider_js();
+```
+
+and evaluate it after `callTool` exists and before user code runs.
+
+- [ ] **Step 6: Route local providers before upstream host calls**
+
+In `runner_drive.rs`, before `enqueue_tool_call(...)`, branch on `try_parse_local_provider_call(&id)`. For now, return `unknown_tool` for recognized providers until Tasks 3 and 4 implement dispatch:
+
+```rust
+if let Some(local) = crate::local_provider::try_parse_local_provider_call(&id)? {
+    enqueue_local_provider_call(self, seq, local, params, deadline, cfg, &mut pending_tool_calls);
+} else {
+    enqueue_tool_call(self, seq, id, params, deadline, cfg, &mut pending_tool_calls);
+}
+```
+
+If the exact future type of `pending_tool_calls` makes this awkward, implement a `dispatch_tool_call(...)` helper that returns the same future output type as upstream tool calls.
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p labby-codemode local_provider --all-features`
+
+Expected: PASS.
+
+Run: `cargo test -p labby-codemode --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/labby-codemode/src
+git commit -m "feat: add code mode local provider routing"
+```
+
+---
+
+### Task 2: Durable Jailed Workspace Backend
+
+**Files:**
+- Create: `crates/labby-codemode/src/state.rs`
+- Create: `crates/labby-codemode/src/state/path.rs`
+- Create: `crates/labby-codemode/src/state/workspace.rs`
+- Create: `crates/labby-codemode/src/state/quota.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/config.rs`
+- Test: module tests in the new files
+
+**Interfaces:**
+- Produces: `WorkspaceRoot::new(root: PathBuf) -> Result<Self, ToolError>`.
+- Produces: `VirtualPath::parse(raw: &str) -> Result<Self, ToolError>`.
+- Produces: `StateWorkspace::write_file`, `read_file`, `list`, `glob`, `search_files`, `replace_in_files`, `plan_edits`, `apply_edit_plan`.
+
+- [ ] **Step 1: Write failing path tests**
+
+Create tests in `crates/labby-codemode/src/state/path.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_path_accepts_rooted_and_relative_paths() {
+        assert_eq!(VirtualPath::parse("/src/app.rs").unwrap().as_str(), "src/app.rs");
+        assert_eq!(VirtualPath::parse("src/app.rs").unwrap().as_str(), "src/app.rs");
+    }
+
+    #[test]
+    fn virtual_path_rejects_escape_and_host_paths() {
+        for raw in ["../secret", "/../secret", "C:/Users/x", "C:relative", "/"] {
+            assert!(VirtualPath::parse(raw).is_err(), "{raw} should fail");
+        }
+    }
+
+    #[test]
+    fn virtual_path_normalizes_windows_separators() {
+        assert_eq!(VirtualPath::parse("src\\\\app.rs").unwrap().as_str(), "src/app.rs");
+    }
+}
+```
+
+- [ ] **Step 2: Implement virtual path parser**
+
+Create `crates/labby-codemode/src/state.rs`:
+
+```rust
+pub(crate) mod path;
+pub(crate) mod quota;
+pub(crate) mod workspace;
+```
+
+Add `mod state;` to `lib.rs`.
+
+Create `crates/labby-codemode/src/state/path.rs` with:
+
+```rust
+use std::path::{Component, Path};
+
+use crate::error::ToolError;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct VirtualPath(String);
+
+impl VirtualPath {
+    pub(crate) fn parse(raw: &str) -> Result<Self, ToolError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "/" {
+            return Err(ToolError::InvalidParam {
+                message: "state path must name a file or directory inside the workspace".to_string(),
+                param: "path".to_string(),
+            });
+        }
+        let normalized = trimmed.replace('\\', "/");
+        if normalized.starts_with('/') && normalized.len() == 1 {
+            return Err(ToolError::InvalidParam {
+                message: "state path must not be workspace root".to_string(),
+                param: "path".to_string(),
+            });
+        }
+        if has_windows_drive_prefix(&normalized) {
+            return Err(path_traversal(&normalized));
+        }
+        let stripped = normalized.trim_start_matches('/');
+        let mut parts = Vec::new();
+        for component in Path::new(stripped).components() {
+            match component {
+                Component::Normal(value) => {
+                    let part = value.to_string_lossy();
+                    if !part.is_empty() {
+                        parts.push(part.to_string());
+                    }
+                }
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    return Err(path_traversal(raw));
+                }
+            }
+        }
+        if parts.is_empty() {
+            return Err(ToolError::InvalidParam {
+                message: "state path must name a file or directory inside the workspace".to_string(),
+                param: "path".to_string(),
+            });
+        }
+        let value = parts.join("/");
+        reject_credential_like_path(&value)?;
+        Ok(Self(value))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn path_traversal(raw: &str) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "path_traversal".to_string(),
+        message: format!("state path `{raw}` escapes the workspace"),
+    }
+}
+
+fn reject_credential_like_path(path: &str) -> Result<(), ToolError> {
+    let lower = path.to_ascii_lowercase();
+    let denied = [
+        ".env",
+        ".ssh/",
+        ".git/config",
+        ".git/credentials",
+        ".aws/",
+        ".config/gcloud/",
+        ".netrc",
+        "id_rsa",
+        "id_ed25519",
+    ];
+    if denied.iter().any(|needle| lower == *needle || lower.contains(needle)) {
+        return Err(ToolError::Sdk {
+            sdk_kind: "permission_denied".to_string(),
+            message: "state path is denied because it looks credential-related".to_string(),
+        });
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add workspace read/write/list tests**
+
+In `state/workspace.rs`, add tests:
+
+```rust
+#[tokio::test]
+async fn workspace_writes_reads_and_reopens() {
+    let temp = tempfile::tempdir().unwrap();
+    let ws = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default()).unwrap();
+    ws.write_file(&VirtualPath::parse("/src/app.rs").unwrap(), "fn main() {}\n").await.unwrap();
+    assert_eq!(
+        ws.read_file(&VirtualPath::parse("src/app.rs").unwrap()).await.unwrap().content,
+        "fn main() {}\n"
+    );
+    let ws2 = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default()).unwrap();
+    assert_eq!(ws2.list(&VirtualPath::parse("src").unwrap()).await.unwrap().entries.len(), 1);
+}
+```
+
+- [ ] **Step 4: Implement workspace backend**
+
+Create `state/quota.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub(crate) struct StateWorkspaceLimits {
+    pub(crate) max_file_bytes: usize,
+    pub(crate) max_total_bytes: u64,
+    pub(crate) max_entries: u64,
+    pub(crate) max_result_bytes: usize,
+}
+
+impl Default for StateWorkspaceLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: 1024 * 1024,
+            max_total_bytes: 64 * 1024 * 1024,
+            max_entries: 10_000,
+            max_result_bytes: 1024 * 1024,
+        }
+    }
+}
+```
+
+Create `state/workspace.rs`:
+
+```rust
+use std::path::PathBuf;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::ToolError;
+use super::path::VirtualPath;
+use super::quota::StateWorkspaceLimits;
+
+#[derive(Debug, Clone)]
+pub(crate) struct StateWorkspace {
+    root: PathBuf,
+    limits: StateWorkspaceLimits,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ReadFileResult {
+    pub(crate) path: String,
+    pub(crate) content: String,
+    pub(crate) bytes: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ListResult {
+    pub(crate) entries: Vec<String>,
+}
+
+impl StateWorkspace {
+    pub(crate) fn new(root: PathBuf, limits: StateWorkspaceLimits) -> Result<Self, ToolError> {
+        std::fs::create_dir_all(&root).map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to create code mode workspace root: {err}"),
+        })?;
+        Ok(Self { root, limits })
+    }
+
+    fn resolve(&self, path: &VirtualPath) -> PathBuf {
+        self.root.join(path.as_str())
+    }
+
+    pub(crate) async fn write_file(&self, path: &VirtualPath, content: &str) -> Result<(), ToolError> {
+        if content.len() > self.limits.max_file_bytes {
+            return Err(ToolError::InvalidParam {
+                message: format!("state file content is {} bytes; maximum is {}", content.len(), self.limits.max_file_bytes),
+                param: "content".to_string(),
+            });
+        }
+        let destination = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(internal_io("create state directory"))?;
+        }
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        let tmp = destination.with_extension("tmp-labby-state");
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)
+            .await
+            .map_err(internal_io("create state temp file"))?;
+        file.write_all(content.as_bytes()).await.map_err(internal_io("write state temp file"))?;
+        file.flush().await.map_err(internal_io("flush state temp file"))?;
+        tokio::fs::rename(&tmp, &destination).await.map_err(internal_io("move state temp file"))?;
+        Ok(())
+    }
+
+    pub(crate) async fn read_file(&self, path: &VirtualPath) -> Result<ReadFileResult, ToolError> {
+        let destination = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &destination)?;
+        let mut file = tokio::fs::File::open(&destination).await.map_err(not_found_or_internal("open state file"))?;
+        let mut content = String::new();
+        file.take(self.limits.max_result_bytes as u64 + 1)
+            .read_to_string(&mut content)
+            .await
+            .map_err(internal_io("read state file"))?;
+        if content.len() > self.limits.max_result_bytes {
+            return Err(ToolError::Sdk {
+                sdk_kind: "response_too_large".to_string(),
+                message: "state read result exceeded max result bytes".to_string(),
+            });
+        }
+        Ok(ReadFileResult { path: path.as_str().to_string(), bytes: content.len(), content })
+    }
+
+    pub(crate) async fn list(&self, path: &VirtualPath) -> Result<ListResult, ToolError> {
+        let dir = self.resolve(path);
+        labby_runtime::path_safety::reject_existing_symlink_ancestors(&self.root, &dir)?;
+        let mut read_dir = tokio::fs::read_dir(&dir).await.map_err(not_found_or_internal("read state directory"))?;
+        let mut entries = Vec::new();
+        while let Some(entry) = read_dir.next_entry().await.map_err(internal_io("read state directory entry"))? {
+            entries.push(entry.file_name().to_string_lossy().to_string());
+            if entries.len() as u64 > self.limits.max_entries {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "response_too_large".to_string(),
+                    message: "state list exceeded max entries".to_string(),
+                });
+            }
+        }
+        entries.sort();
+        Ok(ListResult { entries })
+    }
+}
+
+fn internal_io(action: &'static str) -> impl FnOnce(std::io::Error) -> ToolError {
+    move |err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to {action}: {err}"),
+    }
+}
+
+fn not_found_or_internal(action: &'static str) -> impl FnOnce(std::io::Error) -> ToolError {
+    move |err| ToolError::Sdk {
+        sdk_kind: if err.kind() == std::io::ErrorKind::NotFound { "not_found" } else { "internal_error" }.to_string(),
+        message: format!("failed to {action}: {err}"),
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p labby-codemode state:: --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src/state.rs crates/labby-codemode/src/state crates/labby-codemode/src/lib.rs
+git commit -m "feat: add code mode state workspace"
+```
+
+---
+
+### Task 3: State Provider Methods
+
+**Files:**
+- Modify: `crates/labby-codemode/src/local_provider.rs`
+- Create: `crates/labby-codemode/src/state/provider.rs`
+- Modify: `crates/labby-codemode/src/state.rs`
+- Modify: `crates/labby-codemode/src/runner_drive.rs`
+- Modify: `crates/labby-codemode/src/config.rs`
+- Test: module tests in `state/provider.rs`
+
+**Interfaces:**
+- Consumes: `LocalProviderCall`.
+- Produces: `dispatch_state_method(workspace: &StateWorkspace, method: &str, params: Value) -> Result<Value, ToolError>`.
+- Produces V1 methods: `readFile`, `writeFile`, `list`, `readdir`, `glob`, `searchFiles`, `replaceInFiles`, `planEdits`, `applyEditPlan`.
+
+- [ ] **Step 1: Write failing provider dispatch tests**
+
+In `state/provider.rs`:
+
+```rust
+#[tokio::test]
+async fn write_and_read_file_dispatch_round_trip() {
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = StateWorkspace::new(temp.path().to_path_buf(), StateWorkspaceLimits::default()).unwrap();
+    dispatch_state_method(&workspace, "writeFile", serde_json::json!({
+        "path": "/src/app.rs",
+        "content": "fn main() {}\n"
+    })).await.unwrap();
+    let result = dispatch_state_method(&workspace, "readFile", serde_json::json!({
+        "path": "src/app.rs"
+    })).await.unwrap();
+    assert_eq!(result["content"], "fn main() {}\n");
+}
+```
+
+- [ ] **Step 2: Implement method param parsing and dispatch**
+
+Create `state/provider.rs`:
+
+```rust
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::error::ToolError;
+use super::path::VirtualPath;
+use super::workspace::StateWorkspace;
+
+#[derive(Deserialize)]
+struct PathParams {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct WriteFileParams {
+    path: String,
+    content: String,
+}
+
+pub(crate) async fn dispatch_state_method(
+    workspace: &StateWorkspace,
+    method: &str,
+    params: Value,
+) -> Result<Value, ToolError> {
+    match method {
+        "readFile" => {
+            let params: PathParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace.read_file(&VirtualPath::parse(&params.path)?).await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        "writeFile" => {
+            let params: WriteFileParams = serde_json::from_value(params).map_err(invalid_params)?;
+            workspace.write_file(&VirtualPath::parse(&params.path)?, &params.content).await?;
+            Ok(json!({ "ok": true, "path": params.path }))
+        }
+        "list" | "readdir" => {
+            let params: PathParams = serde_json::from_value(params).map_err(invalid_params)?;
+            let result = workspace.list(&VirtualPath::parse(&params.path)?).await?;
+            serde_json::to_value(result).map_err(serialize_error)
+        }
+        other => Err(ToolError::Sdk {
+            sdk_kind: "unknown_tool".to_string(),
+            message: format!("unknown state method `{other}`"),
+        }),
+    }
+}
+
+fn invalid_params(err: serde_json::Error) -> ToolError {
+    ToolError::InvalidParam {
+        message: format!("invalid state params: {err}"),
+        param: "params".to_string(),
+    }
+}
+
+fn serialize_error(err: serde_json::Error) -> ToolError {
+    ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to serialize state result: {err}"),
+    }
+}
+```
+
+Wire `pub(crate) mod provider;` in `state.rs`.
+
+- [ ] **Step 3: Implement glob/search/replace/plan/apply**
+
+Add bounded state operations as ordinary `StateWorkspace` methods and call them from
+`dispatch_state_method`. Do not add public methods outside the V1 list.
+
+Use these V1 parameter/result shapes:
+
+```rust
+#[derive(Deserialize)]
+struct GlobParams {
+    pattern: String,
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct GlobResult {
+    matches: Vec<String>,
+    truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct SearchFilesParams {
+    pattern: String,
+    query: String,
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct SearchMatch {
+    path: String,
+    line: usize,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct SearchFilesResult {
+    matches: Vec<SearchMatch>,
+    truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct ReplaceInFilesParams {
+    pattern: String,
+    search: String,
+    replace: String,
+    #[serde(default = "default_true")]
+    dry_run: bool,
+}
+
+#[derive(Serialize)]
+struct ReplaceInFilesResult {
+    changed: Vec<String>,
+    dry_run: bool,
+}
+
+#[derive(Deserialize)]
+struct PlanEditsParams {
+    edits: Vec<FileEdit>,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+struct FileEdit {
+    path: String,
+    search: String,
+    replace: String,
+}
+
+#[derive(Serialize)]
+struct EditPlanResult {
+    plan_id: String,
+    edits: Vec<FileEdit>,
+}
+
+#[derive(Deserialize)]
+struct ApplyEditPlanParams {
+    plan_id: String,
+}
+```
+
+Implementation details:
+
+- `glob`: walk the workspace root with `tokio::fs::read_dir` or a small recursive helper, convert every file to its virtual path, match with the `globset` crate only if it is already present or added as a narrow dependency, otherwise use the `glob` crate with the resolved workspace-prefixed pattern and reject patterns that resolve outside the workspace. Return sorted paths and set `truncated: true` when the requested/default limit is hit.
+- `searchFiles`: call `glob`, read only files at or below `max_file_bytes`, perform literal substring search line-by-line, cap each line preview to 512 chars, cap total matches to `limit.unwrap_or(200)`, and return `response_too_large` if accumulated serialized result bytes exceed `max_result_bytes`.
+- `replaceInFiles`: call `searchFiles` for candidate files, reject empty `search`, for `dry_run: true` return the paths that would change, for `dry_run: false` read each candidate, replace all literal occurrences, and write via `write_file`.
+- `planEdits`: validate each `FileEdit` with `VirtualPath::parse`, reject empty `search`, compute a stable plan id with `sha256` over canonical JSON for the edit list, persist the plan as JSON under `.labby-state/plans/<plan_id>.json` inside the jailed workspace, and return the plan id plus normalized edits.
+- `applyEditPlan`: read `.labby-state/plans/<plan_id>.json`, copy each target file to `.labby-state/rollback/<plan_id>/...` before editing, apply replacements using `write_file`, and on the first failure restore already-modified files from rollback copies before returning the error.
+
+- [ ] **Step 4: Connect state provider to runner drive**
+
+In `runner_drive.rs`, when a local provider call is `LocalProviderName::State`, construct/open the current workspace and call `dispatch_state_method`. Settle the runner with `ToolResult` or `ToolError` exactly like upstream calls.
+
+Use an isolated default workspace root derived from config:
+
+```rust
+let workspace_root = cfg.lab_home.join("code-mode-workspaces").join("default");
+let workspace = StateWorkspace::new(workspace_root, StateWorkspaceLimits::from_config(cfg))?;
+let value = dispatch_state_method(&workspace, &local.method, params).await?;
+```
+
+If `CodeModeConfig` does not yet carry `lab_home`, add a host-neutral config field or a `CodeModeHost` method that returns the workspace root.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p labby-codemode state:: --all-features`
+
+Expected: PASS.
+
+Run: `cargo test -p labby-codemode --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src/state.rs crates/labby-codemode/src/state crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/config.rs
+git commit -m "feat: add code mode state provider"
+```
+
+---
+
+### Task 4: Local Git Provider
+
+**Files:**
+- Create: `crates/labby-codemode/src/git.rs`
+- Create: `crates/labby-codemode/src/git/command.rs`
+- Create: `crates/labby-codemode/src/git/provider.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner_drive.rs`
+- Test: module tests in `git/command.rs` and `git/provider.rs`
+
+**Interfaces:**
+- Produces: `dispatch_git_method(workspace: &StateWorkspace, method: &str, params: Value) -> Result<Value, ToolError>`.
+- Produces V1 methods: `init`, `status`, `add`, `commit`, `log`, `diff`.
+
+- [ ] **Step 1: Write failing argv tests**
+
+Create `git/command.rs` tests:
+
+```rust
+#[test]
+fn git_status_builds_fixed_argv() {
+    let cmd = GitCommandSpec::status();
+    assert_eq!(cmd.args, vec!["-c", "core.hooksPath=/dev/null", "status", "--short"]);
+}
+
+#[test]
+fn git_rejects_unsupported_method() {
+    assert!(GitCommandSpec::for_method("push", serde_json::json!({})).is_err());
+}
+```
+
+- [ ] **Step 2: Implement git command specs**
+
+Create `git.rs`:
+
+```rust
+pub(crate) mod command;
+pub(crate) mod provider;
+```
+
+Add `mod git;` to `lib.rs`.
+
+Create `git/command.rs`:
+
+```rust
+use serde_json::Value;
+
+use crate::error::ToolError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitCommandSpec {
+    pub(crate) args: Vec<String>,
+}
+
+impl GitCommandSpec {
+    pub(crate) fn status() -> Self {
+        Self {
+            args: base_args(["status", "--short"]),
+        }
+    }
+
+    pub(crate) fn for_method(method: &str, _params: Value) -> Result<Self, ToolError> {
+        match method {
+            "init" => Ok(Self { args: base_args(["init"]) }),
+            "status" => Ok(Self::status()),
+            "add" => Ok(Self { args: base_args(["add", "--"]) }),
+            "commit" => Ok(Self { args: base_args(["commit", "--no-gpg-sign", "-m"]) }),
+            "log" => Ok(Self { args: base_args(["log", "--oneline", "-n", "20"]) }),
+            "diff" => Ok(Self { args: base_args(["diff", "--"]) }),
+            other => Err(ToolError::Sdk {
+                sdk_kind: "unknown_tool".to_string(),
+                message: format!("unknown git method `{other}`"),
+            }),
+        }
+    }
+}
+
+fn base_args<const N: usize>(tail: [&str; N]) -> Vec<String> {
+    let mut args = vec![
+        "-c".to_string(),
+        "core.hooksPath=/dev/null".to_string(),
+        "-c".to_string(),
+        "protocol.file.allow=never".to_string(),
+        "-c".to_string(),
+        "protocol.ext.allow=never".to_string(),
+    ];
+    args.extend(tail.into_iter().map(str::to_string));
+    args
+}
+```
+
+- [ ] **Step 3: Implement guarded git execution**
+
+Create `git/provider.rs` with an async runner using `tokio::process::Command`:
+
+```rust
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+
+use crate::error::ToolError;
+
+pub(crate) async fn run_git(workspace_root: &Path, args: &[String]) -> Result<String, ToolError> {
+    let mut command = Command::new("/usr/bin/git");
+    command
+        .args(args)
+        .current_dir(workspace_root)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let output = tokio::time::timeout(Duration::from_secs(10), command.output())
+        .await
+        .map_err(|_| ToolError::Sdk {
+            sdk_kind: "timeout".to_string(),
+            message: "git command timed out".to_string(),
+        })?
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "internal_error".to_string(),
+            message: format!("failed to run git: {err}"),
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).chars().take(64 * 1024).collect::<String>();
+    let stderr = String::from_utf8_lossy(&output.stderr).chars().take(16 * 1024).collect::<String>();
+    if !output.status.success() {
+        return Err(ToolError::Sdk {
+            sdk_kind: "git_failed".to_string(),
+            message: format!("git failed: {}", redact_git_output(&stderr)),
+        });
+    }
+    Ok(redact_git_output(&stdout))
+}
+
+fn redact_git_output(value: &str) -> String {
+    value
+        .replace("https://", "https://[REDACTED]@")
+        .replace("ghp_", "[REDACTED]")
+}
+```
+
+If `/usr/bin/git` is not portable enough for this repo, implement a resolver that finds `git` once outside the workspace and stores the absolute path. Do not run a relative `git` from inside the workspace.
+
+- [ ] **Step 4: Implement git provider dispatch**
+
+`dispatch_git_method` should parse object params:
+
+```rust
+pub(crate) async fn dispatch_git_method(
+    workspace: &StateWorkspace,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, ToolError> {
+    let spec = GitCommandSpec::for_method(method, params)?;
+    let stdout = run_git(workspace.root_path(), &spec.args).await?;
+    Ok(serde_json::json!({ "ok": true, "stdout": stdout }))
+}
+```
+
+Support:
+
+- `git.init({})`
+- `git.status({})`
+- `git.add({ path })`
+- `git.commit({ message, authorName, authorEmail })`
+- `git.log({ limit? })`
+- `git.diff({ path? })`
+
+Build method-specific argv in `GitCommandSpec::for_method`:
+
+- `init`: ignore params and return `base_args(["init"])`.
+- `status`: ignore params and return `base_args(["status", "--short"])`.
+- `add`: parse `{ path }`, validate with `VirtualPath::parse`, and append the virtual path after `["add", "--"]`.
+- `commit`: parse `{ message, authorName, authorEmail }`, reject an empty message, and append `["commit", "--no-gpg-sign", "--author", "<name> <email>", "-m", message]`.
+- `log`: parse optional `{ limit }`, clamp to `1..=50`, and append `["log", "--oneline", "-n", limit]`.
+- `diff`: parse optional `{ path }`; without a path use `["diff", "--"]`, with a path validate via `VirtualPath::parse` and append the virtual path after `--`.
+
+- [ ] **Step 5: Wire git provider to runner drive**
+
+In the local provider routing branch from Task 1, dispatch `LocalProviderName::Git` with the same workspace root as state.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p labby-codemode git:: --all-features`
+
+Expected: PASS.
+
+Run: `cargo test -p labby-codemode --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/labby-codemode/src/git.rs crates/labby-codemode/src/git crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/lib.rs
+git commit -m "feat: add local code mode git provider"
+```
+
+---
+
+### Task 5: Docs, Smoke, And Final Verification
+
+**Files:**
+- Modify: `docs/dev/CODE_MODE.md`
+- Create: `tests/smoke-code-mode-state-git.sh`
+- Modify: `crates/labby-codemode/src/tests_ts_signatures.rs`
+- Modify: `crates/labby-codemode/src/tests_ids_schema.rs`
+- Modify: `CHANGELOG.md` if this repo keeps unreleased entries for user-facing changes
+
+**Interfaces:**
+- Consumes: all V1 `state.*` and `git.*` methods.
+- Produces: smoke proof and user-facing docs that match implemented schema.
+
+- [ ] **Step 1: Update docs with exact V1 surface**
+
+In `docs/dev/CODE_MODE.md`, add a section:
+
+```markdown
+### Local State And Git Providers
+
+Code Mode exposes two local sandbox globals when enabled: `state` and `git`.
+They are not upstream MCP tools and they do not grant host filesystem or shell access.
+
+V1 state methods:
+- `state.readFile({ path })`
+- `state.writeFile({ path, content })`
+- `state.list({ path })` / `state.readdir({ path })`
+- `state.glob({ pattern })`
+- `state.searchFiles({ pattern, query })`
+- `state.replaceInFiles({ pattern, search, replace, dryRun })`
+- `state.planEdits({ edits })`
+- `state.applyEditPlan({ planId })`
+
+V1 git methods:
+- `git.init({})`
+- `git.status({})`
+- `git.add({ path })`
+- `git.commit({ message, authorName, authorEmail })`
+- `git.log({ limit })`
+- `git.diff({ path })`
+
+Remote git operations, hidden git auth, checkout/branch/remotes, archive/hash/detect,
+and advanced JSON helpers are not V1.
+```
+
+- [ ] **Step 2: Add smoke script**
+
+Create `tests/smoke-code-mode-state-git.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export LAB_HOME="$TMP/lab-home"
+mkdir -p "$LAB_HOME"
+
+cd "$ROOT"
+cargo run --all-features -- codemode --json --code '
+await state.writeFile({ path: "/src/app.rs", content: "fn main() { println!(\"hi\"); }\n" });
+const read = await state.readFile({ path: "/src/app.rs" });
+const matches = await state.searchFiles({ pattern: "src/**/*.rs", query: "println" });
+await git.init({});
+await git.add({ path: "/src/app.rs" });
+await git.commit({ message: "initial state", authorName: "Lab", authorEmail: "lab@example.invalid" });
+const status = await git.status({});
+const log = await git.log({ limit: 1 });
+return { read: read.content, matches: matches.matches.length, status, log };
+'
+```
+
+Adjust the CLI invocation to the repo's actual Code Mode command if it differs. Keep `LAB_HOME` isolated.
+
+- [ ] **Step 3: Add negative smoke or integration checks**
+
+Add test cases for:
+
+```text
+state.readFile({ path: "/../secret" }) => path_traversal
+state.writeFile({ path: "/.env", content: "TOKEN=x" }) => permission_denied
+git.status({ dir: "/../outside" }) => path_traversal or invalid_param
+upstream named state/git cannot shadow local providers
+```
+
+- [ ] **Step 4: Run focused verification**
+
+Run: `cargo test -p labby-codemode --all-features`
+
+Expected: PASS.
+
+Run: `cargo test -p labby --test architecture_orchestrator --all-features`
+
+Expected: PASS.
+
+Run: `bash tests/smoke-code-mode-state-git.sh`
+
+Expected: PASS and output includes committed git log/status data.
+
+- [ ] **Step 5: Run full verification**
+
+Run: `cargo nextest run --workspace --all-features`
+
+Expected: PASS.
+
+Run: `cargo build --workspace --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/dev/CODE_MODE.md tests/smoke-code-mode-state-git.sh crates/labby-codemode/src/tests_ts_signatures.rs crates/labby-codemode/src/tests_ids_schema.rs CHANGELOG.md
+git commit -m "docs: document code mode state git v1"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** V1 local providers, workspace jail, state methods, local git methods, budgets/caps, concurrency, docs, smoke, and all-features verification are covered. V2 exclusions are explicitly listed in the epic and are not implemented in this plan.
+
+**Placeholder scan:** No `TBD`, `TODO`, or unconstrained “handle edge cases” steps remain. Steps name exact files, commands, expected results, and method names.
+
+**Type consistency:** `LocalProviderCall`, `LocalProviderName`, `VirtualPath`, `StateWorkspace`, `StateWorkspaceLimits`, `dispatch_state_method`, and `dispatch_git_method` are introduced before later tasks consume them.

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -1024,7 +1024,7 @@ git commit -m "feat: add local code mode git provider"
 - Consumes: all V1 `state.*` and `git.*` methods.
 - Produces: smoke proof and user-facing docs that match implemented schema.
 
-- [ ] **Step 1: Update docs with exact V1 surface**
+- [x] **Step 1: Update docs with exact V1 surface**
 
 In `docs/dev/CODE_MODE.md`, add a section:
 
@@ -1056,7 +1056,7 @@ Remote git operations, hidden git auth, checkout/branch/remotes, archive/hash/de
 and advanced JSON helpers are not V1.
 ```
 
-- [ ] **Step 2: Add smoke script**
+- [x] **Step 2: Add smoke script**
 
 Create `tests/smoke-code-mode-state-git.sh`:
 
@@ -1087,7 +1087,7 @@ return { read: read.content, matches: matches.matches.length, status, log };
 
 Adjust the CLI invocation to the repo's actual Code Mode command if it differs. Keep `LAB_HOME` isolated.
 
-- [ ] **Step 3: Add negative smoke or integration checks**
+- [x] **Step 3: Add negative smoke or integration checks**
 
 Add test cases for:
 
@@ -1098,7 +1098,11 @@ git.status({ dir: "/../outside" }) => path_traversal or invalid_param
 upstream named state/git cannot shadow local providers
 ```
 
-- [ ] **Step 4: Run focused verification**
+Covered by focused unit tests in `labby-codemode` for path traversal,
+credential path rejection, symlink escapes, local-provider namespace routing,
+state provider failures, and git command validation.
+
+- [x] **Step 4: Run focused verification**
 
 Run: `cargo test -p labby-codemode --all-features`
 
@@ -1112,7 +1116,7 @@ Run: `bash tests/smoke-code-mode-state-git.sh`
 
 Expected: PASS and output includes committed git log/status data.
 
-- [ ] **Step 5: Run full verification**
+- [x] **Step 5: Run full verification**
 
 Run: `cargo nextest run --workspace --all-features`
 
@@ -1122,10 +1126,10 @@ Run: `cargo build --workspace --all-features`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
-git add docs/dev/CODE_MODE.md tests/smoke-code-mode-state-git.sh crates/labby-codemode/src/tests_ts_signatures.rs crates/labby-codemode/src/tests_ids_schema.rs CHANGELOG.md
+git add docs/dev/CODE_MODE.md tests/smoke-code-mode-state-git.sh crates/labby-codemode/src/state/provider.rs CHANGELOG.md docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
 git commit -m "docs: document code mode state git v1"
 ```
 

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -599,7 +599,7 @@ git commit -m "feat: add code mode state workspace"
 - Produces: `dispatch_state_method(workspace: &StateWorkspace, method: &str, params: Value) -> Result<Value, ToolError>`.
 - Produces V1 methods: `readFile`, `writeFile`, `list`, `readdir`, `glob`, `searchFiles`, `replaceInFiles`, `planEdits`, `applyEditPlan`.
 
-- [ ] **Step 1: Write failing provider dispatch tests**
+- [x] **Step 1: Write failing provider dispatch tests**
 
 In `state/provider.rs`:
 
@@ -619,7 +619,7 @@ async fn write_and_read_file_dispatch_round_trip() {
 }
 ```
 
-- [ ] **Step 2: Implement method param parsing and dispatch**
+- [x] **Step 2: Implement method param parsing and dispatch**
 
 Create `state/provider.rs`:
 
@@ -687,7 +687,7 @@ fn serialize_error(err: serde_json::Error) -> ToolError {
 
 Wire `pub(crate) mod provider;` in `state.rs`.
 
-- [ ] **Step 3: Implement glob/search/replace/plan/apply**
+- [x] **Step 3: Implement glob/search/replace/plan/apply**
 
 Add bounded state operations as ordinary `StateWorkspace` methods and call them from
 `dispatch_state_method`. Do not add public methods outside the V1 list.
@@ -774,7 +774,7 @@ Implementation details:
 - `planEdits`: validate each `FileEdit` with `VirtualPath::parse`, reject empty `search`, compute a stable plan id with `sha256` over canonical JSON for the edit list, persist the plan as JSON under `.labby-state/plans/<plan_id>.json` inside the jailed workspace, and return the plan id plus normalized edits.
 - `applyEditPlan`: read `.labby-state/plans/<plan_id>.json`, copy each target file to `.labby-state/rollback/<plan_id>/...` before editing, apply replacements using `write_file`, and on the first failure restore already-modified files from rollback copies before returning the error.
 
-- [ ] **Step 4: Connect state provider to runner drive**
+- [x] **Step 4: Connect state provider to runner drive**
 
 In `runner_drive.rs`, when a local provider call is `LocalProviderName::State`, construct/open the current workspace and call `dispatch_state_method`. Settle the runner with `ToolResult` or `ToolError` exactly like upstream calls.
 
@@ -788,7 +788,7 @@ let value = dispatch_state_method(&workspace, &local.method, params).await?;
 
 If `CodeModeConfig` does not yet carry `lab_home`, add a host-neutral config field or a `CodeModeHost` method that returns the workspace root.
 
-- [ ] **Step 5: Run tests**
+- [x] **Step 5: Run tests**
 
 Run: `cargo test -p labby-codemode state:: --all-features`
 
@@ -798,7 +798,7 @@ Run: `cargo test -p labby-codemode --all-features`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/labby-codemode/src/state.rs crates/labby-codemode/src/state crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/config.rs

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -54,7 +54,7 @@
 - Produces: `try_parse_local_provider_call(id: &str) -> Result<Option<LocalProviderCall>, ToolError>`.
 - Produces: top-level JS globals `state` and `git` that call reserved IDs such as `state::readFile`.
 
-- [ ] **Step 1: Add failing ID parsing tests**
+- [x] **Step 1: Add failing ID parsing tests**
 
 Add tests in `crates/labby-codemode/src/tests_ids_schema.rs`:
 
@@ -88,13 +88,13 @@ fn local_provider_ids_reject_bad_methods() {
 }
 ```
 
-- [ ] **Step 2: Run failing tests**
+- [x] **Step 2: Run failing tests**
 
 Run: `cargo test -p labby-codemode local_provider_ids --all-features`
 
 Expected: FAIL with unresolved module or function `local_provider`.
 
-- [ ] **Step 3: Implement local provider parser**
+- [x] **Step 3: Implement local provider parser**
 
 Create `crates/labby-codemode/src/local_provider.rs`:
 
@@ -161,7 +161,7 @@ Modify `crates/labby-codemode/src/lib.rs`:
 mod local_provider;
 ```
 
-- [ ] **Step 4: Add state/git proxy generation tests**
+- [x] **Step 4: Add state/git proxy generation tests**
 
 Add tests in `crates/labby-codemode/src/tests_normalize.rs` or existing preamble tests:
 
@@ -176,7 +176,7 @@ fn state_and_git_globals_are_present_in_preamble() {
 }
 ```
 
-- [ ] **Step 5: Implement local provider proxy JS**
+- [x] **Step 5: Implement local provider proxy JS**
 
 Modify `crates/labby-codemode/src/preamble.rs`:
 
@@ -219,7 +219,7 @@ let local_provider_proxy = crate::preamble::generate_local_provider_js();
 
 and evaluate it after `callTool` exists and before user code runs.
 
-- [ ] **Step 6: Route local providers before upstream host calls**
+- [x] **Step 6: Route local providers before upstream host calls**
 
 In `runner_drive.rs`, before `enqueue_tool_call(...)`, branch on `try_parse_local_provider_call(&id)`. For now, return `unknown_tool` for recognized providers until Tasks 3 and 4 implement dispatch:
 
@@ -233,7 +233,7 @@ if let Some(local) = crate::local_provider::try_parse_local_provider_call(&id)? 
 
 If the exact future type of `pending_tool_calls` makes this awkward, implement a `dispatch_tool_call(...)` helper that returns the same future output type as upstream tool calls.
 
-- [ ] **Step 7: Run tests**
+- [x] **Step 7: Run tests**
 
 Run: `cargo test -p labby-codemode local_provider --all-features`
 
@@ -243,7 +243,7 @@ Run: `cargo test -p labby-codemode --all-features`
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add crates/labby-codemode/src

--- a/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
+++ b/docs/superpowers/plans/2026-06-28-code-mode-state-git-v1.md
@@ -268,7 +268,7 @@ git commit -m "feat: add code mode local provider routing"
 - Produces: `VirtualPath::parse(raw: &str) -> Result<Self, ToolError>`.
 - Produces: `StateWorkspace::write_file`, `read_file`, `list`, `glob`, `search_files`, `replace_in_files`, `plan_edits`, `apply_edit_plan`.
 
-- [ ] **Step 1: Write failing path tests**
+- [x] **Step 1: Write failing path tests**
 
 Create tests in `crates/labby-codemode/src/state/path.rs`:
 
@@ -297,7 +297,7 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Implement virtual path parser**
+- [x] **Step 2: Implement virtual path parser**
 
 Create `crates/labby-codemode/src/state.rs`:
 
@@ -405,7 +405,7 @@ fn reject_credential_like_path(path: &str) -> Result<(), ToolError> {
 }
 ```
 
-- [ ] **Step 3: Add workspace read/write/list tests**
+- [x] **Step 3: Add workspace read/write/list tests**
 
 In `state/workspace.rs`, add tests:
 
@@ -424,7 +424,7 @@ async fn workspace_writes_reads_and_reopens() {
 }
 ```
 
-- [ ] **Step 4: Implement workspace backend**
+- [x] **Step 4: Implement workspace backend**
 
 Create `state/quota.rs`:
 
@@ -569,13 +569,13 @@ fn not_found_or_internal(action: &'static str) -> impl FnOnce(std::io::Error) ->
 }
 ```
 
-- [ ] **Step 5: Run tests**
+- [x] **Step 5: Run tests**
 
 Run: `cargo test -p labby-codemode state:: --all-features`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/labby-codemode/src/state.rs crates/labby-codemode/src/state crates/labby-codemode/src/lib.rs

--- a/tests/smoke-code-mode-state-git.sh
+++ b/tests/smoke-code-mode-state-git.sh
@@ -11,7 +11,7 @@ mkdir -p "$LAB_HOME"
 cd "$ROOT"
 cargo run --all-features -- --json gateway code exec --code '
 async () => {
-  await state.writeFile({ path: "/src/app.rs", content: "fn main() { println(\"hi\"); }\n" });
+  await state.writeFile({ path: "/src/app.rs", content: "fn main() { println!(\"hi\"); }\n" });
   const read = await state.readFile({ path: "/src/app.rs" });
   const matches = await state.searchFiles({ pattern: "src/**/*.rs", query: "println" });
   await git.init({});

--- a/tests/smoke-code-mode-state-git.sh
+++ b/tests/smoke-code-mode-state-git.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export LAB_HOME="$TMP/lab-home"
+mkdir -p "$LAB_HOME"
+
+cd "$ROOT"
+cargo run --all-features -- --json gateway code exec --code '
+async () => {
+  await state.writeFile({ path: "/src/app.rs", content: "fn main() { println(\"hi\"); }\n" });
+  const read = await state.readFile({ path: "/src/app.rs" });
+  const matches = await state.searchFiles({ pattern: "src/**/*.rs", query: "println" });
+  await git.init({});
+  await git.add({ path: "/src/app.rs" });
+  await git.commit({ message: "initial state", authorName: "Lab", authorEmail: "lab@example.invalid" });
+  const status = await git.status({});
+  const log = await git.log({ limit: 1 });
+  return { read: read.content, matches: matches.matches.length, status, log };
+}
+'


### PR DESCRIPTION
## Summary
- add reserved local Code Mode providers for state and git so upstreams cannot shadow them
- add jailed durable LAB_HOME-backed state workspace with V1 file/search/replace/edit-plan methods
- add local-only guarded git commands: init, status, add, commit, log, diff
- document exact V1 surface and explicit V2 exclusions, with isolated smoke coverage

## Verification
- cargo test -p labby-codemode --all-features
- cargo test -p labby --test architecture_orchestrator --all-features
- bash tests/smoke-code-mode-state-git.sh
- cargo nextest run --workspace --all-features
- cargo build --workspace --all-features

## Beads
- closes lab-juyjf
- closes lab-juyjf.1
- closes lab-juyjf.2
- closes lab-juyjf.3
- closes lab-juyjf.4
- closes lab-juyjf.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reserved local Code Mode providers `state` and `git` with a jailed, durable workspace and a minimal local-only git command set, now with serialized access and stricter I/O guards. Delivers the V1 surface and guards called for in Linear lab-juyjf (+ .1–.5).

- **New Features**
  - Reserve `state`/`git` namespaces and intercept before upstream routing.
  - Add `$LAB_HOME/code-mode-workspaces/` with quotas; V1 `state.*` (file ops, glob, search, edit plans) and local-only `git.*` (init, status, add, commit, log, diff).
  - JS preamble exposes `globalThis.state` and `globalThis.git`; docs and smoke tests included.

- **Bug Fixes**
  - Serialize local provider calls against the workspace to avoid races; fix the smoke fixture.
  - Harden path normalization, glob/temp-file behavior, and symlink handling; block traversal.
  - Bound git stdout/stderr reads, preserve platform git discovery, and redact only credential-bearing HTTPS URLs.

<sup>Written for commit 4d5e14cdfb5b7319ffe097e312374ce306dedc53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Code Mode “state” workspace and “git” sandbox V1 tools (file read/write/list, bounded search/replace, edit-plan + apply, plus `git` init/status/add/commit/log/diff) scoped to the Code Mode workspace.
  * Introduced local-provider namespaced calls and preinstalled `state`/`git` globals with method-specific capabilities.
* **Bug Fixes**
  * Hardened execution with workspace-relative path validation, quota limits, symlink/traversal protections, output truncation, timeouts, and sensitive-output redaction.
* **Documentation**
  * Documented the V1 `state.*` and `git.*` method inventory and constraints.
* **Tests**
  * Added a smoke test covering state + local Git flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->