### PR TITLE
Fix Incus Tailscale hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to this project will be documented in this file.
   or manual release-version lookup. The old web setup flow remains available as
   `labby setup wizard`, while `labby setup incus` keeps advanced bootstrap flags.
 
+### Fixed
+
+- **Incus Tailscale hostname stability** — Incus bootstrap now sets the
+  container hostname and passes an explicit Tailscale hostname during join so
+  images built on CI runners do not register random runner names in the tailnet.
+
 ---
 
 ## [0.28.0] - 2026-06-27

--- a/crates/labby/src/cli/setup.rs
+++ b/crates/labby/src/cli/setup.rs
@@ -124,7 +124,7 @@ pub enum SetupCommand {
     #[command(alias = "incus-backup")]
     Incusbackup(IncusBackupArgs),
     /// Bootstrap or converge the supported Incus Labby gateway container.
-    Incus(IncusBootstrapArgs),
+    Incus(Box<IncusBootstrapArgs>),
     /// Copy the labby binary into ~/.local/bin so it is callable in your own terminal.
     Install,
     /// Install the Claude Code plugin for a configured service.
@@ -306,6 +306,9 @@ pub struct IncusBootstrapArgs {
     /// Run tailscale up with --ssh when TS_AUTHKEY is set.
     #[arg(long)]
     pub tailscale_ssh: bool,
+    /// Hostname to register with Tailscale; defaults to the Incus container name.
+    #[arg(long)]
+    pub tailscale_hostname: Option<String>,
     /// Allow install.sh cargo fallback if the release asset is unavailable.
     #[arg(long)]
     pub allow_source_fallback: bool,
@@ -331,6 +334,7 @@ impl Default for IncusBootstrapArgs {
             skip_install: false,
             dry_run: false,
             tailscale_ssh: false,
+            tailscale_hostname: None,
             allow_source_fallback: false,
             yes: false,
         }
@@ -605,7 +609,7 @@ async fn run_command(command: SetupCommand, format: OutputFormat) -> Result<Exit
             run_incus_backup_command(args, format).await?;
         }
         SetupCommand::Incus(args) => {
-            run_incus_bootstrap_command(args, format).await?;
+            run_incus_bootstrap_command(*args, format).await?;
         }
         SetupCommand::Install => {
             let dest = install_self()?;
@@ -684,6 +688,7 @@ async fn run_incus_bootstrap_command(args: IncusBootstrapArgs, format: OutputFor
         skip_install: args.skip_install,
         dry_run: args.dry_run,
         tailscale_ssh: args.tailscale_ssh,
+        tailscale_hostname: args.tailscale_hostname,
         allow_source_fallback: args.allow_source_fallback,
     };
     crate::dispatch::setup::incus::run_incus_bootstrap(options)?;

--- a/crates/labby/src/dispatch/setup/incus.rs
+++ b/crates/labby/src/dispatch/setup/incus.rs
@@ -60,6 +60,7 @@ pub(crate) struct IncusBootstrapOptions {
     pub skip_install: bool,
     pub dry_run: bool,
     pub tailscale_ssh: bool,
+    pub tailscale_hostname: Option<String>,
     pub allow_source_fallback: bool,
 }
 
@@ -241,6 +242,13 @@ pub(crate) fn bootstrap_command(
     push_flag(&mut args, "--skip-install", options.skip_install);
     push_flag(&mut args, "--dry-run", options.dry_run);
     push_flag(&mut args, "--tailscale-ssh", options.tailscale_ssh);
+    if let Some(hostname) = options
+        .tailscale_hostname
+        .as_deref()
+        .or(options.name.as_deref())
+    {
+        push_option(&mut args, "--tailscale-hostname", Some(hostname));
+    }
     push_flag(
         &mut args,
         "--allow-source-fallback",
@@ -495,6 +503,25 @@ config:
 
         let err = bootstrap_command(&artifacts, &options).unwrap_err();
         assert_eq!(err.kind(), "incus_bootstrap_invalid_options");
+    }
+
+    #[test]
+    fn passes_container_name_as_tailscale_hostname() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifacts = materialize_bootstrap_artifacts(dir.path()).unwrap();
+        let options = IncusBootstrapOptions {
+            name: Some("labby".to_string()),
+            dry_run: true,
+            ..IncusBootstrapOptions::default()
+        };
+
+        let command = bootstrap_command(&artifacts, &options).unwrap();
+
+        assert!(has_arg_pair(
+            &command.args,
+            "--tailscale-hostname",
+            OsStr::new("labby")
+        ));
     }
 
     fn has_arg_pair(args: &[OsString], flag: &str, value: &OsStr) -> bool {

--- a/crates/labby/src/dispatch/setup/provision.rs
+++ b/crates/labby/src/dispatch/setup/provision.rs
@@ -25,6 +25,7 @@ const LAB_HOME: &str = "/home/lab";
 const LAB_PATH: &str =
     "/home/lab/.local/bin:/home/lab/.cargo/bin:/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin";
 const TS_AUTHKEY_ENV: &str = "TS_AUTHKEY";
+const TS_HOSTNAME_ENV: &str = "LABBY_TAILSCALE_HOSTNAME";
 const TS_AUTHKEY_PATH: &str = "/run/labby-ts-authkey";
 const LAB_ZPROFILE: &str = "/home/lab/.zprofile";
 const LABBY_IMAGE_YAML: &str = include_str!("../../../../../config/incus/labby-image.yaml");
@@ -557,11 +558,16 @@ async fn install_and_join_tailscale() -> Result<(), ToolError> {
             run_image_provision_action("tailscale-install").await?;
         }
         write_tailscale_authkey(&authkey)?;
-        run_checked(
-            "tailscale",
-            &["up", &format!("--auth-key=file:{TS_AUTHKEY_PATH}")],
-        )
-        .await?;
+        let auth_arg = format!("--auth-key=file:{TS_AUTHKEY_PATH}");
+        if let Some(hostname) = tailscale_hostname() {
+            run_checked(
+                "tailscale",
+                &["up", &auth_arg, &format!("--hostname={hostname}")],
+            )
+            .await?;
+        } else {
+            run_checked("tailscale", &["up", &auth_arg]).await?;
+        }
         Ok(())
     }
     .await;
@@ -571,6 +577,13 @@ async fn install_and_join_tailscale() -> Result<(), ToolError> {
 
 fn tailscale_authkey() -> Option<String> {
     std::env::var(TS_AUTHKEY_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn tailscale_hostname() -> Option<String> {
+    std::env::var(TS_HOSTNAME_ENV)
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())

--- a/docs/generated/cli-help.md
+++ b/docs/generated/cli-help.md
@@ -1298,6 +1298,9 @@ Options:
       --tailscale-ssh
           Run tailscale up with --ssh when TS_AUTHKEY is set
 
+      --tailscale-hostname <TAILSCALE_HOSTNAME>
+          Hostname to register with Tailscale; defaults to the Incus container name
+
       --allow-source-fallback
           Allow install.sh cargo fallback if the release asset is unavailable
 

--- a/scripts/incus-bootstrap.sh
+++ b/scripts/incus-bootstrap.sh
@@ -17,6 +17,7 @@ LOCAL_BINARY=""
 SKIP_INSTALL=0
 DRY_RUN=0
 TAILSCALE_SSH=0
+TAILSCALE_HOSTNAME=""
 ALLOW_SOURCE_FALLBACK=0
 APPLY_BACKUP_CONFIG=1
 
@@ -45,6 +46,7 @@ Options:
   --skip-install              Use the labby binary already baked into the selected image
   --dry-run                   Print commands only
   --tailscale-ssh             Run tailscale up with --ssh when TS_AUTHKEY is set
+  --tailscale-hostname NAME    Tailscale hostname (default: container name)
   --allow-source-fallback     Allow install.sh cargo fallback if release asset is unavailable
   -h, --help                  Show this help
 
@@ -468,6 +470,7 @@ while [ "$#" -gt 0 ]; do
         --skip-install) SKIP_INSTALL=1; shift ;;
         --dry-run|--print-only) DRY_RUN=1; shift ;;
         --tailscale-ssh) TAILSCALE_SSH=1; shift ;;
+        --tailscale-hostname) TAILSCALE_HOSTNAME="${2:?missing --tailscale-hostname value}"; shift 2 ;;
         --allow-source-fallback) ALLOW_SOURCE_FALLBACK=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) fail "unknown argument: $1" ;;
@@ -496,6 +499,9 @@ if [ "$SKIP_INSTALL" -eq 1 ] && [ -n "$LOCAL_BINARY" ]; then
 fi
 if [ -n "$LOCAL_BINARY" ] && [ "$DRY_RUN" -eq 0 ] && [ ! -f "$LOCAL_BINARY" ]; then
     fail "--local-binary path does not exist: $LOCAL_BINARY"
+fi
+if [ -z "$TAILSCALE_HOSTNAME" ]; then
+    TAILSCALE_HOSTNAME="$NAME"
 fi
 
 INCUS_AVAILABLE=1
@@ -541,6 +547,7 @@ verify_container_substrate
 ensure_tun_device
 ensure_container_networking
 apply_backup_config
+run incus exec "$NAME" -- hostnamectl set-hostname "$TAILSCALE_HOSTNAME"
 
 if [ "$SKIP_INSTALL" -eq 1 ]; then
     run incus exec "$NAME" -- test -x /usr/local/bin/labby
@@ -572,7 +579,7 @@ if [ -n "${TS_AUTHKEY:-}" ]; then
 	elif ! incus exec "$NAME" -- sh -c "command -v tailscale >/dev/null 2>&1"; then
 		run incus exec "$NAME" -- sh -c "curl -fsSL https://tailscale.com/install.sh | sh"
 	fi
-	ts_args="--auth-key=file:/run/labby-ts-authkey"
+	ts_args="--auth-key=file:/run/labby-ts-authkey --hostname=$TAILSCALE_HOSTNAME"
 	if [ "$TAILSCALE_SSH" -eq 1 ]; then
 		ts_args="$ts_args --ssh"
 	fi


### PR DESCRIPTION
## Summary
- set the Incus container hostname during bootstrap before Tailscale join
- pass an explicit Tailscale hostname, defaulting to the Incus container name
- add a regression test for generated bootstrap arguments and document the new flag

## Verification
- cargo fmt --all --check
- sh -n scripts/incus-bootstrap.sh
- shellcheck scripts/incus-bootstrap.sh
- TS_AUTHKEY=dummy sh scripts/incus-bootstrap.sh --dry-run --skip-install --name labby --storage-driver dir --no-backup-config
- just docs-generate && just docs-check
- cargo test -p labby --all-features setup -- --nocapture
- cargo clippy -p labby --all-features -- -D warnings

## Live fix
- Updated current container hostname/Tailscale hostname to labby; host tailnet now reports labby.manatee-triceratops.ts.net.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the hostname used when Incus containers join Tailscale to stop random CI runner names from appearing in the tailnet. Sets the container hostname during bootstrap and joins Tailscale with an explicit hostname (default: container name).

- **Bug Fixes**
  - Set container hostname before Tailscale join.
  - Add `--tailscale-hostname` CLI flag (defaults to container name).
  - Pass hostname to provisioner via `LABBY_TAILSCALE_HOSTNAME`; use `tailscale up --hostname`.
  - Update `incus-bootstrap.sh` to set hostname with `hostnamectl` and include `--hostname` on join.
  - Add regression test for bootstrap args and update CLI docs.

<sup>Written for commit f03683bed649cd3d09f16df8de6e99477da70ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

