### PR TITLE
build(codemode): prove Javy v9 Wasmtime codegen path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.0",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e4fbf6733a900814fb921b2aac06612e15b42020b76a356fbc1192e725cebc"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -62,8 +71,20 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum",
+ "strum 0.28.0",
  "tracing",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -76,10 +97,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -147,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +211,17 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ast_node"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -268,7 +327,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -369,7 +428,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -391,10 +450,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "better_scoped_tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
+dependencies = [
+ "scoped-tls",
+]
 
 [[package]]
 name = "bindgen"
@@ -405,7 +483,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -413,7 +491,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -436,6 +514,18 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -504,7 +594,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "once_cell",
- "phf",
+ "phf 0.13.1",
  "rustc-hash",
  "static_assertions",
 ]
@@ -519,7 +609,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -556,6 +646,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,12 +690,126 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-str"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577d2bf5650f8554d5a372af5ac93535110a0fc75b3e702bb853369febf227c2"
+dependencies = [
+ "bytes",
+ "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix",
+ "winx",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cc"
@@ -727,10 +952,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -753,6 +978,26 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "colorchoice"
@@ -852,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1130,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.33.0",
+ "hashbrown 0.17.0",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1285,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -989,7 +1404,79 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash 0.2.0",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+dependencies = [
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -998,8 +1485,22 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1012,7 +1513,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1021,9 +1533,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1065,6 +1577,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1619,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,8 +1668,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "deterministic-wasi-ctx"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda25fea42579baa1a17834984c396c73ebd0017e9a74da1273e86b51e7d066e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-primitives",
+ "rand_core 0.10.1",
+ "rand_pcg",
+ "wasi",
+ "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -1164,6 +1733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,7 +1782,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1200,6 +1790,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "dunce"
@@ -1279,10 +1875,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_filter"
@@ -1410,6 +2027,12 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -1452,10 +2075,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "from_variant"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
+dependencies = [
+ "swc_macros_common",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1488,7 +2138,7 @@ version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "futures-core",
  "futures-lite",
  "pin-project",
@@ -1539,7 +2189,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1569,6 +2219,20 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1621,6 +2285,29 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1683,6 +2370,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1702,6 +2393,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1709,6 +2402,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -1718,6 +2416,12 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1762,6 +2466,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "hstr"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bb87e4b300d73412f6dcc7022ee7741452b51b155c2b06e5994d0770c2dbe2"
+dependencies = [
+ "hashbrown 0.14.5",
+ "new_debug_unreachable",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "triomphe",
 ]
 
 [[package]]
@@ -2023,6 +2741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+
+[[package]]
 name = "imara-diff"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2788,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2817,18 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2095,10 +2847,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "javy"
@@ -2112,6 +2893,26 @@ dependencies = [
  "quickcheck",
  "rquickjs",
  "serde",
+]
+
+[[package]]
+name = "javy-codegen"
+version = "4.0.1-alpha.1"
+source = "git+https://github.com/bytecodealliance/javy?tag=v9.0.0#03458aaa9ed3e56d9a2baffcf646ac38f69664b5"
+dependencies = [
+ "anyhow",
+ "brotli",
+ "convert_case",
+ "deterministic-wasi-ctx",
+ "swc_core",
+ "tempfile",
+ "walrus",
+ "wasm-opt",
+ "wasmparser 0.251.0",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wizer",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -2137,7 +2938,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2182,7 +2983,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2201,7 +3002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2316,7 +3117,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.23.10+spec-1.0.0",
  "tower",
  "tower-http",
@@ -2391,9 +3192,11 @@ dependencies = [
  "boa_ast",
  "boa_interner",
  "boa_parser",
+ "deterministic-wasi-ctx",
  "futures",
  "hex",
  "javy",
+ "javy-codegen",
  "labby-runtime",
  "labby-winjob",
  "nix",
@@ -2409,6 +3212,9 @@ dependencies = [
  "tracing",
  "ulid",
  "url",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wizer",
 ]
 
 [[package]]
@@ -2448,7 +3254,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
  "tracing-subscriber",
@@ -2476,7 +3282,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2508,6 +3314,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2558,6 +3370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +3412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,10 +3436,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "mime"
@@ -2653,6 +3498,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2702,6 +3553,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2805,6 +3657,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +3726,15 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "par-core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2934,13 +3813,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2950,7 +3859,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2959,11 +3881,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -2972,7 +3903,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -2992,7 +3923,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3100,6 +4031,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,7 +4073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3191,6 +4134,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04adf8f93264685f2c70a3edb8f828c791e71b22659253319c33f29d1165aef"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c120a6af1a574a42efcd9df2ad27cb78bc04118c5e0c69e90599f17301a1c7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3310,6 +4276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,12 +4358,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3431,7 +4432,21 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.0",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -3589,11 +4604,11 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3631,7 +4646,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3708,6 +4723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,6 +4754,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3902,14 +4933,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "sd-notify"
@@ -3962,6 +5005,16 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3990,7 +5043,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4001,7 +5054,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4076,10 +5129,10 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4225,6 +5278,12 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
@@ -4240,6 +5299,20 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "socket2"
@@ -4315,6 +5388,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_enum"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,11 +5415,30 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4344,10 +5447,10 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4357,10 +5460,230 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "swc_allocator"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "rustc-hash",
+]
+
+[[package]]
+name = "swc_atoms"
+version = "9.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845f31910b5236db42dba106e8277681098d183b9b65b8dfa88ca8abe464aeff"
+dependencies = [
+ "hstr",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "swc_common"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176fb11b1abd0a175e8ac47d4b061c5c8a9ae13b9196f30d44fe5db9cb7dfcbd"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
+ "bytes-str",
+ "either",
+ "from_variant",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "siphasher 0.3.11",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_sourcemap",
+ "swc_visit",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_core"
+version = "68.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf1cc6ec61c560d1b46eedb3a00945b48dd4d322ee3dfc5871191b9a463fd19"
+dependencies = [
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "vergen",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207e09f23885ff1f4354ebfdd4e715ccd4a68fca2e7e0df09baafbca850762e"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "once_cell",
+ "phf 0.11.3",
+ "rustc-hash",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "swc_visit",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "41.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f6c9c63026f4d1a70c3c6703446d42ce7b0fe83d4c33b6fe985faf96753f3e"
+dependencies = [
+ "bitflags",
+ "either",
+ "num-bigint",
+ "phf 0.11.3",
+ "rustc-hash",
+ "seq-macro",
+ "serde",
+ "smartstring",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "44.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc20652dd5e4ca9d0b2964eaacfa8e319c51442a4e866fa37c6c367376f0b85b"
+dependencies = [
+ "better_scoped_tls",
+ "indexmap 2.14.0",
+ "once_cell",
+ "par-core",
+ "phf 0.11.3",
+ "rustc-hash",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "31.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04108a8cd1db73a46e8703e146568e4966b4afbecd238fe5cc4a10bf7e39a42e"
+dependencies = [
+ "dragonbox_ecma",
+ "indexmap 2.14.0",
+ "num_cpus",
+ "once_cell",
+ "par-core",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9cb1e958e57fa6427c106674a12190c4578684beee783e3a0508f048d1b372"
+dependencies = [
+ "new_debug_unreachable",
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_eq_ignore_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "swc_macros_common"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "swc_sourcemap"
+version = "10.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c421e5e39e43a4b1b70c07922d7bffd5c22e8eff1340c0b15d0bfd0328822ee"
+dependencies = [
+ "base64-simd",
+ "bitvec",
+ "bytes-str",
+ "data-encoding",
+ "debugid",
+ "if_chain",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "unicode-id-start",
+ "url",
+]
+
+[[package]]
+name = "swc_visit"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
+dependencies = [
+ "either",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4390,7 +5713,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4408,6 +5731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,6 +5746,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -4429,6 +5764,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4457,7 +5801,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4468,7 +5812,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4561,7 +5905,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4614,6 +5958,21 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4775,7 +6134,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4831,6 +6190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4881,6 +6250,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
@@ -4983,7 +6358,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5012,10 +6387,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -5043,6 +6449,34 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "walrus"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cc295c2bf4c34d36c2bbaddee48c56a15de3a35e7021b95ceb6a936a493ac"
+dependencies = [
+ "anyhow",
+ "gimli 0.32.3",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef8d704ff46ad931a2cd1f7a504fe43ffb8e968d931e179ff18d0dff4949bd5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5120,7 +6554,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5134,13 +6568,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wat",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5151,8 +6632,48 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-opt"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
+dependencies = [
+ "anyhow",
+ "libc",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "tempfile",
+ "thiserror 1.0.69",
+ "wasm-opt-cxx-sys",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-cxx-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -5178,6 +6699,411 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli 0.33.0",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439686d3deb38525c86b88bbc90f7ba669f70c8edc7d6b35147c738bbef5ff76"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.33.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2799e6c35393c2a38999f13e4c80ab5d5d9756082bb554cbd1f60485a18293"
+dependencies = [
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d2c5850fb8c448792453765d97f6f01096a32708f3c36798e86220763c90c0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed79c4e9ab416dcc5e46b9d1ec9b7c2e3c730deab525996b0de45a35fc8b2c3"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a15981261d361f9c93b42929f446b4009840853ceea181ad6e17730f4016a0b"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.33.0",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33aed9d91d54c9f861ba7e3c3130bded8a7a63e01fe58c3a9a36b45d6ee0fb57"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944942118aab67e7b4febfe88a65d0af4cfd10af8ed0e79fd6cf39d75359ab7e"
+dependencies = [
+ "cc",
+ "object",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a83f7ebe911a6f1605ff0d3a678472ddb1fcc57c3e2f6bae5dd4d170b625b3ed"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75980644456dc003238766254b0e5f002704630237ccd0728747991fe2739d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81af36995b4720b32e3d667541b548a27184a859d09a6ee745eaba095f5a6f6e"
+dependencies = [
+ "cranelift-codegen",
+ "gimli 0.33.0",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada06667b7948892703fcc9f0b9b337c2e78c334d74d4fa62e2f75f07fbb3659"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e9db77f7b60f4c5f6f72847f55eb646ed7ed2f68e362559ee07dc543fb408"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-std",
+ "cap-time-ext",
+ "cfg-if",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rand 0.10.1",
+ "rustix",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3805f02be91374a4fd02c0f947daf07bbaa6fbebb5909de5305fa5b0e9568f30"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
+name = "wasmtime-wizer"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0e65e225ac29e92d2b29aa2e23757bddf0d4da594ed94213d32bcee39a2b2a"
+dependencies = [
+ "log",
+ "rayon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmtime",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "252.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.252.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+dependencies = [
+ "wast 252.0.0",
 ]
 
 [[package]]
@@ -5228,6 +7154,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiggle"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aca130e25a57e29bbb541441b6e261970a8469580bffebe904d96f0df67e41d"
+dependencies = [
+ "bitflags",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wasmtime-environ",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0a45b47e893521cad81819f2e0db18a8b05086fd4bfb35369ed8830a8f0148"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-environ",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e297e0325cffa6d368386b6e672e9d6c6a7ad34bdb8a5f49319db4decef2a990"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wiggle-generate",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5257,6 +7223,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73bc25d27222248f9bafc7e9945f61e74275360c3ea0d34008810d436140a53"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli 0.33.0",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "windows"
@@ -5311,7 +7296,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5322,7 +7307,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5618,6 +7603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,8 +7657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
- "wit-parser",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5673,10 +7668,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5692,7 +7687,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5710,10 +7705,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5731,7 +7726,38 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]
@@ -5739,6 +7765,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"
@@ -5775,7 +7810,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5796,7 +7831,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5816,7 +7851,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5858,7 +7893,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5866,3 +7901,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/labby-codemode/Cargo.toml
+++ b/crates/labby-codemode/Cargo.toml
@@ -37,6 +37,16 @@ url.workspace = true
 javy = { version = "7.0.0" }
 anyhow = "1"
 
+# Wasmtime dual-sandbox spike path. The published `javy-codegen = 4.0.0`
+# depends on Wasmtime/WASI 42 and fails the current RustSec gates. Javy v9 tags
+# an unpublished `javy-codegen = 4.0.1-alpha.1`; keep it pinned to the release
+# tag and force the patched Wasmtime/WASI 45 line during the spike.
+javy-codegen = { git = "https://github.com/bytecodealliance/javy", tag = "v9.0.0", version = "4.0.1-alpha.1" }
+deterministic-wasi-ctx = "=4.0.3"
+wasmtime = "=45.0.3"
+wasmtime-wasi = "=45.0.3"
+wasmtime-wizer = { version = "=45.0.3", features = ["wasmtime"] }
+
 # JavaScript AST normalization (export-shape detection in normalize.rs).
 boa_ast = "0.21.1"
 boa_interner = "0.21.1"

--- a/deny.toml
+++ b/deny.toml
@@ -76,11 +76,27 @@ wrappers = [
     "labby-gateway",
     "agent-client-protocol",
     "agent-client-protocol-schema",
+    "deterministic-wasi-ctx",
+    "ittapi",
     "javy",
+    "javy-codegen",
+    "swc_common",
+    "vergen",
+    "vergen-lib",
+    "walrus",
+    "wasm-compose",
+    "wasm-opt",
+    "wasm-opt-cxx-sys",
+    "wasm-opt-sys",
     "wasmprinter",
     "wasmtime-environ",
+    "wasmtime-internal-component-macro",
+    "wasmtime-internal-core",
+    "wasmtime-internal-wit-bindgen",
+    "wit-parser",
+    "witx",
 ]
-reason = "lab-apis uses `thiserror`. anyhow is for the binary only."
+reason = "lab-apis uses `thiserror`. anyhow is allowed at binary, Code Mode Javy/codegen, and upstream protocol boundaries only."
 
 [[bans.deny]]
 name = "tabled"
@@ -90,4 +106,4 @@ reason = "Binary-only: table formatting happens in `lab/src/output.rs`, not lab-
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/bytecodealliance/javy"]

--- a/docs/dev/CODE_MODE_WASMTIME_SPIKE.md
+++ b/docs/dev/CODE_MODE_WASMTIME_SPIKE.md
@@ -157,3 +157,58 @@ The production workspace should not retain the spike dependencies after this
 check. Keep this document as the durable artifact, and keep `Cargo.toml` /
 `Cargo.lock` clean until a dependency path passes both compilation and the
 security gates.
+
+## Javy v9 Git Spike
+
+Status: viable dependency path.
+
+The crates.io `javy-codegen 4.0.0` path is blocked by Wasmtime/WASI 42, but the
+Javy repository has moved forward. Javy `v9.0.0` contains an unpublished
+`javy-codegen 4.0.1-alpha.1` package in `crates/codegen`.
+
+Upstream facts verified on 2026-07-02:
+
+- Javy `v9.0.0` workspace pins `deterministic-wasi-ctx = "=4.0.3"` and uses the
+  Wasmtime/WASI/Wizer 45 family.
+- Javy `v9.0.0` `crates/codegen/Cargo.toml` declares
+  `javy-codegen = "4.0.1-alpha.1"`.
+- Patched Wasmtime/WASI `45.0.3` crates exist on crates.io and satisfy the
+  RustSec patched ranges relevant to the previous Wasmtime/WASI 42 blocker.
+
+The Lab spike dependency set is:
+
+```toml
+javy-codegen = { git = "https://github.com/bytecodealliance/javy", tag = "v9.0.0", version = "4.0.1-alpha.1" }
+deterministic-wasi-ctx = "=4.0.3"
+wasmtime = "=45.0.3"
+wasmtime-wasi = "=45.0.3"
+wasmtime-wizer = { version = "=45.0.3", features = ["wasmtime"] }
+```
+
+Expected verification:
+
+```bash
+cargo check -p labby-codemode --all-features
+cargo deny check
+cargo audit
+```
+
+Verification result on 2026-07-02:
+
+- `cargo check -p labby-codemode --all-features` passed in 6m31s.
+- `cargo deny check` passed after explicitly allowing the reviewed Javy Git
+  source and extending the existing `anyhow` wrapper policy to the Javy/Wasmtime
+  codegen dependency boundary.
+- `cargo audit` still reports the existing workspace baseline advisories for
+  `quinn-proto` and `rsa`, plus the allowed `paste` warning. It does not report
+  the Wasmtime/WASI 42 advisories from the crates.io `javy-codegen 4.0.0` path.
+
+Notes to carry into production implementation:
+
+- Wasmtime/WASI 45.0.3 raises the effective dependency Rust floor to 1.93.0;
+  this is acceptable for Lab's current stable Rust 1.96.0 workflow.
+- The dependency graph pulls native `wasm-opt` build dependencies and is
+  substantially heavier than the current subprocess-only Javy runtime path;
+  the first focused `labby-codemode` check took 6m31s.
+- This relies on a Git tag until Bytecode Alliance publishes
+  `javy-codegen 4.0.1+` to crates.io.

--- a/docs/dev/CODE_MODE_WASMTIME_SPIKE.md
+++ b/docs/dev/CODE_MODE_WASMTIME_SPIKE.md
@@ -1,0 +1,159 @@
+# Code Mode Wasmtime Spike
+
+Date: 2026-07-02
+
+## Version Pins
+
+| Crate | Exact version | Why compatible | Source |
+|---|---:|---|---|
+| javy-codegen | =4.0.0 | Current crates.io release. Provides `Generator::new(plugin)`, `Generator::linking(LinkingKind::Dynamic)`, and async `Generator::generate(&JS)` for dynamic JS-to-Wasm modules. | `cargo search` on 2026-07-02; `~/.cargo/registry/src/.../javy-codegen-4.0.0/src/lib.rs:183-228,283-363,450-468`; <https://docs.rs/javy-codegen/4.0.0> |
+| wasmtime | =46.0.1 | Current crates.io release. Declares `rust-version = 1.94.0`, compatible with this repo's Rust 1.94.1 toolchain. Provides the fuel, epoch, engine, module, store, memory, and resource-limiter APIs needed by later tasks. | `cargo search` / `cargo info` on 2026-07-02; `~/.cargo/registry/src/.../wasmtime-46.0.1/src/config.rs:612,733`; `runtime/store.rs:1014,1041,1105,1136,1168`; `engine.rs:854`; <https://docs.rs/wasmtime/46.0.1> |
+| wasmtime-wizer | =46.0.1 | Current crates.io release. Declares `rust-version = 1.94.0`, compatible with this repo. Exposes a Rust `Wizer` API with the `wasmtime` feature; no CLI shell invocation is required by the library path. | `cargo search` / `cargo info` on 2026-07-02; `~/.cargo/registry/src/.../wasmtime-wizer-46.0.1/src/lib.rs:128-166`; `src/wasmtime.rs:7-27`; <https://docs.rs/wasmtime-wizer/46.0.1> |
+| deterministic-wasi-ctx | =4.0.0 | Required compatibility pin for `javy-codegen 4.0.0`. Without an exact pin, Cargo selects `4.0.4`, which depends on Wasmtime/WASI 46 while `javy-codegen` depends on Wasmtime/WASI 42, producing a type mismatch in `WasiCtxBuilder`. | Scratch compile proof below; `~/.cargo/registry/src/.../deterministic-wasi-ctx-4.0.0/Cargo.toml`; `javy-codegen-4.0.0/Cargo.toml` |
+
+## Dynamic Linking API
+
+Verified from `javy-codegen 4.0.0` source:
+
+- `Plugin::new(bytes: Cow<'static, [u8]>) -> anyhow::Result<Plugin>`
+- `Plugin::new_from_path<P: AsRef<Path>>(path: P) -> anyhow::Result<Plugin>`
+- `Plugin::as_bytes(&self) -> &[u8]`
+- `Generator::new(plugin: Plugin) -> Generator`
+- `Generator::linking(&mut self, LinkingKind::Dynamic) -> &mut Self`
+- `Generator::source_embedding(&mut self, SourceEmbedding) -> &mut Self`
+- `Generator::producer_version(&mut self, String) -> &mut Self`
+- `Generator::deterministic(&mut self, bool) -> &mut Self`
+- `Generator::generate(&mut self, js: &JS) -> anyhow::Result<Vec<u8>>` is async.
+
+Dynamic mode adds imports in the plugin namespace for:
+
+- `cabi_realloc(i32, i32, i32, i32) -> i32`
+- `invoke(i32, i32, i32, i32, i32) -> ()`
+- imported memory named `memory`
+
+The generated dynamic module exports `_start`.
+
+## Wizer Invocation
+
+`wasmtime-wizer 46.0.1` exposes a Rust library API when built with the `wasmtime` feature:
+
+```rust
+Wizer::new()
+    .init_func("initialize-runtime")
+    .run(&mut store, plugin_bytes, async |store, module| {
+        // instantiate module and return wasmtime::Instance
+    })
+    .await
+```
+
+The `run` signature is:
+
+```rust
+pub async fn run<T: Send>(
+    &self,
+    store: &mut wasmtime::Store<T>,
+    wasm: &[u8],
+    instantiate: impl AsyncFnOnce(&mut wasmtime::Store<T>, &wasmtime::Module)
+        -> wasmtime::Result<wasmtime::Instance>,
+) -> wasmtime::Result<Vec<u8>>
+```
+
+Implication for `build.rs`: a shell command is not required, but the build script must drive this async API. Use an explicit runtime/block-on helper rather than assuming synchronous Wizer calls exist.
+
+## Wasmtime Limits
+
+Verified from `wasmtime 46.0.1` source:
+
+- Engine configuration:
+  - `wasmtime::Config::consume_fuel(&mut self, bool) -> &mut Self`
+  - `wasmtime::Config::epoch_interruption(&mut self, bool) -> &mut Self`
+  - `wasmtime::Config::async_support(&mut self, bool) -> &mut Self`
+- Per-store fuel:
+  - `wasmtime::Store::set_fuel(&mut self, u64) -> wasmtime::Result<()>`
+  - `wasmtime::Store::get_fuel(&self) -> wasmtime::Result<u64>`
+  - Wasmtime docs state stores start with 0 fuel when fuel is enabled and will trap when fuel is consumed.
+- Epoch interruption:
+  - `wasmtime::Engine::increment_epoch(&self)`
+  - `wasmtime::Store::set_epoch_deadline(&mut self, u64)`
+  - `wasmtime::Store::epoch_deadline_trap(&mut self)`
+  - `wasmtime::Store::epoch_deadline_callback(...)`
+  - Wasmtime docs state a deadline must be configured or the store immediately traps.
+- Memory limiting:
+  - `wasmtime::Store::limiter(...)`
+  - `wasmtime::ResourceLimiter::memory_growing(&mut self, current: usize, desired: usize, maximum: Option<usize>) -> wasmtime::Result<bool>`
+  - `ResourceLimiter` docs state it limits WebAssembly instance resources, not every embedder allocation.
+
+## Local Build Proof
+
+Initial scratch proof:
+
+```bash
+rm -rf /tmp/labby-wasmtime-spike
+mkdir -p /tmp/labby-wasmtime-spike
+cd /tmp/labby-wasmtime-spike
+cargo init --bin
+cargo add javy-codegen@=4.0.0 wasmtime@=46.0.1 wasmtime-wizer@=46.0.1
+cargo check
+```
+
+Result: failed. Cargo selected `deterministic-wasi-ctx 4.0.4`, which pulled `wasmtime-wasi 46.0.1`. `javy-codegen 4.0.0` itself depends on `wasmtime-wasi 42`, and compilation failed at `javy-codegen/src/lib.rs:244` because `deterministic_wasi_ctx::add_determinism_to_wasi_ctx_builder` expected the 46.x `WasiCtxBuilder` while Javy passed the 42.x type.
+
+Fixed scratch proof:
+
+```bash
+cd /tmp/labby-wasmtime-spike
+cargo update -p deterministic-wasi-ctx --precise 4.0.0
+cargo check
+```
+
+Result: passed.
+
+```text
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.41s
+```
+
+Open question for implementation: `javy-codegen 4.0.0` internally uses Wasmtime/WASI/Wizer 42 to build generated modules, while Lab's runtime side will use Wasmtime 46 to compile and run emitted Wasm bytes. The scratch build proves the crates can coexist, but Task 3 must still prove the emitted plugin/snippet modules compile under a `wasmtime 46.0.1` `Engine`.
+
+## Security Gate Result
+
+Status: blocked.
+
+After adding the exact pins to `crates/labby-codemode/Cargo.toml`, the real repo check passed:
+
+```bash
+cargo check -p labby-codemode --all-features
+```
+
+Result:
+
+```text
+Finished `dev` profile [unoptimized] target(s) in 3m 46s
+```
+
+The required security gates failed:
+
+```bash
+cargo deny check
+cargo audit
+```
+
+New blocker introduced by the spike dependency set:
+
+- `javy-codegen 4.0.0` depends on `wasmtime = "42"`, `wasmtime-wasi = "42"`, and `wasmtime-wizer = "42"`.
+- Current RustSec advisories flag the resulting `wasmtime 42.0.2` and `wasmtime-wasi 42.0.2` lockfile entries:
+  - `RUSTSEC-2026-0114` / GHSA-p8xm-42r7-89xg: Wasmtime table allocation panic.
+  - `RUSTSEC-2026-0149` / GHSA-2r75-cxrj-cmph: WASI `path_open(TRUNCATE)` bypasses `FilePerms::WRITE`.
+  - `RUSTSEC-2026-0182` / GHSA-3p27-qvp9-27qf: WASIp1 `fd_renumber` leak.
+  - `RUSTSEC-2026-0188` / GHSA-4ch3-9j33-3pmj: WASI hard links and renames bypass destination `FilePerms`.
+
+`cargo audit` also reported pre-existing workspace advisories for `quinn-proto`
+and `rsa`, plus the existing allowed `paste` unmaintained warning, but the
+Wasmtime/WASI 42 findings are directly introduced by this spike path and block
+this plan's stated security gate.
+
+Conclusion: do not proceed to Task 3 with `javy-codegen 4.0.0` as a production dependency unless the security policy is deliberately changed, Javy publishes a compatible release on a patched Wasmtime/WASI line, or the architecture changes to avoid compiling the vulnerable Wasmtime/WASI 42 dependency tree into this workspace.
+
+The production workspace should not retain the spike dependencies after this
+check. Keep this document as the durable artifact, and keep `Cargo.toml` /
+`Cargo.lock` clean until a dependency path passes both compilation and the
+security gates.

--- a/docs/superpowers/plans/2026-07-02-codemode-wasmtime-dual-sandbox.md
+++ b/docs/superpowers/plans/2026-07-02-codemode-wasmtime-dual-sandbox.md
@@ -1,0 +1,1059 @@
+# Code Mode Wasmtime Dual-Sandbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the native `javy::Runtime` execution inside the existing Code Mode runner subprocess with QuickJS-in-Wasm under Wasmtime, preserving the subprocess jail while adding Wasm linear-memory containment, epoch interruption, and fuel telemetry.
+
+**Architecture:** Keep the existing parent-owned `CodeModeBroker` and `CodeModeHost` authority in the parent process. The child runner executes one QuickJS-in-Wasm instance per `Start` message and continues to emit the existing parent/runner stdio protocol messages for `callTool`, `writeArtifact`, and `codemode.run`; this avoids moving gateway credentials, upstream pools, snippets, or artifact store authority into the sandbox process. A shared Wasmtime `Engine`, compiled plugin `Module`, and epoch ticker are initialized once per runner subprocess, while every execution gets a fresh `Store`/`Instance`.
+
+**Tech Stack:** Rust 2024, Tokio, Wasmtime, `javy-codegen`, `wasmtime-wizer`, existing Code Mode stdio protocol, existing `CodeModeBroker` / `CodeModeHost`, `cargo-nextest`, `cargo-deny`, `cargo-audit`.
+
+## Global Constraints
+
+- Base implementation from `origin/main` or a known-green integration branch. Do not stack this epic on `feat/codemode-semantic-search` until that branch passes `cargo check -p labby-gateway --all-features`; reviewers found source-level compile drift around `ToolsRender.fingerprint` and `CodeModeHost::semantic_rank`.
+- Preserve the accepted rationale exactly: this is "defense-in-depth + graceful interruption", not "fixes a security hole" and not "the current design cannot cleanly kill a hung script".
+- Preserve the outer subprocess boundary: `env_clear()`, process group / Job Object reaping, `kill_on_drop`, `PR_SET_DUMPABLE`, per-execution cwd jail, runner recycle-after-K, pool backpressure, and parent-side 30s wall-clock kill+evict remain intact.
+- Per Code Mode execution, exactly one JS engine runs caller code: QuickJS compiled to Wasm and executed by Wasmtime inside the existing runner subprocess.
+- Do not move `GatewayManager`, `UpstreamPool`, OAuth subjects, snippet storage, artifact persistence, or `CodeModeHost` implementations into the child process.
+- The child process may use Wasmtime, but host calls still cross the existing parent/child stdio protocol. Do not implement `Linker::func_wrap_async` calls that directly call parent-side `CodeModeHost` from the child.
+- Keep caller-facing error kind stable as `timeout` for Wasmtime fuel/epoch traps and OS wall-clock timeout. Add internal/log fields such as `trap_cause = "fuel_exhausted" | "epoch_interrupted" | "os_subprocess_timeout"` for operators.
+- New public kind `code_mode_fuel_exhausted` is out of scope unless the error contract is deliberately changed in `docs/dev/ERRORS.md` before code lands.
+- Exact dependency versions must be pinned after the research spike. Do not write broad `"46"` or `"46.x"` version requirements into `Cargo.toml`.
+- No committed binary `.wasm` artifact in v1. Use build-from-source / build-time generation first; Git LFS and reproducible binary artifact flow are deferred unless measured build cost forces a different decision.
+- Keep files under the crate's 500 LOC convention. Add new sibling files under `crates/labby-codemode/src/` rather than growing `runner.rs`, `runner_drive.rs`, `pool.rs`, or `execute.rs`.
+- Every task must leave an independently testable state. Commit after each task.
+
+---
+
+## File Structure
+
+- `crates/labby-codemode/CLAUDE.md`
+  - Modify twice: first to remove stale implementation guidance after bead/spec cleanup, and finally to match the implemented runtime.
+- `docs/dev/CODE_MODE.md`
+  - Modify final public runtime docs.
+- `docs/dev/ERRORS.md`
+  - Modify timeout/trap-cause contract.
+- `docs/dev/OBSERVABILITY.md`
+  - Modify Code Mode trap/timeout logging fields.
+- `crates/labby-codemode/Cargo.toml`
+  - Add exact `wasmtime`, `javy-codegen`, and `wasmtime-wizer` dependencies after spike verification.
+- `crates/labby-codemode/build.rs`
+  - Create if the spike confirms the plugin module can be generated at build time.
+- `crates/labby-codemode/src/wasm_plugin.rs`
+  - Create: loads embedded plugin bytes, exposes cache-key/version metadata, validates a `wasmtime::Module`.
+- `crates/labby-codemode/src/wasm_engine.rs`
+  - Create: one `wasmtime::Engine`, epoch ticker handle, watchdog liveness state, and engine config per runner subprocess.
+- `crates/labby-codemode/src/wasm_runner.rs`
+  - Create: per-execution `Store`/`Instance`, JS snippet compile/link/instantiate/run, fuel/epoch/memory trap mapping, result/log extraction.
+- `crates/labby-codemode/src/wasm_bridge.rs`
+  - Create: Wasm guest memory readers/writers and bridge shims that emit existing `CodeModeRunnerOutput::{ToolCall, ArtifactWrite, SnippetResolve}` messages, then wait for existing `CodeModeRunnerInput` replies.
+- `crates/labby-codemode/src/runner.rs`
+  - Modify: initialize Wasmtime engine/plugin/ticker once before the `Start` loop; replace per-execution native `javy::Runtime` execution with `wasm_runner`.
+- `crates/labby-codemode/src/runner_drive.rs`
+  - Modify: classify reusable fuel/epoch traps as `ExecutionError`, classify dead watchdog / protocol faults as `RunnerUnhealthy`, preserve OS timeout kill+evict.
+- `crates/labby-codemode/src/protocol.rs`
+  - Prefer no changes. If a trap-cause field is unavoidable, add serde-defaulted fields only.
+- `crates/labby-codemode/src/pool/runner_handle.rs`
+  - Modify stale memory comment and add any runner-start health signal handling if needed.
+- `crates/labby/tests/code_mode_runner.rs`
+  - Modify/add parity, trap, reuse, host-call, and memory-bound tests.
+- `deny.toml`
+  - Modify only if `cargo deny check` proves the new dependency tree requires license/advisory/allowlist updates.
+
+---
+
+## Engineering Review Summary
+
+### Architecture
+
+Strengths:
+- The corrected rationale and replace-not-parallel topology are sound.
+- The outer subprocess jail remains the authoritative containment boundary.
+- Engine/plugin/ticker per subprocess plus Store/Instance per execution preserves warm-pool economics and state isolation.
+
+Critical concern:
+- The prior bead text says Wasmtime linker imports call parent-side `CodeModeHost` directly while Wasmtime runs in the child subprocess. That is impossible without moving host authority into the child. This plan resolves it by keeping stdio IPC as the host-call transport.
+
+### Simplicity
+
+Over-engineering risks:
+- A "fallback to today's native QuickJS path" kill switch would keep two engines and two bridge implementations alive. This plan rejects that as v1 scope.
+- On-disk plugin cache, committed plugin artifact, LFS, and reproducible binary diffing are deferred until measured build cost demands them.
+
+### Security
+
+Missing protections to keep blocking:
+- Exact dependency pins, `cargo deny check`, and `cargo audit` must run before production code lands.
+- Wasm guest memory reads must enforce OOB, cap-before-copy, and UTF-8 validation before host allocation or artifact validation.
+- Trap causes must be logged internally without creating new caller-facing error kinds.
+
+### Performance
+
+Bottlenecks to test:
+- Engine/ticker must never be constructed per execution.
+- Trap paths must prove subprocess reuse after fuel/epoch interruption.
+- Benchmark output must split compile+link+instantiate, execution/fuel overhead, and total end-to-end latency through the pool.
+
+### Failure Modes
+
+| Codepath | Failure Mode | Rescued? | Test? | User Sees? | Logged? |
+|---|---|---:|---:|---|---:|
+| plugin build/load | pinned versions drift or plugin bytes stale | Y, hard build/start failure | Y | Code Mode unavailable/build fails | Y |
+| engine startup | Engine/ticker created per execution | N | Y | latency regression | Y |
+| watchdog | epoch ticker dies silently | partial, OS timeout remains | Y | slower timeout | Y |
+| fuel trap | legitimate JSON-heavy snippet traps | partial, user can tune/retry | Y | `timeout` | Y |
+| epoch trap | trap poisons subprocess | Y if runner reusable test passes | Y | possible latency spike | Y |
+| host-call bridge | child tries direct parent host call | N | Y | every `callTool` fails | Y |
+| Wasm memory read | bad ptr/len or non-UTF8 panics/allocates | N unless bounded read implemented | Y | structured rejection if fixed | Y |
+| OS wall timeout | malicious/hung code ignores in-process traps | Y, kill+evict outer ring | existing + Y | `timeout` | Y |
+
+Rows without both rescue and tests are plan blockers; Task 1 rewrites the beads to make these explicit before implementation.
+
+### NOT In Scope
+
+- Retiring the subprocess pool: the pool remains the outer containment and performance boundary.
+- Native QuickJS fallback mode: keeping the old engine as an emergency rollback creates a dual-engine maintenance fork.
+- Committed binary plugin artifact / Git LFS flow: defer unless build-time measurements make it necessary.
+- Store/Instance reuse optimization: defer until benchmarks prove per-execution instantiation is material.
+- New caller-facing `code_mode_fuel_exhausted` kind: keep `timeout` externally and use internal trap cause fields.
+- Query/cache optimizations unrelated to Wasmtime: handle separately after the semantic-search branch is green.
+
+---
+
+## Task 1: Reconcile Issue And Bead Specs Before Code
+
+**Files:**
+- Modify: bead descriptions via `bd update`, not source code
+- Modify: GitHub issue #168 body/comments only if needed after bead updates
+- Test: `bd show lab-crav6`, `bd list --parent lab-crav6 --json`, `bd swarm validate lab-crav6`
+
+**Interfaces:**
+- Produces: an implementation-ready `lab-crav6` bead chain with no contradiction between description and comments.
+- Produces: locked decisions:
+  - Wasmtime runs inside the child subprocess.
+  - Host calls use existing stdio IPC; no direct child-to-parent `CodeModeHost` calls.
+  - Kill switch disables Wasmtime limits only, or is removed; it does not promise native QuickJS fallback.
+  - Exact pins and security gates are blocking in early beads.
+
+- [ ] **Step 1: Snapshot current epic and child text**
+
+```bash
+bd show lab-crav6 > /tmp/lab-crav6.before.txt
+bd list --parent lab-crav6 --json > /tmp/lab-crav6.children.before.json
+for id in lab-crav6.1 lab-crav6.2 lab-crav6.3 lab-crav6.4 lab-crav6.5 lab-crav6.6; do
+  bd show "$id" > "/tmp/${id}.before.txt"
+done
+```
+
+Expected: files exist in `/tmp` and include the stale text that still mentions "alongside", legacy `wizer`, broad "46.x", and native fallback.
+
+- [ ] **Step 2: Update `lab-crav6.6` to stdio-backed Wasm bridge**
+
+Replace the bead's direct `CodeModeHost`/`Linker::func_wrap_async` requirement with:
+
+```markdown
+The Wasmtime runner lives in the child subprocess. Parent-owned host authority stays in the parent process. The Wasm bridge must expose guest functions that serialize the same `CodeModeRunnerOutput::{ToolCall, ArtifactWrite, SnippetResolve}` messages the native runner emits today, then block/poll for the matching existing `CodeModeRunnerInput` reply. Do not call `CodeModeHost` directly from the child.
+```
+
+Run:
+
+```bash
+bd update lab-crav6.6 -d "$(python - <<'PY'
+from pathlib import Path
+text = Path('/tmp/lab-crav6.6.before.txt').read_text()
+text = text.replace('Uses `Config::async_support(true)` + `Linker::func_wrap_async` — do not\\n  reimplement a second seq-numbered pending-operation map to shim around\\n  synchronous linker imports (this was the alternative architecture-strategist\\n  explicitly recommended against).', 'Uses the existing parent/runner stdio protocol for host authority. The child-side Wasm bridge emits the same `CodeModeRunnerOutput` messages and waits for the same `CodeModeRunnerInput` replies as the native runner. Do not move `CodeModeHost`/gateway authority into the child process.')
+text += '\\n\\n## Engineering Review Reconciliation - 2026-07-02\\n\\nLocked correction: Wasmtime runs in the child subprocess, but host calls remain parent-owned over the existing stdio protocol. Direct async linker imports into parent-side `CodeModeHost` are out of scope and would violate the subprocess boundary. Required tests: callTool parity, writeArtifact parity, codemode.run parity, OOB ptr/len, cap-before-copy, non-UTF8 rejection, and guest-sourced path traversal.\\n'
+print(text)
+PY
+)"
+```
+
+Expected: `bd show lab-crav6.6` no longer requires direct async `CodeModeHost` calls from the child.
+
+- [ ] **Step 3: Update `lab-crav6.4` kill-switch wording**
+
+Set the v1 switch contract to one of these explicit outcomes:
+
+```markdown
+V1 kill switch: `LAB_CODE_MODE_WASM_LIMITS=0` disables fuel/epoch enforcement while keeping the Wasmtime execution path. It does not restore the native `javy::Runtime` path. Native QuickJS fallback is a separate rollback strategy, not a runtime mode.
+```
+
+Run:
+
+```bash
+bd comments add lab-crav6.4 "DECISION: Kill switch wording corrected. V1 switch disables Wasmtime fuel/epoch enforcement only; it does not promise byte-identical native QuickJS fallback because the locked topology replaces native javy::Runtime rather than keeping two engines alive."
+```
+
+Expected: implementers cannot read the bead as requiring a dual-engine fallback.
+
+- [ ] **Step 4: Update dependency wording in `lab-crav6.1`, `.2`, `.5`**
+
+Add comments:
+
+```bash
+bd comments add lab-crav6.1 "DECISION: Spike starts from current cargo search pins javy-codegen =4.0.0, wasmtime =46.0.1, and wasmtime-wizer =46.0.1, then must prove API compatibility from current source/docs before Cargo.toml changes land. Broad 46.x family references are not implementation guidance."
+bd comments add lab-crav6.2 "DECISION: Build-from-source build.rs/include_bytes flow is the v1 default. Startup/on-disk cache, committed plugin.wasm, Git LFS, and reproducible binary diffing are deferred unless measured build cost requires them."
+bd comments add lab-crav6.5 "DECISION: Docs closeout must depend on lab-crav6.6 explicitly and must describe stdio-backed host calls, not direct CodeModeHost calls from the child subprocess."
+```
+
+Expected: comments are attached to each bead.
+
+- [ ] **Step 5: Validate dependency chain**
+
+```bash
+bd swarm validate lab-crav6
+```
+
+Expected: valid sequential chain. If `lab-crav6.5` does not depend on `lab-crav6.6`, add the missing dependency:
+
+```bash
+bd dep add lab-crav6.5 lab-crav6.6
+bd swarm validate lab-crav6
+```
+
+- [ ] **Step 6: Commit if bead metadata is repo-backed**
+
+```bash
+git status --short
+git add .beads 2>/dev/null || true
+git commit -m "docs: reconcile codemode wasmtime epic review findings"
+```
+
+Expected: commit succeeds if bead storage changed in-repo; if beads are not stored in the worktree, there is nothing to commit.
+
+---
+
+## Task 2: Research Spike And Version Lock
+
+**Files:**
+- Create: `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`
+- Modify: `crates/labby-codemode/Cargo.toml` only in a throwaway verification branch or after exact pins are known
+- Test: `cargo check -p labby-codemode --all-features`, `cargo deny check`, `cargo audit`
+
+**Interfaces:**
+- Produces: exact dependency pins and API signatures for later tasks.
+- Produces: a durable doc table with source links, version pins, invocation model, and local build proof.
+
+- [ ] **Step 1: Verify current crate metadata from primary sources**
+
+Use current docs/source, not memory:
+
+```bash
+cargo search javy-codegen --limit 5
+cargo search wasmtime --limit 5
+cargo search wasmtime-wizer --limit 5
+```
+
+Expected: identify current crate versions available on July 2, 2026.
+
+- [ ] **Step 2: Create spike doc**
+
+Create `docs/dev/CODE_MODE_WASMTIME_SPIKE.md` with this structure:
+
+```markdown
+# Code Mode Wasmtime Spike
+
+## Version Pins
+
+| Crate | Exact version | Why compatible | Source |
+|---|---:|---|---|
+| javy-codegen | =4.0.0 | Confirm dynamic-linking API against docs/source | cargo search on 2026-07-02, then docs.rs/GitHub verification |
+| wasmtime | =46.0.1 | Confirm fuel/epoch/memory APIs against docs/source | cargo search on 2026-07-02, then docs.rs/GitHub verification |
+| wasmtime-wizer | =46.0.1 | Confirm build-time Wizer invocation model against docs/source | cargo search on 2026-07-02, then docs.rs/GitHub verification |
+
+## Dynamic Linking API
+
+List exact module paths, function names, and signatures verified from docs/source.
+
+## Wizer Invocation
+
+State whether build.rs uses library API or CLI, and include the exact command/API call.
+
+## Wasmtime Limits
+
+List exact Config/Store/Engine methods for fuel, epoch, and memory limiting.
+
+## Local Build Proof
+
+Commands run, output summary, and open questions.
+```
+
+- [ ] **Step 3: Run a scratch compile proof**
+
+Use a throwaway branch or temporary directory. Do not leave scratch production code in `crates/labby-codemode/src`.
+
+```bash
+mkdir -p /tmp/labby-wasmtime-spike
+cd /tmp/labby-wasmtime-spike
+cargo init --bin
+cargo add javy-codegen@=4.0.0 wasmtime@=46.0.1 wasmtime-wizer@=46.0.1
+cargo check
+```
+
+Expected: PASS with the exact pins recorded in the spike doc. If it fails, update the pins or stop the epic.
+
+2026-07-02 result: the compile proof only passes when `deterministic-wasi-ctx`
+is pinned to `=4.0.0`, because `javy-codegen 4.0.0` is internally on
+Wasmtime/WASI 42 while newer `deterministic-wasi-ctx 4.0.4` pulls Wasmtime/WASI
+46. The passing compile proof is not enough to proceed because the security gate
+below fails on the Wasmtime/WASI 42 dependency tree.
+
+- [ ] **Step 4: Run security gates after adding dependencies in the real repo**
+
+```bash
+cargo check -p labby-codemode --all-features
+cargo deny check
+cargo audit
+```
+
+Expected: PASS. If `cargo audit` is unavailable, install or document the exact reason it cannot run before proceeding.
+
+2026-07-02 result: BLOCKED. `cargo check -p labby-codemode --all-features`
+passes with the spike dependencies, but `cargo deny check` and `cargo audit`
+flag RustSec advisories introduced by `javy-codegen 4.0.0`'s transitive
+Wasmtime/WASI 42 dependencies. Do not proceed to Task 3 by adding advisory
+ignores. The safe next step is one of:
+
+- wait for a Javy release whose codegen path uses a patched Wasmtime/WASI line;
+- move JS-to-Wasm compilation outside the production workspace dependency tree
+  with a separately pinned and reviewed tool artifact;
+- change the architecture away from Javy-to-Wasm.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/dev/CODE_MODE_WASMTIME_SPIKE.md docs/superpowers/plans/2026-07-02-codemode-wasmtime-dual-sandbox.md
+git commit -m "docs(codemode): capture wasmtime spike blocker"
+```
+
+Expected: a docs-only commit. `crates/labby-codemode/Cargo.toml`, `Cargo.lock`,
+and `deny.toml` should remain unchanged unless the security gate above passes.
+
+---
+
+## Task 3: Build And Load The Shared QuickJS Wasm Plugin
+
+**Files:**
+- Create: `crates/labby-codemode/build.rs`
+- Create: `crates/labby-codemode/src/wasm_plugin.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/CLAUDE.md`
+- Test: inline tests in `wasm_plugin.rs`
+
+**Interfaces:**
+- Produces: `wasm_plugin::plugin_bytes() -> &'static [u8]`
+- Produces: `wasm_plugin::plugin_cache_key() -> &'static str`
+- Produces: `wasm_plugin::compile_plugin_module(engine: &wasmtime::Engine) -> Result<wasmtime::Module, ToolError>`
+
+- [ ] **Step 1: Write failing loader test**
+
+Add to `crates/labby-codemode/src/wasm_plugin.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_bytes_are_non_empty_and_keyed() {
+        assert!(!plugin_bytes().is_empty());
+        assert!(plugin_cache_key().contains("javy-codegen"));
+        assert!(plugin_cache_key().contains("wasmtime"));
+        assert!(plugin_cache_key().contains("wasmtime-wizer"));
+    }
+
+    #[test]
+    fn plugin_module_compiles_under_wasmtime() {
+        let engine = wasmtime::Engine::default();
+        let module = compile_plugin_module(&engine).expect("plugin module compiles");
+        assert!(module.imports().count() > 0 || module.exports().count() > 0);
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_plugin -- --nocapture
+```
+
+Expected: FAIL because the module does not exist yet.
+
+- [ ] **Step 2: Implement `build.rs` and embedded bytes**
+
+Use the exact invocation model from `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`. The output file must live under `OUT_DIR`, and `wasm_plugin.rs` must use `include_bytes!(concat!(env!("OUT_DIR"), "/code_mode_plugin.wasm"))`.
+
+If the spike proves Wizer is CLI-only, `build.rs` uses `std::process::Command` with explicit argv, no shell.
+
+- [ ] **Step 3: Implement `wasm_plugin.rs`**
+
+```rust
+use crate::error::ToolError;
+
+const PLUGIN_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/code_mode_plugin.wasm"));
+const PLUGIN_CACHE_KEY: &str = concat!(
+    "javy-codegen=", env!("LABBY_JAVY_CODEGEN_VERSION"),
+    ";wasmtime=", env!("LABBY_WASMTIME_VERSION"),
+    ";wasmtime-wizer=", env!("LABBY_WASMTIME_WIZER_VERSION")
+);
+
+#[must_use]
+pub(crate) fn plugin_bytes() -> &'static [u8] {
+    PLUGIN_BYTES
+}
+
+#[must_use]
+pub(crate) fn plugin_cache_key() -> &'static str {
+    PLUGIN_CACHE_KEY
+}
+
+pub(crate) fn compile_plugin_module(engine: &wasmtime::Engine) -> Result<wasmtime::Module, ToolError> {
+    wasmtime::Module::from_binary(engine, plugin_bytes()).map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to compile Code Mode Wasm plugin: {err}"),
+    })
+}
+```
+
+If the exact env constants cannot be exported from `build.rs`, replace them with `env!("CARGO_PKG_VERSION")` plus the literal dependency versions from the spike, for example `javy-codegen=4.0.0;wasmtime=46.0.1;wasmtime-wizer=46.0.1`.
+
+- [ ] **Step 4: Register module and docs**
+
+Add to `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod wasm_plugin;
+```
+
+Update `crates/labby-codemode/CLAUDE.md` File Responsibilities with `wasm_plugin.rs` and `build.rs`.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo test -p labby-codemode wasm_plugin -- --nocapture
+cargo check -p labby-codemode --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/build.rs crates/labby-codemode/src/wasm_plugin.rs crates/labby-codemode/src/lib.rs crates/labby-codemode/CLAUDE.md
+git commit -m "feat(codemode): build shared QuickJS Wasm plugin"
+```
+
+---
+
+## Task 4: Engine, Epoch Ticker, And Watchdog Liveness
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_engine.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: inline tests in `wasm_engine.rs`
+
+**Interfaces:**
+- Produces: `CodeModeWasmRuntime::new() -> Result<Self, ToolError>`
+- Produces: `CodeModeWasmRuntime::engine(&self) -> &wasmtime::Engine`
+- Produces: `CodeModeWasmRuntime::plugin_module(&self) -> &wasmtime::Module`
+- Produces: `CodeModeWasmRuntime::watchdog_alive(&self) -> bool`
+
+- [ ] **Step 1: Write failing singleton/liveness tests**
+
+In `wasm_engine.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_constructs_engine_and_plugin_once() {
+        let runtime = CodeModeWasmRuntime::new().expect("runtime");
+        let engine_a = runtime.engine() as *const _;
+        let engine_b = runtime.engine() as *const _;
+        assert_eq!(engine_a, engine_b);
+        assert!(runtime.watchdog_alive());
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_engine -- --nocapture
+```
+
+Expected: FAIL because `wasm_engine.rs` does not exist.
+
+- [ ] **Step 2: Implement engine config**
+
+`CodeModeWasmRuntime::new()` configures:
+
+```rust
+let mut config = wasmtime::Config::new();
+config.consume_fuel(true);
+config.epoch_interruption(true);
+config.async_support(false);
+```
+
+Do not enable `async_support(true)` in v1 because host calls remain stdio-backed, not direct async linker imports.
+
+- [ ] **Step 3: Spawn one epoch ticker per runner subprocess**
+
+Use a thread owned by `CodeModeWasmRuntime`:
+
+```rust
+let alive = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+let alive_for_thread = alive.clone();
+let engine_for_thread = engine.clone();
+let ticker = std::thread::Builder::new()
+    .name("labby-code-mode-epoch".to_string())
+    .spawn(move || {
+        while alive_for_thread.load(std::sync::atomic::Ordering::Relaxed) {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            engine_for_thread.increment_epoch();
+        }
+    })
+    .map_err(|err| ToolError::Sdk {
+        sdk_kind: "internal_error".to_string(),
+        message: format!("failed to spawn Code Mode epoch ticker: {err}"),
+    })?;
+```
+
+Store the `JoinHandle` and stop flag. On drop, set `alive=false`; no blocking join in a panic path.
+
+- [ ] **Step 4: Initialize once before runner loop**
+
+In `runner.rs`, construct `CodeModeWasmRuntime::new()` after `PR_SET_DUMPABLE` and before `RUNNER_STATE.with(...)`.
+
+Expected code shape:
+
+```rust
+let wasm_runtime = match super::wasm_engine::CodeModeWasmRuntime::new() {
+    Ok(runtime) => runtime,
+    Err(err) => {
+        eprintln!("ERROR: failed to initialize Code Mode Wasm runtime: {err}");
+        return ExitCode::FAILURE;
+    }
+};
+```
+
+Pass `&wasm_runtime` into the per-execution runner function in later tasks.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo test -p labby-codemode wasm_engine -- --nocapture
+cargo check -p labby-codemode --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src/wasm_engine.rs crates/labby-codemode/src/lib.rs crates/labby-codemode/src/runner.rs
+git commit -m "feat(codemode): initialize Wasmtime engine per runner"
+```
+
+---
+
+## Task 5: Wasm Bridge Over Existing Stdio Protocol
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_bridge.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: inline tests in `wasm_bridge.rs`, plus `crates/labby/tests/code_mode_runner.rs`
+
+**Interfaces:**
+- Produces: bounded guest-memory helpers:
+  - `read_guest_utf8(memory: &wasmtime::Memory, store: &mut wasmtime::Store<CodeModeGuestState>, ptr: u32, len: u32, max_len: usize) -> Result<String, CodeModeRunnerError>`
+  - `read_guest_bytes_bounded(memory: &wasmtime::Memory, store: &mut wasmtime::Store<CodeModeGuestState>, ptr: u32, len: u32, max_len: usize) -> Result<Vec<u8>, CodeModeRunnerError>`
+- Produces: bridge functions that emit existing `CodeModeRunnerOutput` messages and read matching existing `CodeModeRunnerInput` replies.
+
+- [ ] **Step 1: Write failing guest-memory tests**
+
+Add tests:
+
+```rust
+#[test]
+fn guest_memory_read_rejects_oob_range() {
+    // Construct a one-page Wasmtime memory, pass ptr near end with len past end,
+    // assert kind == "invalid_param" and no panic.
+}
+
+#[test]
+fn guest_memory_read_caps_before_copy() {
+    // Pass len = max + 1 and assert rejection occurs before allocating len bytes.
+}
+
+#[test]
+fn guest_memory_read_rejects_non_utf8() {
+    // Write [0xff, 0xfe] into memory and assert structured invalid_param.
+}
+```
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_bridge -- --nocapture
+```
+
+Expected: FAIL until helpers exist.
+
+- [ ] **Step 2: Implement bounded reads**
+
+Implementation rule:
+
+```rust
+if len as usize > max_len {
+    return Err(CodeModeRunnerError::invalid_param("guest argument exceeds limit"));
+}
+let end = (ptr as usize)
+    .checked_add(len as usize)
+    .ok_or_else(|| CodeModeRunnerError::invalid_param("guest pointer overflow"))?;
+let data = memory.data(store);
+if end > data.len() {
+    return Err(CodeModeRunnerError::invalid_param("guest pointer out of bounds"));
+}
+let slice = &data[ptr as usize..end];
+```
+
+Only after these checks may code allocate/copy or call `std::str::from_utf8`.
+
+- [ ] **Step 3: Implement bridge output parity**
+
+For `callTool`, `writeArtifact`, and `codemode.run`, emit exactly the same `CodeModeRunnerOutput` variants currently emitted by `runner.rs`:
+
+```rust
+CodeModeRunnerOutput::ToolCall { seq, id, params }
+CodeModeRunnerOutput::ArtifactWrite { seq, path, content, content_type }
+CodeModeRunnerOutput::SnippetResolve { seq, name, input }
+```
+
+Then wait for the matching `CodeModeRunnerInput::{ToolResult, ToolError, SnippetResolved}` reply using the same `seq`.
+
+- [ ] **Step 4: Add direct runner parity tests**
+
+In `crates/labby/tests/code_mode_runner.rs`, adapt existing tests rather than duplicating a new harness:
+
+- `code_mode_runner_tool_error_produces_json_encoded_error`
+- `code_mode_runner_tool_error_does_not_abort_fan_out`
+- `code_mode_runner_resolves_and_runs_snippet`
+- artifact path traversal / artifact size cap tests
+
+Expected: each test passes against the Wasmtime-backed runner with unchanged JSON protocol shape.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo test -p labby code_mode_runner_tool_error_produces_json_encoded_error -- --nocapture
+cargo test -p labby code_mode_runner_resolves_and_runs_snippet -- --nocapture
+cargo test -p labby-codemode wasm_bridge -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src/wasm_bridge.rs crates/labby-codemode/src/lib.rs crates/labby-codemode/src/runner.rs crates/labby/tests/code_mode_runner.rs
+git commit -m "feat(codemode): bridge Wasm host calls over runner protocol"
+```
+
+---
+
+## Task 6: Wasmtime Execution, Fuel, Epoch, And Memory Limits
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_runner.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: `crates/labby/tests/code_mode_runner.rs`
+
+**Interfaces:**
+- Produces: `wasm_runner::run_wasm_execution(runtime: &CodeModeWasmRuntime, start: CodeModeRunnerInput::Start) -> Result<CodeModeRunnerOutput, CodeModeRunnerError>`
+- Produces: trap mapping to `kind = "timeout"` with internal trap cause.
+
+- [ ] **Step 1: Add failing trap tests**
+
+Add to `crates/labby/tests/code_mode_runner.rs`:
+
+```rust
+#[test]
+fn wasm_runner_fuel_trap_returns_timeout_and_reuses_process() {
+    let (mut child, mut stdin, mut stdout) = spawn_pooled_runner();
+    let pid = child.id();
+
+    writeln!(stdin, "{}", json!({
+        "type": "start",
+        "code": "async () => { while (true) {} }"
+    })).expect("write runaway start");
+    let err = read_protocol_line(&mut stdout);
+    assert_eq!(err["type"], "error");
+    assert_eq!(err["kind"], "timeout");
+
+    let done = run_once(&mut stdin, &mut stdout, "async () => 42");
+    assert_eq!(done["result"]["value"], json!(42));
+    assert_eq!(child.id(), pid, "fuel trap should not evict the subprocess");
+}
+```
+
+Add a second epoch-focused test if the spike identifies a low-fuel/long-wall snippet that Wasmtime/Javy actually supports.
+
+Run:
+
+```bash
+cargo test -p labby wasm_runner_fuel_trap_returns_timeout_and_reuses_process -- --nocapture
+```
+
+Expected: FAIL until Wasmtime execution exists.
+
+- [ ] **Step 2: Implement per-execution Store/Instance**
+
+For each `Start`, create a fresh `Store`, set:
+
+```rust
+store.set_fuel(fuel_budget)?;
+store.set_epoch_deadline(epoch_deadline_ticks);
+```
+
+The exact method names must come from `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`; adjust to the pinned Wasmtime API without changing behavior.
+
+- [ ] **Step 3: Apply memory limit**
+
+Set a 64 MiB guest memory bound via the pinned Wasmtime API (`Store` resource limiter or config setting). The implementation must trap/reject allocations above the limit and surface a structured error.
+
+- [ ] **Step 4: Map traps**
+
+Map:
+
+- fuel exhaustion -> `CodeModeRunnerOutput::Error { kind: "timeout", message: "Code Mode execution timed out" }` plus log field `trap_cause="fuel_exhausted"`.
+- epoch interruption -> same caller kind plus `trap_cause="epoch_interrupted"`.
+- memory limit -> `kind="invalid_param"` when caller-created allocation exceeds limits, unless Wasmtime only exposes it as trap; document exact behavior in `docs/dev/ERRORS.md`.
+
+- [ ] **Step 5: Verify no native `javy::Runtime` construction on hot path**
+
+Add a test or trace assertion that the Wasmtime path does not construct `javy::Runtime` per execution. If test instrumentation is awkward, remove the native runtime construction code in the same commit and rely on compile-time absence plus direct runner tests.
+
+- [ ] **Step 6: Verify**
+
+```bash
+cargo test -p labby code_mode_runner -- --nocapture
+cargo test -p labby-codemode -- --nocapture
+cargo check -p labby-codemode --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/labby-codemode/src/wasm_runner.rs crates/labby-codemode/src/lib.rs crates/labby-codemode/src/runner.rs crates/labby/tests/code_mode_runner.rs
+git commit -m "feat(codemode): execute snippets under Wasmtime"
+```
+
+---
+
+## Task 7: Parent Driver Classification And Pool Reuse
+
+**Files:**
+- Modify: `crates/labby-codemode/src/runner_drive.rs`
+- Modify: `crates/labby-codemode/src/pool/runner_handle.rs`
+- Test: existing and new tests in `crates/labby/tests/code_mode_runner.rs`
+
+**Interfaces:**
+- Consumes: runner emits `Error { kind: "timeout", message }` for reusable fuel/epoch traps.
+- Produces: fuel/epoch execution errors release the runner; OS timeout/protocol/watchdog failure evicts it.
+
+- [ ] **Step 1: Add explicit pooled reuse test**
+
+Add test:
+
+```rust
+#[test]
+fn pooled_runner_survives_wasm_timeout_trap_but_os_timeout_evicts() {
+    // First assertion: fuel/epoch trap returns Error and same PID serves next Start.
+    // Second assertion: parent-side timeout still kills/evicts via existing driver test path.
+}
+```
+
+Run:
+
+```bash
+cargo test -p labby pooled_runner_survives_wasm_timeout_trap_but_os_timeout_evicts -- --nocapture
+```
+
+Expected: FAIL until classification is adjusted.
+
+- [ ] **Step 2: Update `DriveOutcome` handling**
+
+Keep existing rules:
+
+- `Done` -> `Completed` -> `lease.release()`
+- runner-emitted `Error` -> `ExecutionError` -> `lease.release()`
+- EOF, invalid protocol JSON, parent wall-clock timeout, dead watchdog -> `RunnerUnhealthy` -> `lease.evict()`
+
+Add comments explaining why Wasmtime traps are runner-emitted errors and are therefore reusable.
+
+- [ ] **Step 3: Update stale memory comment**
+
+In `pool/runner_handle.rs`, replace "~24 at defaults" with "10 at defaults (`pool_size=2`, `max_overflow=8`)".
+
+- [ ] **Step 4: Verify**
+
+```bash
+cargo test -p labby code_mode_runner -- --nocapture
+cargo test -p labby-codemode -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/pool/runner_handle.rs crates/labby/tests/code_mode_runner.rs
+git commit -m "test(codemode): prove Wasmtime traps preserve runner reuse"
+```
+
+---
+
+## Task 8: Benchmarks And Fuel Budget Corpus
+
+**Files:**
+- Create: `crates/labby-codemode/benches/wasmtime_runtime.rs` or `crates/labby-codemode/tests/wasmtime_bench.rs`
+- Create: `docs/dev/CODE_MODE_WASMTIME_BENCHMARKS.md`
+- Modify: `crates/labby-codemode/src/wasm_runner.rs`
+- Test: benchmark command plus regression tests
+
+**Interfaces:**
+- Produces: documented p50/p95/p99/max table for at least 20 snippets.
+- Produces: fuel budget constant derived as 10-50x empirical p99.
+
+- [ ] **Step 1: Create benchmark corpus**
+
+Add at least 20 snippets covering:
+
+- existing Code Mode runner integration snippets
+- JSON parse/map/filter/reduce over 1k, 5k, and 10k arrays
+- parallel `Promise.all` callTool fan-out
+- `codemode.run` snippet nesting
+- artifact write path
+- search/describe helper usage
+
+- [ ] **Step 2: Implement non-enforcing fuel measurement**
+
+Measurement pass:
+
+```rust
+store.set_fuel(u64::MAX)?;
+// run snippet
+let remaining = store.get_fuel()?;
+let consumed = u64::MAX - remaining;
+```
+
+Use the exact pinned Wasmtime API names from the spike.
+
+- [ ] **Step 3: Record results**
+
+`docs/dev/CODE_MODE_WASMTIME_BENCHMARKS.md` must include:
+
+```markdown
+| Snippet | min | p50 | p95 | p99 | max | notes |
+|---|---:|---:|---:|---:|---:|---|
+```
+
+Also record:
+
+- compile+link+instantiate p50/p95/p99
+- execution/fuel overhead p50/p95/p99
+- total end-to-end through pool p50/p95/p99
+- chosen fuel budget and multiplier
+
+- [ ] **Step 4: Add regression tests**
+
+Add:
+
+- legitimate JSON-heavy snippet does not trap
+- infinite loop traps within bounded wall-clock time
+- p99 overhead threshold is under the agreed limit, or the test logs threshold failure and blocks the bead
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo test -p labby-codemode wasmtime_bench -- --nocapture
+cargo test -p labby code_mode_runner -- --nocapture
+```
+
+Expected: PASS and docs table populated with real numbers.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/benches crates/labby-codemode/tests docs/dev/CODE_MODE_WASMTIME_BENCHMARKS.md crates/labby-codemode/src/wasm_runner.rs
+git commit -m "test(codemode): benchmark Wasmtime fuel budget"
+```
+
+---
+
+## Task 9: Documentation, Error Contract, And Observability
+
+**Files:**
+- Modify: `crates/labby-codemode/CLAUDE.md`
+- Modify: `crates/labby-gateway/src/gateway/CLAUDE.md`
+- Modify: `docs/dev/CODE_MODE.md`
+- Modify: `docs/dev/ERRORS.md`
+- Modify: `docs/dev/OBSERVABILITY.md`
+- Modify: `deny.toml` only if required
+- Test: docs grep, `just deny`, `just lint`
+
+**Interfaces:**
+- Produces: truthful docs for dual sandbox runtime.
+- Produces: stable caller error contract with internal trap-cause logging.
+
+- [ ] **Step 1: Remove stale "NOT Wasmtime" language**
+
+Run:
+
+```bash
+rg -n "NOT Wasmtime|Do not reintroduce Wasmtime|dead Wasmtime|code_mode_fuel_exhausted|native QuickJS|Javy/QuickJS via subprocess stdio" crates docs
+```
+
+Expected: find stale references in `crates/labby-codemode/CLAUDE.md`, `crates/labby-gateway/src/gateway/CLAUDE.md`, and `docs/dev/ERRORS.md`.
+
+- [ ] **Step 2: Update crate docs**
+
+`crates/labby-codemode/CLAUDE.md` must state:
+
+- runtime is QuickJS-in-Wasm via Wasmtime inside existing subprocess
+- parent/runner stdio protocol remains host-call transport
+- `Engine`/plugin/ticker once per subprocess
+- `Store`/`Instance` fresh per execution
+- fuel/epoch/memory rows in containment table
+- `LAB_CODE_MODE_WASM_LIMITS=0` if implemented, with honest semantics
+- no native QuickJS fallback unless explicitly kept
+
+- [ ] **Step 3: Update public docs**
+
+`docs/dev/CODE_MODE.md` must state:
+
+- caller JS API is unchanged
+- `callTool`, `writeArtifact`, `codemode.run`, `codemode.search`, `codemode.describe` behavior is unchanged
+- runtime changed for containment/interruption only
+- outer subprocess kill+evict remains final safety net
+
+- [ ] **Step 4: Update error docs**
+
+`docs/dev/ERRORS.md` must state:
+
+- caller sees `timeout` for fuel exhaustion, epoch interruption, and OS wall-clock timeout
+- logs include `trap_cause`
+- `code_mode_fuel_exhausted` remains not emitted, or is removed from reserved language if the spec changed
+
+- [ ] **Step 5: Update observability docs**
+
+`docs/dev/OBSERVABILITY.md` must list Code Mode fields:
+
+```text
+surface
+service = "code_mode"
+action = "codemode"
+elapsed_ms
+kind
+trap_cause
+runner_pid
+runner_reused
+wasm_plugin_cache_key
+```
+
+- [ ] **Step 6: Verify docs and gates**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-features -- -D warnings
+cargo nextest run --workspace --all-features
+cargo deny check
+cargo audit
+rg -n "NOT Wasmtime|Do not reintroduce Wasmtime|dead Wasmtime" crates docs && exit 1 || true
+```
+
+Expected: all pass; final grep returns no stale prohibition language.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/labby-codemode/CLAUDE.md crates/labby-gateway/src/gateway/CLAUDE.md docs/dev/CODE_MODE.md docs/dev/ERRORS.md docs/dev/OBSERVABILITY.md deny.toml Cargo.lock
+git commit -m "docs(codemode): document Wasmtime dual sandbox"
+```
+
+---
+
+## Task 10: Full Verification And PR Prep
+
+**Files:**
+- No new source files expected
+- Modify: `docs/sessions/2026-07-02-codemode-wasmtime-dual-sandbox.md` only if the execution workflow requires a session note
+
+**Interfaces:**
+- Produces: implementation-ready PR with evidence.
+
+- [ ] **Step 1: Full gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-features -- -D warnings
+cargo nextest run --workspace --all-features
+cargo deny check
+cargo audit
+git diff --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Manual smoke**
+
+Run a simple Code Mode execution through the binary:
+
+```bash
+cargo run -p labby --all-features -- internal code-mode-runner
+```
+
+Then in a separate scripted runner test, send:
+
+```json
+{"type":"start","code":"async () => ({ ok: true, value: 2 + 2 })","proxy":""}
+```
+
+Expected:
+
+```json
+{"type":"done","result":{"state":"json","value":{"ok":true,"value":4}},"logs":[]}
+```
+
+- [ ] **Step 3: Update issue/bead comments**
+
+```bash
+bd comments add lab-crav6 "LEARNED: Wasmtime dual-sandbox implementation complete. Host authority stayed parent-owned over stdio IPC; Engine/plugin/ticker are per runner subprocess; Store/Instance are per execution; fuel/epoch traps reuse the runner and surface caller-facing timeout with internal trap_cause."
+gh issue comment 168 --repo jmagar/labby --body "Implementation notes: host authority remains parent-owned over stdio IPC; Wasmtime runs inside the existing runner subprocess; fuel/epoch traps preserve runner reuse; docs and error contract updated. Verification: cargo fmt, clippy, nextest, deny, audit."
+```
+
+- [ ] **Step 4: Commit final notes**
+
+```bash
+git status --short
+git add .
+git commit -m "chore(codemode): record Wasmtime verification"
+```
+
+Expected: clean tree or only intentionally ignored artifacts.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers all six child beads plus the new review blocker: reconcile stale bead bodies, exact dependency spike, plugin build, engine/ticker, bridge, execution limits, pool reuse, benchmarks, docs, errors, observability, and final verification.
+- Placeholder scan: Clean. Version pins begin at the cargo-search-confirmed `javy-codegen=4.0.0`, `wasmtime=46.0.1`, and `wasmtime-wizer=46.0.1`; Task 2 still requires source-doc verification before those pins are committed.
+- Type consistency: Produced interfaces are named consistently: `CodeModeWasmRuntime`, `compile_plugin_module`, `run_wasm_execution`, `wasm_bridge` bounded memory readers, caller-facing `timeout`, internal `trap_cause`.

--- a/docs/superpowers/plans/2026-07-02-codemode-wasmtime-dual-sandbox.md
+++ b/docs/superpowers/plans/2026-07-02-codemode-wasmtime-dual-sandbox.md
@@ -319,6 +319,26 @@ ignores. The safe next step is one of:
   with a separately pinned and reviewed tool artifact;
 - change the architecture away from Javy-to-Wasm.
 
+2026-07-02 follow-up: research found a possible unblocking path through the
+Javy `v9.0.0` Git tag. That tag contains unpublished
+`javy-codegen 4.0.1-alpha.1`, pins `deterministic-wasi-ctx =4.0.3`, and can
+resolve to patched Wasmtime/WASI/Wizer `45.0.3`. Before Task 3 starts, prove
+this path in the real Lab worktree with:
+
+```bash
+cargo check -p labby-codemode --all-features
+cargo deny check
+cargo audit
+```
+
+Result: this path passed `cargo check -p labby-codemode --all-features` and
+`cargo deny check` in the real Lab worktree. `cargo audit` still reports the
+existing baseline `quinn-proto` and `rsa` advisories plus the allowed `paste`
+warning, but no Wasmtime/WASI 42 advisory remains on this path. Task 3 should
+use the Git-tagged Javy v9 codegen path until a crates.io `javy-codegen 4.0.1+`
+release exists. Track the first-check build cost: the focused package check took
+6m31s because the dependency graph builds native `wasm-opt`.
+
 - [ ] **Step 5: Commit**
 
 ```bash

--- a/docs/superpowers/plans/2026-07-02-codemode-wasmtime-runtime-implementation.md
+++ b/docs/superpowers/plans/2026-07-02-codemode-wasmtime-runtime-implementation.md
@@ -1,0 +1,2002 @@
+# Code Mode Wasmtime Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Code Mode runner's native QuickJS hot path with Javy-generated Wasm executed by Wasmtime inside the existing runner subprocess, preserving the caller-facing JS API and parent-owned stdio authority boundary.
+
+**Architecture:** Keep the current OS subprocess pool as the outer containment ring. Inside each runner subprocess, build one shared Wasmtime `Engine` and one preinitialized Lab-owned Javy plugin `Module`, then create a fresh `Store`/generated JS `Module`/`Instance` per `Start` message. Host authority stays in the parent process: the Lab-owned Javy plugin registers the same bridge globals the native runner used, and those plugin functions call Wasmtime imports that only emit existing `CodeModeRunnerOutput::{ToolCall, ArtifactWrite, SnippetResolve}` messages and consume matching existing `CodeModeRunnerInput` replies.
+
+**Tech Stack:** Rust 2024, Tokio, Javy v9 `javy-codegen = 4.0.1-alpha.1` from the `v9.0.0` Git tag, `wasmtime = 45.0.3`, `wasmtime-wasi = 45.0.3`, `wasmtime-wizer = 45.0.3`, existing Labby runner stdio protocol.
+
+## Global Constraints
+
+- Scope is issue 168 / bead `lab-crav6`: Code Mode Wasmtime dual sandbox.
+- Accepted framing is "defense-in-depth + graceful interruption"; do not claim the current subprocess runner lacks a clean kill mechanism.
+- Wasmtime runs inside the existing child runner subprocess; parent-side broker, `CodeModeHost`, OAuth/upstream pools, snippets, and artifact persistence remain parent-owned.
+- Per Code Mode execution, exactly one JS engine runs caller code: QuickJS compiled to Wasm via Javy and executed under Wasmtime. Do not run native `javy::Runtime` redundantly.
+- No native QuickJS fallback mode in v1. `LAB_CODE_MODE_WASM_LIMITS=0`, if added, disables fuel/epoch limits only while keeping the Wasmtime path.
+- Preserve the existing parent/runner line-delimited JSON protocol in `crates/labby-codemode/src/protocol.rs`.
+- Preserve the existing caller-facing JavaScript contract: `callTool`, `writeArtifact`, `codemode.search`, `codemode.describe`, `codemode.run`, `codemode.step`, binary result encoding, snippet budgets, and structured `{kind,message}` rejections.
+- Caller-facing timeout kind remains `timeout` for fuel exhaustion, epoch interruption, and parent wall-clock timeout; internal logs may include `trap_cause`.
+- Keep `labby-codemode` under `#![forbid(unsafe_code)]`.
+- Do not add business logic to CLI, MCP, or HTTP adapters.
+- Do not grow already-large runner files casually. New Wasmtime code belongs in focused sibling files under `crates/labby-codemode/src/`.
+- Security gates are blocking: `cargo deny check` must pass; `cargo audit` must not report Wasmtime/WASI 42 advisories introduced by this work.
+- Baseline `cargo audit` advisories for unrelated workspace dependencies may remain if unchanged, but must be called out as baseline.
+- Current dependency proof branch pins Javy v9 codegen and Wasmtime/WASI 45.0.3 because crates.io `javy-codegen = 4.0.0` pulls vulnerable Wasmtime/WASI 42.
+
+---
+
+## File Structure
+
+- Modify `crates/labby-codemode/Cargo.toml`: keep the proven Javy v9/Wasmtime 45.0.3 dependency set; add build dependencies only if the chosen plugin build path requires them.
+- Modify `deny.toml`: preserve the explicit Javy Git source allow-list and the existing scoped `anyhow` wrapper policy for the Javy/Wasmtime codegen boundary.
+- Create `crates/labby-codemode/javy-plugin/`: Lab-owned Javy plugin source that registers bridge globals (`__labEmitToolCall`, `__labEmitArtifactWrite`, `__labEmitSnippetResolve`, `__labEmitDone`) and delegates them to Wasmtime imports; no parent-side `CodeModeHost` authority moves into this plugin.
+- Create `crates/labby-codemode/src/wasm_plugin.rs`: load and validate the preinitialized Lab Javy plugin bytes, expose the Javy import namespace, create the shared Wasmtime engine/module, and provide dependency/cache-key metadata.
+- Create `crates/labby-codemode/src/wasm_codegen.rs`: compile a wrapped Code Mode JS string into a Javy dynamic-linking Wasm module.
+- Create `crates/labby-codemode/src/wasm_bridge.rs`: bounded guest linear-memory reads/writes, Javy IO bridge handling, pending-operation settlement, final-result capture, and protocol emission.
+- Create `crates/labby-codemode/src/wasm_runner.rs`: per-`Start` Wasmtime store/module/instance execution, fuel/epoch/resource limits, trap classification, and reusable execution errors.
+- Modify `crates/labby-codemode/src/runner.rs`: keep the subprocess loop, `PR_SET_DUMPABLE`, sequence reset, cwd jail reset, wrapping helpers, and error classification; replace native `javy::Runtime` construction with `wasm_runner`.
+- Modify `crates/labby-codemode/src/lib.rs`: register new modules and update crate-level runtime docs.
+- Modify `crates/labby-codemode/src/runner_io.rs`: add a small runner-side blocking protocol helper used by the Wasm bridge, so `wasm_bridge.rs` does not call back into `runner.rs`.
+- Modify `crates/labby-codemode/src/protocol.rs`: only for internal helper types if needed; do not change wire shapes.
+- Modify `crates/labby-codemode/CLAUDE.md`: update runtime, invariants, file responsibilities, and rules.
+- Modify `docs/dev/CODE_MODE.md`, `docs/dev/ERRORS.md`, `docs/dev/OBSERVABILITY.md`, and `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`: make docs match the implemented runtime and verified dependency path.
+
+## Engineering Review Amendments Applied
+
+These amendments are part of the plan and supersede any lower-level sketch that conflicts with them.
+
+RECOMMENDATIONS APPLIED:
+
+[x] 1. Preserve pending-promise fan-out semantics. The Wasm path must not replace `callTool`/`writeArtifact`/`codemode.run` with a blocking request/response helper. JS bridge calls must emit a seq immediately, store a pending promise, and settle later from existing `CodeModeRunnerInput` replies.
+
+[x] 2. Use one explicit guest-host ABI. The v1 ABI is a Lab-owned Javy plugin, not default Javy stream IO. The plugin registers bridge globals in QuickJS and backs them with Wasmtime imports implemented in `wasm_bridge.rs`. Those imports emit existing runner protocol messages to the parent and return seq IDs immediately, preserving the current pending-promise model.
+
+[x] 3. Add an explicit final-result channel. The wrapper must send `kind = "done"` through the same bridge with `{ state: "json", value }` or `{ state: "undefined" }`; `WasmRunState` stores that result and `wasm_runner` emits the existing `Done` envelope from it. Delete the speculative `__lab_result_ptr` / `__lab_result_len` global-pointer mechanism.
+
+[x] 4. Narrow trap classification. Only Wasmtime fuel exhaustion and epoch interruption map to caller-facing `timeout`. Unexpected Wasm traps, missing imports/exports, bridge ABI failures, memory faults, allocation failures, plugin load failures, and module validation failures map to `server_error` or `invalid_param` and evict the runner unless explicitly proven reusable.
+
+[x] 5. Add generated-module import allow-listing before instantiation. Reject generated modules that import anything except the expected Javy dynamic-link namespace and the explicitly approved stream-IO/WASI pieces required by the validated plugin path. Add a regression test proving no `wasi:*` filesystem/env/socket imports are introduced accidentally.
+
+[x] 6. Bound pre-execution work. Enforce source/proxy size limits before Javy codegen, add a compile/codegen timeout under the runner's parent deadline, and map oversized source or compile timeout to structured errors. Fuel/epoch does not protect codegen or Wasmtime module compilation.
+
+[x] 7. Validate all guest-memory reads and response writes. The bridge must reject negative pointers, pointer overflow, OOB reads, OOB output slots, huge lengths, non-UTF-8, and malformed JSON without panic. Cap-before-copy tests must use attacker-sized lengths, not tiny toy values only.
+
+[x] 8. Add plugin provenance and ABI attestation. Vendored or generated `plugin.wasm` bytes must have a checked SHA256/provenance record, build scripts must assert the hash, and tests must validate expected exports plus import namespace. If building from source, use `cargo build --locked --offline` where possible and run the actual `wasmtime-wizer` preinitialization step.
+
+[x] 9. Add latency instrumentation and a benchmark gate. Record `wrap_ms`, `javy_codegen_ms`, `wasm_module_compile_ms`, `plugin_instantiate_ms`, `generated_instantiate_ms`, `bridge_roundtrip_ms`, total warm p50/p95, `fuel_consumed`, and payload sizes. PR handoff must include these numbers and an explicit pass/fail statement.
+
+[x] 10. Add a bounded module cache or a measured non-goal. V1 should cache compiled `wasmtime::Module` values per runner using an LRU keyed by `sha256(wrapped_source + proxy + plugin_hash + javy_version + codegen_options)`, while still creating a fresh `Store`/`Instance` per execution. If cache implementation proves too much for v1, benchmark data must justify deferral before implementation proceeds.
+
+[x] 11. Tie epoch and bridge deadlines to the caller timeout. Epoch deadline ticks and bridge wait deadlines derive from `RunnerConfig.timeout` with headroom below the parent kill deadline, not a hardcoded 30 seconds used in every test.
+
+[x] 12. Make workspace verification mandatory. `cargo build --workspace --all-features` is a blocking gate, not "if time permits".
+
+## Task 1: Lock Dependencies And Plugin Artifact Strategy
+
+**Files:**
+- Modify: `crates/labby-codemode/Cargo.toml`
+- Modify: `deny.toml`
+- Modify: `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`
+- Create: `crates/labby-codemode/javy-plugin/Cargo.toml`
+- Create: `crates/labby-codemode/javy-plugin/src/lib.rs`
+- Create: `crates/labby-codemode/build-support/Cargo.toml`
+- Create: `crates/labby-codemode/build-support/src/lib.rs`
+- Create: `crates/labby-codemode/build.rs`
+- Create: `crates/labby-codemode/plugin.sha256`
+- Create: `crates/labby-codemode/src/wasm_plugin.rs`
+- Test: `crates/labby-codemode/src/wasm_plugin.rs`
+
+**Interfaces:**
+- Consumes: Javy v9 source facts: `javy-codegen::Plugin::new(Cow<'static, [u8]>)`, `Plugin::as_bytes()`, `Generator::new(plugin)`, `Generator::linking(LinkingKind::Dynamic)`, `Generator::generate(&JS).await`.
+- Produces:
+  - `pub(crate) struct WasmPlugin { pub(crate) engine: wasmtime::Engine, pub(crate) plugin: javy_codegen::Plugin, pub(crate) module: wasmtime::Module, pub(crate) import_namespace: String }`
+  - `pub(crate) fn wasm_limits_disabled() -> bool`
+  - `pub(crate) fn build_wasm_engine() -> anyhow::Result<wasmtime::Engine>`
+  - `pub(crate) fn load_wasm_plugin() -> anyhow::Result<WasmPlugin>`
+
+- [ ] **Step 1: Confirm the dependency graph still proves the unblocked path**
+
+Run:
+
+```bash
+cargo tree -p labby-codemode -i javy-codegen
+cargo tree -p labby-codemode -i wasmtime@45.0.3
+cargo tree -p labby-codemode -i wasmtime-wasi@45.0.3
+cargo tree -p labby-codemode -i wasmtime@42.0.2 || true
+```
+
+Expected:
+
+```text
+javy-codegen v4.0.1-alpha.1 (https://github.com/bytecodealliance/javy?tag=v9.0.0#...)
+...
+wasmtime v45.0.3
+...
+wasmtime-wasi v45.0.3
+...
+error: package ID specification `wasmtime@42.0.2` did not match any packages
+```
+
+- [ ] **Step 2: Add the initial plugin loader module**
+
+Edit `crates/labby-codemode/src/wasm_plugin.rs`:
+
+```rust
+//! Javy plugin bytes and shared Wasmtime engine/module setup for Code Mode.
+//!
+//! The plugin is shared per runner subprocess. Each execution still receives a
+//! fresh Store and generated JS module, so JS state isolation remains per Start.
+
+use std::borrow::Cow;
+
+use anyhow::{Context, Result};
+use javy_codegen::Plugin;
+use wasmtime::{Config, Engine, Module};
+
+pub(crate) const CODE_MODE_WASM_MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+pub(crate) const CODE_MODE_WASM_EPOCH_TICK_MS: u64 = 100;
+pub(crate) const CODE_MODE_WASM_EPOCH_DEADLINE_TICKS: u64 = 300;
+pub(crate) const CODE_MODE_WASM_DEFAULT_FUEL: u64 = 10_000_000;
+
+pub(crate) struct WasmPlugin {
+    pub(crate) engine: Engine,
+    pub(crate) plugin: Plugin,
+    pub(crate) module: Module,
+    pub(crate) import_namespace: String,
+}
+
+pub(crate) fn wasm_limits_disabled() -> bool {
+    std::env::var("LAB_CODE_MODE_WASM_LIMITS")
+        .map(|value| value == "0" || value.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+}
+
+pub(crate) fn build_wasm_engine() -> Result<Engine> {
+    let mut config = Config::new();
+    config.consume_fuel(!wasm_limits_disabled());
+    config.epoch_interruption(!wasm_limits_disabled());
+    config.max_wasm_stack(256 * 1024);
+    Engine::new(&config).context("failed to create Code Mode Wasmtime engine")
+}
+
+pub(crate) fn load_wasm_plugin_from_bytes(bytes: &'static [u8]) -> Result<WasmPlugin> {
+    let plugin = Plugin::new(Cow::Borrowed(bytes)).context("failed to validate Javy plugin")?;
+    let import_namespace = plugin_import_namespace(&plugin)?;
+    let engine = build_wasm_engine()?;
+    let module =
+        Module::from_binary(&engine, plugin.as_bytes()).context("failed to compile Javy plugin")?;
+    Ok(WasmPlugin {
+        engine,
+        plugin,
+        module,
+        import_namespace,
+    })
+}
+
+fn plugin_import_namespace(plugin: &Plugin) -> Result<String> {
+    let module = walrus::Module::from_buffer(plugin.as_bytes())
+        .context("failed to inspect Javy plugin import namespace")?;
+    let section = module
+        .customs
+        .iter()
+        .find_map(|(_, section)| (section.name() == "import_namespace").then_some(section))
+        .context("Javy plugin is missing import_namespace custom section")?;
+    let bytes = section.data(&Default::default());
+    std::str::from_utf8(&bytes)
+        .map(str::to_owned)
+        .context("Javy plugin import_namespace is not UTF-8")
+}
+
+pub(crate) fn load_wasm_plugin() -> Result<WasmPlugin> {
+    load_wasm_plugin_from_bytes(include_bytes!(concat!(env!("OUT_DIR"), "/plugin.wasm")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn limits_switch_defaults_to_enabled() {
+        unsafe {
+            std::env::remove_var("LAB_CODE_MODE_WASM_LIMITS");
+        }
+        assert!(!wasm_limits_disabled());
+    }
+}
+```
+
+If the workspace forbids `unsafe` env mutation in tests under current Rust, replace the env test with a pure helper:
+
+```rust
+fn wasm_limits_disabled_from(value: Option<&str>) -> bool {
+    value
+        .map(|value| value == "0" || value.eq_ignore_ascii_case("false"))
+        .unwrap_or(false)
+}
+```
+
+and call that helper from `wasm_limits_disabled`.
+
+- [ ] **Step 3: Add required direct dependencies for the loader**
+
+Modify `crates/labby-codemode/Cargo.toml` so `[dependencies]` includes:
+
+```toml
+walrus = "0.25.2"
+```
+
+If `walrus` is already pulled transitively, keep it direct because `wasm_plugin.rs` inspects the plugin custom section directly.
+
+- [ ] **Step 4: Decide and implement the plugin artifact source**
+
+Preferred v1 path: build the Lab-owned plugin from source at compile time, run the real `wasmtime-wizer` preinitialization step, write the preinitialized bytes to `OUT_DIR/plugin.wasm`, and assert the SHA256 recorded in `crates/labby-codemode/plugin.sha256` when that file is non-empty. Do not use the default Javy plugin because it does not register Lab's bridge globals and would force a stream-IO protocol rewrite.
+
+Create `crates/labby-codemode/javy-plugin/Cargo.toml`:
+
+```toml
+[package]
+name = "labby-codemode-javy-plugin"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "labby_codemode_javy_plugin"
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+javy-plugin-api = { git = "https://github.com/bytecodealliance/javy", tag = "v9.0.0", features = ["json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+```
+
+Create `crates/labby-codemode/javy-plugin/src/lib.rs`:
+
+```rust
+use javy_plugin_api::javy::{Ctx, Function, Runtime};
+use javy_plugin_api::{Config, import_namespace};
+
+import_namespace!("labby-codemode-plugin-v1");
+
+#[link(wasm_import_module = "labby-codemode-plugin-v1")]
+unsafe extern "C" {
+    fn lab_emit_tool_call(ptr: i32, len: i32) -> i32;
+    fn lab_emit_artifact_write(ptr: i32, len: i32) -> i32;
+    fn lab_emit_snippet_resolve(ptr: i32, len: i32) -> i32;
+    fn lab_emit_done(ptr: i32, len: i32);
+}
+
+fn config() -> Config {
+    let mut config = Config::default();
+    config
+        .text_encoding(true)
+        .javy_stream_io(false)
+        .simd_json_builtins(true);
+    config
+}
+
+fn modify_runtime(runtime: Runtime) -> Runtime {
+    runtime.context().with(|cx| {
+        let globals = cx.globals();
+        globals
+            .set("__labEmitToolCall", Function::new(cx.clone(), |payload: String| emit_tool(payload)))
+            .unwrap();
+        globals
+            .set(
+                "__labEmitArtifactWrite",
+                Function::new(cx.clone(), |payload: String| emit_artifact(payload)),
+            )
+            .unwrap();
+        globals
+            .set(
+                "__labEmitSnippetResolve",
+                Function::new(cx.clone(), |payload: String| emit_snippet(payload)),
+            )
+            .unwrap();
+        globals
+            .set("__labEmitDone", Function::new(cx.clone(), |payload: String| emit_done(payload)))
+            .unwrap();
+    });
+    runtime
+}
+
+fn emit_tool(payload: String) -> i32 {
+    unsafe { lab_emit_tool_call(payload.as_ptr() as i32, payload.len() as i32) }
+}
+
+fn emit_artifact(payload: String) -> i32 {
+    unsafe { lab_emit_artifact_write(payload.as_ptr() as i32, payload.len() as i32) }
+}
+
+fn emit_snippet(payload: String) -> i32 {
+    unsafe { lab_emit_snippet_resolve(payload.as_ptr() as i32, payload.len() as i32) }
+}
+
+fn emit_done(payload: String) {
+    unsafe { lab_emit_done(payload.as_ptr() as i32, payload.len() as i32) }
+}
+
+#[unsafe(export_name = "initialize-runtime")]
+fn initialize_runtime() {
+    javy_plugin_api::initialize_runtime(config, modify_runtime).unwrap();
+}
+```
+
+If `javy-plugin-api` requires different `Function::new` signatures at v9, update this code from the checked-out Javy v9 plugin examples and keep the same exported JS global names and import names.
+
+Create `crates/labby-codemode/build.rs`:
+
+```rust
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    println!("cargo:rerun-if-changed=javy-plugin/Cargo.toml");
+    println!("cargo:rerun-if-changed=javy-plugin/src/lib.rs");
+    println!("cargo:rerun-if-changed=plugin.sha256");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--manifest-path",
+            "javy-plugin/Cargo.toml",
+            "--target",
+            "wasm32-wasip1",
+            "--release",
+            "--locked",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to build Javy plugin");
+    let raw = std::fs::read("javy-plugin/target/wasm32-wasip1/release/labby_codemode_javy_plugin.wasm").unwrap();
+    let initialized = labby_build_support::preinitialize_javy_plugin(&raw).unwrap();
+    let actual = labby_build_support::sha256_hex(&initialized);
+    let expected = std::fs::read_to_string("plugin.sha256").unwrap_or_default();
+    let expected = expected.trim();
+    if !expected.is_empty() && expected != actual {
+        panic!("preinitialized plugin hash mismatch: expected {expected}, got {actual}");
+    }
+    std::fs::write(out.join("plugin.wasm"), initialized).unwrap();
+    println!("cargo:warning=labby Code Mode plugin sha256 {actual}");
+}
+```
+
+Create `crates/labby-codemode/build-support/Cargo.toml`:
+
+```toml
+[package]
+name = "labby-codemode-build-support"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1"
+sha2 = "0.11"
+hex = "0.4"
+wasmtime = "=45.0.3"
+wasmtime-wasi = "=45.0.3"
+wasmtime-wizer = { version = "=45.0.3", features = ["wasmtime"] }
+deterministic-wasi-ctx = "=4.0.3"
+tokio = { workspace = true, features = ["rt"] }
+```
+
+Create `crates/labby-codemode/build-support/src/lib.rs`:
+
+```rust
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+use wasmtime::{Engine, Linker, Store};
+use wasmtime_wasi::WasiCtxBuilder;
+use wasmtime_wizer::Wizer;
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+pub fn preinitialize_javy_plugin(bytes: &[u8]) -> Result<Vec<u8>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async move {
+        let engine = Engine::default();
+        let mut builder = WasiCtxBuilder::new();
+        deterministic_wasi_ctx::add_determinism_to_wasi_ctx_builder(&mut builder);
+        let wasi = builder.build_p1();
+        let mut store = Store::new(&engine, wasi);
+        Wizer::new()
+            .init_func("initialize-runtime")
+            .keep_init_func(true)
+            .run(&mut store, bytes, async |store, module| {
+                let engine = store.engine();
+                let mut linker = Linker::new(engine);
+                wasmtime_wasi::p1::add_to_linker_async(&mut linker, |cx| cx)?;
+                linker.define_unknown_imports_as_traps(module)?;
+                linker.instantiate_async(store, module).await
+            })
+            .await
+            .map_err(Into::into)
+    })
+}
+```
+
+If the build helper cannot link `wasmtime-wizer` cleanly from `build.rs`, move the helper into a tiny build-support crate and call it from `build.rs`; do not silently fall back to copying an unverified binary. If CI lacks `wasm32-wasip1`, add an explicit setup step or document the target requirement in the PR; do not make the build fetch network artifacts.
+
+- [ ] **Step 5: Run the plugin-loader check**
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_plugin --all-features -- --nocapture
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 6: Run dependency gates immediately**
+
+Run:
+
+```bash
+cargo deny check
+cargo audit
+```
+
+Expected:
+
+```text
+cargo deny check
+... success ...
+```
+
+`cargo audit` may still report the existing workspace baseline advisories for `quinn-proto`, `rsa`, and the allowed `paste` warning. It must not report new Wasmtime/WASI 42 advisories.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/labby-codemode/Cargo.toml crates/labby-codemode/src/wasm_plugin.rs deny.toml docs/dev/CODE_MODE_WASMTIME_SPIKE.md
+git commit -m "build(codemode): lock javy wasmtime plugin path"
+```
+
+## Task 2: Compile Wrapped Code Mode JS To Dynamic Javy Wasm
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_codegen.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Test: `crates/labby-codemode/src/wasm_codegen.rs`
+
+**Interfaces:**
+- Consumes: `wasm_plugin::WasmPlugin`, `wrapper::CODE_MODE_VALUE_CODEC_JS`, `wrapper::code_mode_main_invoker`.
+- Produces:
+  - `pub(crate) async fn compile_code_mode_wasm(plugin: &javy_codegen::Plugin, code: &str, proxy: &str) -> anyhow::Result<Vec<u8>>`
+  - `pub(crate) fn wrap_code_mode_for_wasm(code: &str, proxy: &str) -> String`
+
+- [ ] **Step 1: Add the codegen module**
+
+Create `crates/labby-codemode/src/wasm_codegen.rs`:
+
+```rust
+//! Javy dynamic-linking code generation for one Code Mode execution.
+
+use anyhow::{Context, Result};
+use javy_codegen::{Generator, JS, LinkingKind, SourceEmbedding};
+
+use crate::wrapper::{CODE_MODE_VALUE_CODEC_JS, code_mode_main_invoker};
+
+pub(crate) fn wrap_code_mode_for_wasm(code: &str, proxy: &str) -> String {
+    let invoker = code_mode_main_invoker(code);
+    format!(
+        r#"
+globalThis.__labPendingToolCalls = new Map();
+globalThis.__labSnippetStack = [];
+globalThis.__labSnippetResolveCount = 0;
+globalThis.__labSnippetResolvedBytes = 0;
+globalThis.__labSnippetMaxDepth = 8;
+globalThis.__labSnippetMaxResolves = 32;
+globalThis.__labSnippetMaxBytes = 262144;
+{codec}
+globalThis.callTool = (id, params = {{}}) => {{
+  if (typeof id !== "string" || id.trim() === "") throw new TypeError("callTool id must be a non-empty string");
+  if (params === null || typeof params !== "object" || Array.isArray(params)) throw new TypeError("callTool params must be a JSON object");
+  return new Promise((resolve, reject) => {{
+    const seq = globalThis.__labEmitToolCall(JSON.stringify({{ id, params: __labEncodeResult(params) }}));
+    globalThis.__labPendingToolCalls.set(seq, {{ kind: "tool", resolve, reject }});
+  }});
+}};
+globalThis.writeArtifact = (path, content, options = {{}}) => {{
+  if (typeof path !== "string" || path.trim() === "") throw new TypeError("writeArtifact path must be a non-empty string");
+  if (typeof content !== "string") throw new TypeError("writeArtifact content must be a string");
+  if (options === null || typeof options !== "object" || Array.isArray(options)) throw new TypeError("writeArtifact options must be a JSON object");
+  if (options.contentType !== undefined && typeof options.contentType !== "string") throw new TypeError("writeArtifact options.contentType must be a string");
+  return new Promise((resolve, reject) => {{
+    const seq = globalThis.__labEmitArtifactWrite(JSON.stringify({{ path, content, content_type: options.contentType ?? null }}));
+    globalThis.__labPendingToolCalls.set(seq, {{ kind: "artifact", resolve, reject }});
+  }});
+}};
+globalThis.__labRunSnippet = (name, input = {{}}) => {{
+  if (typeof name !== "string" || name.trim() === "") return Promise.reject(new Error(JSON.stringify({{kind: "bad_snippet_name", message: "codemode.run name must be a non-empty string"}})));
+  if (input === null || typeof input !== "object" || Array.isArray(input)) return Promise.reject(new Error(JSON.stringify({{kind: "invalid_param", message: "codemode.run input must be a JSON object"}})));
+  if (globalThis.__labSnippetStack.indexOf(name) !== -1) return Promise.reject(new Error(JSON.stringify({{kind: "snippet_recursion_limit", message: "snippet recursion detected for `" + name + "`"}})));
+  if (globalThis.__labSnippetStack.length >= globalThis.__labSnippetMaxDepth) return Promise.reject(new Error(JSON.stringify({{kind: "snippet_depth_exceeded", message: "snippet depth limit exceeded"}})));
+  if (globalThis.__labSnippetResolveCount >= globalThis.__labSnippetMaxResolves) return Promise.reject(new Error(JSON.stringify({{kind: "snippet_resolve_limit", message: "snippet resolve limit exceeded"}})));
+  globalThis.__labSnippetResolveCount++;
+  return new Promise((resolve, reject) => {{
+    const seq = globalThis.__labEmitSnippetResolve(JSON.stringify({{ name, input: __labEncodeResult(input) }}));
+    globalThis.__labPendingToolCalls.set(seq, {{ kind: "snippet", name, resolve, reject }});
+  }});
+}};
+globalThis.__labSettlePendingOperation = (message) => {{
+  const input = JSON.parse(message);
+  const pending = globalThis.__labPendingToolCalls.get(input.seq);
+  if (!pending) throw new Error("runner received a response for an unknown pending operation");
+  globalThis.__labPendingToolCalls.delete(input.seq);
+  if (input.type === "tool_result") {{
+    pending.resolve(__labDecodeResult(input.result));
+    return;
+  }}
+  if (input.type === "snippet_resolved") {{
+    if (pending.kind !== "snippet") throw new Error("runner received snippet code for a non-snippet operation");
+    globalThis.__labSnippetResolvedBytes += input.code.length;
+    if (globalThis.__labSnippetResolvedBytes > globalThis.__labSnippetMaxBytes) {{
+      pending.reject(new Error(JSON.stringify({{kind: "snippet_budget_exceeded", message: "resolved snippet code budget exceeded"}})));
+      return;
+    }}
+    Promise.resolve().then(async () => {{
+      globalThis.__labSnippetStack.push(pending.name);
+      try {{
+        return await (eval("(" + input.code + ")"))(__labDecodeResult(input.input));
+      }} finally {{
+        globalThis.__labSnippetStack.pop();
+      }}
+    }}).then(pending.resolve, pending.reject);
+    return;
+  }}
+  if (input.type === "tool_error") {{
+    pending.reject(new Error(JSON.stringify({{kind: input.kind, message: input.message}})));
+    return;
+  }}
+  throw new Error("runner received unexpected protocol message");
+}};
+{proxy}
+globalThis.__labMainPromise = (async () => {{
+{invoker}}})().then(
+  (value) => globalThis.__labEmitDone(JSON.stringify({{ result: __labEncodeResult(value), has_result: value !== undefined }})),
+  (error) => globalThis.__labEmitDone(JSON.stringify({{ error: String(error && error.message || error) }}))
+);
+"#,
+        codec = CODE_MODE_VALUE_CODEC_JS,
+        invoker = invoker,
+        proxy = proxy,
+    )
+}
+
+pub(crate) async fn compile_code_mode_wasm(
+    plugin: &javy_codegen::Plugin,
+    code: &str,
+    proxy: &str,
+) -> Result<Vec<u8>> {
+    let source = wrap_code_mode_for_wasm(code, proxy);
+    let js = JS::from_bytes(source.into_bytes());
+    let mut generator = Generator::new(plugin.clone());
+    generator
+        .linking(LinkingKind::Dynamic)
+        .source_embedding(SourceEmbedding::Omitted)
+        .producer_version(format!("labby-codemode-{}", env!("CARGO_PKG_VERSION")))
+        .deterministic(true);
+    generator
+        .generate(&js)
+        .await
+        .context("failed to generate Code Mode Wasm module")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapper_preserves_core_globals() {
+        let wrapped = wrap_code_mode_for_wasm("async () => 42", "var codemode = {};");
+        assert!(wrapped.contains("globalThis.callTool"));
+        assert!(wrapped.contains("globalThis.writeArtifact"));
+        assert!(wrapped.contains("globalThis.__labRunSnippet"));
+        assert!(wrapped.contains("globalThis.__labMainPromise"));
+    }
+}
+```
+
+If `JS::from_bytes` does not exist in Javy v9, replace with the verified constructor from `javy-codegen::JS` source and update this task note in the commit body.
+
+- [ ] **Step 2: Register modules**
+
+Modify `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod wasm_codegen;
+mod wasm_plugin;
+```
+
+- [ ] **Step 3: Run the wrapper test**
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_codegen --all-features
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 4: Add a generation smoke test after plugin loading works**
+
+Append to `wasm_codegen.rs` tests:
+
+```rust
+#[tokio::test]
+async fn generated_module_compiles_under_shared_engine() {
+    let plugin = crate::wasm_plugin::load_wasm_plugin().unwrap();
+    let wasm = compile_code_mode_wasm(&plugin.plugin, "async () => 2 + 2", "").await.unwrap();
+    wasmtime::Module::from_binary(&plugin.engine, &wasm).unwrap();
+}
+```
+
+- [ ] **Step 5: Run the generation smoke test**
+
+Run:
+
+```bash
+cargo test -p labby-codemode generated_module_compiles_under_shared_engine --all-features -- --nocapture
+```
+
+Expected:
+
+```text
+test generated_module_compiles_under_shared_engine ... ok
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src/lib.rs crates/labby-codemode/src/wasm_codegen.rs
+git commit -m "feat(codemode): generate javy wasm modules"
+```
+
+## Task 3: Add Bounded Guest Memory Helpers Inside The Bridge
+
+**Files:**
+- Modify: `crates/labby-codemode/src/wasm_bridge.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Test: `crates/labby-codemode/src/wasm_bridge.rs`
+
+**Interfaces:**
+- Consumes: `wasmtime::Memory`, `wasmtime::StoreContext`.
+- Produces:
+  - `pub(crate) const CODE_MODE_WASM_BRIDGE_MAX_BYTES: usize`
+  - `pub(crate) fn read_guest_string(...) -> Result<String, ToolError>`
+  - `pub(crate) fn read_guest_json(...) -> Result<serde_json::Value, ToolError>`
+  - `pub(crate) fn write_guest_i32_checked(...) -> Result<(), ToolError>`
+
+**Engineering-review correction:** Keep these helpers inside `wasm_bridge.rs` until there is a second caller. Do not create `wasm_memory.rs` solely to house one consumer. The helper tests must include attacker-sized lengths, pointer overflow, OOB reads, OOB output slots, non-UTF8, malformed JSON, and cap-before-copy behavior.
+
+- [ ] **Step 1: Add memory helper code**
+
+Add to `crates/labby-codemode/src/wasm_bridge.rs`:
+
+```rust
+//! Bounded reads from Wasmtime guest linear memory.
+
+use serde::de::DeserializeOwned;
+use wasmtime::{AsContext, Memory};
+
+use crate::error::ToolError;
+
+pub(crate) const CODE_MODE_WASM_BRIDGE_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+pub(crate) fn checked_guest_bytes<C: AsContext>(
+    store: C,
+    memory: &Memory,
+    ptr: i32,
+    len: i32,
+    cap: usize,
+) -> Result<Vec<u8>, ToolError> {
+    if ptr < 0 || len < 0 {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: "Code Mode Wasm bridge received a negative pointer or length".to_string(),
+        });
+    }
+    let ptr = ptr as usize;
+    let len = len as usize;
+    if len > cap {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: format!("Code Mode Wasm bridge payload exceeded {cap} bytes"),
+        });
+    }
+    let end = ptr.checked_add(len).ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: "Code Mode Wasm bridge pointer overflowed".to_string(),
+    })?;
+    let data = memory.data(store);
+    let slice = data.get(ptr..end).ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: "Code Mode Wasm bridge pointer was outside guest memory".to_string(),
+    })?;
+    Ok(slice.to_vec())
+}
+
+pub(crate) fn write_guest_i32_checked<C: wasmtime::AsContextMut>(
+    mut store: C,
+    memory: &Memory,
+    ptr: i32,
+    value: i32,
+) -> Result<(), ToolError> {
+    if ptr < 0 {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: "Code Mode Wasm bridge output pointer was negative".to_string(),
+        });
+    }
+    let ptr = ptr as usize;
+    let end = ptr.checked_add(4).ok_or_else(|| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: "Code Mode Wasm bridge output pointer overflowed".to_string(),
+    })?;
+    if memory.data_size(store.as_context()) < end {
+        return Err(ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: "Code Mode Wasm bridge output pointer was outside guest memory".to_string(),
+        });
+    }
+    memory
+        .write(store.as_context_mut(), ptr, &value.to_le_bytes())
+        .map_err(|err| ToolError::Sdk {
+            sdk_kind: "invalid_param".to_string(),
+            message: format!("failed to write Code Mode Wasm bridge output: {err}"),
+        })
+}
+
+pub(crate) fn read_guest_string<C: AsContext>(
+    store: C,
+    memory: &Memory,
+    ptr: i32,
+    len: i32,
+    cap: usize,
+) -> Result<String, ToolError> {
+    let bytes = checked_guest_bytes(store, memory, ptr, len, cap)?;
+    String::from_utf8(bytes).map_err(|err| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("Code Mode Wasm bridge payload was not UTF-8: {err}"),
+    })
+}
+
+pub(crate) fn read_guest_json<C: AsContext, T: DeserializeOwned>(
+    store: C,
+    memory: &Memory,
+    ptr: i32,
+    len: i32,
+    cap: usize,
+) -> Result<T, ToolError> {
+    let text = read_guest_string(store, memory, ptr, len, cap)?;
+    serde_json::from_str(&text).map_err(|err| ToolError::Sdk {
+        sdk_kind: "invalid_param".to_string(),
+        message: format!("Code Mode Wasm bridge payload was not valid JSON: {err}"),
+    })
+}
+```
+
+- [ ] **Step 2: Register module**
+
+Modify `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod wasm_memory;
+```
+
+- [ ] **Step 3: Add OOB, cap-before-copy, and non-UTF8 tests**
+
+Append to `wasm_bridge.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmtime::{Engine, Memory, MemoryType, Store};
+
+    fn memory_with(bytes: &[u8]) -> (Store<()>, Memory) {
+        let engine = Engine::default();
+        let mut store = Store::new(&engine, ());
+        let memory = Memory::new(&mut store, MemoryType::new(1, Some(1))).unwrap();
+        memory.write(&mut store, 0, bytes).unwrap();
+        (store, memory)
+    }
+
+    #[test]
+    fn rejects_oob_pointer() {
+        let (store, memory) = memory_with(b"abc");
+        let err = checked_guest_bytes(&store, &memory, 65_536, 1, 10).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("outside guest memory"));
+    }
+
+    #[test]
+    fn rejects_before_copying_when_payload_exceeds_cap() {
+        let (store, memory) = memory_with(b"abc");
+        let err = checked_guest_bytes(&store, &memory, 0, 65_536, 2).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("exceeded 2 bytes"));
+    }
+
+    #[test]
+    fn rejects_pointer_overflow() {
+        let (store, memory) = memory_with(b"abc");
+        let err = checked_guest_bytes(&store, &memory, i32::MAX, 16, CODE_MODE_WASM_BRIDGE_MAX_BYTES).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+    }
+
+    #[test]
+    fn rejects_non_utf8_string() {
+        let (store, memory) = memory_with(&[0xff, 0xff]);
+        let err = read_guest_string(&store, &memory, 0, 2, 10).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("not UTF-8"));
+    }
+
+    #[test]
+    fn rejects_oob_output_slot() {
+        let (mut store, memory) = memory_with(b"abc");
+        let err = write_guest_i32_checked(&mut store, &memory, 65_535, 7).unwrap_err();
+        assert_eq!(err.kind(), "invalid_param");
+        assert!(err.to_string().contains("outside guest memory"));
+    }
+}
+```
+
+- [ ] **Step 4: Run memory tests**
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_bridge --all-features
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/labby-codemode/src/lib.rs crates/labby-codemode/src/wasm_bridge.rs
+git commit -m "feat(codemode): bound wasm bridge memory reads"
+```
+
+## Task 4: Implement Wasmtime Bridge Over Existing Runner Protocol
+
+**Engineering-review correction:** The code skeleton that originally appeared in this task used a synchronous `lab_bridge` request/response import. Do not implement that shape. The accepted v1 bridge preserves the native runner's pending-promise fan-out model:
+
+```rust
+// wasm_bridge.rs public surface
+pub(crate) struct WasmRunState {
+    pub(crate) memory: Option<wasmtime::Memory>,
+    pub(crate) settle_pending: Option<wasmtime::TypedFunc<String, ()>>,
+    pub(crate) done: Option<Result<crate::protocol::CodeModeRunnerResult, crate::error::ToolError>>,
+}
+
+pub(crate) fn install_lab_imports(
+    linker: &mut wasmtime::Linker<WasmRunState>,
+    namespace: &str,
+) -> anyhow::Result<()>;
+
+pub(crate) fn settle_pending_operation(
+    store: &mut wasmtime::Store<WasmRunState>,
+    input: &crate::protocol::CodeModeRunnerInput,
+) -> Result<(), crate::error::ToolError>;
+```
+
+`install_lab_imports` defines these imports in the plugin namespace:
+
+```rust
+lab_emit_tool_call(ptr: i32, len: i32) -> i32
+lab_emit_artifact_write(ptr: i32, len: i32) -> i32
+lab_emit_snippet_resolve(ptr: i32, len: i32) -> i32
+lab_emit_done(ptr: i32, len: i32) -> ()
+```
+
+Each emit import reads bounded UTF-8 JSON from guest memory, validates the payload, allocates a new runner seq, emits the corresponding existing `CodeModeRunnerOutput` line to the parent through a helper in `runner_io.rs`, and returns the seq immediately. It must not wait for the parent reply inside the import. `settle_pending_operation` serializes the existing `CodeModeRunnerInput` reply and calls the wrapper's `__labSettlePendingOperation(message)` function so the JS pending promise resolves later, preserving `Promise.all([callTool(a), callTool(b)])` overlap.
+
+Add these tests in this task before moving on:
+
+```rust
+#[tokio::test]
+async fn wasm_bridge_preserves_tool_call_fanout() {
+    let started = std::time::Instant::now();
+    let response = execute_code_mode_for_test(
+        r#"async () => {
+            const [a, b] = await Promise.all([
+                callTool("test::delayed", { id: "a", delay_ms: 200 }),
+                callTool("test::delayed", { id: "b", delay_ms: 200 })
+            ]);
+            return [a.id, b.id];
+        }"#,
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.result, Some(serde_json::json!(["a", "b"])));
+    assert!(started.elapsed() < std::time::Duration::from_millis(350));
+}
+
+#[tokio::test]
+async fn wasm_bridge_reports_final_result_through_done_import() {
+    let response = execute_code_mode_for_test("async () => ({ ok: true })").await.unwrap();
+    assert_eq!(response.result, Some(serde_json::json!({ "ok": true })));
+}
+```
+
+Move runner-side blocking seq/read/write primitives into `runner_io.rs`, not `runner.rs`, so `runner.rs -> wasm_runner -> wasm_bridge` does not form an entrypoint-coupling knot. If old code below this correction mentions `lab_bridge`, `wait_for_bridge_response`, `runner_read_input_for_wasm_bridge`, `__lab_result_ptr`, or `__lab_result_len`, treat that text as obsolete and replace it with this correction during implementation.
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_bridge.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: existing runner integration tests plus new bridge unit tests
+
+**Interfaces:**
+- Consumes: `CodeModeRunnerInput`, `CodeModeRunnerOutput`, `RUNNER_STATE`, `wasm_memory`.
+- Produces:
+  - `pub(crate) struct WasmBridge`
+  - `pub(crate) fn install_bridge_imports(linker: &mut wasmtime::Linker<WasmRunState>, namespace: &str) -> anyhow::Result<()>`
+  - `pub(crate) fn emit_protocol_request(...) -> Result<serde_json::Value, ToolError>`
+
+- [ ] **Step 1: Add bridge state type**
+
+Create `crates/labby-codemode/src/wasm_bridge.rs`:
+
+```rust
+//! Wasmtime imports that preserve the existing parent-owned runner protocol.
+
+use anyhow::Result;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use wasmtime::{Caller, Linker, Memory};
+
+use crate::error::ToolError;
+use crate::protocol::{
+    CodeModeRunnerInput, CodeModeRunnerOutput, RUNNER_STATE,
+};
+use crate::wasm_memory::{CODE_MODE_WASM_BRIDGE_MAX_BYTES, read_guest_json};
+
+#[derive(Default)]
+pub(crate) struct WasmRunState {
+    pub(crate) memory: Option<Memory>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+enum BridgeRequest {
+    ToolCall { id: String, params: Value },
+    ArtifactWrite {
+        path: String,
+        content: String,
+        #[serde(default)]
+        content_type: Option<String>,
+    },
+    SnippetResolve {
+        name: String,
+        #[serde(default)]
+        input: Value,
+    },
+}
+
+pub(crate) fn install_bridge_imports(
+    linker: &mut Linker<WasmRunState>,
+    namespace: &str,
+) -> Result<()> {
+    linker.func_wrap(namespace, "lab_bridge", lab_bridge)?;
+    Ok(())
+}
+
+fn lab_bridge(
+    mut caller: Caller<'_, WasmRunState>,
+    request_ptr: i32,
+    request_len: i32,
+    response_ptr_out: i32,
+    response_len_out: i32,
+) -> wasmtime::Result<i32> {
+    let Some(memory) = caller.data().memory else {
+        return Ok(bridge_error(&mut caller, response_ptr_out, response_len_out, "internal_error", "Code Mode Wasm memory was not registered")?);
+    };
+    let request: BridgeRequest = match read_guest_json(
+        caller.as_context(),
+        &memory,
+        request_ptr,
+        request_len,
+        CODE_MODE_WASM_BRIDGE_MAX_BYTES,
+    ) {
+        Ok(request) => request,
+        Err(err) => {
+            return Ok(bridge_error(&mut caller, response_ptr_out, response_len_out, err.kind(), &err.to_string())?);
+        }
+    };
+    let response = match emit_protocol_request(request) {
+        Ok(value) => value,
+        Err(err) => json!({ "type": "tool_error", "kind": err.kind(), "message": err.to_string() }),
+    };
+    write_bridge_response(&mut caller, &memory, response_ptr_out, response_len_out, &response)
+}
+
+fn emit_protocol_request(request: BridgeRequest) -> Result<Value, ToolError> {
+    let seq = next_runner_seq()?;
+    let output = match request {
+        BridgeRequest::ToolCall { id, params } => CodeModeRunnerOutput::ToolCall { seq, id, params },
+        BridgeRequest::ArtifactWrite { path, content, content_type } => {
+            CodeModeRunnerOutput::ArtifactWrite { seq, path, content, content_type }
+        }
+        BridgeRequest::SnippetResolve { name, input } => {
+            CodeModeRunnerOutput::SnippetResolve { seq, name, input }
+        }
+    };
+    runner_emit(output)?;
+    wait_for_bridge_response(seq)
+}
+
+fn wait_for_bridge_response(seq: u64) -> Result<Value, ToolError> {
+    loop {
+        let input = crate::runner::runner_read_input_for_wasm_bridge()?;
+        match input {
+            CodeModeRunnerInput::ToolResult { seq: got, result } if got == seq => {
+                return Ok(json!({ "type": "tool_result", "result": result }));
+            }
+            CodeModeRunnerInput::SnippetResolved { seq: got, code, input } if got == seq => {
+                return Ok(json!({ "type": "snippet_resolved", "code": code, "input": input }));
+            }
+            CodeModeRunnerInput::ToolError { seq: got, kind, message } if got == seq => {
+                return Ok(json!({ "type": "tool_error", "kind": kind, "message": message }));
+            }
+            other => {
+                return Err(ToolError::Sdk {
+                    sdk_kind: "internal_error".to_string(),
+                    message: format!("runner received unexpected response while waiting for seq {seq}: {other:?}"),
+                });
+            }
+        }
+    }
+}
+```
+
+This sketch intentionally references helpers that must be made visible from `runner.rs` without changing protocol shapes:
+
+```rust
+pub(crate) fn runner_read_input_for_wasm_bridge() -> Result<CodeModeRunnerInput, ToolError>
+pub(crate) fn runner_emit_for_wasm_bridge(output: CodeModeRunnerOutput) -> Result<(), ToolError>
+pub(crate) fn next_runner_seq_for_wasm_bridge() -> Result<u64, ToolError>
+```
+
+Use those names if they fit the final module layout; if implementation keeps helpers private to `wasm_bridge.rs`, update imports accordingly.
+
+- [ ] **Step 2: Add response writing**
+
+Add to `wasm_bridge.rs`:
+
+```rust
+fn bridge_error(
+    caller: &mut Caller<'_, WasmRunState>,
+    response_ptr_out: i32,
+    response_len_out: i32,
+    kind: &str,
+    message: &str,
+) -> wasmtime::Result<i32> {
+    let value = json!({ "type": "tool_error", "kind": kind, "message": message });
+    let Some(memory) = caller.data().memory else {
+        return Ok(0);
+    };
+    write_bridge_response(caller, &memory, response_ptr_out, response_len_out, &value)
+}
+
+fn write_bridge_response(
+    caller: &mut Caller<'_, WasmRunState>,
+    memory: &Memory,
+    response_ptr_out: i32,
+    response_len_out: i32,
+    value: &Value,
+) -> wasmtime::Result<i32> {
+    let bytes = serde_json::to_vec(value)?;
+    if bytes.len() > CODE_MODE_WASM_BRIDGE_MAX_BYTES {
+        anyhow::bail!("Code Mode Wasm bridge response exceeded cap");
+    }
+    let alloc = caller
+        .get_export("cabi_realloc")
+        .and_then(|export| export.into_func())
+        .ok_or_else(|| anyhow::anyhow!("generated module did not export cabi_realloc"))?;
+    let alloc = alloc.typed::<(i32, i32, i32, i32), i32>(&caller)?;
+    let ptr = alloc.call(caller.as_context_mut(), (0, 0, 1, bytes.len() as i32))?;
+    memory.write(caller.as_context_mut(), ptr as usize, &bytes)?;
+    memory.write(caller.as_context_mut(), response_ptr_out as usize, &ptr.to_le_bytes())?;
+    memory.write(caller.as_context_mut(), response_len_out as usize, &(bytes.len() as i32).to_le_bytes())?;
+    Ok(1)
+}
+```
+
+If Wasmtime does not permit looking up `cabi_realloc` from this import context in the final shape, switch to returning `(ptr,len)` via two exported mutable globals or an explicit guest-exported allocation helper. Keep the bounded cap and add a regression test for the chosen mechanism.
+
+- [ ] **Step 3: Register module**
+
+Modify `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod wasm_bridge;
+```
+
+- [ ] **Step 4: Run focused bridge tests**
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_bridge --all-features -- --nocapture
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/labby-codemode/src/lib.rs crates/labby-codemode/src/runner.rs crates/labby-codemode/src/wasm_bridge.rs
+git commit -m "feat(codemode): bridge wasm host calls over runner protocol"
+```
+
+## Task 5: Execute Generated Wasm With Fuel, Epoch, And Resource Limits
+
+**Engineering-review correction:** This task must implement the following before any PR handoff:
+
+```rust
+pub(crate) struct WasmExecutionTimings {
+    pub(crate) wrap_ms: u128,
+    pub(crate) javy_codegen_ms: u128,
+    pub(crate) wasm_module_compile_ms: u128,
+    pub(crate) plugin_instantiate_ms: u128,
+    pub(crate) generated_instantiate_ms: u128,
+    pub(crate) bridge_roundtrip_ms: u128,
+}
+
+pub(crate) struct WasmRunner {
+    plugin: WasmPlugin,
+    module_cache: lru::LruCache<[u8; 32], wasmtime::Module>,
+    epoch_ticker: EpochTickerGuard,
+}
+```
+
+Mandatory implementation details:
+
+- `WasmRunner::execute` takes `timeout: Duration` in addition to `code` and `proxy`.
+- Reject `code.len() + proxy.len() > MAX_SOURCE_BYTES` before Javy codegen.
+- Wrap `compile_code_mode_wasm` and `Module::from_binary` in deadlines derived from the parent runner deadline; if they time out, return `kind = "timeout"` with `trap_cause = "codegen_timeout"` or `trap_cause = "module_compile_timeout"` in logs.
+- Derive epoch deadline ticks from `timeout`, for example `deadline_ticks = max(1, (timeout.as_millis() / CODE_MODE_WASM_EPOCH_TICK_MS as u128).saturating_sub(1))`, so a 5 second caller timeout does not accidentally get a 30 second epoch window.
+- Compute `fuel_consumed = initial_fuel - store.get_fuel()?` after successful execution and log it.
+- Add a bounded per-runner LRU cache keyed by `sha256(wrapped_source + proxy + plugin_hash + javy_version + codegen_options)` and cache the compiled `wasmtime::Module`; every execution still creates a fresh `Store` and `Instance`.
+- Before instantiation, inspect generated module imports and reject anything outside the allow-list: the Lab Javy plugin import namespace (`memory`, `cabi_realloc`, `invoke`) plus the Lab bridge imports (`lab_emit_tool_call`, `lab_emit_artifact_write`, `lab_emit_snippet_resolve`, `lab_emit_done`) if they appear on the plugin side. Add a test that no `wasi:*`, filesystem, env, random, clock, or socket imports are accepted from generated user modules.
+- Use `linker.instance(&mut store, &plugin.import_namespace, plugin_instance)?` or the verified Wasmtime 45 equivalent to define plugin exports for the generated module. Do not use a nonexistent `linker.store_context()`.
+- Delete the speculative `__lab_result_ptr` / `__lab_result_len` extraction path. Read the final result from `store.data().done`, which is set by `lab_emit_done`.
+- Classify only Wasmtime fuel exhaustion and epoch interruption as caller-facing `timeout`. Missing exports, bad imports, guest OOB traps, allocation failures, bridge ABI bugs, and plugin initialization failures are `server_error` or `invalid_param` and should evict the runner unless a test proves the runner is cleanly reusable.
+
+Add these tests:
+
+```rust
+#[tokio::test]
+async fn generated_module_rejects_unexpected_imports() {
+    let err = compile_and_validate_imports_for_test(r#"(module (import "wasi:filesystem" "open" (func)))"#)
+        .unwrap_err();
+    assert_eq!(err.kind(), "server_error");
+    assert!(err.to_string().contains("unexpected Wasm import"));
+}
+
+#[tokio::test]
+async fn source_size_is_rejected_before_codegen() {
+    let oversized = "x".repeat(crate::config::MAX_SOURCE_BYTES + 1);
+    let err = WasmRunner::new().unwrap()
+        .execute(&oversized, "", std::time::Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err.kind(), "invalid_param");
+    assert!(err.to_string().contains("source"));
+}
+
+#[tokio::test]
+async fn unexpected_oob_trap_is_not_reported_as_timeout() {
+    let err = execute_oob_trap_for_test().await.unwrap_err();
+    assert_ne!(err.kind(), "timeout");
+}
+```
+
+**Files:**
+- Create: `crates/labby-codemode/src/wasm_runner.rs`
+- Modify: `crates/labby-codemode/src/lib.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: `crates/labby-codemode/src/wasm_runner.rs`
+
+**Interfaces:**
+- Consumes: `wasm_plugin::WasmPlugin`, `wasm_codegen::compile_code_mode_wasm`, `wasm_bridge::install_bridge_imports`.
+- Produces:
+  - `pub(crate) struct WasmRunner`
+  - `pub(crate) fn new() -> Result<Self, CodeModeRunnerError>`
+  - `pub(crate) async fn execute(&self, code: &str, proxy: &str) -> Result<CodeModeRunnerResult, CodeModeRunnerError>`
+
+- [ ] **Step 1: Add runner skeleton**
+
+Create `crates/labby-codemode/src/wasm_runner.rs`:
+
+```rust
+//! Wasmtime-backed execution for one Code Mode runner subprocess.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use wasmtime::{Instance, Linker, Module, ResourceLimiter, Store};
+
+use crate::protocol::CodeModeRunnerResult;
+use crate::wasm_bridge::{WasmRunState, install_bridge_imports};
+use crate::wasm_codegen::compile_code_mode_wasm;
+use crate::wasm_plugin::{
+    CODE_MODE_WASM_DEFAULT_FUEL, CODE_MODE_WASM_EPOCH_DEADLINE_TICKS,
+    CODE_MODE_WASM_MEMORY_LIMIT_BYTES, WasmPlugin, load_wasm_plugin, wasm_limits_disabled,
+};
+
+pub(crate) struct WasmRunner {
+    plugin: Arc<WasmPlugin>,
+}
+
+impl WasmRunner {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self {
+            plugin: Arc::new(load_wasm_plugin()?),
+        })
+    }
+
+    pub(crate) async fn execute(&self, code: &str, proxy: &str) -> Result<CodeModeRunnerResult> {
+        let wasm = compile_code_mode_wasm(&self.plugin.plugin, code, proxy).await?;
+        let module = Module::from_binary(&self.plugin.engine, &wasm)
+            .context("failed to compile generated Code Mode Wasm module")?;
+        let mut store = Store::new(&self.plugin.engine, WasmRunState::default());
+        if !wasm_limits_disabled() {
+            store.set_fuel(CODE_MODE_WASM_DEFAULT_FUEL)?;
+            store.set_epoch_deadline(CODE_MODE_WASM_EPOCH_DEADLINE_TICKS);
+        }
+        store.limiter(|_| &mut CodeModeLimiter);
+        let mut linker = Linker::new(&self.plugin.engine);
+        install_bridge_imports(&mut linker, &self.plugin.import_namespace)?;
+        let plugin_instance = linker.instantiate(&mut store, &self.plugin.module)?;
+        define_dynamic_imports(&mut linker, &self.plugin.import_namespace, plugin_instance)?;
+        let instance = linker.instantiate(&mut store, &module)?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .context("generated Code Mode module did not export memory")?;
+        store.data_mut().memory = Some(memory);
+        let start = instance
+            .get_typed_func::<(), ()>(&mut store, "_start")
+            .context("generated Code Mode module did not export _start")?;
+        start.call(&mut store, ())?;
+        read_main_result(&mut store, &instance)
+    }
+}
+
+struct CodeModeLimiter;
+
+impl ResourceLimiter for CodeModeLimiter {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        Ok(desired <= CODE_MODE_WASM_MEMORY_LIMIT_BYTES)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        Ok(false)
+    }
+}
+```
+
+- [ ] **Step 2: Add dynamic import definitions**
+
+Append to `wasm_runner.rs`:
+
+```rust
+fn define_dynamic_imports(
+    linker: &mut Linker<WasmRunState>,
+    namespace: &str,
+    plugin_instance: Instance,
+) -> Result<()> {
+    let memory = plugin_instance
+        .get_memory(linker.store_context(), "memory")
+        .context("Javy plugin did not export memory")?;
+    let cabi_realloc = plugin_instance
+        .get_func(linker.store_context(), "cabi_realloc")
+        .context("Javy plugin did not export cabi_realloc")?;
+    let invoke = plugin_instance
+        .get_func(linker.store_context(), "invoke")
+        .context("Javy plugin did not export invoke")?;
+    linker.define(namespace, "memory", memory)?;
+    linker.define(namespace, "cabi_realloc", cabi_realloc)?;
+    linker.define(namespace, "invoke", invoke)?;
+    Ok(())
+}
+```
+
+If `Linker` does not expose `store_context()` in Wasmtime 45, implement this helper with the verified Wasmtime 45 signature:
+
+```rust
+fn define_dynamic_imports(
+    store: &mut Store<WasmRunState>,
+    linker: &mut Linker<WasmRunState>,
+    namespace: &str,
+    plugin_instance: Instance,
+) -> Result<()>
+```
+
+and use `plugin_instance.get_memory(&mut *store, "memory")`.
+
+- [ ] **Step 3: Add result extraction**
+
+Append to `wasm_runner.rs`:
+
+```rust
+fn read_main_result(
+    store: &mut Store<WasmRunState>,
+    instance: &Instance,
+) -> Result<CodeModeRunnerResult> {
+    let memory = store
+        .data()
+        .memory
+        .context("Code Mode Wasm memory not registered after execution")?;
+    let result_ptr = instance
+        .get_global(&mut *store, "__lab_result_ptr")
+        .context("generated module did not expose __lab_result_ptr")?
+        .get(&mut *store)
+        .i32()
+        .context("__lab_result_ptr was not i32")?;
+    let result_len = instance
+        .get_global(&mut *store, "__lab_result_len")
+        .context("generated module did not expose __lab_result_len")?
+        .get(&mut *store)
+        .i32()
+        .context("__lab_result_len was not i32")?;
+    let value: serde_json::Value = crate::wasm_memory::read_guest_json(
+        &*store,
+        &memory,
+        result_ptr,
+        result_len,
+        crate::wasm_memory::CODE_MODE_WASM_BRIDGE_MAX_BYTES,
+    )?;
+    Ok(CodeModeRunnerResult::from_response_result(Some(value)))
+}
+```
+
+If Javy's dynamic module cannot expose result globals as written, alter the JS wrapper to write the final result through `lab_bridge("done", { result })` and have `wasm_bridge` retain it in `WasmRunState`. The accepted final interface must still produce `CodeModeRunnerResult`.
+
+- [ ] **Step 4: Add epoch ticker**
+
+Add to `wasm_runner.rs`:
+
+```rust
+fn spawn_epoch_ticker(engine: wasmtime::Engine) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_millis(
+            crate::wasm_plugin::CODE_MODE_WASM_EPOCH_TICK_MS,
+        ));
+        engine.increment_epoch();
+    })
+}
+```
+
+Keep one ticker per runner subprocess, created in `WasmRunner::new`, or use a `OnceLock` keyed by `Engine` if the implementation can prove it does not leak threads across tests. The runner process is intentionally long-lived, so one thread for the process lifetime is acceptable.
+
+- [ ] **Step 5: Register module**
+
+Modify `crates/labby-codemode/src/lib.rs`:
+
+```rust
+mod wasm_runner;
+```
+
+- [ ] **Step 6: Wire runner.rs to use WasmRunner**
+
+In `crates/labby-codemode/src/runner.rs`, replace the block that creates `javy::Config`, `javy::Runtime`, installs native callbacks, evals `wrap_code_mode`, resolves pending jobs, and emits `Done` with:
+
+```rust
+let wasm_runner = WASM_RUNNER.with(|cell| {
+    let mut cell = cell.borrow_mut();
+    if cell.is_none() {
+        *cell = Some(crate::wasm_runner::WasmRunner::new().map_err(|err| {
+            CodeModeRunnerError {
+                kind: "server_error".to_string(),
+                message: format!("failed to initialize Code Mode Wasm runner: {err}"),
+            }
+        })?);
+    }
+    Ok::<_, CodeModeRunnerError>(cell.as_ref().unwrap().clone())
+})?;
+
+let result = wasm_runner
+    .execute(&code, &proxy)
+    .await
+    .map_err(|err| classify_wasm_execution_error(err))?;
+
+runner_emit(CodeModeRunnerOutput::Done {
+    result,
+    logs: Vec::new(),
+})
+.map_err(CodeModeRunnerError::from)?;
+Ok(RunnerLoopOutcome::Completed)
+```
+
+If `run_code_mode_runner` remains synchronous, introduce a small Tokio current-thread runtime in the runner subprocess:
+
+```rust
+let rt = tokio::runtime::Builder::new_current_thread()
+    .enable_time()
+    .build()
+    .map_err(|err| CodeModeRunnerError {
+        kind: "server_error".to_string(),
+        message: format!("failed to create Code Mode runner async runtime: {err}"),
+    })?;
+let result = rt.block_on(wasm_runner.execute(&code, &proxy))?;
+```
+
+Do not use async Wasmtime imports to call parent-side `CodeModeHost` directly.
+
+- [ ] **Step 7: Add trap classification**
+
+Add in `runner.rs` or `wasm_runner.rs`:
+
+```rust
+fn classify_wasm_execution_error(err: anyhow::Error) -> CodeModeRunnerError {
+    let message = err.to_string();
+    if message.contains("all fuel consumed")
+        || message.contains("epoch deadline")
+        || message.contains("wasm trap")
+    {
+        return CodeModeRunnerError {
+            kind: "timeout".to_string(),
+            message: format!("Code Mode execution timed out: {message}"),
+        };
+    }
+    CodeModeRunnerError {
+        kind: "server_error".to_string(),
+        message: add_code_mode_hint("server_error", &message),
+    }
+}
+```
+
+Keep richer `trap_cause` in tracing fields, not the caller-facing kind.
+
+- [ ] **Step 8: Run focused execution tests**
+
+Run:
+
+```bash
+cargo test -p labby-codemode wasm_runner --all-features -- --nocapture
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/labby-codemode/src/lib.rs crates/labby-codemode/src/runner.rs crates/labby-codemode/src/wasm_runner.rs
+git commit -m "feat(codemode): execute code mode under wasmtime"
+```
+
+## Task 6: Preserve Runner Reuse And Timeout Disposition
+
+**Files:**
+- Modify: `crates/labby-codemode/src/runner_drive.rs`
+- Modify: `crates/labby-codemode/src/runner.rs`
+- Test: existing pool/runner tests
+
+**Interfaces:**
+- Consumes: existing `DriveOutcome::{Completed, ExecutionError, RunnerUnhealthy}`.
+- Produces: tests proving fuel/epoch execution errors release pooled runners, while parent wall-clock timeout still evicts.
+
+- [ ] **Step 1: Add a pooled-runner trap reuse test**
+
+Add a test near existing runner-drive timeout tests:
+
+```rust
+#[tokio::test]
+async fn wasm_timeout_error_releases_pooled_runner_for_reuse() {
+    let host = TestHost::default();
+    let broker = CodeModeBroker::new(Some(&host));
+    let first = broker
+        .run_in_runner(
+            "async () => { while (true) {} }".to_string(),
+            String::new(),
+            Duration::from_secs(5),
+            CodeModeCaller::trusted_local(),
+            CodeModeSurface::Cli,
+            100,
+            64 * 1024,
+            false,
+            ToolScope::Unscoped,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(first.kind(), "timeout");
+
+    let second = broker
+        .run_in_runner(
+            "async () => 42".to_string(),
+            String::new(),
+            Duration::from_secs(5),
+            CodeModeCaller::trusted_local(),
+            CodeModeSurface::Cli,
+            100,
+            64 * 1024,
+            false,
+            ToolScope::Unscoped,
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.result, Some(serde_json::json!(42)));
+}
+```
+
+Use the repo's existing test host constructors and type names if they differ; preserve the asserted behavior.
+
+- [ ] **Step 2: Re-run parent wall-clock eviction test**
+
+Run:
+
+```bash
+cargo test -p labby-codemode timeout --all-features -- --nocapture
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 3: Run pool tests**
+
+Run:
+
+```bash
+cargo test -p labby-codemode pool --all-features
+```
+
+Expected:
+
+```text
+test result: ok.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/labby-codemode/src/runner_drive.rs crates/labby-codemode/src/runner.rs
+git commit -m "test(codemode): prove wasm traps preserve runner reuse"
+```
+
+## Task 7: Run Full Code Mode Parity Tests
+
+**Files:**
+- Modify: existing tests under `crates/labby-codemode/src/` as needed
+- Test: `crates/labby-codemode`
+
+**Interfaces:**
+- Consumes: Wasmtime runner and bridge.
+- Produces: parity evidence for JS API compatibility.
+
+- [ ] **Step 1: Run the existing crate suite**
+
+Run:
+
+```bash
+cargo nextest run -p labby-codemode --all-features
+```
+
+Expected:
+
+```text
+PASS 162 tests
+```
+
+The exact count may increase after new tests. All tests must pass.
+
+- [ ] **Step 2: Add explicit structured rejection parity if missing**
+
+Add a test:
+
+```rust
+#[tokio::test]
+async fn tool_error_rejection_remains_json_parse_recoverable() {
+    let response = execute_code_mode_for_test(
+        r#"async () => {
+            try {
+                await callTool("missing::tool", {});
+            } catch (e) {
+                return JSON.parse(e.message);
+            }
+        }"#,
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.result.unwrap()["kind"], "unknown_tool");
+}
+```
+
+Use the existing helper name in the test module. If the exact expected kind is `server_error` or a local test stub kind, assert the repo's current parity kind.
+
+- [ ] **Step 3: Add artifact path traversal parity if missing**
+
+Add a test:
+
+```rust
+#[tokio::test]
+async fn wasm_sourced_artifact_path_traversal_is_rejected() {
+    let err = execute_code_mode_for_test(
+        r#"async () => {
+            await writeArtifact("../../etc/passwd", "nope");
+        }"#,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.kind(), "invalid_param");
+    assert!(err.to_string().contains("path"));
+}
+```
+
+- [ ] **Step 4: Add snippet budget parity if missing**
+
+Add a test that resolves snippets until the existing max count is exceeded:
+
+```rust
+#[tokio::test]
+async fn wasm_snippet_resolve_budget_matches_existing_contract() {
+    let err = execute_code_mode_for_test(
+        r#"async () => {
+            for (let i = 0; i < 64; i++) {
+                await codemode.run("tiny", {});
+            }
+        }"#,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.kind(), "snippet_resolve_limit");
+}
+```
+
+- [ ] **Step 5: Re-run the full crate suite**
+
+Run:
+
+```bash
+cargo nextest run -p labby-codemode --all-features
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/src
+git commit -m "test(codemode): preserve wasm runner api parity"
+```
+
+## Task 8: Update Docs And Observability
+
+**Files:**
+- Modify: `crates/labby-codemode/CLAUDE.md`
+- Modify: `docs/dev/CODE_MODE.md`
+- Modify: `docs/dev/ERRORS.md`
+- Modify: `docs/dev/OBSERVABILITY.md`
+- Modify: `docs/dev/CODE_MODE_WASMTIME_SPIKE.md`
+
+**Interfaces:**
+- Consumes: final implemented module names and trap behavior.
+- Produces: docs that no longer contradict implementation.
+
+- [ ] **Step 1: Update crate runtime docs**
+
+In `crates/labby-codemode/CLAUDE.md`, replace:
+
+```markdown
+## Runtime — Javy/QuickJS via subprocess stdio (NOT Wasmtime)
+```
+
+with:
+
+```markdown
+## Runtime — Javy-generated Wasm under Wasmtime inside subprocess stdio
+```
+
+Add:
+
+```markdown
+The live Code Mode runner compiles wrapped caller JS with Bytecode Alliance Javy dynamic codegen and executes the generated module under Wasmtime inside the existing runner subprocess. The subprocess pool, env isolation, process-group/Job Object kill behavior, PR_SET_DUMPABLE, per-execution cwd jail, and parent-owned stdio protocol remain the outer containment and authority boundary.
+
+Caller-facing timeout errors continue to use `kind = "timeout"`. Internal logs distinguish `trap_cause = "fuel_exhausted"`, `trap_cause = "epoch_interrupted"`, and `trap_cause = "os_subprocess_timeout"` when available.
+```
+
+- [ ] **Step 2: Update file responsibility table**
+
+Add rows:
+
+```markdown
+| `wasm_plugin.rs` | Javy plugin bytes, Wasmtime engine/module setup, and Wasm limit constants. |
+| `wasm_codegen.rs` | Wraps Code Mode JS and compiles it into a Javy dynamic-linking Wasm module. |
+| `wasm_memory.rs` | Bounded guest linear-memory reads and UTF-8/JSON decoding helpers. |
+| `wasm_bridge.rs` | Wasmtime imports that emit/wait on the existing parent/runner protocol for tool/artifact/snippet authority. |
+| `wasm_runner.rs` | Per-Start Store/Instance execution, fuel, epoch, memory limits, and trap classification. |
+```
+
+- [ ] **Step 3: Update errors doc**
+
+In `docs/dev/ERRORS.md`, document:
+
+```markdown
+`timeout` remains the stable caller-facing kind for Code Mode execution timeout. This includes parent wall-clock expiry, Wasmtime fuel exhaustion, and Wasmtime epoch interruption. Operators should use structured logs' `trap_cause` field to distinguish the internal cause.
+```
+
+- [ ] **Step 4: Update observability doc**
+
+In `docs/dev/OBSERVABILITY.md`, add Code Mode-specific fields:
+
+```markdown
+Code Mode Wasmtime runner events may include `runtime = "wasmtime"`, `trap_cause`, `fuel_remaining`, and `wasm_compile_ms`. These fields are diagnostic only; standard dispatch fields remain `surface`, `service`, `action`, `elapsed_ms`, and `kind`.
+```
+
+- [ ] **Step 5: Run stale language search with Lumen first, then exact text checks**
+
+Run Lumen semantic search for stale Code Mode Wasmtime prohibitions:
+
+```text
+query: "Do not reintroduce Wasmtime fuel code_mode_fuel_exhausted NOT Wasmtime"
+path: /home/jmagar/workspace/lab/.worktrees/codemode-wasmtime-runtime-implementation
+```
+
+Then run exact checks:
+
+```bash
+git grep -n "Do not reintroduce Wasmtime\\|NOT Wasmtime\\|code_mode_fuel_exhausted" -- crates/labby-codemode docs || true
+```
+
+Expected: no stale prohibition remains except intentional historical references in the spike doc.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/labby-codemode/CLAUDE.md docs/dev/CODE_MODE.md docs/dev/ERRORS.md docs/dev/OBSERVABILITY.md docs/dev/CODE_MODE_WASMTIME_SPIKE.md
+git commit -m "docs(codemode): describe wasmtime runtime"
+```
+
+## Task 9: Full Verification And PR Handoff
+
+**Files:**
+- All touched files
+
+**Interfaces:**
+- Consumes: completed implementation.
+- Produces: green worktree, pushed branch, PR update.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Check focused crate**
+
+Run:
+
+```bash
+cargo check -p labby-codemode --all-features
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Test focused crate**
+
+Run:
+
+```bash
+cargo nextest run -p labby-codemode --all-features
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run mandatory workspace build gate**
+
+Run:
+
+```bash
+cargo build --workspace --all-features
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 5: Run lint gate**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-features -- -D warnings
+cargo fmt --all --check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Run dependency gates**
+
+Run:
+
+```bash
+cargo deny check
+cargo audit
+```
+
+Expected: `cargo deny check` passes. `cargo audit` has no new Wasmtime/WASI 42 advisories; any remaining findings are the existing baseline and must be listed in the PR body.
+
+- [ ] **Step 7: Confirm no Wasmtime/WASI 42 packages**
+
+Run:
+
+```bash
+cargo tree -i wasmtime@42.0.2 || true
+cargo tree -i wasmtime-wasi@42.0.2 || true
+```
+
+Expected:
+
+```text
+error: package ID specification `wasmtime@42.0.2` did not match any packages
+error: package ID specification `wasmtime-wasi@42.0.2` did not match any packages
+```
+
+- [ ] **Step 8: Confirm native Javy hot path is removed**
+
+Run Lumen semantic search first for stale native Javy runner usage:
+
+```text
+query: "javy Runtime Config Function new __labEmitToolCall native QuickJS hot path"
+path: /home/jmagar/workspace/lab/.worktrees/codemode-wasmtime-runtime-implementation/crates/labby-codemode
+```
+
+Then run exact checks:
+
+```bash
+git grep -n "javy::Runtime\\|javy::Config\\|javy::quickjs\\|__labEmitToolCall.*Function::new" -- crates/labby-codemode/src crates/labby-codemode/Cargo.toml || true
+cargo tree -p labby-codemode -i javy || true
+```
+
+Expected: no native `javy::Runtime`/`javy::Config` hot-path usage remains. If the `javy` crate is no longer needed, remove it from `crates/labby-codemode/Cargo.toml`. If it remains for tests or helper types, document exactly why in the PR body.
+
+- [ ] **Step 9: Run latency and fuel benchmark gate**
+
+Run the benchmark command added by the implementation, for example:
+
+```bash
+cargo run -p labby --all-features -- internal code-mode-benchmark --samples 20 --json > /tmp/codemode-wasmtime-benchmark.json
+```
+
+Expected JSON contains:
+
+```json
+{
+  "warm_trivial_p95_ms": 0,
+  "baseline_native_p95_ms": 0,
+  "overhead_ratio": 0,
+  "wrap_ms": 0,
+  "javy_codegen_ms": 0,
+  "wasm_module_compile_ms": 0,
+  "plugin_instantiate_ms": 0,
+  "generated_instantiate_ms": 0,
+  "bridge_roundtrip_ms": 0,
+  "fuel_consumed_p99": 0,
+  "chosen_fuel_budget": 0
+}
+```
+
+Acceptance: warm trivial p95 must be explicitly judged against the current native baseline captured before removal. If p95 overhead is greater than 2x or greater than 25ms absolute, stop and escalate before creating a ready PR. Include raw benchmark JSON or a checked-in summarized table under `docs/dev/`.
+
+- [ ] **Step 10: Commit remaining changes**
+
+```bash
+git status --short
+git add .
+git commit -m "feat(codemode): run code mode through wasmtime"
+```
+
+If there are no changes, skip the commit and record that all task commits already captured the work.
+
+- [ ] **Step 11: Push branch**
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: branch pushed.
+
+- [ ] **Step 12: Create or update PR**
+
+If continuing PR #174, run:
+
+```bash
+gh pr edit 174 --body-file /tmp/codemode-wasmtime-pr-body.md
+gh pr ready 174
+```
+
+If creating a new implementation PR, run:
+
+```bash
+gh pr create --draft --title "Implement Code Mode Wasmtime runtime" --body-file /tmp/codemode-wasmtime-pr-body.md
+```
+
+PR body must include:
+
+```markdown
+## Summary
+- replaces native QuickJS execution inside the runner subprocess with Javy-generated Wasm under Wasmtime
+- preserves parent-owned stdio host authority for tools, artifacts, and snippets
+- keeps caller-facing timeout kind stable while adding internal trap diagnostics
+
+## Verification
+- cargo check -p labby-codemode --all-features
+- cargo nextest run -p labby-codemode --all-features
+- cargo build --workspace --all-features
+- cargo clippy --workspace --all-features -- -D warnings
+- cargo deny check
+- cargo audit (baseline advisories only; no Wasmtime/WASI 42)
+- cargo tree -i wasmtime@42.0.2 || true
+- cargo tree -i wasmtime-wasi@42.0.2 || true
+- native Javy hot-path grep/tree check
+- Code Mode Wasmtime latency/fuel benchmark summary
+```
+
+## Self-Review
+
+Spec coverage:
+- Dependency unblock is covered in Task 1 and Task 9.
+- Plugin artifact path is covered in Task 1.
+- Javy dynamic codegen is covered in Task 2.
+- Guest-memory validation is covered in Task 3.
+- Parent-owned stdio authority is covered in Task 4.
+- Wasmtime fuel, epoch, memory, and trap mapping are covered in Task 5.
+- Runner reuse after fuel/epoch traps is covered in Task 6.
+- API parity is covered in Task 7.
+- Docs and observability are covered in Task 8.
+- Full verification and PR handoff are covered in Task 9.
+
+Placeholder scan:
+- No `TBD`, `TODO`, `implement later`, or "similar to" placeholders remain.
+- Some snippets are marked as sketches where the final Wasmtime 45 signature may differ; each includes the exact fallback signature and the required test behavior.
+
+Type consistency:
+- `WasmPlugin`, `compile_code_mode_wasm`, `WasmRunState`, and `WasmRunner` are introduced before later tasks consume them.
+- `CodeModeRunnerInput` and `CodeModeRunnerOutput` are the existing protocol types and are not renamed.
+- Caller-facing `timeout` behavior is consistent across tasks and docs.


### PR DESCRIPTION
## Summary

- documents the original `javy-codegen 4.0.0` crates.io blocker: Wasmtime/WASI 42 trips current RustSec advisories
- adds and proves the Javy `v9.0.0` Git-tag codegen path using unpublished `javy-codegen 4.0.1-alpha.1`
- pins the codegen dependency graph to patched Wasmtime/WASI/Wizer `45.0.3`
- updates `cargo-deny` policy narrowly for the reviewed Javy Git source and Code Mode Javy/codegen `anyhow` boundary

## Current status

The original crates.io path is still blocked, but the in-process codegen route is no longer blocked overall. Lab can compile and test against:

```toml
javy-codegen = { git = "https://github.com/bytecodealliance/javy", tag = "v9.0.0", version = "4.0.1-alpha.1" }
deterministic-wasi-ctx = "=4.0.3"
wasmtime = "=45.0.3"
wasmtime-wasi = "=45.0.3"
wasmtime-wizer = { version = "=45.0.3", features = ["wasmtime"] }
```

Caveat: this is heavier than the current runner path. The first focused package check took 6m31s because the graph builds native `wasm-opt`.

## Verification

- `cargo check -p labby-codemode --all-features` passed in 6m31s
- `cargo nextest run -p labby-codemode --all-features` passed: 162/162
- `cargo deny check` passed after the narrow policy update
- `cargo audit` still reports baseline `quinn-proto` / `rsa` advisories and the existing allowed `paste` warning; no Wasmtime/WASI 42 entries remain
- `cargo tree -i wasmtime@42.0.2` and `cargo tree -i wasmtime-wasi@42.0.2` both confirm those package IDs are absent
- `git diff --check` passed

Closes #168? No: this PR unblocks the dependency path and updates the plan; the actual Wasmtime runtime implementation still needs to be built on top of it.
