### PR TITLE
fix: sync Cargo.lock to 0.30.0 (unblock --locked CI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "labby-primitives"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "thiserror 2.0.18",
  "url",


### PR DESCRIPTION
PR #175 bumped the workspace to 0.30.0 but `labby-primitives` stayed at 0.29.0 in Cargo.lock, so every `--locked` CI job on main fails immediately (`cannot update the lock file because --locked was passed`). This one-line lock sync fixes it. Verified locally: `cargo check --workspace --all-features --locked` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `labby-primitives` in Cargo.lock from 0.29.0 to 0.30.0 to match the workspace bump and fix `--locked` CI failures. Verified: `cargo check --workspace --all-features --locked` passes.

<sup>Written for commit d74eb38790826645e824bcf92d7d48c1c37392fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

