### PR TITLE
fix(setup): uv-python provision fails on /root/uv.toml permission denied

### DIFF
--- a/config/incus/labby-image.yaml
+++ b/config/incus/labby-image.yaml
@@ -129,6 +129,11 @@ actions:
       # LABBY_PROVISION_ACTION: uv-python
       runuser -u labby -- env HOME=/home/labby USER=labby LOGNAME=labby XDG_CONFIG_HOME=/home/labby/.config XDG_CACHE_HOME=/home/labby/.cache XDG_DATA_HOME=/home/labby/.local/share sh -lc '
       set -eu
+      # uv discovers config by walking up from the CWD; the provision runs from
+      # root'\''s home, so uv would try to read /root/uv.toml (unreadable by labby).
+      # Pin the CWD to the labby home and disable ambient uv config discovery.
+      cd "$HOME"
+      export UV_NO_CONFIG=1
       mkdir -p "$HOME/.local/bin"
       tmp="$(mktemp -d)"
       trap '\''rm -rf "$tmp"'\'' EXIT


### PR DESCRIPTION
## Problem

Running `labby setup --provision` (via `scripts/incus-bootstrap.sh`) aborts at the `uv-python` action:

```
error: failed to open file `/root/uv.toml`: Permission denied (os error 13)
```

`uv python install` discovers config by walking up from the current directory. Provision runs from root's home, so `uv` (running as the `labby` user via `runuser`) tries to read `/root/uv.toml`, which it can't. The failure aborts provision before the systemd-unit-write + `systemctl enable --now` step, so the gateway never comes up on a fresh converge.

## Fix

In the uv-python action (`config/incus/labby-image.yaml`), `cd "$HOME"` and `export UV_NO_CONFIG=1` so uv operates from the labby home and ignores any ambient config file. Sibling actions (node/rust-go/agent-clis) use absolute `$HOME` paths and aren't affected.

Found while deploying 0.30.0 to the live Incus gateway container; verified the full provision completes unattended after this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `uv-python` provision failure by preventing `uv` from reading `/root/uv.toml`. Provision now completes and the gateway service enables on fresh converge.

- **Bug Fixes**
  - Run `uv` from the labby home by `cd "$HOME"` to avoid config discovery in `/root`.
  - Set `UV_NO_CONFIG=1` so `uv` ignores any ambient `uv.toml`.
  - Change scoped to `config/incus/labby-image.yaml` uv-python action; other actions unaffected.

<sup>Written for commit 7b97cd21f2398f5e0b4664dba9088f664ba7ca5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved provisioning process reliability by adjusting configuration discovery settings to prevent initialization errors during system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->