### PR TITLE
fix(incus): stale 'su - lab' → 'su - labby' after lab→labby rename

### DIFF
--- a/scripts/ci/smoke-incus-image.sh
+++ b/scripts/ci/smoke-incus-image.sh
@@ -213,7 +213,7 @@ incus_cmd start "$container_name"
 wait_for_running "$container_name"
 
 log "checking baked toolchain"
-incus_cmd exec "$container_name" -- su - lab -c 'set -e
+incus_cmd exec "$container_name" -- su - labby -c 'set -e
 node --version
 npm --version
 uv --version

--- a/scripts/incus-bootstrap.sh
+++ b/scripts/incus-bootstrap.sh
@@ -618,7 +618,7 @@ fi
 
 cat <<DONE
 Done. Manual steps remain:
-  1. incus exec $NAME -- su - lab
+  1. incus exec $NAME -- su - labby
   2. claude login && codex login && gemini
   3. verify service: incus exec $NAME -- systemctl status labby --no-pager
   4. verify readiness: incus exec $NAME -- curl -fsS http://127.0.0.1:8765/ready


### PR DESCRIPTION
Two leftover `su - lab` references from the lab→labby user rename:

- `scripts/ci/smoke-incus-image.sh:216` — **latent bug**: the baked-toolchain smoke check runs `su - lab -c '...'` but the provisioned user is `labby`, so it would fail on a fresh image.
- `scripts/incus-bootstrap.sh:621` — cosmetic manual-steps hint.

Both corrected to `su - labby`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two stale 'su - lab' references after the lab→labby rename. The Incus image smoke test and bootstrap manual hint now use 'su - labby' to prevent failures on fresh images and keep instructions accurate.

<sup>Written for commit 6d01b5f81e4015a63d11370f4c3950e22b190bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

