### PR TITLE
feat(ui): hide feature-gated services absent from this build (lab-x4mw2)

### DIFF
--- a/apps/gateway-admin/app/(admin)/chat/page.tsx
+++ b/apps/gateway-admin/app/(admin)/chat/page.tsx
@@ -1,4 +1,5 @@
 import { ChatShell } from '@/components/chat/chat-shell'
+import { CapabilityGuard } from '@/components/capability-guard'
 
 export const metadata = {
   title: 'Chat',
@@ -6,5 +7,9 @@ export const metadata = {
 }
 
 export default function ChatPage() {
-  return <ChatShell />
+  return (
+    <CapabilityGuard need="acp" label="Chat">
+      <ChatShell />
+    </CapabilityGuard>
+  )
 }

--- a/apps/gateway-admin/app/(admin)/marketplace/page.tsx
+++ b/apps/gateway-admin/app/(admin)/marketplace/page.tsx
@@ -1,7 +1,12 @@
 import { MarketplaceListContent } from '@/components/marketplace/marketplace-list-content'
+import { CapabilityGuard } from '@/components/capability-guard'
 
 export const metadata = { title: 'Marketplace — Labby' }
 
 export default function MarketplacePage() {
-  return <MarketplaceListContent />
+  return (
+    <CapabilityGuard need="marketplace" label="Marketplace">
+      <MarketplaceListContent />
+    </CapabilityGuard>
+  )
 }

--- a/apps/gateway-admin/app/(admin)/marketplace/plugin/page.tsx
+++ b/apps/gateway-admin/app/(admin)/marketplace/plugin/page.tsx
@@ -1,10 +1,13 @@
 import { Suspense } from 'react'
 import { MarketplacePluginPageClient } from './plugin-page-client'
+import { CapabilityGuard } from '@/components/capability-guard'
 
 export default function MarketplacePluginPage() {
   return (
-    <Suspense fallback={null}>
-      <MarketplacePluginPageClient />
-    </Suspense>
+    <CapabilityGuard need="marketplace" label="Marketplace">
+      <Suspense fallback={null}>
+        <MarketplacePluginPageClient />
+      </Suspense>
+    </CapabilityGuard>
   )
 }

--- a/apps/gateway-admin/app/(admin)/nodes/page.tsx
+++ b/apps/gateway-admin/app/(admin)/nodes/page.tsx
@@ -1,6 +1,11 @@
 import { NodesPage } from '@/components/nodes/nodes-page'
+import { CapabilityGuard } from '@/components/capability-guard'
 
 export default function NodesPageRoute() {
-  return <NodesPage />
+  return (
+    <CapabilityGuard need="nodes" label="Nodes">
+      <NodesPage />
+    </CapabilityGuard>
+  )
 }
 

--- a/apps/gateway-admin/app/(admin)/page.tsx
+++ b/apps/gateway-admin/app/(admin)/page.tsx
@@ -39,6 +39,7 @@ import type { DrillTarget } from '@/components/dashboard/drill'
 import { gatewayDetailHref } from '@/lib/api/gateway-config'
 import { useGateways } from '@/lib/hooks/use-gateways'
 import { useDashboardMetrics } from '@/lib/hooks/use-dashboard-metrics'
+import { useCapabilities } from '@/lib/hooks/use-capabilities'
 import { fetchFleetDevices } from '@/lib/api/device-client'
 import {
   WINDOW_LABELS,
@@ -69,7 +70,17 @@ function PanelHeading({ title, hint }: { title: string; hint?: string }) {
 
 export default function OverviewPage() {
   const { data: gateways, isLoading: gatewaysLoading } = useGateways()
-  const { data: devices, error: devicesError } = useSWR('/fleet-devices', () => fetchFleetDevices())
+  const capabilities = useCapabilities()
+  // Only fetch fleet devices when the catalog confirms the `nodes` service is
+  // present. A null SWR key tells SWR not to fetch, so a gateway-only build
+  // never hits `/v1/nodes`. `nodesUnavailable` = catalog resolved and `nodes`
+  // is confidently absent → render the Devices tile as "n/a".
+  const nodesAvailable = capabilities.ready && capabilities.nodes
+  const nodesUnavailable = capabilities.ready && !capabilities.nodes
+  const { data: devices, error: devicesError } = useSWR(
+    nodesAvailable ? '/fleet-devices' : null,
+    () => fetchFleetDevices(),
+  )
   const [activeWindow, setActiveWindow] = useState<MetricsWindow>('24h')
   const [drill, setDrill] = useState<DrillTarget | null>(null)
   const { data: metrics, error: metricsError, mutate: reloadMetrics } = useDashboardMetrics(activeWindow)
@@ -158,9 +169,9 @@ export default function OverviewPage() {
           />
           <StatTile
             label="Devices"
-            value={live.connectedDevices}
+            value={nodesUnavailable ? 'n/a' : live.connectedDevices}
             icon={HardDrive}
-            loading={!devices && !devicesError}
+            loading={nodesAvailable && !devices && !devicesError}
           />
           <StatTile
             label="Tool calls"

--- a/apps/gateway-admin/app/(admin)/page.tsx
+++ b/apps/gateway-admin/app/(admin)/page.tsx
@@ -40,6 +40,7 @@ import { gatewayDetailHref } from '@/lib/api/gateway-config'
 import { useGateways } from '@/lib/hooks/use-gateways'
 import { useDashboardMetrics } from '@/lib/hooks/use-dashboard-metrics'
 import { useCapabilities } from '@/lib/hooks/use-capabilities'
+import { capabilityAvailable } from '@/lib/capabilities'
 import { fetchFleetDevices } from '@/lib/api/device-client'
 import {
   WINDOW_LABELS,
@@ -75,7 +76,7 @@ export default function OverviewPage() {
   // present. A null SWR key tells SWR not to fetch, so a gateway-only build
   // never hits `/v1/nodes`. `nodesUnavailable` = catalog resolved and `nodes`
   // is confidently absent → render the Devices tile as "n/a".
-  const nodesAvailable = capabilities.ready && capabilities.nodes
+  const nodesAvailable = capabilityAvailable(capabilities, 'nodes')
   const nodesUnavailable = capabilities.ready && !capabilities.nodes
   const { data: devices, error: devicesError } = useSWR(
     nodesAvailable ? '/fleet-devices' : null,
@@ -171,7 +172,10 @@ export default function OverviewPage() {
             label="Devices"
             value={nodesUnavailable ? 'n/a' : live.connectedDevices}
             icon={HardDrive}
-            loading={nodesAvailable && !devices && !devicesError}
+            // Skeleton until the catalog resolves (`!ready`) so the tile does
+            // not flash `0` before we know whether `nodes` exists; then only
+            // while the confirmed fetch is in flight.
+            loading={!capabilities.ready || (nodesAvailable && !devices && !devicesError)}
           />
           <StatTile
             label="Tool calls"

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -10,6 +10,7 @@
 import * as React from 'react'
 import { usePathname } from 'next/navigation'
 import { ChatSessionProvider } from '@/lib/chat/chat-session-provider'
+import { useCapabilities } from '@/lib/hooks/use-capabilities'
 import { FloatingChatFab } from '@/components/floating-chat-fab'
 import { FloatingChatPopover } from '@/components/floating-chat-popover'
 import { FloatingChatShell } from '@/components/floating-chat-shell'
@@ -67,6 +68,12 @@ export function AdminLayoutClient({
   const pathname = usePathname()
   const isOnChatPage = pathname === '/chat' || pathname === '/chat/'
 
+  // Only surface the floating chat entrypoint once the catalog confirms the
+  // `acp` service is present. Until the catalog resolves (`!ready`) we keep the
+  // FAB hidden to avoid a flash, and on a gateway-only build it stays hidden.
+  const capabilities = useCapabilities()
+  const chatAvailable = capabilities.ready && capabilities.acp
+
   // Only auto-bootstrap a session when the chat surface is actually visible.
   // Without this gate the provider would mint an empty session on every admin
   // page load, leaving orphan sessions + SSE streams on the backend.
@@ -101,7 +108,7 @@ export function AdminLayoutClient({
       <div className={!isOnChatPage ? 'pb-20 md:pb-0' : undefined}>
         {children}
       </div>
-      {!isOnChatPage && (
+      {!isOnChatPage && chatAvailable && (
         <>
           <FloatingChatFab
             open={open}

--- a/apps/gateway-admin/components/admin-layout-client.tsx
+++ b/apps/gateway-admin/components/admin-layout-client.tsx
@@ -11,6 +11,7 @@ import * as React from 'react'
 import { usePathname } from 'next/navigation'
 import { ChatSessionProvider } from '@/lib/chat/chat-session-provider'
 import { useCapabilities } from '@/lib/hooks/use-capabilities'
+import { capabilityAvailable } from '@/lib/capabilities'
 import { FloatingChatFab } from '@/components/floating-chat-fab'
 import { FloatingChatPopover } from '@/components/floating-chat-popover'
 import { FloatingChatShell } from '@/components/floating-chat-shell'
@@ -72,7 +73,7 @@ export function AdminLayoutClient({
   // `acp` service is present. Until the catalog resolves (`!ready`) we keep the
   // FAB hidden to avoid a flash, and on a gateway-only build it stays hidden.
   const capabilities = useCapabilities()
-  const chatAvailable = capabilities.ready && capabilities.acp
+  const chatAvailable = capabilityAvailable(capabilities, 'acp')
 
   // Only auto-bootstrap a session when the chat surface is actually visible.
   // Without this gate the provider would mint an empty session on every admin

--- a/apps/gateway-admin/components/app-sidebar.tsx
+++ b/apps/gateway-admin/components/app-sidebar.tsx
@@ -38,6 +38,23 @@ import {
   sessionPrimaryEmail,
 } from '@/lib/auth/session-presenter'
 import { logoutBrowserSession, useBrowserSession } from '@/lib/auth/session'
+import { useCapabilities } from '@/lib/hooks/use-capabilities'
+import type { Capabilities, CapabilityKey } from '@/lib/capabilities'
+
+/**
+ * Nav routes backed by a feature-gated service. Entries not listed here are
+ * always shown (they're served by the always-on gateway/base surfaces).
+ */
+const NAV_ROUTE_CAPABILITY: Record<string, CapabilityKey> = {
+  '/chat': 'acp',
+  '/nodes': 'nodes',
+  '/marketplace': 'marketplace',
+}
+
+function navItemVisible(url: string, capabilities: Capabilities): boolean {
+  const need = NAV_ROUTE_CAPABILITY[url]
+  return need == null || capabilities[need]
+}
 
 export const primarySidebarNavigation = [
   {
@@ -103,6 +120,11 @@ export const secondarySidebarNavigation = [
 export function AppSidebar() {
   const pathname = usePathname()
   const session = useBrowserSession()
+  const capabilities = useCapabilities()
+
+  const visiblePrimaryNavigation = primarySidebarNavigation.filter((item) =>
+    navItemVisible(item.url, capabilities),
+  )
 
   const isActive = (url: string) => {
     if (url === '/') return pathname === '/'
@@ -132,7 +154,7 @@ export function AppSidebar() {
           <SidebarGroupLabel>Navigation</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {primarySidebarNavigation.map((item) => (
+              {visiblePrimaryNavigation.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild isActive={isActive(item.url)} tooltip={item.title}>
                     <Link href={item.url}>

--- a/apps/gateway-admin/components/capability-guard.tsx
+++ b/apps/gateway-admin/components/capability-guard.tsx
@@ -4,16 +4,24 @@ import type { ReactNode } from 'react'
 
 import { useCapabilities } from '@/lib/hooks/use-capabilities'
 import type { CapabilityKey } from '@/lib/capabilities'
-import { ServiceUnavailableNotice } from '@/components/service-unavailable-notice'
+import {
+  CapabilityPending,
+  ServiceUnavailableNotice,
+} from '@/components/service-unavailable-notice'
 
 /**
- * Renders `children` unless the required capability is confidently absent from
- * the server build, in which case it shows a "not available in this build"
- * notice instead of letting the page fail with an opaque `404`.
+ * Renders `children` only once the catalog confirms the required capability is
+ * available. Until the catalog has resolved (`!caps.ready`) it renders a brief
+ * loading placeholder INSTEAD OF the children, so the guarded page's `/v1/*`
+ * fetches never fire on a gated build before the catalog can swap in the
+ * "not available in this build" notice. Once resolved, a confidently-absent
+ * capability shows the notice; otherwise the children render.
  *
- * Fail-open: while the catalog is loading (or on fetch error) the capability is
- * reported available, so the page renders normally and the notice only appears
- * once the catalog confirms the service is gated out.
+ * Fail-open: the per-capability boolean stays available whenever the catalog
+ * has NOT given a definitive answer — real data received or errored — not on a
+ * loading flag (the catalog's `fallbackData: []` makes `isLoading` false on the
+ * first render). So a fetch error renders the children normally; only a
+ * resolved catalog that omits the backing service shows the notice.
  */
 export function CapabilityGuard({
   need,
@@ -25,6 +33,9 @@ export function CapabilityGuard({
   children: ReactNode
 }) {
   const capabilities = useCapabilities()
+  if (!capabilities.ready) {
+    return <CapabilityPending />
+  }
   if (!capabilities[need]) {
     return <ServiceUnavailableNotice serviceName={label} />
   }

--- a/apps/gateway-admin/components/capability-guard.tsx
+++ b/apps/gateway-admin/components/capability-guard.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import { useCapabilities } from '@/lib/hooks/use-capabilities'
+import type { CapabilityKey } from '@/lib/capabilities'
+import { ServiceUnavailableNotice } from '@/components/service-unavailable-notice'
+
+/**
+ * Renders `children` unless the required capability is confidently absent from
+ * the server build, in which case it shows a "not available in this build"
+ * notice instead of letting the page fail with an opaque `404`.
+ *
+ * Fail-open: while the catalog is loading (or on fetch error) the capability is
+ * reported available, so the page renders normally and the notice only appears
+ * once the catalog confirms the service is gated out.
+ */
+export function CapabilityGuard({
+  need,
+  label,
+  children,
+}: {
+  need: CapabilityKey
+  label: string
+  children: ReactNode
+}) {
+  const capabilities = useCapabilities()
+  if (!capabilities[need]) {
+    return <ServiceUnavailableNotice serviceName={label} />
+  }
+  return <>{children}</>
+}

--- a/apps/gateway-admin/components/service-unavailable-notice.tsx
+++ b/apps/gateway-admin/components/service-unavailable-notice.tsx
@@ -1,4 +1,18 @@
-import { CircleAlert } from 'lucide-react'
+import { CircleAlert, Loader2 } from 'lucide-react'
+
+/**
+ * Brief centered spinner shown while the catalog has not yet resolved
+ * (`!capabilities.ready`). Rendered by `CapabilityGuard` INSTEAD OF the guarded
+ * children so their `/v1/*` fetches do not fire before the catalog confirms the
+ * backing service exists.
+ */
+export function CapabilityPending() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <Loader2 className="size-6 animate-spin text-aurora-text-muted" />
+    </div>
+  )
+}
 
 /**
  * Full-page state shown when a feature-gated service was not compiled into this

--- a/apps/gateway-admin/components/service-unavailable-notice.tsx
+++ b/apps/gateway-admin/components/service-unavailable-notice.tsx
@@ -1,0 +1,21 @@
+import { CircleAlert } from 'lucide-react'
+
+/**
+ * Full-page state shown when a feature-gated service was not compiled into this
+ * `labby` build, so its page has no backing `/v1/*` routes. Replaces the opaque
+ * `404` a gated page would otherwise hit.
+ */
+export function ServiceUnavailableNotice({ serviceName }: { serviceName: string }) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-6 text-center">
+      <CircleAlert className="size-10 text-aurora-warn" />
+      <h2 className="text-lg font-semibold text-aurora-text-primary">
+        {serviceName} is not available in this build
+      </h2>
+      <p className="max-w-md text-sm text-aurora-text-muted">
+        This Labby binary was compiled without the {serviceName.toLowerCase()} service, so this page
+        has nothing to show. Rebuild with the corresponding feature enabled to use it.
+      </p>
+    </div>
+  )
+}

--- a/apps/gateway-admin/lib/capabilities.test.ts
+++ b/apps/gateway-admin/lib/capabilities.test.ts
@@ -8,7 +8,6 @@ const ALL = [
   { name: 'acp' },
   { name: 'device' },
   { name: 'marketplace' },
-  { name: 'stash' },
 ]
 
 test('all capabilities available when their services are present', () => {
@@ -16,8 +15,7 @@ test('all capabilities available when their services are present', () => {
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
-  assert.equal(caps.stash, true)
-  assert.equal(caps.isLoading, false)
+  assert.equal(caps.ready, true)
 })
 
 test('gateway-only catalog hides gated capabilities', () => {
@@ -25,7 +23,7 @@ test('gateway-only catalog hides gated capabilities', () => {
   assert.equal(caps.acp, false)
   assert.equal(caps.nodes, false)
   assert.equal(caps.marketplace, false)
-  assert.equal(caps.stash, false)
+  assert.equal(caps.ready, true)
 })
 
 test('nodes capability is backed by the "device" service, not "nodes"', () => {
@@ -33,23 +31,35 @@ test('nodes capability is backed by the "device" service, not "nodes"', () => {
   assert.equal(deriveCapabilities([{ name: 'nodes' }], false, false).nodes, false)
 })
 
-test('fail-open while loading', () => {
+test('ready is false while the catalog is loading', () => {
   const caps = deriveCapabilities([], true, false)
+  assert.equal(caps.ready, false)
+  // Fail-open while unresolved.
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
-  assert.equal(caps.stash, true)
-  assert.equal(caps.isLoading, true)
 })
 
-test('fail-open on catalog error', () => {
+test('ready is true once real data has arrived', () => {
+  assert.equal(deriveCapabilities([{ name: 'gateway' }], false, false).ready, true)
+})
+
+test('ready is true on catalog error, but capabilities stay fail-open', () => {
   const caps = deriveCapabilities([{ name: 'gateway' }], false, true)
+  assert.equal(caps.ready, true)
   assert.equal(caps.acp, true)
+  assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
 })
 
-test('fail-open on empty catalog (no confident data)', () => {
+test('fallbackData first render: empty services + isLoading false + no error → not ready, fail-open', () => {
+  // The catalog SWR hook sets `fallbackData: []`, so on the very first render
+  // `isLoading` is already false while no data has arrived. `ready` must be
+  // false here so guarded pages do not render children (and fire /v1 fetches)
+  // before the catalog resolves.
   const caps = deriveCapabilities([], false, false)
+  assert.equal(caps.ready, false)
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
+  assert.equal(caps.marketplace, true)
 })

--- a/apps/gateway-admin/lib/capabilities.test.ts
+++ b/apps/gateway-admin/lib/capabilities.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { deriveCapabilities } from './capabilities'
+
+const ALL = [
+  { name: 'gateway' },
+  { name: 'acp' },
+  { name: 'device' },
+  { name: 'marketplace' },
+  { name: 'stash' },
+]
+
+test('all capabilities available when their services are present', () => {
+  const caps = deriveCapabilities(ALL, false, false)
+  assert.equal(caps.acp, true)
+  assert.equal(caps.nodes, true)
+  assert.equal(caps.marketplace, true)
+  assert.equal(caps.stash, true)
+  assert.equal(caps.isLoading, false)
+})
+
+test('gateway-only catalog hides gated capabilities', () => {
+  const caps = deriveCapabilities([{ name: 'gateway' }, { name: 'doctor' }], false, false)
+  assert.equal(caps.acp, false)
+  assert.equal(caps.nodes, false)
+  assert.equal(caps.marketplace, false)
+  assert.equal(caps.stash, false)
+})
+
+test('nodes capability is backed by the "device" service, not "nodes"', () => {
+  assert.equal(deriveCapabilities([{ name: 'device' }], false, false).nodes, true)
+  assert.equal(deriveCapabilities([{ name: 'nodes' }], false, false).nodes, false)
+})
+
+test('fail-open while loading', () => {
+  const caps = deriveCapabilities([], true, false)
+  assert.equal(caps.acp, true)
+  assert.equal(caps.nodes, true)
+  assert.equal(caps.marketplace, true)
+  assert.equal(caps.stash, true)
+  assert.equal(caps.isLoading, true)
+})
+
+test('fail-open on catalog error', () => {
+  const caps = deriveCapabilities([{ name: 'gateway' }], false, true)
+  assert.equal(caps.acp, true)
+  assert.equal(caps.marketplace, true)
+})
+
+test('fail-open on empty catalog (no confident data)', () => {
+  const caps = deriveCapabilities([], false, false)
+  assert.equal(caps.acp, true)
+  assert.equal(caps.nodes, true)
+})

--- a/apps/gateway-admin/lib/capabilities.test.ts
+++ b/apps/gateway-admin/lib/capabilities.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { deriveCapabilities } from './capabilities'
+import { capabilityAvailable, deriveCapabilities } from './capabilities'
 
 const ALL = [
   { name: 'gateway' },
@@ -11,7 +11,7 @@ const ALL = [
 ]
 
 test('all capabilities available when their services are present', () => {
-  const caps = deriveCapabilities(ALL, false, false)
+  const caps = deriveCapabilities(ALL, false)
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
@@ -19,7 +19,7 @@ test('all capabilities available when their services are present', () => {
 })
 
 test('gateway-only catalog hides gated capabilities', () => {
-  const caps = deriveCapabilities([{ name: 'gateway' }, { name: 'doctor' }], false, false)
+  const caps = deriveCapabilities([{ name: 'gateway' }, { name: 'doctor' }], false)
   assert.equal(caps.acp, false)
   assert.equal(caps.nodes, false)
   assert.equal(caps.marketplace, false)
@@ -27,39 +27,51 @@ test('gateway-only catalog hides gated capabilities', () => {
 })
 
 test('nodes capability is backed by the "device" service, not "nodes"', () => {
-  assert.equal(deriveCapabilities([{ name: 'device' }], false, false).nodes, true)
-  assert.equal(deriveCapabilities([{ name: 'nodes' }], false, false).nodes, false)
+  assert.equal(deriveCapabilities([{ name: 'device' }], false).nodes, true)
+  assert.equal(deriveCapabilities([{ name: 'nodes' }], false).nodes, false)
 })
 
-test('ready is false while the catalog is loading', () => {
-  const caps = deriveCapabilities([], true, false)
+test('empty catalog → not ready, fail-open', () => {
+  // The catalog SWR hook sets `fallbackData: []`, so on the first render no data
+  // has arrived yet and `ready` must be false — `deriveCapabilities` keys off
+  // `services.length`, not a loading flag. Guarded surfaces stay fail-open
+  // (available) until the catalog resolves so nothing is hidden prematurely.
+  const caps = deriveCapabilities([], false)
   assert.equal(caps.ready, false)
-  // Fail-open while unresolved.
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
 })
 
 test('ready is true once real data has arrived', () => {
-  assert.equal(deriveCapabilities([{ name: 'gateway' }], false, false).ready, true)
+  assert.equal(deriveCapabilities([{ name: 'gateway' }], false).ready, true)
 })
 
 test('ready is true on catalog error, but capabilities stay fail-open', () => {
-  const caps = deriveCapabilities([{ name: 'gateway' }], false, true)
+  const caps = deriveCapabilities([{ name: 'gateway' }], true)
   assert.equal(caps.ready, true)
   assert.equal(caps.acp, true)
   assert.equal(caps.nodes, true)
   assert.equal(caps.marketplace, true)
 })
 
-test('fallbackData first render: empty services + isLoading false + no error → not ready, fail-open', () => {
-  // The catalog SWR hook sets `fallbackData: []`, so on the very first render
-  // `isLoading` is already false while no data has arrived. `ready` must be
-  // false here so guarded pages do not render children (and fire /v1 fetches)
-  // before the catalog resolves.
-  const caps = deriveCapabilities([], false, false)
-  assert.equal(caps.ready, false)
-  assert.equal(caps.acp, true)
-  assert.equal(caps.nodes, true)
-  assert.equal(caps.marketplace, true)
+test('capabilityAvailable requires the catalog to have confirmed the service', () => {
+  const ready = deriveCapabilities(ALL, false)
+  assert.equal(capabilityAvailable(ready, 'acp'), true)
+
+  const gatewayOnly = deriveCapabilities([{ name: 'gateway' }], false)
+  assert.equal(capabilityAvailable(gatewayOnly, 'acp'), false)
+
+  // While UNRESOLVED (`!ready`) fail-open availability is NOT enough to fetch —
+  // capabilityAvailable stays false so consumers hold off until the catalog answers.
+  const unresolved = deriveCapabilities([], false)
+  assert.equal(unresolved.acp, true)
+  assert.equal(capabilityAvailable(unresolved, 'acp'), false)
+
+  // On catalog ERROR the answer is definitive (`ready`) and fail-open, so
+  // capabilityAvailable is true: attempt the fetch rather than disable a
+  // possibly-present service over a transient catalog error.
+  const errored = deriveCapabilities([{ name: 'gateway' }], true)
+  assert.equal(errored.acp, true)
+  assert.equal(capabilityAvailable(errored, 'acp'), true)
 })

--- a/apps/gateway-admin/lib/capabilities.ts
+++ b/apps/gateway-admin/lib/capabilities.ts
@@ -2,7 +2,7 @@
  * Feature-gated capability derivation for the admin UI.
  *
  * The `labby` binary can be compiled without certain services (`acp`, `nodes`,
- * `stash`, `marketplace`). When a service is gated out at compile time it never
+ * `marketplace`). When a service is gated out at compile time it never
  * registers, so it is absent from `/v1/catalog`. The UI reads that same catalog
  * to decide which feature-specific pages and nav entries to show, so a
  * gateway-only build hides Chat/Nodes/Marketplace instead of letting those
@@ -11,6 +11,12 @@
  * `deriveCapabilities` is a pure function over the catalog service list so it
  * can be unit-tested without React; `useCapabilities` (in
  * `lib/hooks/use-capabilities.ts`) wraps it around the live catalog hook.
+ *
+ * Fail-open is keyed on whether the catalog has RESOLVED — i.e. real data has
+ * arrived (`services.length > 0`) or the fetch errored — not on a loading flag.
+ * The catalog SWR hook sets `fallbackData: []`, so `isLoading` is already
+ * `false` on the first render even though no data has arrived yet; `ready`
+ * captures the "definitive answer received" condition that `isLoading` cannot.
  */
 
 /** Feature-gated capabilities the UI conditionally exposes. */
@@ -21,14 +27,20 @@ export interface Capabilities {
   nodes: boolean
   /** Plugin/agent marketplace (`/marketplace`). Backend service `marketplace`. */
   marketplace: boolean
-  /** Component snapshot store. Backend service `stash`. */
-  stash: boolean
-  /** True until the catalog has resolved at least once. */
-  isLoading: boolean
+  /**
+   * True once the catalog has given a definitive answer — either real data has
+   * arrived (`services.length > 0`) or the fetch errored. Until then callers
+   * must not treat an absent capability as confirmed: the per-capability
+   * booleans stay fail-open (available) while `!ready`, but consumers that fire
+   * `/v1/*` requests (guarded pages, the chat bootstrap, the dashboard nodes
+   * tile) should wait for `ready` before fetching so a gated build never emits
+   * the background `404` we are avoiding.
+   */
+  ready: boolean
 }
 
-/** Gated capability keys (excludes the always-true `isLoading` field). */
-export type CapabilityKey = 'acp' | 'nodes' | 'marketplace' | 'stash'
+/** Gated capability keys (excludes the `ready` meta-field). */
+export type CapabilityKey = 'acp' | 'nodes' | 'marketplace'
 
 /**
  * Backend service name backing each capability. Note the `nodes` capability is
@@ -39,7 +51,6 @@ export const CAPABILITY_SERVICE: Record<CapabilityKey, string> = {
   acp: 'acp',
   nodes: 'device',
   marketplace: 'marketplace',
-  stash: 'stash',
 }
 
 /** Minimal shape `deriveCapabilities` needs from a catalog service entry. */
@@ -50,26 +61,32 @@ interface NamedService {
 /**
  * Derive capability flags from the catalog service list.
  *
- * Fail-open: a capability is only reported ABSENT when the catalog has
- * confidently resolved (not loading, no error, non-empty) and omits its
- * backing service. While the catalog is loading, errored, or empty, every
- * capability is reported available so a transient fetch problem never hides a
- * surface that actually exists.
+ * Fail-open: a capability is only reported ABSENT when the catalog has given a
+ * definitive answer (`ready`) and omits its backing service. While the catalog
+ * has not resolved (no data yet, empty due to `fallbackData: []`), every
+ * capability is reported available so a transient fetch state never hides a
+ * surface that actually exists. On error the catalog is also treated as
+ * definitive-but-fail-open: `ready` is true, but every capability stays
+ * available so a fetch failure never hides a working surface.
  */
 export function deriveCapabilities(
   services: readonly NamedService[],
   isLoading: boolean,
   hasError: boolean,
 ): Capabilities {
-  const confident = !isLoading && !hasError && services.length > 0
+  // `ready` = the catalog has given a definitive answer. `isLoading` is
+  // deliberately ignored: `fallbackData: []` makes it false on the first render
+  // before any data has arrived, so it cannot distinguish "resolved to empty"
+  // from "not resolved yet".
+  void isLoading
+  const ready = hasError || services.length > 0
   const has = (name: string) => services.some((service) => service.name === name)
-  const cap = (key: CapabilityKey) => !confident || has(CAPABILITY_SERVICE[key])
+  const cap = (key: CapabilityKey) => !ready || hasError || has(CAPABILITY_SERVICE[key])
 
   return {
     acp: cap('acp'),
     nodes: cap('nodes'),
     marketplace: cap('marketplace'),
-    stash: cap('stash'),
-    isLoading,
+    ready,
   }
 }

--- a/apps/gateway-admin/lib/capabilities.ts
+++ b/apps/gateway-admin/lib/capabilities.ts
@@ -71,14 +71,13 @@ interface NamedService {
  */
 export function deriveCapabilities(
   services: readonly NamedService[],
-  isLoading: boolean,
   hasError: boolean,
 ): Capabilities {
-  // `ready` = the catalog has given a definitive answer. `isLoading` is
-  // deliberately ignored: `fallbackData: []` makes it false on the first render
-  // before any data has arrived, so it cannot distinguish "resolved to empty"
-  // from "not resolved yet".
-  void isLoading
+  // `ready` = the catalog has given a definitive answer. A loading flag can't
+  // drive this: the catalog SWR hook sets `fallbackData: []`, so `isLoading` is
+  // already false on the first render before any data has arrived — it cannot
+  // distinguish "resolved to empty" from "not resolved yet". `services.length`
+  // can (a running gateway always registers gateway/doctor/setup).
   const ready = hasError || services.length > 0
   const has = (name: string) => services.some((service) => service.name === name)
   const cap = (key: CapabilityKey) => !ready || hasError || has(CAPABILITY_SERVICE[key])
@@ -89,4 +88,20 @@ export function deriveCapabilities(
     marketplace: cap('marketplace'),
     ready,
   }
+}
+
+/**
+ * True only once the catalog has confirmed the backing service is present
+ * (`ready && caps[key]`). Consumers that fire `/v1/*` requests — guarded pages,
+ * the chat bootstrap, the dashboard nodes tile — gate on this so a gated build
+ * never emits the background `404` we are avoiding, and so they also hold off
+ * during the brief pre-resolution window rather than fetching optimistically.
+ *
+ * Safe to gate fetches on because the catalog resolves exactly once:
+ * `useCommandCatalog` disables revalidate-on-stale/focus/reconnect, so `ready`
+ * goes false→true a single time and never flaps back (which would otherwise
+ * re-fire these gated fetches).
+ */
+export function capabilityAvailable(caps: Capabilities, key: CapabilityKey): boolean {
+  return caps.ready && caps[key]
 }

--- a/apps/gateway-admin/lib/capabilities.ts
+++ b/apps/gateway-admin/lib/capabilities.ts
@@ -1,0 +1,75 @@
+/**
+ * Feature-gated capability derivation for the admin UI.
+ *
+ * The `labby` binary can be compiled without certain services (`acp`, `nodes`,
+ * `stash`, `marketplace`). When a service is gated out at compile time it never
+ * registers, so it is absent from `/v1/catalog`. The UI reads that same catalog
+ * to decide which feature-specific pages and nav entries to show, so a
+ * gateway-only build hides Chat/Nodes/Marketplace instead of letting those
+ * pages fail with an opaque `404` from their missing `/v1/*` routes.
+ *
+ * `deriveCapabilities` is a pure function over the catalog service list so it
+ * can be unit-tested without React; `useCapabilities` (in
+ * `lib/hooks/use-capabilities.ts`) wraps it around the live catalog hook.
+ */
+
+/** Feature-gated capabilities the UI conditionally exposes. */
+export interface Capabilities {
+  /** ACP chat runtime (`/chat`). Backend service `acp`. */
+  acp: boolean
+  /** Fleet/node management (`/nodes`). Backend service `device`. */
+  nodes: boolean
+  /** Plugin/agent marketplace (`/marketplace`). Backend service `marketplace`. */
+  marketplace: boolean
+  /** Component snapshot store. Backend service `stash`. */
+  stash: boolean
+  /** True until the catalog has resolved at least once. */
+  isLoading: boolean
+}
+
+/** Gated capability keys (excludes the always-true `isLoading` field). */
+export type CapabilityKey = 'acp' | 'nodes' | 'marketplace' | 'stash'
+
+/**
+ * Backend service name backing each capability. Note the `nodes` capability is
+ * backed by the service registered as `device` (the Cargo feature is `nodes`
+ * but the registry name is `device`).
+ */
+export const CAPABILITY_SERVICE: Record<CapabilityKey, string> = {
+  acp: 'acp',
+  nodes: 'device',
+  marketplace: 'marketplace',
+  stash: 'stash',
+}
+
+/** Minimal shape `deriveCapabilities` needs from a catalog service entry. */
+interface NamedService {
+  name: string
+}
+
+/**
+ * Derive capability flags from the catalog service list.
+ *
+ * Fail-open: a capability is only reported ABSENT when the catalog has
+ * confidently resolved (not loading, no error, non-empty) and omits its
+ * backing service. While the catalog is loading, errored, or empty, every
+ * capability is reported available so a transient fetch problem never hides a
+ * surface that actually exists.
+ */
+export function deriveCapabilities(
+  services: readonly NamedService[],
+  isLoading: boolean,
+  hasError: boolean,
+): Capabilities {
+  const confident = !isLoading && !hasError && services.length > 0
+  const has = (name: string) => services.some((service) => service.name === name)
+  const cap = (key: CapabilityKey) => !confident || has(CAPABILITY_SERVICE[key])
+
+  return {
+    acp: cap('acp'),
+    nodes: cap('nodes'),
+    marketplace: cap('marketplace'),
+    stash: cap('stash'),
+    isLoading,
+  }
+}

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -20,6 +20,7 @@
 
 import * as React from 'react'
 import { createAcpFetcher } from '@/lib/acp/fetch'
+import { useCapabilities } from '@/lib/hooks/use-capabilities'
 import {
   toProjects,
   appendSessionEvent,
@@ -178,6 +179,12 @@ export function ChatSessionProvider({
   onSessionPanelClose,
   autoBootstrap = false,
 }: ChatSessionProviderProps) {
+  // Feature-gated capabilities. The provider mounts on EVERY admin page, so its
+  // init effect must not touch `/v1/acp/*` until the catalog confirms `acp` is
+  // present — otherwise a gateway-only build 404s app-wide in the background.
+  const capabilities = useCapabilities()
+  const acpAvailable = capabilities.ready && capabilities.acp
+
   // ---- State ----
   const [runs, setRuns] = React.useState<ACPRun[]>([])
   const [sessionsLoaded, setSessionsLoaded] = React.useState(false)
@@ -515,9 +522,16 @@ export function ChatSessionProvider({
       return
     }
 
+    // Gate the ACP catalog/session fetches on confirmed availability so the
+    // provider does not fire `/v1/acp/provider` + `/v1/acp/sessions` on every
+    // admin page of a build compiled without the `acp` service. While the
+    // catalog is unresolved (`!ready`) we hold off; once it confirms `acp` is
+    // absent we never fetch.
+    if (!acpAvailable) return
+
     void refreshProvider()
     void refreshSessions()
-  }, [refreshProvider, refreshSessions])
+  }, [acpAvailable, refreshProvider, refreshSessions])
 
   // Sync providerHealth when selectedProviderId or providers list changes
   React.useEffect(() => {

--- a/apps/gateway-admin/lib/chat/chat-session-provider.tsx
+++ b/apps/gateway-admin/lib/chat/chat-session-provider.tsx
@@ -21,6 +21,7 @@
 import * as React from 'react'
 import { createAcpFetcher } from '@/lib/acp/fetch'
 import { useCapabilities } from '@/lib/hooks/use-capabilities'
+import { capabilityAvailable } from '@/lib/capabilities'
 import {
   toProjects,
   appendSessionEvent,
@@ -183,7 +184,7 @@ export function ChatSessionProvider({
   // init effect must not touch `/v1/acp/*` until the catalog confirms `acp` is
   // present — otherwise a gateway-only build 404s app-wide in the background.
   const capabilities = useCapabilities()
-  const acpAvailable = capabilities.ready && capabilities.acp
+  const acpAvailable = capabilityAvailable(capabilities, 'acp')
 
   // ---- State ----
   const [runs, setRuns] = React.useState<ACPRun[]>([])

--- a/apps/gateway-admin/lib/hooks/use-capabilities.ts
+++ b/apps/gateway-admin/lib/hooks/use-capabilities.ts
@@ -11,6 +11,6 @@ import { deriveCapabilities, type Capabilities } from '@/lib/capabilities'
 
 /** Live feature-gated capabilities for the current server build. */
 export function useCapabilities(): Capabilities {
-  const { data, isLoading, error } = useCommandCatalog()
-  return deriveCapabilities(data, isLoading, error != null)
+  const { data, error } = useCommandCatalog()
+  return deriveCapabilities(data, error != null)
 }

--- a/apps/gateway-admin/lib/hooks/use-capabilities.ts
+++ b/apps/gateway-admin/lib/hooks/use-capabilities.ts
@@ -1,0 +1,16 @@
+/**
+ * React hook exposing feature-gated capabilities derived from `/v1/catalog`.
+ *
+ * Reuses the same catalog fetch as the ⌘K palette (`useCommandCatalog`) so no
+ * extra request is made. See `lib/capabilities.ts` for the pure derivation and
+ * fail-open semantics.
+ */
+
+import { useCommandCatalog } from '@/lib/hooks/use-command-catalog'
+import { deriveCapabilities, type Capabilities } from '@/lib/capabilities'
+
+/** Live feature-gated capabilities for the current server build. */
+export function useCapabilities(): Capabilities {
+  const { data, isLoading, error } = useCommandCatalog()
+  return deriveCapabilities(data, isLoading, error != null)
+}


### PR DESCRIPTION
## Problem (lab-x4mw2)

On a gateway-only build, `acp`/`nodes`/`marketplace` are compile-gated out, so the web UI's Chat/Nodes/Marketplace surfaces call `/v1/acp`, `/v1/nodes`, `/v1/marketplace` and get **bodyless 404s** — opaque failures with no explanation.

## Approach

Derive capabilities from the **existing** `GET /v1/catalog` (registry-driven — compiled-out services never appear there, and the UI already fetches it for the ⌘K palette). No new backend endpoint.

- `lib/capabilities.ts` — pure `deriveCapabilities()` (unit-tested) + `nodes → device` service mapping + a `ready` flag
- `lib/hooks/use-capabilities.ts` — hook over the shared catalog fetch (SWR dedups → one request)
- `components/capability-guard.tsx` + `service-unavailable-notice.tsx` — page guard, loading placeholder, and "not available in this build" notice
- `app-sidebar.tsx` — hides Chat/Nodes/Marketplace nav when their service is absent
- chat/nodes/marketplace + `marketplace/plugin` `page.tsx` — wrapped in `<CapabilityGuard>`
- `chat-session-provider.tsx` + `admin-layout-client.tsx` — the app-wide floating-chat provider no longer fetches `/v1/acp` unless `acp` is present; the FAB hides when it's absent
- `app/(admin)/page.tsx` — the dashboard Devices tile skips its `/v1/nodes` fetch (shows `n/a`) when `nodes` is absent

**Fail-open, resolved-gated:** capabilities key off whether the catalog has *resolved* (real data received or errored), not a loading flag — SWR's `fallbackData: []` makes `isLoading` false on the first render. The guard shows a brief loader until `ready`, so guarded children never mount (and never fire their `/v1` fetch) before the catalog confirms the service exists. A fetch error fails open (renders normally).

## Review

Two review passes (TypeScript correctness + coverage). Fixed: the first-render flash/404 (P1/P2 — `ready`-gating), and three coverage gaps the review found — the floating-chat FAB fetching `/v1/acp` on every admin page, the dashboard tile fetching `/v1/nodes`, and the unguarded `/marketplace/plugin` sub-route. Dropped the unused `stash` capability (no UI consumer).

## Verification

- `pnpm test:unit` — 476 passed, 0 failed (incl. capabilities cases: present/absent, `device` mapping, `ready`, and the `fallbackData` first-render fail-open)
- `tsc --noEmit` — clean; `eslint` on all changed files — clean