### PR TITLE
[codex] migrate rmcp to 2.1

### DIFF
--- a/.github/workflows/build-incus-image.yml
+++ b/.github/workflows/build-incus-image.yml
@@ -19,17 +19,14 @@ on:
       - Cargo.toml
   pull_request:
     paths:
-      - .github/actions/build-gateway-admin/action.yml
+      # PRs only run the expensive Incus image build when the image definition,
+      # bootstrap/smoke scripts, or this workflow changes. Main pushes stay
+      # broader so the rolling image still captures binary and web asset changes.
       - .github/workflows/build-incus-image.yml
-      - apps/gateway-admin/**
-      - config/Dockerfile
       - config/incus/**
       - scripts/incus-bootstrap.sh
-      - crates/**
       - scripts/ci/build-incus-image.sh
       - scripts/ci/smoke-incus-image.sh
-      - Cargo.lock
-      - Cargo.toml
 
 permissions:
   contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2173,7 +2173,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2435,7 +2435,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2647,7 +2647,7 @@ dependencies = [
  "r2d2_sqlite",
  "regex",
  "reqwest",
- "rmcp",
+ "rmcp 2.1.0",
  "rusqlite",
  "rustix",
  "sd-notify",
@@ -2714,7 +2714,7 @@ dependencies = [
  "labby-runtime",
  "oauth2",
  "reqwest",
- "rmcp",
+ "rmcp 2.1.0",
  "rsa 0.10.0-rc.16",
  "rusqlite",
  "serde",
@@ -2788,7 +2788,7 @@ dependencies = [
  "proptest",
  "regex",
  "reqwest",
- "rmcp",
+ "rmcp 2.1.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3080,7 +3080,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3675,7 +3675,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3713,9 +3713,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4029,9 +4029,40 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros 1.8.0",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -4047,7 +4078,7 @@ dependencies = [
  "process-wrap",
  "rand 0.10.1",
  "reqwest",
- "rmcp-macros",
+ "rmcp-macros 2.1.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4072,7 +4103,7 @@ dependencies = [
  "async-stream",
  "bon",
  "futures",
- "rmcp",
+ "rmcp 1.8.0",
  "serde",
  "serde_json",
  "tokio",
@@ -4082,9 +4113,22 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4110,7 +4154,7 @@ dependencies = [
  "oas3",
  "regex",
  "reqwest",
- "rmcp",
+ "rmcp 1.8.0",
  "rmcp-actix-web",
  "schemars 1.2.1",
  "serde",
@@ -4258,7 +4302,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4315,7 +4359,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4985,7 +5029,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5829,7 +5873,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5979,15 +6023,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6019,28 +6054,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6065,12 +6083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6081,12 +6093,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6101,22 +6107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6131,12 +6125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6147,12 +6135,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6167,12 +6149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6183,12 +6159,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,8 @@ ratatui = "0.30.0"
 crossterm = "0.29"
 
 # mcp
-rmcp = { version = "1.7", features = [
+rmcp = { version = "2.1", features = [
   "server",
-  "macros",
   "transport-io",
   "transport-child-process",
   "transport-streamable-http-server",

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -39,6 +39,7 @@ COPY crates/labby-web/Cargo.toml crates/labby-web/Cargo.toml
 COPY crates/labby-winjob/Cargo.toml crates/labby-winjob/Cargo.toml
 COPY crates/labby-primitives/Cargo.toml crates/labby-primitives/Cargo.toml
 COPY crates/labby-openapi/Cargo.toml crates/labby-openapi/Cargo.toml
+COPY crates/xtask/Cargo.toml crates/xtask/Cargo.toml
 
 # Create stub source files so cargo can parse ALL manifests without error.
 #
@@ -57,8 +58,10 @@ RUN mkdir -p \
       crates/labby-winjob/src \
       crates/labby-primitives/src \
       crates/labby-openapi/src \
+      crates/xtask/src \
       apps/gateway-admin/out \
  && echo 'fn main(){}' > crates/labby/src/main.rs \
+ && echo 'fn main(){}' > crates/xtask/src/main.rs \
  && echo 'fn main(){}' > crates/labby-web/build.rs \
  && touch \
       crates/labby/src/lib.rs \
@@ -82,6 +85,7 @@ RUN mkdir -p \
  && cargo clean -p labby-winjob \
  && cargo clean -p labby-primitives \
  && cargo clean -p labby-openapi \
+ && cargo clean -p xtask \
  && rm -rf \
       crates/*/src \
       apps/gateway-admin/out \

--- a/crates/labby-auth/Cargo.toml
+++ b/crates/labby-auth/Cargo.toml
@@ -48,7 +48,7 @@ oauth2 = { version = "5.0", default-features = false, optional = true }
 
 [dependencies.rmcp-client]
 package = "rmcp"
-version = "1.7"
+version = "2.1"
 default-features = false
 features = ["client", "auth", "transport-streamable-http-client-reqwest"]
 optional = true

--- a/crates/labby-gateway/src/upstream/pool/helpers.rs
+++ b/crates/labby-gateway/src/upstream/pool/helpers.rs
@@ -323,13 +323,14 @@ pub(super) fn cached_upstream_tool(
     upstream_name: &Arc<str>,
 ) -> (String, UpstreamTool) {
     let name = tool.name.to_string();
-    // Absent or null annotations.destructiveHint → false (conservative: only
-    // treat as destructive when explicitly set to true by the upstream server).
-    let destructive = tool
-        .annotations
-        .as_ref()
-        .and_then(|a| a.destructive_hint)
-        .unwrap_or(false);
+    // Fail closed for gateway-side safety gates: an upstream must explicitly
+    // mark a tool read-only or non-destructive before widget callbacks may
+    // bypass destructive confirmation.
+    let destructive = tool.annotations.as_ref().is_none_or(|annotations| {
+        annotations
+            .destructive_hint
+            .unwrap_or_else(|| !annotations.read_only_hint.unwrap_or(false))
+    });
     (
         name,
         UpstreamTool {
@@ -415,5 +416,55 @@ mod tests {
         let (_name, cached) = cached_upstream_tool(tool, &upstream_name);
 
         assert_eq!(cached.output_schema, Some(Value::Object(output_schema)));
+    }
+
+    #[test]
+    fn cached_upstream_tool_fails_closed_without_destructive_annotations() {
+        let upstream_name: Arc<str> = Arc::from("safety");
+        let tool = rmcp::model::Tool::new(
+            "unannotated",
+            "Missing annotations",
+            Arc::new(serde_json::Map::new()),
+        );
+
+        let (_name, cached) = cached_upstream_tool(tool, &upstream_name);
+
+        assert!(
+            cached.destructive,
+            "missing upstream annotations must be treated as destructive"
+        );
+    }
+
+    #[test]
+    fn cached_upstream_tool_honors_explicit_non_destructive_hints() {
+        let upstream_name: Arc<str> = Arc::from("safety");
+
+        let mut read_only =
+            rmcp::model::Tool::new("read_only", "Read only", Arc::new(serde_json::Map::new()));
+        read_only.annotations = Some(rmcp::model::ToolAnnotations::from_raw(
+            None,
+            Some(true),
+            None,
+            None,
+            None,
+        ));
+        let (_name, cached_read_only) = cached_upstream_tool(read_only, &upstream_name);
+        assert!(!cached_read_only.destructive);
+
+        let mut explicitly_non_destructive = rmcp::model::Tool::new(
+            "additive",
+            "Explicitly non-destructive",
+            Arc::new(serde_json::Map::new()),
+        );
+        explicitly_non_destructive.annotations = Some(rmcp::model::ToolAnnotations::from_raw(
+            None,
+            None,
+            Some(false),
+            None,
+            None,
+        ));
+        let (_name, cached_non_destructive) =
+            cached_upstream_tool(explicitly_non_destructive, &upstream_name);
+        assert!(!cached_non_destructive.destructive);
     }
 }

--- a/crates/labby-gateway/src/upstream/pool/helpers.rs
+++ b/crates/labby-gateway/src/upstream/pool/helpers.rs
@@ -296,6 +296,7 @@ pub(super) fn normalize_resource_result_uri(
             | ResourceContents::BlobResourceContents { uri, .. } => {
                 *uri = gateway_uri.to_string();
             }
+            _ => {}
         }
     }
 

--- a/crates/labby-gateway/src/upstream/pool/relay.rs
+++ b/crates/labby-gateway/src/upstream/pool/relay.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Relaying `ClientHandler` for upstream server→client requests.
 //!
 //! The pool's normal upstream connections are served with the unit handler
@@ -78,9 +76,12 @@ use std::time::Instant;
 
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ClientInfo, CreateMessageRequestParams,
-    CreateMessageResult, ElicitRequestParams, ElicitResult, ListRootsResult,
+    CallToolRequestParams, CallToolResult, ClientInfo, ElicitRequestParams, ElicitResult,
 };
+// rmcp 2.1 deprecates sampling/roots under SEP-2577, but the relay still
+// mirrors these legacy server-to-client requests for upstream compatibility.
+#[allow(deprecated)]
+use rmcp::model::{CreateMessageRequestParams, CreateMessageResult, ListRootsResult};
 use rmcp::service::{Peer, RequestContext};
 use rmcp::{ClientHandler, RoleClient, RoleServer};
 use tokio::sync::Mutex;
@@ -89,7 +90,10 @@ use labby_runtime::gateway_config::UpstreamConfig;
 
 use super::super::types::UpstreamCapability;
 use super::connect::connect_upstream_with_handler;
-use super::helpers::{SUBJECT_CONN_IDLE_TTL, SUBJECT_CONN_MAX_ENTRIES, upstream_transport};
+use super::helpers::{
+    SUBJECT_CONN_IDLE_TTL, SUBJECT_CONN_MAX_ENTRIES, estimate_response_size, max_response_bytes,
+    upstream_transport,
+};
 use super::logging::{
     UpstreamRequestLog, log_upstream_request_error, log_upstream_request_finish,
     log_upstream_request_start,
@@ -190,6 +194,11 @@ impl ClientHandler for RelayClientHandler {
     }
 
     /// Relay an upstream sampling request to the downstream agent.
+    ///
+    /// rmcp 2.1 keeps sampling for backwards compatibility but marks it
+    /// deprecated under SEP-2577. Labby intentionally mirrors it while older
+    /// upstreams still raise `sampling/createMessage` during tool calls.
+    #[allow(deprecated)]
     async fn create_message(
         &self,
         params: CreateMessageRequestParams,
@@ -210,6 +219,11 @@ impl ClientHandler for RelayClientHandler {
     }
 
     /// Relay an upstream roots request to the downstream agent.
+    ///
+    /// rmcp 2.1 keeps roots for backwards compatibility but marks it
+    /// deprecated under SEP-2577. Labby intentionally mirrors it while older
+    /// upstreams still raise `roots/list` during tool calls.
+    #[allow(deprecated)]
     async fn list_roots(
         &self,
         _context: RequestContext<RoleClient>,
@@ -332,9 +346,34 @@ impl UpstreamPool {
         let timeout = self.relay_timeout;
         match tokio::time::timeout(timeout, peer.call_tool(params)).await {
             Ok(Ok(result)) => {
+                let response_size = estimate_response_size(&result);
+                let max_bytes = max_response_bytes();
+                if response_size > max_bytes {
+                    self.record_failure_for(
+                        &config.name,
+                        UpstreamCapability::Tools,
+                        format!("response too large: {response_size} bytes"),
+                    )
+                    .await;
+                    log_upstream_request_error(
+                        event,
+                        started.elapsed().as_millis(),
+                        "response_too_large",
+                        None,
+                        Some(response_size),
+                        Some(max_bytes),
+                    );
+                    return Some(Err(format!(
+                        "upstream response too large ({response_size} bytes, max {max_bytes})"
+                    )));
+                }
                 self.record_success_for(&config.name, UpstreamCapability::Tools)
                     .await;
-                log_upstream_request_finish(event, started.elapsed().as_millis(), None);
+                log_upstream_request_finish(
+                    event,
+                    started.elapsed().as_millis(),
+                    Some(response_size),
+                );
                 Some(Ok(result))
             }
             Ok(Err(error)) => {
@@ -1121,6 +1160,128 @@ mod tests {
         );
 
         // Hold the downstream server alive until the relayed call completed.
+        drop(gw_server);
+    }
+
+    /// Relayed calls enforce the same upstream response-size cap as the pooled
+    /// path. The relay invokes `peer.call_tool` directly, so this pins the cap
+    /// at that dedicated branch instead of only proving the shared pooled helper.
+    #[tokio::test]
+    async fn relayed_call_oversized_response_returns_cap_error() {
+        use super::super::entries::healthy_in_process_entry;
+        use crate::upstream::types::UpstreamHealth;
+        use std::collections::HashMap;
+
+        #[derive(Clone)]
+        struct OversizedUpstream;
+        impl ServerHandler for OversizedUpstream {
+            fn get_info(&self) -> ServerInfo {
+                ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            }
+            async fn call_tool(
+                &self,
+                _request: CallToolRequestParams,
+                _context: RequestContext<RoleServer>,
+            ) -> Result<CallToolResult, ErrorData> {
+                let payload = "x".repeat(12 * 1024 * 1024);
+                Ok(CallToolResult::success(vec![ContentBlock::text(payload)]))
+            }
+            async fn list_tools(
+                &self,
+                _request: Option<PaginatedRequestParams>,
+                _context: RequestContext<RoleServer>,
+            ) -> Result<rmcp::model::ListToolsResult, ErrorData> {
+                Ok(rmcp::model::ListToolsResult::with_all_items(vec![
+                    rmcp::model::Tool::new(
+                        "big".to_string(),
+                        "returns a large response".to_string(),
+                        Arc::new(serde_json::Map::new()),
+                    ),
+                ]))
+            }
+        }
+
+        let pool = UpstreamPool::new();
+        let config = super::super::testsupport::test_upstream_config();
+        let name_arc: Arc<str> = Arc::from(config.name.as_str());
+        pool.catalog.write().await.insert(
+            config.name.clone(),
+            healthy_in_process_entry(Arc::clone(&name_arc), HashMap::new()),
+        );
+
+        let (gw_server_transport, agent_transport) =
+            tokio::io::duplex(IN_PROCESS_PEER_BUFFER_BYTES);
+        tokio::spawn(async move {
+            if let Ok(running) = ().serve(agent_transport).await {
+                running.waiting().await.ok();
+            }
+        });
+        let gw_server = TrivialServer
+            .serve(gw_server_transport)
+            .await
+            .expect("downstream server connects");
+        let downstream = gw_server.peer().clone();
+
+        let (upstream_transport, gw_client_transport) =
+            tokio::io::duplex(IN_PROCESS_PEER_BUFFER_BYTES);
+        tokio::spawn(async move {
+            if let Ok(running) = OversizedUpstream.serve(upstream_transport).await {
+                running.waiting().await.ok();
+            }
+        });
+        let service = RelayClientHandler::new(downstream.clone(), Arc::from(config.name.as_str()))
+            .serve(gw_client_transport)
+            .await
+            .expect("relay client connects");
+        let peer = service.peer().clone();
+        let conn = UpstreamConnection {
+            _client_service: service,
+            _server_task: None,
+            peer: peer.clone(),
+            runtime: UpstreamRuntimeMetadata::default(),
+        };
+        pool.relay_connections.write().await.insert(
+            (config.name.clone(), 1, None),
+            RelayCachedConnection {
+                _connection: conn,
+                peer,
+                last_used: Instant::now(),
+            },
+        );
+
+        let result = pool
+            .call_tool_relayed(
+                &config,
+                None,
+                CallToolRequestParams::new("big"),
+                downstream,
+                1,
+            )
+            .await
+            .expect("cached relay connection is present")
+            .expect_err("oversized relayed response should be rejected");
+        assert!(
+            result.contains("too large"),
+            "expected response cap error, got: {result}"
+        );
+
+        let health = pool
+            .upstream_status()
+            .await
+            .into_iter()
+            .find(|(name, _)| name == &config.name)
+            .map(|(_, health)| health)
+            .expect("upstream present in status");
+        assert!(
+            matches!(
+                health,
+                UpstreamHealth::Unhealthy {
+                    consecutive_failures: 1
+                }
+            ),
+            "oversized relayed response must record a circuit-breaker failure, got {health:?}"
+        );
+
         drop(gw_server);
     }
 

--- a/crates/labby-gateway/src/upstream/pool/relay.rs
+++ b/crates/labby-gateway/src/upstream/pool/relay.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Relaying `ClientHandler` for upstream server→client requests.
 //!
 //! The pool's normal upstream connections are served with the unit handler
@@ -76,8 +78,8 @@ use std::time::Instant;
 
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ClientInfo, CreateElicitationRequestParams,
-    CreateElicitationResult, CreateMessageRequestParams, CreateMessageResult, ListRootsResult,
+    CallToolRequestParams, CallToolResult, ClientInfo, CreateMessageRequestParams,
+    CreateMessageResult, ElicitRequestParams, ElicitResult, ListRootsResult,
 };
 use rmcp::service::{Peer, RequestContext};
 use rmcp::{ClientHandler, RoleClient, RoleServer};
@@ -170,9 +172,9 @@ impl ClientHandler for RelayClientHandler {
     /// Relay an upstream elicitation request to the downstream agent.
     async fn create_elicitation(
         &self,
-        params: CreateElicitationRequestParams,
+        params: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
-    ) -> Result<CreateElicitationResult, McpError> {
+    ) -> Result<ElicitResult, McpError> {
         tracing::debug!(
             surface = "dispatch",
             service = "upstream.pool",
@@ -576,10 +578,9 @@ mod tests {
     use std::sync::Arc;
 
     use rmcp::model::{
-        CallToolRequestParams, CallToolResult, ClientCapabilities, Content,
-        CreateElicitationRequestParams, CreateElicitationResult, ElicitationAction,
-        ElicitationSchema, ErrorData, PaginatedRequestParams, PrimitiveSchema, ServerCapabilities,
-        ServerInfo,
+        CallToolRequestParams, CallToolResult, ClientCapabilities, ContentBlock,
+        ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema, ErrorData,
+        PaginatedRequestParams, PrimitiveSchemaDefinition, ServerCapabilities, ServerInfo,
     };
     use rmcp::service::{RequestContext, RunningService};
     use rmcp::{ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceExt};
@@ -605,12 +606,12 @@ mod tests {
 
         async fn create_elicitation(
             &self,
-            _params: CreateElicitationRequestParams,
+            _params: ElicitRequestParams,
             _context: RequestContext<RoleClient>,
-        ) -> Result<CreateElicitationResult, McpError> {
+        ) -> Result<ElicitResult, McpError> {
             let mut content = serde_json::Map::new();
             content.insert("confirm".to_string(), serde_json::Value::Bool(true));
-            Ok(CreateElicitationResult::new(ElicitationAction::Accept)
+            Ok(ElicitResult::new(ElicitationAction::Accept)
                 .with_content(serde_json::Value::Object(content)))
         }
     }
@@ -644,11 +645,11 @@ mod tests {
             let schema = ElicitationSchema::builder()
                 .required_property(
                     "confirm",
-                    PrimitiveSchema::Boolean(rmcp::model::BooleanSchema::default()),
+                    PrimitiveSchemaDefinition::Boolean(rmcp::model::BooleanSchema::default()),
                 )
                 .build()
                 .expect("schema builds");
-            let params = CreateElicitationRequestParams::FormElicitationParams {
+            let params = ElicitRequestParams::FormElicitationParams {
                 meta: None,
                 message: "confirm the action?".to_string(),
                 requested_schema: schema,
@@ -659,7 +660,7 @@ mod tests {
                 .await
                 .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
             let confirmed = matches!(result.action, ElicitationAction::Accept);
-            Ok(CallToolResult::success(vec![Content::text(format!(
+            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "confirmed={confirmed}"
             ))]))
         }

--- a/crates/labby-gateway/src/upstream/pool/resources_list.rs
+++ b/crates/labby-gateway/src/upstream/pool/resources_list.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use rmcp::model::{AnnotateAble, RawResource, Resource};
+use rmcp::model::Resource;
 use serde_json::Value;
 
 use labby_runtime::gateway_config::UpstreamConfig;
@@ -121,10 +121,9 @@ impl UpstreamPool {
         allowed: Option<&BTreeSet<String>>,
     ) -> Vec<Resource> {
         let mut out = vec![
-            RawResource::new("lab://gateway/servers", "gateway/servers")
+            Resource::new("lab://gateway/servers", "gateway/servers")
                 .with_description("Index of upstream MCP servers registered with the gateway")
-                .with_mime_type("application/json")
-                .no_annotation(),
+                .with_mime_type("application/json"),
         ];
         let catalog = self.catalog.read().await;
         let mut names: Vec<&String> = catalog.keys().collect();
@@ -134,13 +133,12 @@ impl UpstreamPool {
         names.sort();
         for name in names {
             out.push(
-                RawResource::new(
+                Resource::new(
                     format!("lab://gateway/{name}/schema"),
                     format!("gateway/{name}/schema"),
                 )
                 .with_description(format!("Tool schemas for upstream `{name}`"))
-                .with_mime_type("application/json")
-                .no_annotation(),
+                .with_mime_type("application/json"),
             );
         }
         out
@@ -354,6 +352,7 @@ mod tests {
             .map(|content| match content {
                 ResourceContents::TextResourceContents { uri, .. }
                 | ResourceContents::BlobResourceContents { uri, .. } => uri.as_str(),
+                _ => "",
             })
             .collect();
 

--- a/crates/labby-gateway/src/upstream/pool/resources_read.rs
+++ b/crates/labby-gateway/src/upstream/pool/resources_read.rs
@@ -67,7 +67,7 @@ impl UpstreamPool {
     /// MCP Apps (mcp-ui) widget resources are referenced by their native
     /// `ui://<upstream>/…` URI — carried in a tool result's
     /// `_meta.ui.resourceUri` — so they must be routed by reverse-lookup and
-    /// returned without any URI rewriting. Content URIs are normalized back to
+    /// returned without any URI rewriting. ContentBlock URIs are normalized back to
     /// the same native URI so the host sees a self-consistent read.
     ///
     /// Returns `None` if no routable upstream lists the URI (caller falls
@@ -321,8 +321,8 @@ mod tests {
         use std::collections::HashMap;
 
         use rmcp::model::{
-            AnnotateAble, ErrorData, ListResourcesResult, PaginatedRequestParams, RawResource,
-            ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
+            ErrorData, ListResourcesResult, PaginatedRequestParams, ReadResourceResult, Resource,
+            ResourceContents, ServerCapabilities, ServerInfo,
         };
         use rmcp::{RoleClient, RoleServer, ServerHandler, ServiceExt};
 
@@ -341,9 +341,10 @@ mod tests {
                 _: Option<PaginatedRequestParams>,
                 _: rmcp::service::RequestContext<RoleServer>,
             ) -> Result<ListResourcesResult, ErrorData> {
-                Ok(ListResourcesResult::with_all_items(vec![
-                    RawResource::new("file:///tmp/big", "big-resource").no_annotation(),
-                ]))
+                Ok(ListResourcesResult::with_all_items(vec![Resource::new(
+                    "file:///tmp/big",
+                    "big-resource",
+                )]))
             }
             async fn read_resource(
                 &self,

--- a/crates/labby-gateway/src/upstream/pool/testsupport.rs
+++ b/crates/labby-gateway/src/upstream/pool/testsupport.rs
@@ -14,10 +14,10 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use rmcp::model::{
-    AnnotateAble, CallToolRequestParams, CallToolResult, ErrorData, GetPromptRequestParams,
-    GetPromptResult, ListPromptsResult, ListResourcesResult, ListToolsResult,
-    PaginatedRequestParams, Prompt, PromptMessage, PromptMessageRole, RawResource,
-    ReadResourceRequestParams, ReadResourceResult, ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResult, ErrorData, GetPromptRequestParams, GetPromptResult,
+    ListPromptsResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams, Prompt,
+    PromptMessage, ReadResourceRequestParams, ReadResourceResult, Resource, Role,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
 use rmcp::{RoleClient, RoleServer, ServerHandler, ServiceExt};
@@ -114,12 +114,11 @@ impl ServerHandler for StaticCatalogServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
         Ok(ListResourcesResult::with_all_items(vec![
-            RawResource::new("file:///tmp/upstream-one", "upstream-one").no_annotation(),
-            RawResource::new(
+            Resource::new("file:///tmp/upstream-one", "upstream-one"),
+            Resource::new(
                 "lab://upstream/old-name/file:///tmp/upstream-two",
                 "upstream-two",
-            )
-            .no_annotation(),
+            ),
         ]))
     }
 
@@ -149,7 +148,7 @@ impl ServerHandler for StaticCatalogServer {
     ) -> Result<GetPromptResult, ErrorData> {
         self.get_prompt_count.fetch_add(1, Ordering::SeqCst);
         Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             format!("proxied {}", request.name),
         )]))
     }

--- a/crates/labby-gateway/src/upstream/pool/tools_call.rs
+++ b/crates/labby-gateway/src/upstream/pool/tools_call.rs
@@ -124,7 +124,7 @@ mod tests {
     use std::time::Instant;
 
     use rmcp::model::{
-        CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
+        CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, ListToolsResult,
         PaginatedRequestParams, ServerCapabilities, ServerInfo,
     };
     use rmcp::{RoleClient, RoleServer, ServerHandler, ServiceExt};
@@ -178,7 +178,7 @@ mod tests {
             ) -> Result<CallToolResult, ErrorData> {
                 // 12 MB of 'x' characters — well above the default 10 MB cap.
                 let payload = "x".repeat(12 * 1024 * 1024);
-                Ok(CallToolResult::success(vec![Content::text(payload)]))
+                Ok(CallToolResult::success(vec![ContentBlock::text(payload)]))
             }
         }
 

--- a/crates/labby-gateway/src/upstream/types.rs
+++ b/crates/labby-gateway/src/upstream/types.rs
@@ -24,8 +24,9 @@ pub struct UpstreamTool {
     pub output_schema: Option<Value>,
     /// Name of the upstream server this tool belongs to.
     pub upstream_name: Arc<str>,
-    /// Whether this tool has been marked as destructive via MCP annotations.destructiveHint.
-    /// Absent or null annotation defaults to false (conservative: only block explicit destructive=true).
+    /// Whether this tool is destructive for gateway-side safety gates.
+    /// Missing annotations fail closed unless the upstream explicitly marks the
+    /// tool read-only or non-destructive.
     pub destructive: bool,
 }
 

--- a/crates/labby/src/cli/serve.rs
+++ b/crates/labby/src/cli/serve.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! `labby serve` — start the MCP server.
 
 use std::net::SocketAddr;

--- a/crates/labby/src/cli/serve.rs
+++ b/crates/labby/src/cli/serve.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! `labby serve` — start the MCP server.
 
 use std::net::SocketAddr;
@@ -1530,7 +1528,7 @@ async fn run_stdio(
         node_role: Some(node_role),
         peers: Arc::clone(&notifier.peers),
         logging_level: Arc::new(std::sync::atomic::AtomicU8::new(
-            crate::mcp::logging::logging_level_rank(rmcp::model::LoggingLevel::Info),
+            crate::mcp::logging::logging_level_rank(crate::mcp::logging::LoggingLevel::Info),
         )),
         route_scope: crate::mcp::route_scope::McpRouteScope::Root,
         relay_session_id: crate::mcp::server::next_relay_session_id(),
@@ -1683,7 +1681,9 @@ fn build_mcp_service_with_scope(
                 node_role,
                 peers,
                 logging_level: Arc::new(std::sync::atomic::AtomicU8::new(
-                    crate::mcp::logging::logging_level_rank(rmcp::model::LoggingLevel::Info),
+                    crate::mcp::logging::logging_level_rank(
+                        crate::mcp::logging::LoggingLevel::Info,
+                    ),
                 )),
                 route_scope,
                 relay_session_id: crate::mcp::server::next_relay_session_id(),

--- a/crates/labby/src/codemode_test_harness.rs
+++ b/crates/labby/src/codemode_test_harness.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Full-stack Code Mode test harness (feature `test-harness`, non-default).
 //!
 //! This module exposes small public wrappers over the crate-private Code Mode

--- a/crates/labby/src/codemode_test_harness.rs
+++ b/crates/labby/src/codemode_test_harness.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Full-stack Code Mode test harness (feature `test-harness`, non-default).
 //!
 //! This module exposes small public wrappers over the crate-private Code Mode
@@ -196,7 +194,7 @@ fn server_with_manager(manager: Arc<GatewayManager>) -> LabMcpServer {
         node_role: None,
         peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         logging_level: Arc::new(AtomicU8::new(logging_level_rank(
-            rmcp::model::LoggingLevel::Emergency,
+            crate::mcp::logging::LoggingLevel::Emergency,
         ))),
         route_scope: McpRouteScope::Root,
         relay_session_id: 0,

--- a/crates/labby/src/mcp/call_tool.rs
+++ b/crates/labby/src/mcp/call_tool.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! `call_tool` dispatch entry: arg parse + service lookup, the gateway
 //! meta-tool routing, the post-meta-tool gates
 //! (visibility / action-allowed / code_mode-hidden / admin-scope /
@@ -18,7 +20,8 @@ use std::time::Instant;
 use rmcp::ErrorData;
 use rmcp::RoleServer;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, LoggingLevel, LoggingMessageNotificationParam,
+    CallToolRequestParams, CallToolResult, ContentBlock, LoggingLevel,
+    LoggingMessageNotificationParam,
 };
 use rmcp::service::RequestContext;
 use serde_json::Value;
@@ -35,7 +38,7 @@ use crate::mcp::catalog::CODE_MODE_TOOL_NAME;
 use crate::mcp::context::{
     auth_context_from_extensions, tool_execute_builtin_action_allowed, tool_execute_scope_allowed,
 };
-use crate::mcp::elicitation::{ElicitResult, elicit_confirm};
+use crate::mcp::elicitation::{ConfirmOutcome, elicit_confirm};
 use crate::mcp::envelope::{build_error, build_error_extra};
 use crate::mcp::error::DispatchError;
 use crate::mcp::result_format::{
@@ -63,7 +66,7 @@ enum WidgetCallbackGate {
 
 fn route_scope_denied_result(service: &str, action: &str, message: String) -> CallToolResult {
     let envelope = build_error(service, action, "route_scope_denied", &message);
-    CallToolResult::error(vec![Content::text(envelope.to_string())])
+    CallToolResult::error(vec![ContentBlock::text(envelope.to_string())])
 }
 
 fn inject_gateway_origin_param(params: Value, subject: Option<&str>) -> Value {
@@ -208,7 +211,7 @@ impl LabMcpServer {
                 "not_found",
                 &format!("service `{service}` is not enabled on the mcp surface"),
             );
-            return Ok(CallToolResult::error(vec![Content::text(
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]));
         }
@@ -228,7 +231,7 @@ impl LabMcpServer {
                 &format!("action `{action}` is not exposed for service `{service}`"),
                 &Value::Object(extra),
             );
-            return Ok(CallToolResult::error(vec![Content::text(
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]));
         }
@@ -246,7 +249,7 @@ impl LabMcpServer {
                     Ok(gate) => gate,
                     Err(err) => {
                         let envelope = tool_error_envelope(&service, "call_tool", &err);
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     }
@@ -265,7 +268,7 @@ impl LabMcpServer {
                              widget callback bypass — use the `execute` tool with confirm:true"
                         ),
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 }
@@ -277,7 +280,7 @@ impl LabMcpServer {
                         &format!("tool `{service}` matched multiple MCP App sibling tools"),
                         &serde_json::json!({ "valid": valid }),
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 }
@@ -299,7 +302,7 @@ impl LabMcpServer {
                                 "required_scopes": ["lab", "lab:admin"],
                             }),
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     }
@@ -320,7 +323,7 @@ impl LabMcpServer {
                         "not_found",
                         &format!("tool `{service}` is hidden while code_mode mode is enabled"),
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 }
@@ -341,7 +344,7 @@ impl LabMcpServer {
                 &format!("action `{action}` for service `{service}` requires `lab:admin` scope"),
                 &serde_json::json!({ "required_scopes": ["lab:admin"] }),
             );
-            return Ok(CallToolResult::error(vec![Content::text(
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]));
         }
@@ -355,19 +358,19 @@ impl LabMcpServer {
                 .any(|a| a.name == action && a.destructive);
             if is_destructive {
                 match elicit_confirm(&context, &service, &action).await {
-                    ElicitResult::Confirmed => {}
-                    ElicitResult::Declined | ElicitResult::Cancelled => {
+                    ConfirmOutcome::Confirmed => {}
+                    ConfirmOutcome::Declined | ConfirmOutcome::Cancelled => {
                         let envelope = build_error(
                             &service,
                             &action,
                             "confirmation_required",
                             &format!("action `{action}` is destructive — confirm to proceed"),
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     }
-                    ElicitResult::NotSupported => {
+                    ConfirmOutcome::NotSupported => {
                         // Client does not support elicitation — allow params["confirm"] == true
                         // as a machine-to-machine bypass (mirrors HTTP's handle_action()).
                         if params.get("confirm").and_then(Value::as_bool) != Some(true) {
@@ -381,12 +384,12 @@ impl LabMcpServer {
                                  that supports MCP elicitation"
                                 ),
                             );
-                            return Ok(CallToolResult::error(vec![Content::text(
+                            return Ok(CallToolResult::error(vec![ContentBlock::text(
                                 envelope.to_string(),
                             )]));
                         }
                     }
-                    ElicitResult::Failed => {
+                    ConfirmOutcome::Failed => {
                         let envelope = build_error(
                             &service,
                             &action,
@@ -395,7 +398,7 @@ impl LabMcpServer {
                                 "action `{action}` is destructive — confirmation failed, retry with a client that supports MCP elicitation"
                             ),
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     }
@@ -441,7 +444,7 @@ impl LabMcpServer {
                         "internal_error",
                         "gateway manager not wired",
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 };
@@ -502,7 +505,7 @@ impl LabMcpServer {
                             "internal_error",
                             "gateway manager not wired",
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     };
@@ -570,7 +573,7 @@ impl LabMcpServer {
                 "not_found",
                 &format!("service `{service}` not found"),
             );
-            Ok(CallToolResult::error(vec![Content::text(
+            Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]))
         }

--- a/crates/labby/src/mcp/call_tool.rs
+++ b/crates/labby/src/mcp/call_tool.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! `call_tool` dispatch entry: arg parse + service lookup, the gateway
 //! meta-tool routing, the post-meta-tool gates
 //! (visibility / action-allowed / code_mode-hidden / admin-scope /
@@ -19,10 +17,7 @@ use std::time::Instant;
 
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, LoggingLevel,
-    LoggingMessageNotificationParam,
-};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
@@ -41,6 +36,7 @@ use crate::mcp::context::{
 use crate::mcp::elicitation::{ConfirmOutcome, elicit_confirm};
 use crate::mcp::envelope::{build_error, build_error_extra};
 use crate::mcp::error::DispatchError;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel, spawn_dispatch_notification};
 use crate::mcp::result_format::{
     estimate_tokens_args, format_dispatch_result, tool_error_envelope,
 };
@@ -114,39 +110,19 @@ impl LabMcpServer {
             return;
         }
 
-        let peer = context.peer.clone();
         let actor_key = crate::mcp::context::actor_key_from_extensions(&context.extensions)
             .map(ToOwned::to_owned);
-        let service = service.to_string();
-        let action = action.to_string();
-        tokio::spawn(async move {
-            let mut payload = serde_json::json!({
-                "surface": "mcp",
-                "service": service,
-                "action": action,
-                "elapsed_ms": elapsed_ms,
-                "kind": "route_scope_denied",
-            });
-            if let Some(actor_key) = actor_key {
-                payload["actor_key"] = serde_json::json!(actor_key);
-            }
-            if let Err(error) = peer
-                .notify_logging_message(
-                    LoggingMessageNotificationParam::new(LoggingLevel::Warning, payload)
-                        .with_logger("lab.mcp.dispatch"),
-                )
-                .await
-            {
-                tracing::debug!(
-                    surface = "mcp",
-                    service = %service,
-                    action = %action,
-                    level = ?LoggingLevel::Warning,
-                    error = %error,
-                    "failed to send rmcp logging notification"
-                );
-            }
-        });
+        spawn_dispatch_notification(
+            context.peer.clone(),
+            actor_key,
+            service.to_string(),
+            action.to_string(),
+            elapsed_ms,
+            DispatchLogOutcome::Failure {
+                level: LoggingLevel::Warning,
+                kind: "route_scope_denied",
+            },
+        );
     }
 
     pub(crate) async fn call_tool_impl(

--- a/crates/labby/src/mcp/call_tool_codemode.rs
+++ b/crates/labby/src/mcp/call_tool_codemode.rs
@@ -16,7 +16,7 @@ use labby_codemode::CodeModeExecutedCall;
 use labby_codemode::{MAX_SOURCE_BYTES, SERVICE as CODE_MODE_SERVICE};
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{CallToolResult, Content, JsonObject, Meta};
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Meta};
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
@@ -303,7 +303,9 @@ impl LabMcpServer {
                 "gateway codemode denied by scope"
             );
             let env = tool_error_envelope(service, "call_tool", &err);
-            return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
+                env.to_string(),
+            )]));
         }
         let Some(manager) = &self.gateway_manager else {
             let envelope = build_error(
@@ -312,7 +314,7 @@ impl LabMcpServer {
                 "unknown_tool",
                 "codemode is not enabled",
             );
-            return Ok(CallToolResult::error(vec![Content::text(
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]));
         };
@@ -327,7 +329,9 @@ impl LabMcpServer {
                     &err.to_string(),
                     &serde_json::json!({ "param": "code" }),
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
         };
         let capability_filter =
@@ -335,7 +339,9 @@ impl LabMcpServer {
                 Ok(filter) => filter,
                 Err(err) => {
                     let env = tool_error_envelope(service, "call_tool", &err);
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
             };
         let code_hash = hash_arguments(&Value::String(code.to_string()));
@@ -397,7 +403,9 @@ impl LabMcpServer {
                     "internal_error",
                     "Code Mode durable pause store is not configured; cannot resume.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             };
             decider.maybe_expire().await;
 
@@ -417,7 +425,9 @@ impl LabMcpServer {
                             "unknown_execution",
                             "No Code Mode run for this resume_token; nothing to reject.",
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
+                            env.to_string(),
+                        )]));
                     }
                     labby_codemode::AuthLoad::Tampered => {
                         let env = build_error(
@@ -426,7 +436,9 @@ impl LabMcpServer {
                             "internal_error",
                             "Code Mode run integrity check failed; refusing to reject.",
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
+                            env.to_string(),
+                        )]));
                     }
                 };
                 let live_actor = actor_key.map(ToOwned::to_owned);
@@ -437,7 +449,9 @@ impl LabMcpServer {
                         "forbidden",
                         "Only the actor that started a Code Mode run may reject it.",
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
                 // Symmetric with the resume path (F2): a run may only be
                 // rejected from the same route scope that started it. Compare
@@ -451,7 +465,9 @@ impl LabMcpServer {
                         "forbidden",
                         "A Code Mode run may only be rejected from the route scope that started it.",
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
                 // Guarded reject: only a still-`paused` run transitions
                 // (`reject_paused`), so this cannot force-terminate a live
@@ -478,7 +494,7 @@ impl LabMcpServer {
                             "Code Mode run rejected. The pending destructive call was not executed.",
                             &serde_json::json!({ "status": "rejected", "execution_id": token }),
                         );
-                        return Ok(CallToolResult::success(vec![Content::text(
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(
                             env.to_string(),
                         )]));
                     }
@@ -490,7 +506,9 @@ impl LabMcpServer {
                             "Code Mode run is not paused (already resumed, rejected, expired, or \
                              unknown); nothing to reject.",
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
+                            env.to_string(),
+                        )]));
                     }
                     Err(err) => {
                         let env = build_error(
@@ -499,7 +517,9 @@ impl LabMcpServer {
                             "internal_error",
                             &format!("failed to reject Code Mode run: {err}"),
                         );
-                        return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
+                            env.to_string(),
+                        )]));
                     }
                 }
             }
@@ -514,7 +534,9 @@ impl LabMcpServer {
                         "unknown_execution",
                         "No paused Code Mode run for this resume_token.",
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
                 labby_codemode::AuthLoad::Tampered => {
                     let env = build_error(
@@ -523,7 +545,9 @@ impl LabMcpServer {
                         "internal_error",
                         "Code Mode run integrity check failed; refusing to resume.",
                     );
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
             };
             if auth_fields.status != labby_codemode::RunLifecycle::Paused {
@@ -534,7 +558,9 @@ impl LabMcpServer {
                     "Code Mode run is not paused (already resumed, rejected, expired, or \
                      terminal); only a paused run can be resumed.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // Code identity: resubmitted code must hash-match the paused run
             // (source is not persisted — the caller resubmits identical code).
@@ -546,7 +572,9 @@ impl LabMcpServer {
                     "Resubmitted Code Mode code does not match the paused run. Resume must \
                      resubmit the identical code.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // Actor identity (V3): the resuming actor must equal the recorded
             // one (None matches only None — never bridges trusted-local↔scoped).
@@ -558,7 +586,9 @@ impl LabMcpServer {
                     "forbidden",
                     "Only the actor that started a Code Mode run may resume it.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // Route-scope identity (F2): the run must be resumed under the SAME
             // protected-route scope it paused in. Fail closed BEFORE the CAS so a
@@ -575,7 +605,9 @@ impl LabMcpServer {
                     "Code Mode run was paused under a different protected-route scope; \
                      refusing to resume across routes.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // Live authorization (V1 — the critical fix): recompute live caps at
             // resume time. The fingerprint alone is NOT an authz check; the
@@ -601,7 +633,9 @@ impl LabMcpServer {
                     "Code Mode authorization changed since the run paused; refusing to resume \
                      with narrowed or revoked scope.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // CAS Paused→Running; loser gets already_resumed.
             if !decider.resume_to_running(&token).await {
@@ -611,7 +645,9 @@ impl LabMcpServer {
                     "already_resumed",
                     "Code Mode run was concurrently resumed or is no longer paused.",
                 );
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
             // Pre-execution intent log (OBSERVABILITY: destructive re-dispatch).
             tracing::info!(
@@ -739,7 +775,9 @@ impl LabMcpServer {
                     })
                     .await;
                 let env = tool_error_envelope(service, "call_tool", &tool_error);
-                return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
+                    env.to_string(),
+                )]));
             }
         };
         response.execution_id = Some(execution_id.clone());
@@ -785,7 +823,9 @@ impl LabMcpServer {
                         "gateway codemode durable error after settle"
                     );
                     let env = build_error(service, "call_tool", "internal_error", &message);
-                    return Ok(CallToolResult::error(vec![Content::text(env.to_string())]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        env.to_string(),
+                    )]));
                 }
                 // Running (never paused) or already terminal-ok — mark completed
                 // and fall through to the normal completed envelope. F5: a
@@ -979,7 +1019,7 @@ fn build_pause_envelope(
             "pending": pending_json,
         }),
     );
-    CallToolResult::error(vec![Content::text(env.to_string())])
+    CallToolResult::error(vec![ContentBlock::text(env.to_string())])
 }
 
 fn code_mode_capabilities_for_scopes(scopes: &[String]) -> CodeModeCallerCapabilities {
@@ -998,7 +1038,7 @@ fn call_result_with_structured(
     structured: Value,
     ui_meta: Option<Meta>,
 ) -> CallToolResult {
-    let mut result = CallToolResult::success(vec![Content::text(text)]);
+    let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
     result.structured_content = Some(structured);
     result.meta = ui_meta;
     result

--- a/crates/labby/src/mcp/call_tool_upstream.rs
+++ b/crates/labby/src/mcp/call_tool_upstream.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Upstream-proxy tail of `call_tool`: raw upstream proxy + subject-scoped
 //! upstream proxy + the no-dispatcher-wired fallback.
 //!
@@ -23,13 +21,13 @@ use std::time::Instant;
 
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, JsonObject, LoggingLevel};
-use rmcp::service::RequestContext;
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, JsonObject};
+use rmcp::service::{Peer, RequestContext};
 
 use crate::mcp::context::{auth_context_from_extensions, oauth_upstream_subject_for_request};
 use crate::mcp::envelope::build_error;
 use crate::mcp::error::canonical_kind;
-use crate::mcp::logging::DispatchLogOutcome;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 use crate::mcp::result_format::{
     estimate_tokens, estimate_tokens_args, format_dispatch_result, tool_error_envelope,
 };
@@ -44,6 +42,13 @@ pub(crate) struct PreResolvedUpstreamTool {
     pub(crate) upstream_name: String,
     pub(crate) tool: UpstreamTool,
     pub(crate) route: &'static str,
+}
+
+fn downstream_supports_relay(peer: &Peer<RoleServer>) -> bool {
+    !peer.supported_elicitation_modes().is_empty()
+        || peer.peer_info().is_some_and(|info| {
+            info.capabilities.sampling.is_some() || info.capabilities.roots.is_some()
+        })
 }
 
 impl LabMcpServer {
@@ -169,7 +174,7 @@ impl LabMcpServer {
             // agent. Falls back to the pooled multiplexed call when the gate is
             // off, the agent can't elicit, or the config can't be resolved.
             let relay_enabled = crate::config::env_flag_enabled("LAB_UPSTREAM_RELAY_ELICITATION")
-                && !context.peer.supported_elicitation_modes().is_empty();
+                && downstream_supports_relay(&context.peer);
             let relay_config = if relay_enabled {
                 match &self.gateway_manager {
                     Some(manager) => manager.upstream_config(&upstream_name).await,
@@ -414,7 +419,7 @@ impl LabMcpServer {
                 // so the dedicated connection authenticates as this caller.
                 let relay_enabled =
                     crate::config::env_flag_enabled("LAB_UPSTREAM_RELAY_ELICITATION")
-                        && !context.peer.supported_elicitation_modes().is_empty();
+                        && downstream_supports_relay(&context.peer);
                 let call_result: Result<CallToolResult, String> = if relay_enabled {
                     tracing::debug!(
                         surface = "mcp",

--- a/crates/labby/src/mcp/call_tool_upstream.rs
+++ b/crates/labby/src/mcp/call_tool_upstream.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Upstream-proxy tail of `call_tool`: raw upstream proxy + subject-scoped
 //! upstream proxy + the no-dispatcher-wired fallback.
 //!
@@ -21,7 +23,7 @@ use std::time::Instant;
 
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content, JsonObject, LoggingLevel};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, JsonObject, LoggingLevel};
 use rmcp::service::RequestContext;
 
 use crate::mcp::context::{auth_context_from_extensions, oauth_upstream_subject_for_request};
@@ -127,7 +129,7 @@ impl LabMcpServer {
                 },
             )
             .await;
-            return Ok(CallToolResult::error(vec![Content::text(
+            return Ok(CallToolResult::error(vec![ContentBlock::text(
                 envelope.to_string(),
             )]));
         }
@@ -305,7 +307,7 @@ impl LabMcpServer {
                         },
                     )
                     .await;
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 }
@@ -357,7 +359,7 @@ impl LabMcpServer {
                         },
                     )
                     .await;
-                    return Ok(CallToolResult::error(vec![Content::text(
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
                         envelope.to_string(),
                     )]));
                 }
@@ -548,7 +550,7 @@ impl LabMcpServer {
                             },
                         )
                         .await;
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             envelope.to_string(),
                         )]));
                     }

--- a/crates/labby/src/mcp/completion.rs
+++ b/crates/labby/src/mcp/completion.rs
@@ -31,11 +31,14 @@ pub(crate) fn action_schema() -> serde_json::Map<String, Value> {
 }
 
 pub(crate) fn completion_info(values: Vec<String>) -> CompletionInfo {
-    CompletionInfo {
-        total: Some(values.len() as u32),
-        has_more: Some(false),
-        values,
-    }
+    let total = values.len() as u32;
+    let has_more = values.len() > CompletionInfo::MAX_VALUES;
+    let values = values
+        .into_iter()
+        .take(CompletionInfo::MAX_VALUES)
+        .collect();
+    CompletionInfo::with_pagination(values, Some(total), has_more)
+        .expect("completion values are capped at rmcp's maximum")
 }
 
 pub(crate) fn complete_prompt_arg(

--- a/crates/labby/src/mcp/elicitation.rs
+++ b/crates/labby/src/mcp/elicitation.rs
@@ -1,11 +1,11 @@
 use rmcp::RoleServer;
 use rmcp::model::{
-    CreateElicitationRequestParams, ElicitationAction, ElicitationSchema, PrimitiveSchema,
+    ElicitRequestParams, ElicitationAction, ElicitationSchema, PrimitiveSchemaDefinition,
 };
 use rmcp::service::RequestContext;
 use serde_json::Value;
 
-pub(crate) enum ElicitResult {
+pub(crate) enum ConfirmOutcome {
     /// User confirmed the destructive action.
     Confirmed,
     /// User explicitly declined.
@@ -22,7 +22,7 @@ pub(crate) async fn elicit_confirm(
     context: &RequestContext<RoleServer>,
     service: &str,
     action: &str,
-) -> ElicitResult {
+) -> ConfirmOutcome {
     if context.peer.supported_elicitation_modes().is_empty() {
         tracing::warn!(
             surface = "mcp",
@@ -35,13 +35,13 @@ pub(crate) async fn elicit_confirm(
             kind = "confirmation_required",
             "destructive action elicitation not supported",
         );
-        return ElicitResult::NotSupported;
+        return ConfirmOutcome::NotSupported;
     }
 
     let Ok(schema) = ElicitationSchema::builder()
         .required_property(
             "confirm",
-            PrimitiveSchema::Boolean(rmcp::model::BooleanSchema::default()),
+            PrimitiveSchemaDefinition::Boolean(rmcp::model::BooleanSchema::default()),
         )
         .build()
     else {
@@ -56,10 +56,10 @@ pub(crate) async fn elicit_confirm(
             kind = "internal_error",
             "destructive action elicitation schema build failed",
         );
-        return ElicitResult::NotSupported;
+        return ConfirmOutcome::NotSupported;
     };
 
-    let params = CreateElicitationRequestParams::FormElicitationParams {
+    let params = ElicitRequestParams::FormElicitationParams {
         meta: None,
         message: format!(
             "Action `{service}.{action}` is destructive and cannot be undone. \
@@ -88,7 +88,7 @@ pub(crate) async fn elicit_confirm(
                         entity_id = %format!("{service}.{action}"),
                         "destructive action elicitation confirmed",
                     );
-                    ElicitResult::Confirmed
+                    ConfirmOutcome::Confirmed
                 } else {
                     tracing::warn!(
                         surface = "mcp",
@@ -101,7 +101,7 @@ pub(crate) async fn elicit_confirm(
                         kind = "confirmation_required",
                         "destructive action elicitation accepted without confirmation",
                     );
-                    ElicitResult::Declined
+                    ConfirmOutcome::Declined
                 }
             }
             ElicitationAction::Decline => {
@@ -116,7 +116,7 @@ pub(crate) async fn elicit_confirm(
                     kind = "confirmation_required",
                     "destructive action elicitation declined",
                 );
-                ElicitResult::Declined
+                ConfirmOutcome::Declined
             }
             ElicitationAction::Cancel => {
                 tracing::warn!(
@@ -130,7 +130,21 @@ pub(crate) async fn elicit_confirm(
                     kind = "confirmation_required",
                     "destructive action elicitation cancelled",
                 );
-                ElicitResult::Cancelled
+                ConfirmOutcome::Cancelled
+            }
+            _ => {
+                tracing::warn!(
+                    surface = "mcp",
+                    service,
+                    action,
+                    actor = "mcp_client",
+                    outcome = "unknown_action",
+                    entity_kind = "destructive_action",
+                    entity_id = %format!("{service}.{action}"),
+                    kind = "confirmation_required",
+                    "destructive action elicitation returned unknown action",
+                );
+                ConfirmOutcome::Cancelled
             }
         },
         Err(_) => {
@@ -145,7 +159,7 @@ pub(crate) async fn elicit_confirm(
                 kind = "confirmation_required",
                 "destructive action elicitation request failed",
             );
-            ElicitResult::Failed
+            ConfirmOutcome::Failed
         }
     }
 }

--- a/crates/labby/src/mcp/elicitation.rs
+++ b/crates/labby/src/mcp/elicitation.rs
@@ -2,7 +2,7 @@ use rmcp::RoleServer;
 use rmcp::model::{
     ElicitRequestParams, ElicitationAction, ElicitationSchema, PrimitiveSchemaDefinition,
 };
-use rmcp::service::RequestContext;
+use rmcp::service::{ElicitationMode, RequestContext};
 use serde_json::Value;
 
 pub(crate) enum ConfirmOutcome {
@@ -23,7 +23,11 @@ pub(crate) async fn elicit_confirm(
     service: &str,
     action: &str,
 ) -> ConfirmOutcome {
-    if context.peer.supported_elicitation_modes().is_empty() {
+    if !context
+        .peer
+        .supported_elicitation_modes()
+        .contains(&ElicitationMode::Form)
+    {
         tracing::warn!(
             surface = "mcp",
             service,

--- a/crates/labby/src/mcp/handlers_prompts.rs
+++ b/crates/labby/src/mcp/handlers_prompts.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Prompt handler bodies (`list_prompts`, `get_prompt`).
 //!
 //! Extracted from `server.rs` (bead `lab-kvji.24.1.2`) as inherent
@@ -16,8 +14,7 @@ use std::time::Instant;
 use rmcp::ErrorData;
 use rmcp::RoleServer;
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, LoggingLevel,
-    PaginatedRequestParams,
+    GetPromptRequestParams, GetPromptResult, ListPromptsResult, PaginatedRequestParams,
 };
 use rmcp::service::RequestContext;
 use serde_json::Value;
@@ -26,7 +23,7 @@ use serde_json::Value;
 use crate::mcp::context::auth_context_from_extensions;
 #[cfg(feature = "gateway")]
 use crate::mcp::context::oauth_upstream_subject_for_request;
-use crate::mcp::logging::DispatchLogOutcome;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 use crate::mcp::server::LabMcpServer;
 
 impl LabMcpServer {

--- a/crates/labby/src/mcp/handlers_prompts.rs
+++ b/crates/labby/src/mcp/handlers_prompts.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Prompt handler bodies (`list_prompts`, `get_prompt`).
 //!
 //! Extracted from `server.rs` (bead `lab-kvji.24.1.2`) as inherent

--- a/crates/labby/src/mcp/handlers_resources.rs
+++ b/crates/labby/src/mcp/handlers_resources.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Resource handler bodies (`list_resources`, `read_resource`).
 //!
 //! Extracted from `server.rs` (bead `lab-kvji.24.1.3`) as inherent
@@ -18,7 +16,7 @@ use std::time::Instant;
 use rmcp::ErrorData;
 use rmcp::RoleServer;
 use rmcp::model::{
-    ListResourcesResult, LoggingLevel, Meta, PaginatedRequestParams, ReadResourceRequestParams,
+    ListResourcesResult, Meta, PaginatedRequestParams, ReadResourceRequestParams,
     ReadResourceResult, Resource, ResourceContents,
 };
 use rmcp::service::RequestContext;
@@ -28,7 +26,7 @@ use crate::mcp::catalog::CODE_MODE_TOOL_NAME;
 #[cfg(feature = "gateway")]
 use crate::mcp::context::oauth_upstream_subject_for_request;
 use crate::mcp::context::{auth_context_from_extensions, code_mode_read_scope_allowed};
-use crate::mcp::logging::DispatchLogOutcome;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 use crate::mcp::server::LabMcpServer;
 
 /// MCP Apps (Claude / SEP-1724) MIME — bound via the tool's `_meta.ui.resourceUri`.

--- a/crates/labby/src/mcp/handlers_resources.rs
+++ b/crates/labby/src/mcp/handlers_resources.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Resource handler bodies (`list_resources`, `read_resource`).
 //!
 //! Extracted from `server.rs` (bead `lab-kvji.24.1.3`) as inherent
@@ -16,8 +18,8 @@ use std::time::Instant;
 use rmcp::ErrorData;
 use rmcp::RoleServer;
 use rmcp::model::{
-    AnnotateAble, ListResourcesResult, LoggingLevel, Meta, PaginatedRequestParams, RawResource,
-    ReadResourceRequestParams, ReadResourceResult, ResourceContents,
+    ListResourcesResult, LoggingLevel, Meta, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, Resource, ResourceContents,
 };
 use rmcp::service::RequestContext;
 use serde_json::{Value, json};
@@ -158,10 +160,9 @@ impl LabMcpServer {
         );
         let auth = auth_context_from_extensions(&context.extensions);
         let mut resources = vec![
-            RawResource::new("lab://catalog", "catalog")
+            Resource::new("lab://catalog", "catalog")
                 .with_description("Full discovery document for all services")
-                .with_mime_type("application/json")
-                .no_annotation(),
+                .with_mime_type("application/json"),
         ];
         if code_mode_app_resources_visible(
             self.code_mode_visibility().await.exposes_synthetic_tools(),
@@ -175,10 +176,9 @@ impl LabMcpServer {
                 let uri = format!("lab://{}/actions", svc.name);
                 let name = format!("{}/actions", svc.name);
                 resources.push(
-                    RawResource::new(uri, name)
+                    Resource::new(uri, name)
                         .with_description(format!("Action list for {}", svc.name))
-                        .with_mime_type("application/json")
-                        .no_annotation(),
+                        .with_mime_type("application/json"),
                 );
             }
         }
@@ -540,13 +540,12 @@ fn code_mode_app_html(uri: &str, history: Option<&Value>) -> Result<String, Stri
     Ok(html)
 }
 
-fn code_mode_app_resource(descriptor: &CodeModeAppResourceDescriptor) -> rmcp::model::Resource {
+fn code_mode_app_resource(descriptor: &CodeModeAppResourceDescriptor) -> Resource {
     let uri = versioned_app_uri(descriptor.uri);
-    RawResource::new(uri.clone(), descriptor.name.to_string())
+    Resource::new(uri.clone(), descriptor.name.to_string())
         .with_description("Read-only MCP App for Code Mode call traces")
         .with_mime_type(descriptor.runtime.mime())
         .with_meta(code_mode_app_resource_meta(&uri))
-        .no_annotation()
 }
 
 /// Host runtime a Code Mode app URI targets. Callers must pass a table URI; an
@@ -581,7 +580,7 @@ fn code_mode_app_resources_visible(
     exposes_synthetic_tools && code_mode_read_scope_allowed(auth)
 }
 
-fn code_mode_app_resources() -> Vec<rmcp::model::Resource> {
+fn code_mode_app_resources() -> Vec<Resource> {
     CODE_MODE_APP_RESOURCE_DESCRIPTORS
         .iter()
         .filter(|descriptor| descriptor.runtime.listed())
@@ -825,6 +824,7 @@ mod tests {
                 assert!(meta.0.get("prefersBorder").is_none());
             }
             ResourceContents::BlobResourceContents { .. } => panic!("expected text resource"),
+            _ => panic!("expected text resource"),
         }
     }
 

--- a/crates/labby/src/mcp/handlers_tools/tests.rs
+++ b/crates/labby/src/mcp/handlers_tools/tests.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Tests for tool-list/catalog visibility + upstream-pool resolution.
 //! Distributed from `server.rs` (bead `lab-kvji.24.1.6`). Duplicates the
 //! small `completion_test_registry` fixture to keep this `tests.rs`
@@ -97,7 +95,7 @@ fn test_server(
     registry: ToolRegistry,
     gateway_manager: Option<Arc<crate::dispatch::gateway::manager::GatewayManager>>,
     route_scope: crate::mcp::route_scope::McpRouteScope,
-    logging_level: rmcp::model::LoggingLevel,
+    logging_level: crate::mcp::logging::LoggingLevel,
 ) -> LabMcpServer {
     LabMcpServer {
         registry: Arc::new(registry),
@@ -360,7 +358,7 @@ async fn list_tools_advertises_code_mode_output_schemas() {
         completion_test_registry(),
         Some(code_mode_manager(true).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(256 * 1024);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -422,7 +420,7 @@ async fn list_tools_promotes_upstream_mcp_app_tools_when_raw_tools_are_hidden() 
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(256 * 1024);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -463,7 +461,7 @@ async fn list_tools_does_not_cold_connect_code_mode_catalog() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -520,7 +518,7 @@ async fn list_tools_does_not_promote_upstream_mcp_app_tools_when_resources_are_n
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -568,7 +566,7 @@ async fn list_tools_skips_upstream_ui_tools_that_collide_with_synthetic_names() 
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -627,7 +625,7 @@ async fn protected_code_mode_list_tools_hides_raw_siblings_and_disallowed_builti
             ["radarr"],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -673,7 +671,7 @@ async fn codemode_description_lists_route_scoped_enabled_upstreams() {
             ["radarr"],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -718,7 +716,7 @@ async fn protected_list_tools_filters_disallowed_builtins_when_code_mode_is_off(
             ["radarr"],
             false,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -771,7 +769,7 @@ async fn call_tool_allows_mcp_app_sibling_callbacks_when_raw_tools_are_hidden() 
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -824,7 +822,7 @@ async fn call_tool_allows_direct_mcp_app_ui_callbacks_with_read_scope() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -874,7 +872,7 @@ async fn call_tool_rejects_priority_zero_direct_mcp_app_ui_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -931,7 +929,7 @@ async fn call_tool_rejects_priority_zero_mcp_app_sibling_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -988,7 +986,7 @@ async fn call_tool_rejects_disabled_mcp_app_sibling_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1063,7 +1061,7 @@ async fn call_tool_preserves_selected_mcp_app_sibling_upstream() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1120,7 +1118,7 @@ async fn call_tool_requires_execute_scope_for_hidden_mcp_app_sibling_callbacks()
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1170,7 +1168,7 @@ async fn call_tool_requires_execute_scope_for_legacy_widget_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     server.code_mode_widget_callbacks_enabled_for_test = true;
     let (transport, _client_transport) = tokio::io::duplex(64);
@@ -1201,7 +1199,7 @@ async fn codemode_requires_execute_scope_not_read_scope() {
         completion_test_registry(),
         Some(code_mode_manager(true).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1232,7 +1230,7 @@ async fn codemode_allows_execute_scope_to_reach_runner_path() {
         completion_test_registry(),
         Some(code_mode_manager(true).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1280,7 +1278,7 @@ async fn codemode_routes_to_code_mode_path() {
         completion_test_registry(),
         Some(code_mode_manager(true).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1349,7 +1347,7 @@ async fn call_tool_allows_execute_scope_for_hidden_mcp_app_sibling_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1414,7 +1412,7 @@ async fn call_tool_honors_route_scope_for_mcp_app_sibling_callbacks() {
             ["gateway"],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
 
     let text = call_tool_error_text(server, "youtube_probe").await;
@@ -1453,7 +1451,7 @@ async fn call_tool_uses_subject_scoped_route_for_oauth_mcp_app_sibling_callbacks
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1506,7 +1504,7 @@ async fn call_tool_blocks_destructive_mcp_app_sibling_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1560,7 +1558,7 @@ async fn call_tool_blocks_destructive_direct_mcp_app_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
 
     let text = call_tool_error_text(server, "youtube_delete_ui").await;
@@ -1587,7 +1585,7 @@ async fn call_tool_blocks_destructive_legacy_widget_callbacks() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     server.code_mode_widget_callbacks_enabled_for_test = true;
     let (transport, _client_transport) = tokio::io::duplex(64);
@@ -1637,7 +1635,7 @@ async fn call_tool_allows_legacy_widget_callbacks_for_route_allowed_upstream() {
             ["gateway"],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     server.code_mode_widget_callbacks_enabled_for_test = true;
     let (transport, _client_transport) = tokio::io::duplex(64);
@@ -1696,7 +1694,7 @@ async fn call_tool_honors_route_scope_for_legacy_widget_callbacks() {
             ["gateway"],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     server.code_mode_widget_callbacks_enabled_for_test = true;
     let (transport, _client_transport) = tokio::io::duplex(64);
@@ -1782,7 +1780,7 @@ async fn call_tool_rejects_ambiguous_mcp_app_sibling_callbacks_when_one_candidat
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1869,7 +1867,7 @@ async fn call_tool_rejects_ambiguous_non_destructive_mcp_app_sibling_callbacks()
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -1926,7 +1924,7 @@ async fn call_tool_blocks_destructive_mcp_app_sibling_callback() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2012,7 +2010,7 @@ async fn call_tool_refuses_ambiguous_mcp_app_sibling_callback() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2059,7 +2057,7 @@ async fn call_tool_rejects_hidden_tool_without_ui_sibling_in_code_mode() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2109,7 +2107,7 @@ async fn call_tool_allows_direct_mcp_app_ui_tool_in_code_mode() {
         completion_test_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2145,7 +2143,7 @@ async fn snapshot_catalog_hides_builtin_tools_when_code_mode_is_enabled() {
         completion_test_registry(),
         Some(code_mode_manager(true).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
 
     let snapshot = server.snapshot_catalog().await;
@@ -2169,7 +2167,7 @@ async fn snapshot_catalog_shows_no_gateway_tools_when_surface_is_disabled() {
         completion_test_registry(),
         Some(code_mode_manager(false).await),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
 
     let snapshot = server.snapshot_catalog().await;
@@ -2194,7 +2192,7 @@ async fn protected_scope_denies_direct_code_mode_calls_when_hidden() {
             ["radarr"],
             false,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2238,7 +2236,7 @@ async fn server_reads_current_pool_from_gateway_manager() {
         node_role: None,
         peers: Arc::clone(&notifier.peers),
         logging_level: Arc::new(AtomicU8::new(logging_level_rank(
-            rmcp::model::LoggingLevel::Info,
+            crate::mcp::logging::LoggingLevel::Info,
         ))),
         route_scope: crate::mcp::route_scope::McpRouteScope::Root,
         relay_session_id: 0,
@@ -2289,7 +2287,7 @@ async fn snapshot_catalog_hides_mcp_disabled_virtual_services() {
         crate::registry::build_default_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Info,
+        crate::mcp::logging::LoggingLevel::Info,
     );
 
     let snapshot = server.snapshot_catalog().await;
@@ -2344,13 +2342,13 @@ async fn gateway_add_through_mcp_protected_route_suppresses_hidden_enrichment_su
             ["gateway".to_string()],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let peer_server = test_server(
         ToolRegistry::new(),
         None,
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(256 * 1024);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2433,13 +2431,13 @@ async fn gateway_pending_import_approve_through_mcp_protected_route_suppresses_h
             ["gateway".to_string()],
             true,
         ),
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let peer_server = test_server(
         ToolRegistry::new(),
         None,
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(256 * 1024);
     let running = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(
@@ -2517,7 +2515,7 @@ async fn service_actions_json_filters_to_allowed_mcp_actions() {
         crate::registry::build_default_registry(),
         Some(manager),
         crate::mcp::route_scope::McpRouteScope::Root,
-        rmcp::model::LoggingLevel::Info,
+        crate::mcp::logging::LoggingLevel::Info,
     );
 
     let value = server
@@ -2733,7 +2731,7 @@ fn serve_codemode(
         completion_test_registry(),
         Some(manager),
         route_scope,
-        rmcp::model::LoggingLevel::Emergency,
+        crate::mcp::logging::LoggingLevel::Emergency,
     );
     let (transport, _client_transport) = tokio::io::duplex(64);
     rmcp::service::serve_directly::<rmcp::RoleServer, _, _, std::io::Error, _>(

--- a/crates/labby/src/mcp/handlers_tools/tests.rs
+++ b/crates/labby/src/mcp/handlers_tools/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Tests for tool-list/catalog visibility + upstream-pool resolution.
 //! Distributed from `server.rs` (bead `lab-kvji.24.1.6`). Duplicates the
 //! small `completion_test_registry` fixture to keep this `tests.rs`

--- a/crates/labby/src/mcp/in_process_peer.rs
+++ b/crates/labby/src/mcp/in_process_peer.rs
@@ -1,11 +1,9 @@
-#![allow(deprecated)]
-
 //! MCP-owned in-process peer construction for built-in Lab services.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 
-use rmcp::model::LoggingLevel;
+use crate::mcp::logging::LoggingLevel;
 use rmcp::{RoleClient, ServiceExt};
 use tokio::sync::RwLock;
 

--- a/crates/labby/src/mcp/in_process_peer.rs
+++ b/crates/labby/src/mcp/in_process_peer.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! MCP-owned in-process peer construction for built-in Lab services.
 
 use std::sync::Arc;

--- a/crates/labby/src/mcp/logging.rs
+++ b/crates/labby/src/mcp/logging.rs
@@ -1,13 +1,59 @@
-#![allow(deprecated)]
-
 use std::sync::atomic::Ordering;
 
 use rmcp::RoleServer;
-use rmcp::model::{LoggingLevel, LoggingMessageNotificationParam};
-use rmcp::service::RequestContext;
+use rmcp::service::{Peer, RequestContext};
 use serde_json::json;
 
 use super::server::LabMcpServer;
+
+// rmcp 2.1 deprecates the legacy logging capability under SEP-2577, but the
+// server still supports it for clients that have not moved to protocol logging.
+#[allow(deprecated)]
+use rmcp::model::LoggingLevel as RmcpLoggingLevel;
+#[allow(deprecated)]
+use rmcp::model::LoggingMessageNotificationParam;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoggingLevel {
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+    Critical,
+    Alert,
+    Emergency,
+}
+
+impl LoggingLevel {
+    #[allow(deprecated)]
+    pub(crate) fn from_rmcp(level: RmcpLoggingLevel) -> Self {
+        match level {
+            RmcpLoggingLevel::Debug => Self::Debug,
+            RmcpLoggingLevel::Info => Self::Info,
+            RmcpLoggingLevel::Notice => Self::Notice,
+            RmcpLoggingLevel::Warning => Self::Warning,
+            RmcpLoggingLevel::Error => Self::Error,
+            RmcpLoggingLevel::Critical => Self::Critical,
+            RmcpLoggingLevel::Alert => Self::Alert,
+            RmcpLoggingLevel::Emergency => Self::Emergency,
+        }
+    }
+
+    #[allow(deprecated)]
+    fn to_rmcp(self) -> RmcpLoggingLevel {
+        match self {
+            Self::Debug => RmcpLoggingLevel::Debug,
+            Self::Info => RmcpLoggingLevel::Info,
+            Self::Notice => RmcpLoggingLevel::Notice,
+            Self::Warning => RmcpLoggingLevel::Warning,
+            Self::Error => RmcpLoggingLevel::Error,
+            Self::Critical => RmcpLoggingLevel::Critical,
+            Self::Alert => RmcpLoggingLevel::Alert,
+            Self::Emergency => RmcpLoggingLevel::Emergency,
+        }
+    }
+}
 
 pub(crate) enum DispatchLogOutcome {
     Success,
@@ -71,6 +117,37 @@ fn notification_payload(
     (level, payload)
 }
 
+#[allow(deprecated)]
+pub(crate) fn spawn_dispatch_notification(
+    peer: Peer<RoleServer>,
+    actor_key: Option<String>,
+    service: String,
+    action: String,
+    elapsed_ms: u128,
+    outcome: DispatchLogOutcome,
+) {
+    let (level, mut payload) =
+        notification_payload(&service, &action, elapsed_ms, outcome, actor_key.as_deref());
+    tokio::spawn(async move {
+        if let Err(error) = peer
+            .notify_logging_message(
+                LoggingMessageNotificationParam::new(level.to_rmcp(), payload.take())
+                    .with_logger("lab.mcp.dispatch"),
+            )
+            .await
+        {
+            tracing::debug!(
+                surface = "mcp",
+                service = %service,
+                action = %action,
+                level = ?level,
+                error = %error,
+                "failed to send rmcp logging notification"
+            );
+        }
+    });
+}
+
 impl LabMcpServer {
     pub(crate) fn current_logging_level(&self) -> LoggingLevel {
         decode_logging_level(self.logging_level.load(Ordering::Relaxed))
@@ -80,6 +157,7 @@ impl LabMcpServer {
         logging_level_rank(level) >= logging_level_rank(self.current_logging_level())
     }
 
+    #[allow(deprecated)]
     pub(crate) async fn emit_dispatch_notification(
         &self,
         context: &RequestContext<RoleServer>,
@@ -99,7 +177,7 @@ impl LabMcpServer {
         if let Err(error) = context
             .peer
             .notify_logging_message(
-                LoggingMessageNotificationParam::new(level, payload)
+                LoggingMessageNotificationParam::new(level.to_rmcp(), payload)
                     .with_logger("lab.mcp.dispatch"),
             )
             .await
@@ -119,8 +197,7 @@ impl LabMcpServer {
 #[cfg(test)]
 mod tests {
     use super::{decode_logging_level, logging_level_rank, notification_payload};
-    use crate::mcp::logging::DispatchLogOutcome;
-    use rmcp::model::LoggingLevel;
+    use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 
     #[test]
     fn logging_level_encoding_round_trips() {

--- a/crates/labby/src/mcp/logging.rs
+++ b/crates/labby/src/mcp/logging.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::atomic::Ordering;
 
 use rmcp::RoleServer;

--- a/crates/labby/src/mcp/prompts.rs
+++ b/crates/labby/src/mcp/prompts.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use rmcp::model::{
-    GetPromptResult, ListPromptsResult, Prompt, PromptArgument, PromptMessage, PromptMessageRole,
+    GetPromptResult, ListPromptsResult, Prompt, PromptArgument, PromptMessage, Role,
 };
 
 use crate::registry::{RegisteredService, ToolRegistry};
@@ -99,7 +99,7 @@ fn render_run_action(registry: &ToolRegistry, args: &HashMap<String, String>) ->
         action_summary(action_name, action)
     );
 
-    GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::User, text)])
         .with_description(format!("Run {service_name}.{action_name}"))
 }
 
@@ -127,7 +127,7 @@ fn render_service_discover(
         action_catalog(service)
     );
 
-    GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::User, text)])
         .with_description(format!("Discover {service_name}"))
 }
 

--- a/crates/labby/src/mcp/resource_proxy.rs
+++ b/crates/labby/src/mcp/resource_proxy.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! `read_resource` proxy branch bodies: gateway-synthetic, upstream,
 //! and subject-scoped resource proxying.
 //!
@@ -20,12 +18,12 @@ use std::time::Instant;
 
 use rmcp::ErrorData;
 use rmcp::RoleServer;
-use rmcp::model::{LoggingLevel, ReadResourceResult, ResourceContents};
+use rmcp::model::{ReadResourceResult, ResourceContents};
 use rmcp::service::RequestContext;
 
 use crate::config::UpstreamConfig;
 use crate::dispatch::upstream::pool::{UpstreamPool, redact_resource_uri_for_logging};
-use crate::mcp::logging::DispatchLogOutcome;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 use crate::mcp::server::LabMcpServer;
 
 impl LabMcpServer {

--- a/crates/labby/src/mcp/resource_proxy.rs
+++ b/crates/labby/src/mcp/resource_proxy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! `read_resource` proxy branch bodies: gateway-synthetic, upstream,
 //! and subject-scoped resource proxying.
 //!

--- a/crates/labby/src/mcp/result_format.rs
+++ b/crates/labby/src/mcp/result_format.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! Result/envelope formatting + error-info extraction + token estimation.
 //!
 //! Free functions extracted from `server.rs` (bead `lab-kvji.24.1.1`).
@@ -8,7 +6,7 @@
 //! `normalize_upstream_result` intentionally does NOT live here — it is
 //! consolidated into `upstream.rs` (its semantic home) in bead `.5`.
 
-use rmcp::model::{CallToolResult, ContentBlock, LoggingLevel};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -16,7 +14,7 @@ use crate::dispatch::error::ToolError as DispatchToolError;
 use crate::mcp::envelope::{build_error, build_error_extra, build_success};
 use crate::mcp::error::DispatchError;
 use crate::mcp::error::canonical_kind;
-use crate::mcp::logging::DispatchLogOutcome;
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel};
 
 pub(crate) fn tool_error_envelope(service: &str, action: &str, err: &DispatchToolError) -> Value {
     let Ok(Value::Object(mut serialized)) = serde_json::to_value(err) else {

--- a/crates/labby/src/mcp/result_format.rs
+++ b/crates/labby/src/mcp/result_format.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! Result/envelope formatting + error-info extraction + token estimation.
 //!
 //! Free functions extracted from `server.rs` (bead `lab-kvji.24.1.1`).
@@ -6,7 +8,7 @@
 //! `normalize_upstream_result` intentionally does NOT live here — it is
 //! consolidated into `upstream.rs` (its semantic home) in bead `.5`.
 
-use rmcp::model::{CallToolResult, Content, LoggingLevel};
+use rmcp::model::{CallToolResult, ContentBlock, LoggingLevel};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -76,7 +78,7 @@ pub(crate) fn format_dispatch_result(
             );
             let envelope = build_success(service, action, &v);
             (
-                CallToolResult::success(vec![Content::text(envelope.to_string())]),
+                CallToolResult::success(vec![ContentBlock::text(envelope.to_string())]),
                 DispatchLogOutcome::Success,
             )
         }
@@ -121,7 +123,7 @@ pub(crate) fn format_dispatch_result(
                 |ref extra| build_error_extra(service, action, kind, &message, extra),
             );
             (
-                CallToolResult::error(vec![Content::text(envelope.to_string())]),
+                CallToolResult::error(vec![ContentBlock::text(envelope.to_string())]),
                 DispatchLogOutcome::Failure {
                     level: if is_fatal {
                         LoggingLevel::Error

--- a/crates/labby/src/mcp/server.rs
+++ b/crates/labby/src/mcp/server.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! `LabMcpServer` — the MCP `ServerHandler` implementation.
 //!
 //! Extracted from `cli/serve.rs` so that both the stdio and HTTP transports
@@ -16,8 +14,12 @@ use rmcp::model::{
     CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteResult,
     GetPromptRequestParams, GetPromptResult, ListPromptsResult, ListResourcesResult,
     ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo, SetLevelRequestParams,
+    ServerCapabilities, ServerInfo,
 };
+// rmcp 2.1 deprecates legacy logging under SEP-2577; the ServerHandler trait
+// still requires this request type for clients using the old logging flow.
+#[allow(deprecated)]
+use rmcp::model::SetLevelRequestParams;
 use rmcp::service::{NotificationContext, Peer, RequestContext};
 use rmcp::{ErrorData, RoleServer, ServerHandler};
 use tokio::sync::RwLock;
@@ -28,7 +30,7 @@ use crate::dispatch::gateway::manager::GatewayManager;
 use crate::mcp::completion::{complete_prompt_arg, completion_info};
 #[cfg(feature = "gateway")]
 use crate::mcp::context::subject_from_extensions;
-use crate::mcp::logging::{DispatchLogOutcome, logging_level_rank};
+use crate::mcp::logging::{DispatchLogOutcome, LoggingLevel, logging_level_rank};
 use crate::mcp::route_scope::McpRouteScope;
 use crate::registry::ToolRegistry;
 
@@ -114,6 +116,7 @@ fn mcp_apps_ui_extension() -> ExtensionCapabilities {
 }
 
 impl ServerHandler for LabMcpServer {
+    #[allow(deprecated)]
     fn get_info(&self) -> ServerInfo {
         #[cfg(feature = "gateway")]
         let gateway_manager_configured = self.gateway_manager.is_some();
@@ -144,13 +147,16 @@ impl ServerHandler for LabMcpServer {
         ServerInfo::new(builder.build())
     }
 
+    #[allow(deprecated)]
     async fn set_level(
         &self,
         request: SetLevelRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<(), ErrorData> {
-        self.logging_level
-            .store(logging_level_rank(request.level), Ordering::Release);
+        self.logging_level.store(
+            logging_level_rank(LoggingLevel::from_rmcp(request.level)),
+            Ordering::Release,
+        );
         tracing::info!(
             surface = "mcp",
             service = "labby",
@@ -389,7 +395,7 @@ mod tests {
             node_role: None,
             peers: std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
             logging_level: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(
-                logging_level_rank(rmcp::model::LoggingLevel::Info),
+                logging_level_rank(crate::mcp::logging::LoggingLevel::Info),
             )),
             route_scope: crate::mcp::route_scope::McpRouteScope::Root,
             relay_session_id: 0,

--- a/crates/labby/src/mcp/server.rs
+++ b/crates/labby/src/mcp/server.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 //! `LabMcpServer` — the MCP `ServerHandler` implementation.
 //!
 //! Extracted from `cli/serve.rs` so that both the stdio and HTTP transports

--- a/crates/labby/src/mcp/upstream.rs
+++ b/crates/labby/src/mcp/upstream.rs
@@ -7,7 +7,7 @@
 //! the dead `static_kind` helper were deleted. Zero behavior change — the
 //! live path already used `canonical_kind`.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::Value;
 
 use crate::mcp::envelope::{build_error, build_error_extra};
@@ -35,7 +35,7 @@ pub(crate) fn normalize_upstream_result(
             "upstream returned a non-text error payload",
         );
         return (
-            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            CallToolResult::error(vec![ContentBlock::text(envelope.to_string())]),
             "upstream_error",
             true,
         );
@@ -44,7 +44,7 @@ pub(crate) fn normalize_upstream_result(
     let Ok(parsed) = serde_json::from_str::<Value>(text) else {
         let envelope = build_error(service, action, "upstream_error", text);
         return (
-            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            CallToolResult::error(vec![ContentBlock::text(envelope.to_string())]),
             "upstream_error",
             true,
         );
@@ -58,7 +58,7 @@ pub(crate) fn normalize_upstream_result(
     let Some(error_obj) = error_obj else {
         let envelope = build_error(service, action, "upstream_error", text);
         return (
-            CallToolResult::error(vec![Content::text(envelope.to_string())]),
+            CallToolResult::error(vec![ContentBlock::text(envelope.to_string())]),
             "upstream_error",
             true,
         );
@@ -88,7 +88,7 @@ pub(crate) fn normalize_upstream_result(
     };
 
     (
-        CallToolResult::error(vec![Content::text(envelope.to_string())]),
+        CallToolResult::error(vec![ContentBlock::text(envelope.to_string())]),
         kind,
         matches!(
             kind,

--- a/crates/labby/src/mcp/upstream/tests.rs
+++ b/crates/labby/src/mcp/upstream/tests.rs
@@ -3,11 +3,11 @@
 
 use super::normalize_upstream_result;
 use crate::mcp::envelope::build_error;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 #[test]
 fn normalize_upstream_result_preserves_user_errors_without_poisoning_health() {
-    let upstream = CallToolResult::error(vec![Content::text(
+    let upstream = CallToolResult::error(vec![ContentBlock::text(
         build_error("radarr", "movie.add", "missing_param", "need title").to_string(),
     )]);
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -370,10 +370,11 @@ impl BenchRow {
     }
 }
 
-fn summarize(label: &str, binary: &PathBuf, case: &str, samples: &[f64]) -> BenchRow {
+fn summarize(label: &str, binary: &Path, case: &str, samples: &[f64]) -> BenchRow {
     let mut sorted = samples.to_vec();
     sorted.sort_by(f64::total_cmp);
     let sum: f64 = sorted.iter().sum();
+    let sample_count = u32::try_from(sorted.len()).unwrap_or(u32::MAX);
     BenchRow {
         label: label.to_string(),
         binary: binary.display().to_string(),
@@ -383,7 +384,7 @@ fn summarize(label: &str, binary: &PathBuf, case: &str, samples: &[f64]) -> Benc
         median_ms: percentile(&sorted, 0.50),
         p95_ms: percentile(&sorted, 0.95),
         max_ms: *sorted.last().unwrap_or(&f64::NAN),
-        mean_ms: sum / sorted.len() as f64,
+        mean_ms: sum / f64::from(sample_count),
     }
 }
 
@@ -391,6 +392,8 @@ fn percentile(sorted: &[f64], pct: f64) -> f64 {
     if sorted.is_empty() {
         return f64::NAN;
     }
-    let idx = ((sorted.len() - 1) as f64 * pct).round() as usize;
+    let max_idx = sorted.len() - 1;
+    let max_idx_f64 = f64::from(u32::try_from(max_idx).unwrap_or(u32::MAX));
+    let idx = (max_idx_f64 * pct).round().clamp(0.0, max_idx_f64) as usize;
     sorted[idx]
 }


### PR DESCRIPTION
Closes #184.

## Summary

- Bump the workspace `rmcp` dependency and the `labby-auth` renamed client dependency to `2.1` while dropping the unused `macros` feature.
- Update MCP server and gateway code for rmcp 2.1 model/API changes, including `ContentBlock`, `Resource` construction, elicitation type renames, `PrimitiveSchemaDefinition`, prompt roles, and non-exhaustive model handling.
- Keep SEP-2577 deprecated logging/sampling/roots compatibility behind narrow module-level allow islands where Labby intentionally proxies legacy behavior.
- Fix the workspace clippy gate by tightening the `xtask` benchmark summary signatures/conversions.

## Notes

`rmcp 1.8.0` still appears transitively through `rmcp-openapi`/`rmcp-actix-web`; the Labby server/runtime crates (`labby`, `labby-auth`, `labby-gateway`) resolve to `rmcp 2.1.0`.

## Validation

- `cargo nextest run -p labby-gateway --all-features` -> 465 passed, 9 skipped
- `cargo nextest run -p labby --all-features -E 'not test(config::env_merge::tests::backup_pruning_keeps_last_ten) and not test(config::env_merge::tests::preserves_comments_property)'` -> 1518 passed, 6 skipped
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the workspace to `rmcp` 2.1, updates the MCP server and gateway to the new 2.1 models/APIs, adds a logging shim, and tightens gateway safety defaults; also narrows Incus image PR triggers and fixes the Docker cache stub for `xtask` to restore layer reuse (closes #184).

- **Dependencies**
  - Bump `rmcp` and the renamed `labby-auth` client to 2.1; drop the unused `macros` feature.
  - Note: `rmcp 1.8.0` still arrives transitively via `rmcp-openapi`/`rmcp-actix-web`; runtime crates resolve to `rmcp 2.1.0`.

- **Migration**
  - Model/API updates: `Content` -> `ContentBlock`, `CreateElicitation*` -> `Elicit*`, `PromptMessageRole` -> `Role`, `PrimitiveSchema` -> `PrimitiveSchemaDefinition`, `RawResource`/`AnnotateAble` -> `Resource`.
  - Resource listing/reading and gateway helpers adjusted for new `Resource` and `ResourceContents` variants (with non-exhaustive handling).
  - Completion now caps and paginates via `CompletionInfo::MAX_VALUES` and `with_pagination`.
  - Confirmation flow returns `ConfirmOutcome`, only elicits when the client supports `Form`, and handles unknown elicitation actions.
  - Introduce `crate::mcp::logging::LoggingLevel` and a notification helper; map to deprecated `rmcp` logging via narrow `#[allow(deprecated)]` islands, and mirror legacy sampling/roots for upstream compatibility.
  - Gateway safety gates now fail closed: tools are treated as destructive unless the upstream explicitly marks them read-only or non-destructive.
  - `xtask` benchmarks: accept `&Path`, use safe u32 counts, and clamp percentile indexing to satisfy clippy.

<sup>Written for commit 50b8b7534053978b7f267683e1aeb0dac61f2a79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/labby/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

